### PR TITLE
fix: filter worktree list to show only app-managed worktrees

### DIFF
--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -255,14 +255,19 @@ export class WorktreeService {
 
       if (worktreePath) {
         const isMain = worktreePath === mainRepoPath;
-        worktrees.push({
-          path: worktreePath,
-          branch,
-          isMain,
-          repositoryId,
-          // Only non-main worktrees have an index
-          index: isMain ? undefined : getIndexForPath(indexStore, worktreePath),
-        });
+        const index = getIndexForPath(indexStore, worktreePath);
+
+        // Only include worktrees that are registered in the index store (created by this app)
+        // Main worktree is always included
+        if (isMain || index !== undefined) {
+          worktrees.push({
+            path: worktreePath,
+            branch,
+            isMain,
+            repositoryId,
+            index: isMain ? undefined : index,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Worktree list now only shows worktrees registered in `worktree-indexes.json` (created by this app) plus the main worktree
- Worktrees from other environments or manually created ones are no longer displayed
- Resolves the issue where production worktrees appeared in development environment

## Test plan

- [x] Run `pnpm test` - all 243 tests pass
- [x] Run `pnpm typecheck` - no type errors
- [x] Manual verification: confirmed that `wt-002-nw1x` (production) is filtered out from development dashboard

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)