### PR TITLE
refactor: replace vitest with bun:test in server package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,10 +51,12 @@
       },
       "devDependencies": {
         "@types/bun": "^1.1.14",
+        "@types/mock-fs": "^4.13.4",
         "@types/node": "^22.10.1",
         "@types/uuid": "^10.0.0",
+        "memfs": "^4.51.1",
+        "mock-fs": "^5.4.1",
         "typescript": "^5.7.2",
-        "vitest": "^4.0.15",
       },
     },
     "packages/shared": {
@@ -66,8 +68,6 @@
     },
   },
   "packages": {
-    "@acemir/cssom": ["@acemir/cssom@0.9.28", "", {}, "sha512-LuS6IVEivI75vKN8S04qRD+YySP0RmU/cV8UNukhQZvprxF+76Z43TNo/a08eCodaGhT1Us8etqS1ZRY9/Or0A=="],
-
     "@agent-console/client": ["@agent-console/client@workspace:packages/client"],
 
     "@agent-console/server": ["@agent-console/server@workspace:packages/server"],
@@ -75,12 +75,6 @@
     "@agent-console/shared": ["@agent-console/shared@workspace:packages/shared"],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
-
-    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@4.1.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.4", "@csstools/css-color-parser": "^3.1.0", "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4", "lru-cache": "^11.2.2" } }, "sha512-9xiBAtLn4aNsa4mDnpovJvBn72tNEIACyvlqaNJ+ADemR+yeMJWnBudOi2qGDviJa7SwcDOU/TRh5dnET7qk0w=="],
-
-    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@6.7.6", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.1.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.4" } }, "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg=="],
-
-    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -143,18 +137,6 @@
     "@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
-
-    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
-
-    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
-
-    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "^5.1.0", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
-
-    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
-
-    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.0.14", "", { "peerDependencies": { "postcss": "^8.4" } }, "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q=="],
-
-    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -220,6 +202,18 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@jsonjoy.com/base64": ["@jsonjoy.com/base64@1.1.2", "", { "peerDependencies": { "tslib": "2" } }, "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA=="],
+
+    "@jsonjoy.com/buffers": ["@jsonjoy.com/buffers@1.2.1", "", { "peerDependencies": { "tslib": "2" } }, "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA=="],
+
+    "@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@1.0.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g=="],
+
+    "@jsonjoy.com/json-pack": ["@jsonjoy.com/json-pack@1.21.0", "", { "dependencies": { "@jsonjoy.com/base64": "^1.1.2", "@jsonjoy.com/buffers": "^1.2.0", "@jsonjoy.com/codegen": "^1.0.0", "@jsonjoy.com/json-pointer": "^1.0.2", "@jsonjoy.com/util": "^1.9.0", "hyperdyperid": "^1.2.0", "thingies": "^2.5.0", "tree-dump": "^1.1.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg=="],
+
+    "@jsonjoy.com/json-pointer": ["@jsonjoy.com/json-pointer@1.0.2", "", { "dependencies": { "@jsonjoy.com/codegen": "^1.0.0", "@jsonjoy.com/util": "^1.9.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg=="],
+
+    "@jsonjoy.com/util": ["@jsonjoy.com/util@1.9.0", "", { "dependencies": { "@jsonjoy.com/buffers": "^1.0.0", "@jsonjoy.com/codegen": "^1.0.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.53.3", "", { "os": "android", "cpu": "arm" }, "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w=="],
@@ -265,8 +259,6 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ=="],
-
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.17", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.17" } }, "sha512-csIkHIgLb3JisEFQ0vxr2Y57GUNYh447C8xzwj89U/8fdW8LhProdxvnVH6U8M2Y73QKiTIH+LWbK3V2BBZsAg=="],
 
@@ -338,11 +330,9 @@
 
     "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
 
-    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
-
-    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
-
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/mock-fs": ["@types/mock-fs@4.13.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-mXmM0o6lULPI8z3XNnQCpL0BGxPwx1Ul1wXYEPBGl4efShyxW2Rln0JOPEWGyZaYZMM6OVXM/15zUuFMY52ljg=="],
 
     "@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
@@ -358,20 +348,6 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
-    "@vitest/expect": ["@vitest/expect@4.0.15", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.15", "@vitest/utils": "4.0.15", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-Gfyva9/GxPAWXIWjyGDli9O+waHDC0Q0jaLdFP1qPAUUfo1FEXPXUfUkp3eZA0sSq340vPycSyOlYUeM15Ft1w=="],
-
-    "@vitest/mocker": ["@vitest/mocker@4.0.15", "", { "dependencies": { "@vitest/spy": "4.0.15", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-CZ28GLfOEIFkvCFngN8Sfx5h+Se0zN+h4B7yOsPVCcgtiO7t5jt9xQh2E1UkFep+eb9fjyMfuC5gBypwb07fvQ=="],
-
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.0.15", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-SWdqR8vEv83WtZcrfLNqlqeQXlQLh2iilO1Wk1gv4eiHKjEzvgHb2OVc3mIPyhZE6F+CtfYjNlDJwP5MN6Km7A=="],
-
-    "@vitest/runner": ["@vitest/runner@4.0.15", "", { "dependencies": { "@vitest/utils": "4.0.15", "pathe": "^2.0.3" } }, "sha512-+A+yMY8dGixUhHmNdPUxOh0la6uVzun86vAbuMT3hIDxMrAOmn5ILBHm8ajrqHE0t8R9T1dGnde1A5DTnmi3qw=="],
-
-    "@vitest/snapshot": ["@vitest/snapshot@4.0.15", "", { "dependencies": { "@vitest/pretty-format": "4.0.15", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-A7Ob8EdFZJIBjLjeO0DZF4lqR6U7Ydi5/5LIZ0xcI+23lYlsYJAfGn8PrIWTYdZQRNnSRlzhg0zyGu37mVdy5g=="],
-
-    "@vitest/spy": ["@vitest/spy@4.0.15", "", {}, "sha512-+EIjOJmnY6mIfdXtE/bnozKEvTC4Uczg19yeZ2vtCz5Yyb0QQ31QWVQ8hswJ3Ysx/K2EqaNsVanjr//2+P3FHw=="],
-
-    "@vitest/utils": ["@vitest/utils@4.0.15", "", { "dependencies": { "@vitest/pretty-format": "4.0.15", "tinyrainbow": "^3.0.3" } }, "sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA=="],
-
     "@xterm/addon-fit": ["@xterm/addon-fit@0.10.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ=="],
 
     "@xterm/addon-web-links": ["@xterm/addon-web-links@0.11.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q=="],
@@ -379,8 +355,6 @@
     "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
-
-    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -392,8 +366,6 @@
 
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
-    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
-
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "autoprefixer": ["autoprefixer@10.4.22", "", { "dependencies": { "browserslist": "^4.27.0", "caniuse-lite": "^1.0.30001754", "fraction.js": "^5.3.4", "normalize-range": "^0.1.2", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg=="],
@@ -401,8 +373,6 @@
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.10", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-DV5bdJZTzZ0zn0DC24v3jD7Mnidh6xhKa4GfKCbq3sfW8kaWhDdZjP3i81geA8T33tdYqWKw4D3fVv0CwEgKVA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.4", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ZCQ9GEWl73BVm8bu5Fts8nt7MHdbt5vY9bP6WGnUh+r3l8M7CgfyTlwsgCbMC66BNxPr6Xoce3j66Ms5YUQTNA=="],
-
-    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
@@ -418,25 +388,15 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001759", "", {}, "sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw=="],
 
-    "chai": ["chai@6.2.1", "", {}, "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg=="],
-
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie-es": ["cookie-es@2.0.0", "", {}, "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg=="],
 
-    "css-tree": ["css-tree@3.1.0", "", { "dependencies": { "mdn-data": "2.12.2", "source-map-js": "^1.0.1" } }, "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w=="],
-
-    "cssstyle": ["cssstyle@5.3.4", "", { "dependencies": { "@asamuzakjp/css-color": "^4.1.0", "@csstools/css-syntax-patches-for-csstree": "1.0.14", "css-tree": "^3.1.0" } }, "sha512-KyOS/kJMEq5O9GdPnaf82noigg5X5DYn0kZPJTaAsCUaBizp6Xa1y9D4Qoqf/JazEXWuruErHgVXwjN5391ZJw=="],
-
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
-    "data-urls": ["data-urls@6.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^15.0.0" } }, "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA=="],
-
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "default-browser": ["default-browser@5.4.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg=="],
 
@@ -456,19 +416,11 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
-
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
-
-    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
-    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -484,19 +436,15 @@
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "glob-to-regex.js": ["glob-to-regex.js@1.2.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "happy-dom": ["happy-dom@20.0.11", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g=="],
 
     "hono": ["hono@4.10.7", "", {}, "sha512-icXIITfw/07Q88nLSkB9aiUrd8rYzSweK681Kjo/TSggaGbOX4RRyxxm71v+3PC8C/j+4rlxGeoTRxQDkaJkUw=="],
 
-    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
-
-    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
-
-    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "hyperdyperid": ["hyperdyperid@1.2.0", "", {}, "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -512,8 +460,6 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
-    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
-
     "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
 
     "isbot": ["isbot@5.1.32", "", {}, "sha512-VNfjM73zz2IBZmdShMfAUg10prm6t7HFUQmNAEOAVS4YH92ZrZcvkMcGX6cIgBJAzWDzPent/EeAtYEHNPNPBQ=="],
@@ -521,8 +467,6 @@
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
-    "jsdom": ["jsdom@27.2.0", "", { "dependencies": { "@acemir/cssom": "^0.9.23", "@asamuzakjp/dom-selector": "^6.7.4", "cssstyle": "^5.3.3", "data-urls": "^6.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^15.1.0", "ws": "^8.18.3", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -560,7 +504,9 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
-    "mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
+    "memfs": ["memfs@4.51.1", "", { "dependencies": { "@jsonjoy.com/json-pack": "^1.11.0", "@jsonjoy.com/util": "^1.9.0", "glob-to-regex.js": "^1.0.1", "thingies": "^2.5.0", "tree-dump": "^1.0.3", "tslib": "^2.0.0" } }, "sha512-Eyt3XrufitN2ZL9c/uIRMyDwXanLI88h/L3MoWqNY747ha3dMR9dWqp8cRT5ntjZ0U1TNuq4U91ZXK0sMBjYOQ=="],
+
+    "mock-fs": ["mock-fs@5.5.0", "", {}, "sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -572,11 +518,7 @@
 
     "normalize-range": ["normalize-range@0.1.2", "", {}, "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="],
 
-    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
-
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
-
-    "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -594,8 +536,6 @@
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
-    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
-
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
@@ -608,17 +548,11 @@
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "rollup": ["rollup@4.53.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.53.3", "@rollup/rollup-android-arm64": "4.53.3", "@rollup/rollup-darwin-arm64": "4.53.3", "@rollup/rollup-darwin-x64": "4.53.3", "@rollup/rollup-freebsd-arm64": "4.53.3", "@rollup/rollup-freebsd-x64": "4.53.3", "@rollup/rollup-linux-arm-gnueabihf": "4.53.3", "@rollup/rollup-linux-arm-musleabihf": "4.53.3", "@rollup/rollup-linux-arm64-gnu": "4.53.3", "@rollup/rollup-linux-arm64-musl": "4.53.3", "@rollup/rollup-linux-loong64-gnu": "4.53.3", "@rollup/rollup-linux-ppc64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-musl": "4.53.3", "@rollup/rollup-linux-s390x-gnu": "4.53.3", "@rollup/rollup-linux-x64-gnu": "4.53.3", "@rollup/rollup-linux-x64-musl": "4.53.3", "@rollup/rollup-openharmony-arm64": "4.53.3", "@rollup/rollup-win32-arm64-msvc": "4.53.3", "@rollup/rollup-win32-ia32-msvc": "4.53.3", "@rollup/rollup-win32-x64-gnu": "4.53.3", "@rollup/rollup-win32-x64-msvc": "4.53.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
-
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
-    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
@@ -628,43 +562,25 @@
 
     "seroval-plugins": ["seroval-plugins@1.4.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-zir1aWzoiax6pbBVjoYVd0O1QQXgIL3eVGBMsBsNmM8Ukq90yGaWlfx0AB9dTS8GPqrOrbXn79vmItCUP9U3BQ=="],
 
-    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
-
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
-
-    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
-
-    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
-
-    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tailwindcss": ["tailwindcss@4.1.17", "", {}, "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
+    "thingies": ["thingies@2.5.0", "", { "peerDependencies": { "tslib": "^2" } }, "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw=="],
+
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tiny-warning": ["tiny-warning@1.0.3", "", {}, "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="],
 
-    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
-
-    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
-
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
-
-    "tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
-
-    "tldts": ["tldts@7.0.19", "", { "dependencies": { "tldts-core": "^7.0.19" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA=="],
-
-    "tldts-core": ["tldts-core@7.0.19", "", {}, "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "tough-cookie": ["tough-cookie@6.0.0", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w=="],
-
-    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+    "tree-dump": ["tree-dump@1.1.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -684,37 +600,15 @@
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
-    "vitest": ["vitest@4.0.15", "", { "dependencies": { "@vitest/expect": "4.0.15", "@vitest/mocker": "4.0.15", "@vitest/pretty-format": "4.0.15", "@vitest/runner": "4.0.15", "@vitest/snapshot": "4.0.15", "@vitest/spy": "4.0.15", "@vitest/utils": "4.0.15", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.15", "@vitest/browser-preview": "4.0.15", "@vitest/browser-webdriverio": "4.0.15", "@vitest/ui": "4.0.15", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA=="],
-
-    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
-
-    "webidl-conversions": ["webidl-conversions@8.0.0", "", {}, "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA=="],
-
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
-
-    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
-    "whatwg-url": ["whatwg-url@15.1.0", "", { "dependencies": { "tr46": "^6.0.0", "webidl-conversions": "^8.0.0" } }, "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g=="],
-
-    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
-
-    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
-
     "wsl-utils": ["wsl-utils@0.3.0", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-3sFIGLiaDP7rTO4xh3g+b3AzhYDIUGGywE/WsmqzJWDxus5aJXVnPTNC/6L+r2WzrwXqVOdD262OaO+cEyPMSQ=="],
-
-    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
-
-    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
-
-    "@asamuzakjp/dom-selector/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "@happy-dom/global-registrator/@types/node": ["@types/node@20.19.26", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg=="],
 
@@ -732,11 +626,7 @@
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "data-urls/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
-
     "happy-dom/@types/node": ["@types/node@20.19.26", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg=="],
-
-    "jsdom/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/docs/issues/replace-vitest-with-bun-test-server.md
+++ b/docs/issues/replace-vitest-with-bun-test-server.md
@@ -1,0 +1,244 @@
+# Plan: Replace vitest with bun test in server package
+
+Related issue: [#44](https://github.com/ms2sato/agent-console/issues/44)
+
+## Overview
+
+Migrate `packages/server` from vitest to bun:test while refactoring tests to use low-level mocks instead of `vi.mock()`.
+
+## Key Decisions
+
+- **api.test.ts**: Introduce dependency injection to production code
+- **MockPtyFactory**: Maintain existing pattern, adapt for bun:test without mock.module()
+- **Testing guideline**: Use low-level mocks (fetch, fs, process) instead of module-level mocks
+- **File System**: Use mock-fs library for in-memory file system mocking (no temp directories)
+- **PTY**: Keep bun-pty for now, prepare for future Bun.Terminal migration (see Future Work)
+
+## Future Work: Bun.Terminal Migration
+
+When [PR #25415](https://github.com/oven-sh/bun/pull/25415) is merged and available in stable Bun:
+
+1. Replace `bun-pty` with native `Bun.Terminal` API
+2. Update `session-manager.ts` to use `Bun.spawn({ terminal: opts })`
+3. Simplify test mocking (no external dependency to mock)
+
+**API Comparison**:
+| bun-pty | Bun.Terminal |
+|---------|--------------|
+| `spawn(cmd, args, opts)` | `Bun.spawn(cmd, { terminal: opts })` |
+| `pty.onData(cb)` | `data` callback option |
+| `pty.write(data)` | `proc.terminal.write(data)` |
+| `pty.resize(cols, rows)` | `proc.terminal.resize(cols, rows)` |
+
+**Preparation in this PR**: Design PTY abstraction layer to make future migration easier.
+
+## Implementation Phases
+
+### Phase 1: Infrastructure Setup
+
+1. **Update package.json** (already done)
+   - Change test scripts to `bun test src/`
+   - Remove vitest dependency
+   - Add `mock-fs` as devDependency
+
+2. **Update mock-pty.ts**
+   - File: `packages/server/src/__tests__/utils/mock-pty.ts`
+   - Change: `import { vi } from 'vitest'` → `import { mock } from 'bun:test'`
+   - Adapt `vi.fn()` → `mock()`
+
+3. **Create mock-fs helper**
+   - File: `packages/server/src/__tests__/utils/mock-fs-helper.ts`
+   - Wrap mock-fs setup/teardown for consistent usage
+
+### Phase 2: Simple Test Files (No vi.mock)
+
+These files only need import changes:
+
+| File | Changes |
+|------|---------|
+| `lib/__tests__/config.test.ts` | Import from bun:test |
+| `lib/__tests__/error-handler.test.ts` | Import from bun:test |
+| `lib/__tests__/errors.test.ts` | Import from bun:test |
+| `lib/__tests__/server-config.test.ts` | Import from bun:test |
+| `services/__tests__/activity-detector.test.ts` | Import from bun:test |
+| `services/__tests__/env-filter.test.ts` | Import from bun:test |
+| `services/__tests__/persistence-service.test.ts` | Import from bun:test |
+
+### Phase 3: Service Tests with Persistence Mock
+
+**Pattern**: Replace vi.mock for persistence-service with mock-fs (in-memory file system).
+
+#### 3.1 agent-manager.test.ts
+- **Current**: Mocks `persistence-service.js`
+- **Solution**: Use real PersistenceService with mock-fs
+- **Production change**: None (PersistenceService already supports AGENT_CONSOLE_HOME env var)
+
+#### 3.2 repository-manager.test.ts
+- **Current**: Mocks `persistence-service.js`, `config.js`
+- **Solution**:
+  - Use real PersistenceService with mock-fs
+  - Set AGENT_CONSOLE_HOME env var for config
+- **Production change**: None
+
+#### 3.3 persistence-service.test.ts
+- **Current**: Uses real fs with temp directories
+- **Solution**: Migrate to mock-fs for consistency and speed
+- **Production change**: None
+
+### Phase 4: Command Execution Tests
+
+#### 4.1 session-metadata-suggester.test.ts
+- **Current**: Mocks `child_process.execSync`
+- **Solution**: Create spy on execSync or use real commands with fixtures
+- **Production change**: Add optional executor parameter for DI
+
+#### 4.2 worktree-service.test.ts
+- **Current**: Mocks `config.js`, `fs`, `child_process`
+- **Solution**:
+  - Use AGENT_CONSOLE_HOME for config
+  - Use mock-fs for file system operations
+  - Spy on child_process.execSync for git commands
+- **Production change**: None
+
+### Phase 5: Session Manager Tests (Complex)
+
+#### 5.1 session-manager.test.ts
+- **Current Mocks**: bun-pty, persistence-service, agent-manager, config, env-filter
+- **Solution**:
+  - **bun-pty**: Create PTY abstraction interface (DI) - prepares for Bun.Terminal migration
+  - **persistence-service**: Real with mock-fs
+  - **agent-manager**: Create with real persistence + mock-fs
+  - **config**: AGENT_CONSOLE_HOME env var
+  - **env-filter**: Real implementation
+- **Production changes**:
+  - Create `PtyProvider` interface abstraction
+  - `SessionManager` constructor accepts optional `ptyProvider` parameter
+
+```typescript
+// lib/pty-provider.ts (new file)
+export interface PtyInstance {
+  pid: number;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(): void;
+  onData(callback: (data: string) => void): { dispose: () => void };
+  onExit(callback: (event: { exitCode: number; signal?: number }) => void): { dispose: () => void };
+}
+
+export interface PtyProvider {
+  spawn(command: string, args: string[], options: PtySpawnOptions): PtyInstance;
+}
+
+// Default implementation using bun-pty
+export const bunPtyProvider: PtyProvider = {
+  spawn: (cmd, args, opts) => spawn(cmd, args, opts)
+};
+
+// session-manager.ts
+export class SessionManager {
+  constructor(private ptyProvider: PtyProvider = bunPtyProvider) { ... }
+}
+```
+
+This abstraction enables:
+1. Easy mocking in tests without mock.module()
+2. Future migration to Bun.Terminal by creating `bunTerminalProvider`
+
+#### 5.2 session-manager-cleanup.test.ts
+- **Current Mocks**: Same as above + process.kill
+- **Solution**:
+  - Same DI pattern as session-manager.test.ts
+  - Mock process.kill at low level (global assignment)
+  - Use mock-fs for persistence
+- **Production changes**: Same as above
+
+### Phase 6: API Integration Test (DI Required)
+
+#### api.test.ts
+- **Current Mocks**: All service managers (session, repository, worktree, agent, metadata-suggester), open, fs
+- **Solution**: Dependency injection via factory function
+
+**Production changes**:
+```typescript
+// routes/api.ts - Add factory function
+export interface ApiDependencies {
+  sessionManager: typeof sessionManager;
+  repositoryManager: typeof repositoryManager;
+  worktreeService: typeof worktreeService;
+  agentManager: typeof agentManager;
+}
+
+export function createApiRouter(deps: ApiDependencies = {
+  sessionManager,
+  repositoryManager,
+  worktreeService,
+  agentManager
+}): Hono { ... }
+```
+
+**Test approach**:
+- Create mock service objects directly in test
+- Pass to createApiRouter()
+- No module mocking needed
+
+### Phase 7: Worker Handler Test
+
+#### worker-handler.test.ts
+- **Current**: Mocks session-manager, fs
+- **Solution**:
+  - DI for session manager reference
+  - Use mock-fs for image tests
+- **Production change**: Accept sessionManager as parameter
+
+## Files to Modify
+
+### Production Code Changes
+1. `packages/server/src/lib/pty-provider.ts` - **New file**: PTY abstraction interface
+2. `packages/server/src/services/session-manager.ts` - Use PtyProvider DI
+3. `packages/server/src/routes/api.ts` - Add createApiRouter factory
+4. `packages/server/src/websocket/worker-handler.ts` - Add sessionManager DI
+
+### New Test Utilities
+1. `src/__tests__/utils/mock-fs-helper.ts` (new file)
+
+### Test File Changes (all 15 files)
+1. `src/__tests__/api.test.ts`
+2. `src/__tests__/utils/mock-pty.ts`
+3. `src/lib/__tests__/config.test.ts`
+4. `src/lib/__tests__/error-handler.test.ts`
+5. `src/lib/__tests__/errors.test.ts`
+6. `src/lib/__tests__/server-config.test.ts`
+7. `src/services/__tests__/activity-detector.test.ts`
+8. `src/services/__tests__/agent-manager.test.ts`
+9. `src/services/__tests__/env-filter.test.ts`
+10. `src/services/__tests__/persistence-service.test.ts`
+11. `src/services/__tests__/repository-manager.test.ts`
+12. `src/services/__tests__/session-manager-cleanup.test.ts`
+13. `src/services/__tests__/session-manager.test.ts`
+14. `src/services/__tests__/session-metadata-suggester.test.ts`
+15. `src/services/__tests__/worktree-service.test.ts`
+16. `src/websocket/__tests__/worker-handler.test.ts`
+
+## Implementation Order
+
+1. Phase 1: Infrastructure (mock-pty.ts, mock-fs-helper.ts, package.json)
+2. Phase 2: Simple tests (6 files - quick wins, excluding persistence-service.test.ts)
+3. Phase 3: Persistence-dependent tests (3 files - including persistence-service.test.ts migration to mock-fs)
+4. Phase 4: Command execution tests (2 files)
+5. Phase 5: Session manager tests (2 files, requires production changes)
+6. Phase 6: API test (1 file, requires production changes)
+7. Phase 7: Worker handler test (1 file, requires production changes)
+
+## Risk Mitigation
+
+1. **Run tests after each phase** to catch regressions early
+2. **Production changes are minimal** - only adding optional DI parameters
+3. **Existing behavior preserved** - default parameters maintain backward compatibility
+4. **Rollback plan**: Git revert if issues found
+
+## Estimated Effort
+
+- Phase 1-2: 30 minutes
+- Phase 3-4: 1 hour
+- Phase 5-7: 2-3 hours
+- **Total**: 4-5 hours

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,8 +11,8 @@
     "build": "NODE_ENV=production bun build.ts",
     "start": "bun dist/index.js",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "test": "bun test src/",
+    "test:watch": "bun test --watch src/"
   },
   "dependencies": {
     "@agent-console/shared": "*",
@@ -23,9 +23,11 @@
   },
   "devDependencies": {
     "@types/bun": "^1.1.14",
+    "@types/mock-fs": "^4.13.4",
     "@types/node": "^22.10.1",
     "@types/uuid": "^10.0.0",
-    "typescript": "^5.7.2",
-    "vitest": "^4.0.15"
+    "memfs": "^4.51.1",
+    "mock-fs": "^5.4.1",
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/server/src/__tests__/utils/mock-fs-helper.ts
+++ b/packages/server/src/__tests__/utils/mock-fs-helper.ts
@@ -1,0 +1,134 @@
+import { vol } from 'memfs';
+import { mock } from 'bun:test';
+
+/**
+ * Helper for setting up memfs in tests.
+ * Provides consistent setup/teardown and common directory structures.
+ *
+ * IMPORTANT: Call setupMemfs() in beforeEach and cleanupMemfs() in afterEach.
+ */
+
+/**
+ * Sets up memfs to mock the fs module.
+ * Call this in beforeEach before any fs operations.
+ *
+ * @example
+ * ```typescript
+ * beforeEach(() => {
+ *   setupMemfs({
+ *     '/test/config/repositories.json': JSON.stringify([]),
+ *   });
+ * });
+ *
+ * afterEach(() => {
+ *   cleanupMemfs();
+ * });
+ * ```
+ */
+export function setupMemfs(files: Record<string, string> = {}): void {
+  // Reset volume
+  vol.reset();
+
+  // Create directory structure from files
+  vol.fromJSON(files, '/');
+
+  // Mock fs and fs/promises modules
+  mock.module('fs', () => require('memfs').fs);
+  mock.module('node:fs', () => require('memfs').fs);
+  mock.module('fs/promises', () => require('memfs').fs.promises);
+  mock.module('node:fs/promises', () => require('memfs').fs.promises);
+}
+
+/**
+ * Cleans up memfs after tests.
+ * Call this in afterEach.
+ */
+export function cleanupMemfs(): void {
+  vol.reset();
+  delete process.env.AGENT_CONSOLE_HOME;
+}
+
+/**
+ * Creates a standard test config directory structure.
+ * Sets AGENT_CONSOLE_HOME environment variable.
+ *
+ * @param configPath - Path for the config directory (default: '/test/config')
+ * @param initialData - Optional initial data for config files
+ */
+export function setupTestConfigDir(
+  configPath = '/test/config',
+  initialData: {
+    repositories?: unknown[];
+    sessions?: unknown[];
+    agents?: unknown[];
+  } = {}
+): void {
+  const files: Record<string, string> = {};
+
+  // Ensure config directory exists by creating a placeholder
+  // memfs creates parent directories automatically when creating files
+
+  if (initialData.repositories !== undefined) {
+    files[`${configPath}/repositories.json`] = JSON.stringify(initialData.repositories);
+  }
+  if (initialData.sessions !== undefined) {
+    files[`${configPath}/sessions.json`] = JSON.stringify(initialData.sessions);
+  }
+  if (initialData.agents !== undefined) {
+    files[`${configPath}/agents.json`] = JSON.stringify(initialData.agents);
+  }
+
+  // If no initial data, create an empty file to ensure directory exists
+  if (Object.keys(files).length === 0) {
+    files[`${configPath}/.keep`] = '';
+  }
+
+  setupMemfs(files);
+  process.env.AGENT_CONSOLE_HOME = configPath;
+}
+
+/**
+ * Cleans up test config directory and restores environment.
+ */
+export function cleanupTestConfigDir(): void {
+  cleanupMemfs();
+}
+
+/**
+ * Creates a mock git repository structure.
+ *
+ * @param repoPath - Path for the repository
+ * @param options - Repository options
+ * @returns Files object for use with setupMemfs
+ */
+export function createMockGitRepoFiles(
+  repoPath: string,
+  options: {
+    withWorktrees?: string[];
+    withBranches?: string[];
+  } = {}
+): Record<string, string> {
+  const files: Record<string, string> = {
+    [`${repoPath}/.git/HEAD`]: 'ref: refs/heads/main',
+    [`${repoPath}/.git/config`]: '',
+    [`${repoPath}/.git/refs/heads/main`]: 'abc123',
+  };
+
+  // Add branches
+  if (options.withBranches) {
+    for (const branch of options.withBranches) {
+      files[`${repoPath}/.git/refs/heads/${branch}`] = 'def456';
+    }
+  }
+
+  // Add worktrees
+  if (options.withWorktrees) {
+    for (const wtPath of options.withWorktrees) {
+      const wtName = wtPath.split('/').pop();
+      files[`${wtPath}/.git`] = `gitdir: ${repoPath}/.git/worktrees/${wtName}`;
+    }
+  }
+
+  return files;
+}
+

--- a/packages/server/src/lib/__tests__/config.test.ts
+++ b/packages/server/src/lib/__tests__/config.test.ts
@@ -1,85 +1,80 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as os from 'os';
 import * as path from 'path';
+import { getConfigDir, getRepositoriesDir, getRepositoryDir, getServerPid } from '../config.js';
 
 describe('config', () => {
-  const originalEnv = process.env;
+  const originalEnv = process.env.AGENT_CONSOLE_HOME;
 
   beforeEach(() => {
-    vi.resetModules();
-    process.env = { ...originalEnv };
+    // Clear the env var to test default behavior
+    delete process.env.AGENT_CONSOLE_HOME;
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    // Restore original env var
+    if (originalEnv !== undefined) {
+      process.env.AGENT_CONSOLE_HOME = originalEnv;
+    } else {
+      delete process.env.AGENT_CONSOLE_HOME;
+    }
   });
 
   describe('getConfigDir', () => {
-    it('should return default path when AGENT_CONSOLE_HOME is not set', async () => {
+    it('should return default path when AGENT_CONSOLE_HOME is not set', () => {
       delete process.env.AGENT_CONSOLE_HOME;
-      const { getConfigDir } = await import('../config.js');
 
       const expected = path.join(os.homedir(), '.agent-console');
       expect(getConfigDir()).toBe(expected);
     });
 
-    it('should return AGENT_CONSOLE_HOME when set', async () => {
+    it('should return AGENT_CONSOLE_HOME when set', () => {
       process.env.AGENT_CONSOLE_HOME = '/custom/config/path';
-      const { getConfigDir } = await import('../config.js');
 
       expect(getConfigDir()).toBe('/custom/config/path');
     });
 
-    it('should return different paths for different AGENT_CONSOLE_HOME values', async () => {
+    it('should return different paths for different AGENT_CONSOLE_HOME values', () => {
       process.env.AGENT_CONSOLE_HOME = '/path/one';
-      const { getConfigDir: getConfigDir1 } = await import('../config.js');
-      expect(getConfigDir1()).toBe('/path/one');
+      expect(getConfigDir()).toBe('/path/one');
 
-      vi.resetModules();
       process.env.AGENT_CONSOLE_HOME = '/path/two';
-      const { getConfigDir: getConfigDir2 } = await import('../config.js');
-      expect(getConfigDir2()).toBe('/path/two');
+      expect(getConfigDir()).toBe('/path/two');
     });
   });
 
   describe('getServerPid', () => {
-    it('should return current process PID', async () => {
-      const { getServerPid } = await import('../config.js');
-
+    it('should return current process PID', () => {
       expect(getServerPid()).toBe(process.pid);
       expect(typeof getServerPid()).toBe('number');
     });
   });
 
   describe('getRepositoriesDir', () => {
-    it('should return repositories subdirectory of config dir', async () => {
+    it('should return repositories subdirectory of config dir', () => {
       delete process.env.AGENT_CONSOLE_HOME;
-      const { getRepositoriesDir } = await import('../config.js');
 
       const expected = path.join(os.homedir(), '.agent-console', 'repositories');
       expect(getRepositoriesDir()).toBe(expected);
     });
 
-    it('should respect AGENT_CONSOLE_HOME', async () => {
+    it('should respect AGENT_CONSOLE_HOME', () => {
       process.env.AGENT_CONSOLE_HOME = '/custom/path';
-      const { getRepositoriesDir } = await import('../config.js');
 
       expect(getRepositoriesDir()).toBe('/custom/path/repositories');
     });
   });
 
   describe('getRepositoryDir', () => {
-    it('should return repository-specific directory', async () => {
+    it('should return repository-specific directory', () => {
       delete process.env.AGENT_CONSOLE_HOME;
-      const { getRepositoryDir } = await import('../config.js');
 
       const expected = path.join(os.homedir(), '.agent-console', 'repositories', 'owner/repo');
       expect(getRepositoryDir('owner/repo')).toBe(expected);
     });
 
-    it('should handle simple repo names', async () => {
+    it('should handle simple repo names', () => {
       process.env.AGENT_CONSOLE_HOME = '/config';
-      const { getRepositoryDir } = await import('../config.js');
 
       expect(getRepositoryDir('my-repo')).toBe('/config/repositories/my-repo');
     });

--- a/packages/server/src/lib/__tests__/error-handler.test.ts
+++ b/packages/server/src/lib/__tests__/error-handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, spyOn, beforeEach } from 'bun:test';
 import { Hono } from 'hono';
 import { onApiError } from '../error-handler.js';
 import { ValidationError, NotFoundError, ConflictError, InternalError } from '../errors.js';
@@ -71,7 +71,7 @@ describe('Error Handler', () => {
     });
 
     it('should handle non-ApiError with 500 status', async () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
 
       app.get('/test', () => {
         throw new Error('Unexpected error');
@@ -88,7 +88,7 @@ describe('Error Handler', () => {
     });
 
     it('should handle TypeError', async () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
 
       app.get('/test', () => {
         throw new TypeError('Type error occurred');

--- a/packages/server/src/lib/__tests__/errors.test.ts
+++ b/packages/server/src/lib/__tests__/errors.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import {
   ApiError,
   ValidationError,

--- a/packages/server/src/lib/process-utils.ts
+++ b/packages/server/src/lib/process-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Thin wrappers around process functions for testability.
+ *
+ * These wrappers allow tests to mock process operations using mock.module()
+ * without modifying global process object.
+ */
+
+/**
+ * Kill a process by PID.
+ */
+export function processKill(pid: number, signal?: NodeJS.Signals | number): boolean {
+  return process.kill(pid, signal);
+}
+
+/**
+ * Check if a process is alive (exists).
+ */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/server/src/lib/pty-provider.ts
+++ b/packages/server/src/lib/pty-provider.ts
@@ -1,0 +1,65 @@
+import type { IPty } from 'bun-pty';
+
+/**
+ * PTY spawn options (subset of bun-pty options)
+ */
+export interface PtySpawnOptions {
+  name?: string;
+  cols?: number;
+  rows?: number;
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+/**
+ * PTY instance interface matching bun-pty's IPty
+ */
+export type PtyInstance = IPty;
+
+/**
+ * PTY provider interface for dependency injection.
+ * This abstraction enables:
+ * 1. Easy mocking in tests without mock.module()
+ * 2. Future migration to Bun.Terminal when available
+ */
+export interface PtyProvider {
+  spawn(command: string, args: string[], options: PtySpawnOptions): PtyInstance;
+}
+
+/**
+ * Default PtyProvider implementation using bun-pty.
+ * Uses lazy initialization to defer native library loading until first spawn() call.
+ * This allows the module to be imported in test environments without loading native code.
+ *
+ * ## Why lazy require?
+ *
+ * bun-pty is a native module that loads a shared library (librust_pty) at import time.
+ * In test environments, we mock the PtyProvider interface instead of using real PTY.
+ * However, ES module imports are hoisted and evaluated before any test code runs,
+ * causing the native library to load even when not needed.
+ *
+ * By using dynamic require() inside the spawn() method, we defer loading until
+ * the method is actually called, which never happens in tests that use mock providers.
+ *
+ * ## Future: Bun.Terminal migration
+ *
+ * When Bun's native Terminal API lands (https://github.com/oven-sh/bun/pull/25415),
+ * we can replace bun-pty with Bun.spawn({ terminal: opts }). This will eliminate
+ * the need for external native dependencies and simplify this code:
+ *
+ * ```typescript
+ * export const bunTerminalProvider: PtyProvider = {
+ *   spawn(command, args, options) {
+ *     return Bun.spawn([command, ...args], { terminal: options });
+ *   },
+ * };
+ * ```
+ */
+export const bunPtyProvider: PtyProvider = {
+  spawn(command, args, options) {
+    // Dynamic require to defer native library loading (see comment above)
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { spawn } = require('bun-pty');
+    return spawn(command, args, options);
+  },
+};

--- a/packages/server/src/services/__tests__/env-filter.test.ts
+++ b/packages/server/src/services/__tests__/env-filter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { getChildProcessEnv } from '../env-filter.js';
 
 describe('env-filter', () => {

--- a/packages/server/src/services/__tests__/repository-manager.test.ts
+++ b/packages/server/src/services/__tests__/repository-manager.test.ts
@@ -1,79 +1,56 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
 import type { Repository } from '@agent-console/shared';
-
-// Test directory paths - will be set uniquely for each test
-let TEST_CONFIG_DIR: string;
-let TEST_REPO_DIR: string;
-
-// Storage for mocked repositories
-let mockRepositories: Repository[] = [];
-
-// Mock persistence service
-vi.mock('../persistence-service.js', () => ({
-  persistenceService: {
-    loadRepositories: vi.fn(() => mockRepositories),
-    saveRepositories: vi.fn((repos: Repository[]) => {
-      mockRepositories = repos;
-    }),
-  },
-}));
-
-// Mock config
-vi.mock('../../lib/config.js', () => ({
-  getConfigDir: vi.fn(() => TEST_CONFIG_DIR),
-  getRepositoriesDir: vi.fn(() => `${TEST_CONFIG_DIR}/repositories`),
-  getRepositoryDir: vi.fn((orgRepo: string) => `${TEST_CONFIG_DIR}/repositories/${orgRepo}`),
-}));
+import { setupMemfs, cleanupMemfs, createMockGitRepoFiles } from '../../__tests__/utils/mock-fs-helper.js';
 
 describe('RepositoryManager', () => {
+  const TEST_CONFIG_DIR = '/test/config';
+  const TEST_REPO_DIR = '/test/repo';
+  let importCounter = 0;
+
   beforeEach(() => {
-    // Reset modules to get fresh instance
-    vi.resetModules();
-
-    // Generate unique directory paths for each test
-    const uniqueId = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    TEST_CONFIG_DIR = path.join(os.tmpdir(), `agent-console-repo-test-${uniqueId}`);
-    TEST_REPO_DIR = path.join(os.tmpdir(), `test-git-repo-${uniqueId}`);
-
-    // Reset mock storage
-    mockRepositories = [];
-
-    // Create test directories
-    fs.mkdirSync(TEST_CONFIG_DIR, { recursive: true });
-
-    // Create a fake git repo
-    fs.mkdirSync(TEST_REPO_DIR, { recursive: true });
-    fs.mkdirSync(path.join(TEST_REPO_DIR, '.git'));
+    // Set up memfs with config dir and a git repo
+    const gitRepoFiles = createMockGitRepoFiles(TEST_REPO_DIR);
+    setupMemfs({
+      [`${TEST_CONFIG_DIR}/.keep`]: '',
+      ...gitRepoFiles,
+    });
+    process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
   });
 
   afterEach(() => {
-    // Clean up
-    if (fs.existsSync(TEST_CONFIG_DIR)) {
-      fs.rmSync(TEST_CONFIG_DIR, { recursive: true });
-    }
-    if (fs.existsSync(TEST_REPO_DIR)) {
-      fs.rmSync(TEST_REPO_DIR, { recursive: true });
-    }
+    cleanupMemfs();
   });
+
+  // Helper to get fresh module instance
+  async function getRepositoryManager() {
+    const module = await import(`../repository-manager.js?v=${++importCounter}`);
+    return module.RepositoryManager;
+  }
+
+  // Helper to pre-populate repositories file
+  function setupRepositories(repos: Repository[]) {
+    fs.writeFileSync(
+      `${TEST_CONFIG_DIR}/repositories.json`,
+      JSON.stringify(repos)
+    );
+  }
 
   describe('registerRepository', () => {
     it('should register a valid git repository', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       const repo = manager.registerRepository(TEST_REPO_DIR);
 
       expect(repo.id).toBeDefined();
-      expect(repo.name).toBe(path.basename(TEST_REPO_DIR));
+      expect(repo.name).toBe('repo');
       expect(repo.path).toBe(TEST_REPO_DIR);
       expect(repo.registeredAt).toBeDefined();
     });
 
     it('should throw error for non-existent path', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       expect(() => {
@@ -82,23 +59,19 @@ describe('RepositoryManager', () => {
     });
 
     it('should throw error for non-git directory', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
-      const nonGitDir = path.join(os.tmpdir(), 'non-git-dir-' + Date.now());
-      fs.mkdirSync(nonGitDir, { recursive: true });
+      // Create a non-git directory
+      fs.mkdirSync('/non-git-dir', { recursive: true });
 
-      try {
-        expect(() => {
-          manager.registerRepository(nonGitDir);
-        }).toThrow('Not a git repository');
-      } finally {
-        fs.rmSync(nonGitDir, { recursive: true });
-      }
+      expect(() => {
+        manager.registerRepository('/non-git-dir');
+      }).toThrow('Not a git repository');
     });
 
     it('should throw error for duplicate registration', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       manager.registerRepository(TEST_REPO_DIR);
@@ -109,21 +82,21 @@ describe('RepositoryManager', () => {
     });
 
     it('should persist repository via persistence service', async () => {
-      const { persistenceService } = await import('../persistence-service.js');
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       manager.registerRepository(TEST_REPO_DIR);
 
-      expect(vi.mocked(persistenceService.saveRepositories)).toHaveBeenCalled();
-      expect(mockRepositories.length).toBe(1);
-      expect(mockRepositories[0].path).toBe(TEST_REPO_DIR);
+      // Check persisted data
+      const savedData = JSON.parse(fs.readFileSync(`${TEST_CONFIG_DIR}/repositories.json`, 'utf-8'));
+      expect(savedData.length).toBe(1);
+      expect(savedData[0].path).toBe(TEST_REPO_DIR);
     });
   });
 
   describe('unregisterRepository', () => {
     it('should unregister existing repository', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       const repo = manager.registerRepository(TEST_REPO_DIR);
@@ -134,7 +107,7 @@ describe('RepositoryManager', () => {
     });
 
     it('should return false for non-existent repository', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       const result = manager.unregisterRepository('non-existent-id');
@@ -142,23 +115,21 @@ describe('RepositoryManager', () => {
     });
 
     it('should persist unregistration via persistence service', async () => {
-      const { persistenceService } = await import('../persistence-service.js');
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       const repo = manager.registerRepository(TEST_REPO_DIR);
-      vi.mocked(persistenceService.saveRepositories).mockClear();
-
       manager.unregisterRepository(repo.id);
 
-      expect(vi.mocked(persistenceService.saveRepositories)).toHaveBeenCalled();
-      expect(mockRepositories.length).toBe(0);
+      // Check persisted data
+      const savedData = JSON.parse(fs.readFileSync(`${TEST_CONFIG_DIR}/repositories.json`, 'utf-8'));
+      expect(savedData.length).toBe(0);
     });
   });
 
   describe('getRepository', () => {
     it('should return repository by id', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       const registered = manager.registerRepository(TEST_REPO_DIR);
@@ -168,7 +139,7 @@ describe('RepositoryManager', () => {
     });
 
     it('should return undefined for unknown id', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       const result = manager.getRepository('unknown-id');
@@ -178,7 +149,7 @@ describe('RepositoryManager', () => {
 
   describe('getAllRepositories', () => {
     it('should return empty array when no repositories', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       const repos = manager.getAllRepositories();
@@ -186,7 +157,7 @@ describe('RepositoryManager', () => {
     });
 
     it('should return all registered repositories', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       // Register first repo
@@ -194,30 +165,26 @@ describe('RepositoryManager', () => {
       expect(manager.getAllRepositories().length).toBe(1);
 
       // Create and register second repo
-      const testRepo2 = path.join(os.tmpdir(), `test-git-repo-second-${process.pid}-${Date.now()}`);
-      fs.mkdirSync(testRepo2, { recursive: true });
-      fs.mkdirSync(path.join(testRepo2, '.git'));
-
-      try {
-        const repo2 = manager.registerRepository(testRepo2);
-
-        const repos = manager.getAllRepositories();
-        expect(repos.length).toBe(2);
-
-        const repoIds = repos.map(r => r.id);
-        expect(repoIds).toContain(repo1.id);
-        expect(repoIds).toContain(repo2.id);
-      } finally {
-        if (fs.existsSync(testRepo2)) {
-          fs.rmSync(testRepo2, { recursive: true });
-        }
+      const secondRepoFiles = createMockGitRepoFiles('/test/repo2');
+      for (const [path, content] of Object.entries(secondRepoFiles)) {
+        fs.mkdirSync(path.substring(0, path.lastIndexOf('/')), { recursive: true });
+        fs.writeFileSync(path, content);
       }
+
+      const repo2 = manager.registerRepository('/test/repo2');
+
+      const repos = manager.getAllRepositories();
+      expect(repos.length).toBe(2);
+
+      const repoIds = repos.map((r: Repository) => r.id);
+      expect(repoIds).toContain(repo1.id);
+      expect(repoIds).toContain(repo2.id);
     });
   });
 
   describe('findRepositoryByPath', () => {
     it('should find repository by path', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       const registered = manager.registerRepository(TEST_REPO_DIR);
@@ -227,7 +194,7 @@ describe('RepositoryManager', () => {
     });
 
     it('should return undefined for unregistered path', async () => {
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       const result = manager.findRepositoryByPath('/some/other/path');
@@ -237,17 +204,17 @@ describe('RepositoryManager', () => {
 
   describe('loading from disk', () => {
     it('should load repositories from persistence service on construction', async () => {
-      // Pre-populate mock storage
-      mockRepositories = [
+      // Pre-populate repositories file
+      setupRepositories([
         {
           id: 'existing-id',
-          name: path.basename(TEST_REPO_DIR),
+          name: 'repo',
           path: TEST_REPO_DIR,
           registeredAt: '2024-01-01T00:00:00.000Z',
         },
-      ];
+      ]);
 
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       const repos = manager.getAllRepositories();
@@ -257,16 +224,16 @@ describe('RepositoryManager', () => {
 
     it('should skip repositories with missing paths on load', async () => {
       // Pre-populate with a repo that points to non-existent path
-      mockRepositories = [
+      setupRepositories([
         {
           id: 'missing-repo',
           name: 'missing',
           path: '/non/existent/path',
           registeredAt: '2024-01-01T00:00:00.000Z',
         },
-      ];
+      ]);
 
-      const { RepositoryManager } = await import('../repository-manager.js');
+      const RepositoryManager = await getRepositoryManager();
       const manager = new RepositoryManager();
 
       expect(manager.getAllRepositories().length).toBe(0);

--- a/packages/server/src/services/session-metadata-suggester.ts
+++ b/packages/server/src/services/session-metadata-suggester.ts
@@ -178,3 +178,8 @@ export async function suggestSessionMetadata(
 
 export { getBranches };
 export type { SessionMetadataSuggestionRequest, SessionMetadataSuggestionResponse };
+
+/**
+ * Function type for suggestSessionMetadata (for dependency injection)
+ */
+export type SuggestSessionMetadataFn = typeof suggestSessionMetadata;

--- a/packages/server/src/websocket/worker-handler.ts
+++ b/packages/server/src/websocket/worker-handler.ts
@@ -1,20 +1,30 @@
 import type { WSContext } from 'hono/ws';
 import type { WorkerClientMessage } from '@agent-console/shared';
-import { sessionManager } from '../services/session-manager.js';
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { sessionManager as defaultSessionManager } from '../services/session-manager.js';
+import { writeFileSync as defaultWriteFileSync, mkdirSync as defaultMkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { tmpdir as defaultTmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 
-// Directory for storing uploaded images
-const IMAGE_UPLOAD_DIR = join(tmpdir(), 'agent-console-images');
-
-// Ensure image upload directory exists
-try {
-  mkdirSync(IMAGE_UPLOAD_DIR, { recursive: true });
-} catch {
-  // Directory may already exist
+/**
+ * Dependencies for worker handler (enables dependency injection for testing)
+ */
+export interface WorkerHandlerDependencies {
+  sessionManager: {
+    writeWorkerInput: (sessionId: string, workerId: string, data: string) => void;
+    resizeWorker: (sessionId: string, workerId: string, cols: number, rows: number) => void;
+  };
+  writeFileSync: typeof defaultWriteFileSync;
+  mkdirSync: typeof defaultMkdirSync;
+  tmpdir: typeof defaultTmpdir;
 }
+
+const defaultDeps: WorkerHandlerDependencies = {
+  sessionManager: defaultSessionManager,
+  writeFileSync: defaultWriteFileSync,
+  mkdirSync: defaultMkdirSync,
+  tmpdir: defaultTmpdir,
+};
 
 function getExtensionFromMimeType(mimeType: string): string {
   const mimeMap: Record<string, string> = {
@@ -27,41 +37,61 @@ function getExtensionFromMimeType(mimeType: string): string {
   return mimeMap[mimeType] || 'png';
 }
 
-export function handleWorkerMessage(
-  _ws: WSContext,
-  sessionId: string,
-  workerId: string,
-  message: string | ArrayBuffer
-): void {
+/**
+ * Create a worker message handler with the given dependencies
+ */
+export function createWorkerMessageHandler(deps: Partial<WorkerHandlerDependencies> = {}) {
+  const { sessionManager, writeFileSync, mkdirSync, tmpdir } = { ...defaultDeps, ...deps };
+
+  // Directory for storing uploaded images
+  const IMAGE_UPLOAD_DIR = join(tmpdir(), 'agent-console-images');
+
+  // Ensure image upload directory exists
   try {
-    const msgStr = typeof message === 'string' ? message : new TextDecoder().decode(message);
-    const parsed: WorkerClientMessage = JSON.parse(msgStr);
-
-    switch (parsed.type) {
-      case 'input':
-        sessionManager.writeWorkerInput(sessionId, workerId, parsed.data);
-        break;
-      case 'resize':
-        sessionManager.resizeWorker(sessionId, workerId, parsed.cols, parsed.rows);
-        break;
-      case 'image': {
-        // Save image to temp file
-        const ext = getExtensionFromMimeType(parsed.mimeType);
-        const filename = `${randomUUID()}.${ext}`;
-        const filePath = join(IMAGE_UPLOAD_DIR, filename);
-
-        // Decode base64 and write to file
-        const buffer = Buffer.from(parsed.data, 'base64');
-        writeFileSync(filePath, buffer);
-
-        console.log(`Image saved: ${filePath}`);
-
-        // Send file path to PTY stdin (Claude Code will read the image)
-        sessionManager.writeWorkerInput(sessionId, workerId, filePath);
-        break;
-      }
-    }
-  } catch (e) {
-    console.error('Invalid worker message:', e);
+    mkdirSync(IMAGE_UPLOAD_DIR, { recursive: true });
+  } catch {
+    // Directory may already exist
   }
+
+  return function handleWorkerMessage(
+    _ws: WSContext,
+    sessionId: string,
+    workerId: string,
+    message: string | ArrayBuffer
+  ): void {
+    try {
+      const msgStr = typeof message === 'string' ? message : new TextDecoder().decode(message);
+      const parsed: WorkerClientMessage = JSON.parse(msgStr);
+
+      switch (parsed.type) {
+        case 'input':
+          sessionManager.writeWorkerInput(sessionId, workerId, parsed.data);
+          break;
+        case 'resize':
+          sessionManager.resizeWorker(sessionId, workerId, parsed.cols, parsed.rows);
+          break;
+        case 'image': {
+          // Save image to temp file
+          const ext = getExtensionFromMimeType(parsed.mimeType);
+          const filename = `${randomUUID()}.${ext}`;
+          const filePath = join(IMAGE_UPLOAD_DIR, filename);
+
+          // Decode base64 and write to file
+          const buffer = Buffer.from(parsed.data, 'base64');
+          writeFileSync(filePath, buffer);
+
+          console.log(`Image saved: ${filePath}`);
+
+          // Send file path to PTY stdin (Claude Code will read the image)
+          sessionManager.writeWorkerInput(sessionId, workerId, filePath);
+          break;
+        }
+      }
+    } catch (e) {
+      console.error('Invalid worker message:', e);
+    }
+  };
 }
+
+// Default handler for backward compatibility
+export const handleWorkerMessage = createWorkerMessageHandler();


### PR DESCRIPTION
## Summary

- Migrate all test files from vitest to bun:test
- Add infrastructure mocking layer (pty-provider, process-utils, mock-fs-helper)
- Convert api.test.ts to integration tests using infrastructure mocks
- Add PtyProvider abstraction for future Bun.Terminal migration
- Remove vitest dependency from server package

## Key Changes

### New Files
- `packages/server/src/lib/pty-provider.ts` - PTY abstraction with lazy loading for testability
- `packages/server/src/lib/process-utils.ts` - Thin wrappers for process operations
- `packages/server/src/__tests__/utils/mock-fs-helper.ts` - memfs setup utilities

### Testing Strategy
- Infrastructure mocking (fs, child_process, pty-provider) instead of service-level DI
- Dynamic imports with cache busting for fresh module instances per test
- Real services running against mocked infrastructure

## Test Plan

- [x] All 233 server tests pass
- [x] All 78 client tests pass  
- [x] TypeCheck passes
- [x] No vitest imports remain in server package

## Related

- Closes #44
- Follow-up for missing test coverage: #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)