### PR TITLE
refactor: consolidate repository data under repositories directory

### DIFF
--- a/packages/server/src/lib/__tests__/config.test.ts
+++ b/packages/server/src/lib/__tests__/config.test.ts
@@ -50,4 +50,38 @@ describe('config', () => {
       expect(typeof getServerPid()).toBe('number');
     });
   });
+
+  describe('getRepositoriesDir', () => {
+    it('should return repositories subdirectory of config dir', async () => {
+      delete process.env.AGENT_CONSOLE_HOME;
+      const { getRepositoriesDir } = await import('../config.js');
+
+      const expected = path.join(os.homedir(), '.agent-console', 'repositories');
+      expect(getRepositoriesDir()).toBe(expected);
+    });
+
+    it('should respect AGENT_CONSOLE_HOME', async () => {
+      process.env.AGENT_CONSOLE_HOME = '/custom/path';
+      const { getRepositoriesDir } = await import('../config.js');
+
+      expect(getRepositoriesDir()).toBe('/custom/path/repositories');
+    });
+  });
+
+  describe('getRepositoryDir', () => {
+    it('should return repository-specific directory', async () => {
+      delete process.env.AGENT_CONSOLE_HOME;
+      const { getRepositoryDir } = await import('../config.js');
+
+      const expected = path.join(os.homedir(), '.agent-console', 'repositories', 'owner/repo');
+      expect(getRepositoryDir('owner/repo')).toBe(expected);
+    });
+
+    it('should handle simple repo names', async () => {
+      process.env.AGENT_CONSOLE_HOME = '/config';
+      const { getRepositoryDir } = await import('../config.js');
+
+      expect(getRepositoryDir('my-repo')).toBe('/config/repositories/my-repo');
+    });
+  });
 });

--- a/packages/server/src/lib/config.ts
+++ b/packages/server/src/lib/config.ts
@@ -11,6 +11,23 @@ export function getConfigDir(): string {
 }
 
 /**
+ * Get the repositories base directory.
+ * Structure: ~/.agent-console/repositories/
+ */
+export function getRepositoriesDir(): string {
+  return path.join(getConfigDir(), 'repositories');
+}
+
+/**
+ * Get the directory for a specific repository.
+ * Structure: ~/.agent-console/repositories/{org}/{repo}/
+ * @param orgRepo - Organization and repository name (e.g., "owner/repo-name")
+ */
+export function getRepositoryDir(orgRepo: string): string {
+  return path.join(getRepositoriesDir(), orgRepo);
+}
+
+/**
  * Get the current server's PID for session ownership tracking.
  */
 export function getServerPid(): number {

--- a/packages/server/src/services/__tests__/repository-manager.test.ts
+++ b/packages/server/src/services/__tests__/repository-manager.test.ts
@@ -24,6 +24,8 @@ vi.mock('../persistence-service.js', () => ({
 // Mock config
 vi.mock('../../lib/config.js', () => ({
   getConfigDir: vi.fn(() => TEST_CONFIG_DIR),
+  getRepositoriesDir: vi.fn(() => `${TEST_CONFIG_DIR}/repositories`),
+  getRepositoryDir: vi.fn((orgRepo: string) => `${TEST_CONFIG_DIR}/repositories/${orgRepo}`),
 }));
 
 describe('RepositoryManager', () => {

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // Mock config - must be before any imports that use it
 vi.mock('../../lib/config.js', () => ({
   getConfigDir: vi.fn(() => '/test/config'),
+  getRepositoriesDir: vi.fn(() => '/test/config/repositories'),
+  getRepositoryDir: vi.fn((orgRepo: string) => `/test/config/repositories/${orgRepo}`),
 }));
 
 // Mock fs

--- a/packages/server/src/services/repository-manager.ts
+++ b/packages/server/src/services/repository-manager.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Repository } from '@agent-console/shared';
 import { persistenceService } from './persistence-service.js';
-import { getConfigDir } from '../lib/config.js';
+import { getRepositoryDir } from '../lib/config.js';
 
 /**
  * Extract org/repo from git remote URL
@@ -109,30 +109,19 @@ export class RepositoryManager {
   }
 
   /**
-   * Clean up worktrees and templates directories for a repository
+   * Clean up repository data directory (worktrees and templates)
    */
   private cleanupRepositoryData(repoPath: string): void {
     const orgRepo = getOrgRepoFromPath(repoPath);
+    const repoDir = getRepositoryDir(orgRepo);
 
-    // Clean up worktrees directory
-    const worktreesDir = path.join(getConfigDir(), 'worktrees', orgRepo);
-    if (fs.existsSync(worktreesDir)) {
+    // Clean up entire repository directory
+    if (fs.existsSync(repoDir)) {
       try {
-        fs.rmSync(worktreesDir, { recursive: true });
-        console.log(`Cleaned up worktrees: ${worktreesDir}`);
+        fs.rmSync(repoDir, { recursive: true });
+        console.log(`Cleaned up repository data: ${repoDir}`);
       } catch (e) {
-        console.error(`Failed to clean up worktrees: ${worktreesDir}`, e);
-      }
-    }
-
-    // Clean up templates directory
-    const templatesDir = path.join(getConfigDir(), 'templates', orgRepo);
-    if (fs.existsSync(templatesDir)) {
-      try {
-        fs.rmSync(templatesDir, { recursive: true });
-        console.log(`Cleaned up templates: ${templatesDir}`);
-      } catch (e) {
-        console.error(`Failed to clean up templates: ${templatesDir}`, e);
+        console.error(`Failed to clean up repository data: ${repoDir}`, e);
       }
     }
   }


### PR DESCRIPTION
## Summary
- リポジトリデータのディレクトリ構造を整理
- `worktrees/` と `templates/` を `repositories/{org}/{repo}/` 配下に統合
- リポジトリ削除時のクリーンアップを簡素化

## Changes
**変更前:**
```
~/.agent-console/
├── worktrees/owner/repo/branch/
└── templates/owner/repo/
```

**変更後:**
```
~/.agent-console/
└── repositories/owner/repo/
    ├── worktrees/branch/
    └── templates/
```

## Test plan
- [x] 新規worktree作成で新しいパス構造を確認
- [x] ブラウザで動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)