### PR TITLE
fix: generate branch name on server side with type-safe request

### DIFF
--- a/packages/client/src/lib/__tests__/api.test.ts
+++ b/packages/client/src/lib/__tests__/api.test.ts
@@ -261,7 +261,7 @@ describe('API Client', () => {
   });
 
   describe('createWorktree', () => {
-    it('should create worktree successfully', async () => {
+    it('should create worktree successfully with custom mode', async () => {
       const { createWorktree } = await import('../api');
       const mockResponse = {
         worktree: { path: '/path/to/worktree', branch: 'feature-1' },
@@ -269,12 +269,12 @@ describe('API Client', () => {
       };
       vi.mocked(fetch).mockResolvedValue(createMockResponse(mockResponse));
 
-      const result = await createWorktree('repo-id', { branch: 'feature-1' });
+      const result = await createWorktree('repo-id', { mode: 'custom', branch: 'feature-1' });
 
       expect(fetch).toHaveBeenCalledWith('/api/repositories/repo-id/worktrees', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ branch: 'feature-1' }),
+        body: JSON.stringify({ mode: 'custom', branch: 'feature-1' }),
       });
       expect(result).toEqual(mockResponse);
     });
@@ -288,7 +288,7 @@ describe('API Client', () => {
         json: vi.fn().mockResolvedValue({ error: 'Branch already exists' }),
       } as unknown as Response);
 
-      await expect(createWorktree('repo-id', { branch: 'existing' })).rejects.toThrow(
+      await expect(createWorktree('repo-id', { mode: 'custom', branch: 'existing' })).rejects.toThrow(
         'Branch already exists'
       );
     });

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -56,6 +56,18 @@ function getIndexForPath(store: IndexStore, worktreePath: string): number | unde
   return store.indexes[worktreePath];
 }
 
+/**
+ * Generate a random alphanumeric suffix
+ */
+function generateRandomSuffix(length: number): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let suffix = '';
+  for (let i = 0; i < length; i++) {
+    suffix += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return suffix;
+}
+
 // ========== Template Functionality ==========
 
 /**
@@ -423,6 +435,26 @@ export class WorktreeService {
   isWorktreeOf(repoPath: string, worktreePath: string): boolean {
     const worktrees = this.listWorktrees(repoPath, '');
     return worktrees.some(wt => wt.path === worktreePath);
+  }
+
+  /**
+   * Generate next branch name: wt-{index:3 digits}-{4 random alphanumeric}
+   * Uses the next available index from the index store
+   */
+  generateNextBranchName(repoPath: string): string {
+    const orgRepo = getOrgRepoFromRemote(repoPath) || path.basename(repoPath);
+    const repoWorktreeDir = path.join(getRepositoryDir(orgRepo), 'worktrees');
+
+    // Ensure directory exists for index store
+    if (!fs.existsSync(repoWorktreeDir)) {
+      fs.mkdirSync(repoWorktreeDir, { recursive: true });
+    }
+
+    const indexStore = loadIndexStore(repoWorktreeDir);
+    const nextIndex = allocateIndex(indexStore);
+    const suffix = generateRandomSuffix(4);
+
+    return `wt-${String(nextIndex).padStart(3, '0')}-${suffix}`;
   }
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -70,12 +70,31 @@ export interface CreateRepositoryRequest {
   path: string;
 }
 
-export interface CreateWorktreeRequest {
-  branch: string;           // 既存ブランチ名 or 新規ブランチ名
-  baseBranch?: string;      // 新規ブランチの場合のベース
+interface CreateWorktreeBaseRequest {
   autoStartSession?: boolean;
-  agentId?: string;         // autoStartSession時に使用するAgent ID
+  agentId?: string;
 }
+
+interface CreateWorktreeAutoRequest extends CreateWorktreeBaseRequest {
+  mode: 'auto';
+  baseBranch?: string;
+}
+
+interface CreateWorktreeCustomRequest extends CreateWorktreeBaseRequest {
+  mode: 'custom';
+  branch: string;
+  baseBranch?: string;
+}
+
+interface CreateWorktreeExistingRequest extends CreateWorktreeBaseRequest {
+  mode: 'existing';
+  branch: string;
+}
+
+export type CreateWorktreeRequest =
+  | CreateWorktreeAutoRequest
+  | CreateWorktreeCustomRequest
+  | CreateWorktreeExistingRequest;
 
 export interface DeleteWorktreeRequest {
   force?: boolean;          // セッション強制終了して削除


### PR DESCRIPTION
## Summary
- Move branch name generation from client to server for consistency between branch name index and worktree index
- Use discriminated union for CreateWorktreeRequest with type-safe modes:
  - `mode: 'auto'` - auto-generate branch name (no branch field)
  - `mode: 'custom'` - use provided branch name as new branch
  - `mode: 'existing'` - use existing branch (no baseBranch field)
- Update UI with radio buttons for branch naming mode selection

## Test plan
- [x] Verify auto-generate mode creates worktree with server-generated branch name
- [x] Verify custom mode creates worktree with user-specified new branch
- [x] Verify existing mode creates worktree using existing branch
- [x] All tests pass
- [x] TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)