### PR TITLE
refactor: centralize server environment variables to auto-generate BLOCKED_ENV_VARS

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ import { logger } from 'hono/logger';
 import { api } from './routes/api.js';
 import { setupWebSocketRoutes } from './websocket/routes.js';
 import { onApiError } from './lib/error-handler.js';
+import { serverConfig } from './lib/server-config.js';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -40,7 +41,7 @@ process.on('SIGINT', () => {
 const app = new Hono();
 
 // Production mode: serve static files
-const isProduction = process.env.NODE_ENV === 'production';
+const isProduction = serverConfig.NODE_ENV === 'production';
 
 // Global error handler
 app.onError(onApiError);
@@ -75,7 +76,7 @@ if (isProduction) {
   });
 }
 
-const PORT = Number(process.env.PORT) || 3457;
+const PORT = Number(serverConfig.PORT);
 
 console.log(`[${timestamp()}] Server starting on http://localhost:${PORT} (${isProduction ? 'production' : 'development'}) (PID: ${process.pid})`);
 

--- a/packages/server/src/lib/__tests__/server-config.test.ts
+++ b/packages/server/src/lib/__tests__/server-config.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('server-config', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Reset process.env before each test
+    process.env = { ...originalEnv };
+    // Clear module cache to test fresh imports
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    // Restore original process.env
+    process.env = originalEnv;
+  });
+
+  describe('serverConfig', () => {
+    it('should use default values when environment variables are not set', async () => {
+      delete process.env.NODE_ENV;
+      delete process.env.PORT;
+      delete process.env.HOST;
+
+      const { serverConfig } = await import('../server-config.js');
+
+      expect(serverConfig.NODE_ENV).toBeUndefined();
+      expect(serverConfig.PORT).toBe('3457');
+      expect(serverConfig.HOST).toBe('localhost');
+    });
+
+    it('should use environment variable values when set', async () => {
+      process.env.NODE_ENV = 'production';
+      process.env.PORT = '8080';
+      process.env.HOST = '0.0.0.0';
+
+      const { serverConfig } = await import('../server-config.js');
+
+      expect(serverConfig.NODE_ENV).toBe('production');
+      expect(serverConfig.PORT).toBe('8080');
+      expect(serverConfig.HOST).toBe('0.0.0.0');
+    });
+  });
+
+  describe('SERVER_ONLY_ENV_VARS', () => {
+    it('should contain all serverConfig keys', async () => {
+      const { serverConfig, SERVER_ONLY_ENV_VARS } = await import(
+        '../server-config.js'
+      );
+
+      const configKeys = Object.keys(serverConfig);
+      expect(SERVER_ONLY_ENV_VARS).toEqual(configKeys);
+    });
+
+    it('should include NODE_ENV, PORT, and HOST', async () => {
+      const { SERVER_ONLY_ENV_VARS } = await import('../server-config.js');
+
+      expect(SERVER_ONLY_ENV_VARS).toContain('NODE_ENV');
+      expect(SERVER_ONLY_ENV_VARS).toContain('PORT');
+      expect(SERVER_ONLY_ENV_VARS).toContain('HOST');
+    });
+
+    it('should be readonly array', async () => {
+      const { SERVER_ONLY_ENV_VARS } = await import('../server-config.js');
+
+      // TypeScript enforces this at compile time, but we can verify the runtime behavior
+      expect(Array.isArray(SERVER_ONLY_ENV_VARS)).toBe(true);
+    });
+  });
+});

--- a/packages/server/src/lib/server-config.ts
+++ b/packages/server/src/lib/server-config.ts
@@ -1,0 +1,31 @@
+/**
+ * Centralized server-specific environment configuration.
+ *
+ * All server-only environment variables should be defined here.
+ * This serves as a single source of truth and enables automatic
+ * generation of BLOCKED_ENV_VARS for child processes.
+ *
+ * IMPORTANT: Variables that should be passed to child processes
+ * (e.g., PATH, HOME, API keys for child tools) should NOT be added here.
+ * Only add variables that are specific to the server's operation.
+ */
+export const serverConfig = {
+  /** Server's environment mode (development/production) */
+  NODE_ENV: process.env.NODE_ENV,
+  /** Server's port binding */
+  PORT: process.env.PORT ?? '3457',
+  /** Server's host binding */
+  HOST: process.env.HOST ?? 'localhost',
+} as const;
+
+/**
+ * List of environment variable names that are server-only.
+ * Auto-generated from serverConfig keys.
+ * Used by env-filter to prevent these from being passed to child processes.
+ */
+export const SERVER_ONLY_ENV_VARS = Object.keys(serverConfig) as ReadonlyArray<
+  keyof typeof serverConfig
+>;
+
+/** Type for server configuration */
+export type ServerConfig = typeof serverConfig;

--- a/packages/server/src/services/env-filter.ts
+++ b/packages/server/src/services/env-filter.ts
@@ -1,12 +1,10 @@
+import { SERVER_ONLY_ENV_VARS } from '../lib/server-config.js';
+
 /**
  * Environment variables that should NOT be passed to child PTY processes.
- * These are server-specific settings that would interfere with child process behavior.
+ * Auto-generated from server-config.ts to ensure single source of truth.
  */
-const BLOCKED_ENV_VARS = [
-  'NODE_ENV',      // Server's NODE_ENV should not affect child processes
-  'PORT',          // Server's port binding
-  'HOST',          // Server's host binding
-];
+const BLOCKED_ENV_VARS: readonly string[] = SERVER_ONLY_ENV_VARS;
 
 /**
  * Filter environment variables for child PTY processes.


### PR DESCRIPTION
## Summary

- Create `lib/server-config.ts` with centralized server config (NODE_ENV, PORT, HOST)
- Auto-generate `SERVER_ONLY_ENV_VARS` from `serverConfig` keys
- Update `env-filter.ts` to import `BLOCKED_ENV_VARS` from server-config
- Update `index.ts` to use `serverConfig` instead of direct `process.env` access

This ensures a single source of truth for server-specific environment variables and eliminates the need to manually maintain `BLOCKED_ENV_VARS` when adding new vars.

## Test plan

- [x] All existing tests pass
- [x] New tests added for `server-config.ts` module
- [x] TypeScript type check passes

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)