### PR TITLE
feat: add update and deploy script for macOS

### DIFF
--- a/scripts/update-and-deploy-for-mac.sh
+++ b/scripts/update-and-deploy-for-mac.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+echo "==> Fetching latest main..."
+git fetch origin
+git checkout main
+git pull origin main
+
+echo "==> Installing dependencies..."
+pnpm install
+
+echo "==> Building..."
+pnpm build
+
+echo "==> Deploying..."
+pnpm deploy:mac
+
+echo "==> Done!"


### PR DESCRIPTION
## Summary
- Add `scripts/update-and-deploy-for-mac.sh` to automate the update and deployment process
- Script fetches latest main, installs dependencies, builds, and restarts the launch agent

## Test plan
- [ ] Run `./scripts/update-and-deploy-for-mac.sh` and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)