### PR TITLE
feat: use separate config directory for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "pnpm --parallel --filter './packages/*' dev",
+    "dev": "AGENT_CONSOLE_HOME=$HOME/.agent-console-dev pnpm --parallel --filter './packages/*' dev",
     "build": "pnpm --filter @agent-console/shared build && pnpm --filter @agent-console/client build && pnpm --filter @agent-console/server build",
     "start": "NODE_ENV=production node dist/index.js",
     "typecheck": "pnpm --filter './packages/*' typecheck",


### PR DESCRIPTION
## Summary
- 開発時（`pnpm dev`）に `~/.agent-console-dev` を使用するよう設定
- ドッグフーディング環境（`~/.agent-console`）と開発環境のデータを分離

## Motivation
- 開発中のバグがドッグフーディングデータに影響しない
- 問題発生時に「開発版だから」と切り分けしやすい

## Test plan
- [x] `pnpm dev` で起動時に `~/.agent-console-dev` が作成されることを確認
- [x] リポジトリ追加で `~/.agent-console-dev/repositories.json` にデータが保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)