### PR TITLE
feat: add plist template and improve deploy script

### DIFF
--- a/scripts/com.agent-console.plist.template
+++ b/scripts/com.agent-console.plist.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.agent-console</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{BUN_PATH}}</string>
+        <string>{{HOME}}/.agent-console/server/index.js</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>{{HOME}}/.agent-console/server</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>NODE_ENV</key>
+        <string>production</string>
+        <key>PORT</key>
+        <string>{{PORT}}</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/Library/Logs/agent-console/agent-console.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/Library/Logs/agent-console/agent-console.error.log</string>
+</dict>
+</plist>

--- a/scripts/update-and-deploy-for-mac.sh
+++ b/scripts/update-and-deploy-for-mac.sh
@@ -15,7 +15,7 @@ echo "==> Installing dependencies..."
 bun install
 
 echo "==> Building..."
-bun run build
+NODE_ENV=production bun run build
 
 echo "==> Deploying files..."
 mkdir -p ~/.agent-console/server
@@ -23,8 +23,21 @@ rsync -av --delete --exclude node_modules dist/ ~/.agent-console/server/
 cd ~/.agent-console/server
 bun install --production
 
+echo "==> Installing plist..."
+BUN_PATH=$(which bun)
+PORT=${PORT:-6340}
+sed -e "s|{{HOME}}|$HOME|g" \
+    -e "s|{{BUN_PATH}}|$BUN_PATH|g" \
+    -e "s|{{PORT}}|$PORT|g" \
+    "$SCRIPT_DIR/com.agent-console.plist.template" \
+    > ~/Library/LaunchAgents/com.agent-console.plist
+
+echo "==> Cleaning up old logs..."
+rm -rf ~/Library/Logs/agent-console
+mkdir -p ~/Library/Logs/agent-console
+
 echo "==> Restarting service..."
-launchctl kickstart -k gui/$(id -u)/com.agent-console 2>/dev/null || \
-  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.agent-console.plist
+launchctl bootout gui/$(id -u)/com.agent-console 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.agent-console.plist
 
 echo "==> Done!"


### PR DESCRIPTION
## Summary
- Add plist template with placeholders (`{{HOME}}`, `{{BUN_PATH}}`, `{{PORT}}`) for flexible configuration
- Fix deploy script to use bun runtime instead of Node.js (fixes `ERR_UNSUPPORTED_ESM_URL_SCHEME` error after bun migration)
- Move logs to `~/Library/Logs/agent-console/` (macOS standard location)
- Clean up old logs on each deploy to prevent log file growth

## Test plan
- [x] Run `./scripts/update-and-deploy-for-mac.sh` and verify service starts
- [x] Verify logs are written to `~/Library/Logs/agent-console/`
- [x] Verify API responds at `http://localhost:6340/api/sessions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)