### PR TITLE
feat: add automated npm publishing via GitHub Releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.4"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Setup npm authentication
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - name: Publish to npm
+        run: npm publish dist --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "typecheck": "bun run --filter '*' typecheck",
     "test": "bun run typecheck && bun run test:only",
     "test:only": "bun run --filter '*' test",
-    "lint": "bun run --filter '*' lint"
+    "lint": "bun run --filter '*' lint",
+    "release": "gh release create v$(bun -e \"console.log(require('./dist/package.json').version)\") --generate-notes"
   },
   "devDependencies": {
     "typescript": "^5.7.2"

--- a/packages/server/build.ts
+++ b/packages/server/build.ts
@@ -26,13 +26,31 @@ if (!result.success) {
 const distPackageJson = {
   name: 'agent-console',
   version: '0.1.0',
+  description: 'A web application for managing multiple Claude Code instances',
   type: 'module',
+  bin: {
+    'agent-console': './index.js',
+  },
   scripts: {
     start: 'bun index.js',
   },
   dependencies: {
     'bun-pty': '^0.4.2',
   },
+  engines: {
+    bun: '>=1.3.0',
+  },
+  repository: {
+    type: 'git',
+    url: 'git+https://github.com/ms2sato/agent-console.git',
+  },
+  keywords: ['claude', 'claude-code', 'terminal', 'pty', 'bun'],
+  author: 'ms2sato',
+  license: 'MIT',
+  bugs: {
+    url: 'https://github.com/ms2sato/agent-console/issues',
+  },
+  homepage: 'https://github.com/ms2sato/agent-console#readme',
 };
 
 mkdirSync(distDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`.github/workflows/publish.yml`) that triggers on release publication and publishes to npm
- Add `release` script to root `package.json` for creating GitHub Releases with auto-generated notes
- Enhance `dist/package.json` with npm publish metadata including `bin`, `repository`, `keywords`, `author`, and `license`

## Test plan
- [ ] Verify workflow syntax is correct by reviewing the YAML
- [ ] Ensure `NPM_TOKEN` secret is configured in repository settings before first release
- [ ] Test release flow: update version → merge to main → wait for CI → run `bun run release`

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)