### PR TITLE
fix: work around bun-pty env inheritance issue

### DIFF
--- a/packages/server/src/services/__tests__/env-filter.test.ts
+++ b/packages/server/src/services/__tests__/env-filter.test.ts
@@ -15,37 +15,38 @@ describe('env-filter', () => {
   });
 
   describe('getChildProcessEnv', () => {
-    it('should exclude NODE_ENV from child process environment', () => {
+    it('should set NODE_ENV to empty string to override bun-pty inheritance', () => {
       process.env.NODE_ENV = 'production';
       process.env.HOME = '/home/test';
 
       const childEnv = getChildProcessEnv();
 
-      expect(childEnv.NODE_ENV).toBeUndefined();
+      // bun-pty merges env with parent, so we set to empty string to override
+      expect(childEnv.NODE_ENV).toBe('');
       expect(childEnv.HOME).toBe('/home/test');
     });
 
-    it('should exclude PORT from child process environment', () => {
+    it('should set PORT to empty string to override bun-pty inheritance', () => {
       process.env.PORT = '3000';
       process.env.PATH = '/usr/bin';
 
       const childEnv = getChildProcessEnv();
 
-      expect(childEnv.PORT).toBeUndefined();
+      expect(childEnv.PORT).toBe('');
       expect(childEnv.PATH).toBe('/usr/bin');
     });
 
-    it('should exclude HOST from child process environment', () => {
+    it('should set HOST to empty string to override bun-pty inheritance', () => {
       process.env.HOST = '0.0.0.0';
       process.env.USER = 'testuser';
 
       const childEnv = getChildProcessEnv();
 
-      expect(childEnv.HOST).toBeUndefined();
+      expect(childEnv.HOST).toBe('');
       expect(childEnv.USER).toBe('testuser');
     });
 
-    it('should exclude all blocked variables at once', () => {
+    it('should set all blocked variables to empty string', () => {
       process.env.NODE_ENV = 'production';
       process.env.PORT = '6340';
       process.env.HOST = 'localhost';
@@ -54,9 +55,9 @@ describe('env-filter', () => {
 
       const childEnv = getChildProcessEnv();
 
-      expect(childEnv.NODE_ENV).toBeUndefined();
-      expect(childEnv.PORT).toBeUndefined();
-      expect(childEnv.HOST).toBeUndefined();
+      expect(childEnv.NODE_ENV).toBe('');
+      expect(childEnv.PORT).toBe('');
+      expect(childEnv.HOST).toBe('');
       expect(childEnv.HOME).toBe('/home/test');
       expect(childEnv.SHELL).toBe('/bin/zsh');
     });

--- a/packages/server/src/services/env-filter.ts
+++ b/packages/server/src/services/env-filter.ts
@@ -11,6 +11,10 @@ const BLOCKED_ENV_VARS = [
 /**
  * Filter environment variables for child PTY processes.
  * Removes server-specific variables that could interfere with child behavior.
+ *
+ * Note: bun-pty merges the provided env with parent process env instead of replacing it.
+ * To work around this, we explicitly set blocked variables to empty strings to override
+ * the inherited values from the parent process.
  */
 export function getChildProcessEnv(): Record<string, string> {
   const env: Record<string, string> = {};
@@ -19,6 +23,12 @@ export function getChildProcessEnv(): Record<string, string> {
     if (value !== undefined && !BLOCKED_ENV_VARS.includes(key)) {
       env[key] = value;
     }
+  }
+
+  // Explicitly set blocked env vars to empty string to override bun-pty's
+  // parent environment inheritance behavior
+  for (const key of BLOCKED_ENV_VARS) {
+    env[key] = '';
   }
 
   // Ensure color support for PTY processes (required for bun-pty)


### PR DESCRIPTION
## Summary

- Fixed an issue where `NODE_ENV=production` leaked from the server process to child PTY processes
- bun-pty merges provided env with parent process env instead of replacing it, unlike node-pty
- Workaround: explicitly set blocked env vars (`NODE_ENV`, `PORT`, `HOST`) to empty strings

## Background

When running agent-console with `NODE_ENV=production`, child PTY processes (like Claude Code) inherited this value. This caused issues when running tools like vitest within those processes, which failed with "act(...) is not supported in production builds of React."

## Test plan

- [x] Updated unit tests in `env-filter.test.ts` to verify blocked vars are set to empty string
- [x] All server tests pass (224 tests)
- [x] Manual verification: child processes no longer have `NODE_ENV=production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)