### PR TITLE
fix: restore dashboard activity notification broadcast

### DIFF
--- a/packages/server/src/websocket/routes.ts
+++ b/packages/server/src/websocket/routes.ts
@@ -9,22 +9,21 @@ import { handleTerminalMessage } from './terminal-handler.js';
 const dashboardClients = new Set<WSContext>();
 
 // Set up global activity callback to broadcast to all dashboard clients
-// TEST: Disabled to check if this causes the issue
-// sessionManager.setGlobalActivityCallback((sessionId, state) => {
-//   const msg: DashboardServerMessage = {
-//     type: 'session-activity',
-//     sessionId,
-//     activityState: state,
-//   };
-//   const msgStr = JSON.stringify(msg);
-//   for (const client of dashboardClients) {
-//     try {
-//       client.send(msgStr);
-//     } catch (e) {
-//       console.error('Failed to send to dashboard client:', e);
-//     }
-//   }
-// });
+sessionManager.setGlobalActivityCallback((sessionId, state) => {
+  const msg: DashboardServerMessage = {
+    type: 'session-activity',
+    sessionId,
+    activityState: state,
+  };
+  const msgStr = JSON.stringify(msg);
+  for (const client of dashboardClients) {
+    try {
+      client.send(msgStr);
+    } catch (e) {
+      console.error('Failed to send to dashboard client:', e);
+    }
+  }
+});
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type UpgradeWebSocketFn = (handler: (c: any) => any) => any;


### PR DESCRIPTION
## Summary
- Re-enabled the global activity callback that broadcasts session activity state changes to dashboard WebSocket clients
- This callback was accidentally disabled (commented out with "TEST: Disabled to check if this causes the issue") during debugging
- Without this, notifications for state changes (Working→Idle, Working→Waiting for Input) were not being sent to the dashboard

## Test plan
- [ ] Start the server with `pnpm dev`
- [ ] Open the dashboard in a browser
- [ ] Start a Claude session and let it complete a task
- [ ] Verify that the activity badge updates in real-time (Working → Idle)
- [ ] Verify that browser notifications appear when the page is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)