### PR TITLE
refactor: move deploy logic into shell script and improve launchctl handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "typecheck": "pnpm --filter './packages/*' typecheck",
     "test": "pnpm typecheck && pnpm test:only",
     "test:only": "pnpm --filter './packages/*' test",
-    "lint": "pnpm --filter './packages/*' lint",
-    "deploy:mac": "pnpm build && mkdir -p ~/.agent-console/server && rsync -av --delete --exclude node_modules dist/ ~/.agent-console/server/ && cd ~/.agent-console/server && pnpm install --prod && launchctl unload ~/Library/LaunchAgents/com.agent-console.plist && launchctl load ~/Library/LaunchAgents/com.agent-console.plist && echo 'Deployed and restarted'"
+    "lint": "pnpm --filter './packages/*' lint"
   },
   "devDependencies": {
     "typescript": "^5.7.2"

--- a/scripts/update-and-deploy-for-mac.sh
+++ b/scripts/update-and-deploy-for-mac.sh
@@ -17,7 +17,14 @@ pnpm install
 echo "==> Building..."
 pnpm build
 
-echo "==> Deploying..."
-pnpm deploy:mac
+echo "==> Deploying files..."
+mkdir -p ~/.agent-console/server
+rsync -av --delete --exclude node_modules dist/ ~/.agent-console/server/
+cd ~/.agent-console/server
+pnpm install --prod
+
+echo "==> Restarting service..."
+launchctl kickstart -k gui/$(id -u)/com.agent-console 2>/dev/null || \
+  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.agent-console.plist
 
 echo "==> Done!"


### PR DESCRIPTION
## Summary
- Remove `deploy:mac` npm script from package.json (was only used by the shell script)
- Move deploy and service restart logic directly into `update-and-deploy-for-mac.sh`
- Use `launchctl kickstart -k` for service restart (more reliable than unload/load)
- Fall back to `launchctl bootstrap` for initial deployment when service isn't loaded yet

## Test plan
- [x] Run `./scripts/update-and-deploy-for-mac.sh` and verify deployment completes successfully
- [x] Verify service restarts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)