### PR TITLE
feat: load user environment for Claude and unify PORT config

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
 
+const serverPort = process.env.PORT || 3457;
+
 export default defineConfig({
   plugins: [
     TanStackRouterVite(),
@@ -17,11 +19,11 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:3457',
+        target: `http://localhost:${serverPort}`,
         changeOrigin: true,
       },
       '/ws': {
-        target: 'ws://localhost:3457',
+        target: `ws://localhost:${serverPort}`,
         ws: true,
       },
     },

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -157,8 +157,9 @@ describe('SessionManager', () => {
 
       expect(vi.mocked(pty.spawn)).toHaveBeenCalled();
       const callArgs = vi.mocked(pty.spawn).mock.calls[0];
-      expect(callArgs[0]).toBe('claude');
-      expect(callArgs[1]).toEqual(['-c']);
+      // Should spawn login shell with -l -c flags
+      expect(callArgs[0]).toBe(process.env.SHELL || '/bin/bash');
+      expect(callArgs[1]).toEqual(['-l', '-c', 'claude -c']);
       expect(callArgs[2]).toMatchObject({ cwd: '/test/path' });
     });
   });
@@ -290,9 +291,10 @@ describe('SessionManager', () => {
 
       manager.restartSession('dead-session', vi.fn(), vi.fn(), true); // continueConversation = true
 
-      // Verify -c flag was passed
+      // Verify login shell with -l -c flags was used
       const callArgs = vi.mocked(pty.spawn).mock.calls[0];
-      expect(callArgs[1]).toEqual(['-c']);
+      expect(callArgs[0]).toBe(process.env.SHELL || '/bin/bash');
+      expect(callArgs[1]).toEqual(['-l', '-c', 'claude -c']);
     });
   });
 

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -150,7 +150,10 @@ export class SessionManager {
       args.push(...agent.continueArgs);
     }
 
-    const ptyProcess = pty.spawn(agent.command, args, {
+    // Use login shell to load user's environment (.bash_profile, .zprofile, etc.)
+    const shell = process.env.SHELL || '/bin/bash';
+    const fullCommand = [agent.command, ...args].join(' ');
+    const ptyProcess = pty.spawn(shell, ['-l', '-c', fullCommand], {
       name: 'xterm-256color',
       cols: 120,
       rows: 30,
@@ -271,7 +274,10 @@ export class SessionManager {
       args.push(...agent.continueArgs);
     }
 
-    const ptyProcess = pty.spawn(agent.command, args, {
+    // Use login shell to load user's environment (.bash_profile, .zprofile, etc.)
+    const shell = process.env.SHELL || '/bin/bash';
+    const fullCommand = [agent.command, ...args].join(' ');
+    const ptyProcess = pty.spawn(shell, ['-l', '-c', fullCommand], {
       name: 'xterm-256color',
       cols: 120,
       rows: 30,


### PR DESCRIPTION
## Summary

- Spawn Claude via login shell to load user's environment files (`.bash_profile`, `.zprofile`, etc.)
- Unify `PORT` environment variable for both server and Vite dev proxy (default: 3457)

## Changes

### Claude spawn method
```ts
// Before
pty.spawn(agent.command, args, {...})

// After
pty.spawn(shell, ['-l', '-c', fullCommand], {...})
```

The `-l` flag spawns a login shell, which loads user's environment variables (e.g., `PATH` additions, `ANTHROPIC_API_KEY`) before executing Claude.

### PORT environment variable
`PORT=4000 pnpm dev` now configures both server and client proxy to use the same port.

## Test plan

- [x] All existing tests pass
- [x] Manually verified Claude starts correctly with user environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)