### PR TITLE
fix: enable test to run without prior build on fresh clone

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "bun test --preload ./src/test/setup.ts src/",

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -17,8 +17,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"],
-  "references": [
-    { "path": "../shared" }
-  ]
+  "include": ["src"]
 }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -6,8 +6,5 @@
     "lib": ["ES2022"],
     "types": ["bun", "node"]
   },
-  "include": ["src/**/*"],
-  "references": [
-    { "path": "../shared" }
-  ]
+  "include": ["src/**/*"]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,12 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
     }
   },
   "scripts": {

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "composite": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- Reference shared package source files directly instead of dist/ output
- Remove TypeScript project references from client/server packages
- Leverage Bun's ability to execute .ts files directly

This allows `bun run test` to work without `bun run build` on fresh clones or worktrees.

## Test plan
- [x] Verify `bun run test` passes without prior build (deleted dist/, ran test)
- [x] Verify `bun run build` still works correctly
- [x] Verify `bun run typecheck` passes

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)