### PR TITLE
refactor: split SessionSettings component into smaller units

### DIFF
--- a/packages/client/src/components/SessionSettings.tsx
+++ b/packages/client/src/components/SessionSettings.tsx
@@ -1,39 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
-import { useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
 import {
-  updateSessionMetadata,
-  restartAgentWorker,
-  deleteSession,
-  deleteWorktree,
-  openPath,
-  getSession,
-} from '../lib/api';
-import {
-  SettingsIcon,
-  EditIcon,
-  RefreshIcon,
-  FolderIcon,
-  CopyIcon,
-  CloseIcon,
-  TrashIcon,
-} from './Icons';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from './ui/dialog';
-import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogAction,
-  AlertDialogCancel,
-} from './ui/alert-dialog';
+  SessionSettingsMenu,
+  EditSessionDialog,
+  RestartSessionDialog,
+  CloseSessionDialog,
+  DeleteWorktreeDialog,
+  type MenuAction,
+} from './session-settings';
 
 interface SessionSettingsProps {
   sessionId: string;
@@ -46,7 +19,7 @@ interface SessionSettingsProps {
   onSessionRestart?: () => void;
 }
 
-type DialogType = 'edit' | 'close' | 'restart' | 'delete-worktree' | 'confirm-restart' | null;
+type DialogType = MenuAction | null;
 
 export function SessionSettings({
   sessionId,
@@ -58,460 +31,53 @@ export function SessionSettings({
   onTitleChange,
   onSessionRestart,
 }: SessionSettingsProps) {
-  const navigate = useNavigate();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [activeDialog, setActiveDialog] = useState<DialogType>(null);
-  const [branchName, setBranchName] = useState(currentBranch);
-  const [sessionTitle, setSessionTitle] = useState(currentTitle ?? '');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [copySuccess, setCopySuccess] = useState(false);
 
-  // Sync with current values when they change externally
-  useEffect(() => {
-    setBranchName(currentBranch);
-  }, [currentBranch]);
+  const handleMenuAction = (action: MenuAction) => {
+    setActiveDialog(action);
+  };
 
-  useEffect(() => {
-    setSessionTitle(currentTitle ?? '');
-  }, [currentTitle]);
-
-  // Close menu on escape key or clicking outside
-  useEffect(() => {
-    if (!isMenuOpen) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setIsMenuOpen(false);
-      }
-    };
-
-    const handleClickOutside = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (!target.closest('[data-settings-menu]')) {
-        setIsMenuOpen(false);
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    const timeout = setTimeout(() => {
-      document.addEventListener('mousedown', handleClickOutside);
-    }, 0);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      clearTimeout(timeout);
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isMenuOpen]);
-
-  const handleCloseDialog = useCallback(() => {
+  const closeDialog = () => {
     setActiveDialog(null);
-    setBranchName(currentBranch);
-    setSessionTitle(currentTitle ?? '');
-    setError(null);
-  }, [currentBranch, currentTitle]);
-
-  // Check if branch has changed
-  const branchChanged = branchName.trim() !== currentBranch;
-  const titleChanged = sessionTitle.trim() !== (currentTitle ?? '');
-
-  const handleEditSaveClick = () => {
-    const trimmedBranch = branchName.trim();
-
-    if (!trimmedBranch) {
-      setError('Branch name is required');
-      return;
-    }
-
-    // Validate branch name (basic git branch name rules)
-    if (!/^[a-zA-Z0-9._/-]+$/.test(trimmedBranch)) {
-      setError(
-        'Invalid branch name. Use alphanumeric, dots, underscores, slashes, or hyphens.'
-      );
-      return;
-    }
-
-    // If no changes, just close
-    if (!branchChanged && !titleChanged) {
-      handleCloseDialog();
-      return;
-    }
-
-    // If branch changed, show confirmation dialog
-    if (branchChanged) {
-      setActiveDialog('confirm-restart');
-      return;
-    }
-
-    // Only title changed - save directly
-    handleEditSubmit();
-  };
-
-  const handleEditSubmit = async () => {
-    setIsSubmitting(true);
-    setError(null);
-
-    try {
-      const updates: { title?: string; branch?: string } = {};
-
-      if (titleChanged) {
-        updates.title = sessionTitle.trim();
-      }
-      if (branchChanged) {
-        updates.branch = branchName.trim();
-      }
-
-      const result = await updateSessionMetadata(sessionId, updates);
-
-      if (result.title !== undefined && onTitleChange) {
-        onTitleChange(result.title);
-      }
-      if (result.branch) {
-        onBranchChange(result.branch);
-      }
-      setActiveDialog(null);
-
-      // Notify parent that session was restarted (server does this automatically when branch changes)
-      if (branchChanged && onSessionRestart) {
-        onSessionRestart();
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to update session');
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleRestart = async (continueConversation: boolean) => {
-    setIsSubmitting(true);
-    setError(null);
-
-    try {
-      // Get the session to find the first agent worker
-      const session = await getSession(sessionId);
-      if (!session) {
-        throw new Error('Session not found');
-      }
-      const agentWorker = session.workers.find(w => w.type === 'agent');
-      if (!agentWorker) {
-        throw new Error('No agent worker found');
-      }
-      await restartAgentWorker(sessionId, agentWorker.id, continueConversation);
-      setActiveDialog(null);
-      if (onSessionRestart) {
-        onSessionRestart();
-      }
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to restart session'
-      );
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleCloseSession = async () => {
-    setIsSubmitting(true);
-    setError(null);
-
-    try {
-      await deleteSession(sessionId);
-      setActiveDialog(null);
-      navigate({ to: '/' });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to close session');
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleDeleteWorktree = async (force: boolean = false) => {
-    setIsSubmitting(true);
-    setError(null);
-
-    try {
-      // Server-side deleteWorktree also terminates any running sessions
-      await deleteWorktree(repositoryId, worktreePath, force);
-      setActiveDialog(null);
-      navigate({ to: '/' });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to delete worktree';
-      // If deletion failed without force and error mentions untracked files, show retry option
-      if (!force && message.includes('untracked')) {
-        setError('Worktree has untracked files. Click "Force Delete" to proceed anyway.');
-      } else {
-        setError(message);
-      }
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleOpenInFinder = async () => {
-    setIsMenuOpen(false);
-    try {
-      await openPath(worktreePath);
-    } catch (err) {
-      console.error('Failed to open path:', err);
-    }
-  };
-
-  const handleCopyPath = async () => {
-    try {
-      await navigator.clipboard.writeText(worktreePath);
-      setCopySuccess(true);
-      setTimeout(() => setCopySuccess(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy path:', err);
-    }
-    setIsMenuOpen(false);
-  };
-
-  const openDialog = (type: DialogType) => {
-    setIsMenuOpen(false);
-    setActiveDialog(type);
   };
 
   return (
-    <div className="relative" data-settings-menu>
-      {/* Settings button */}
-      <button
-        onClick={() => setIsMenuOpen(!isMenuOpen)}
-        className="text-gray-400 hover:text-white p-1.5 hover:bg-slate-700 rounded"
-        title="Session settings"
-      >
-        <SettingsIcon />
-      </button>
+    <>
+      <SessionSettingsMenu
+        worktreePath={worktreePath}
+        onMenuAction={handleMenuAction}
+      />
 
-      {/* Dropdown menu */}
-      {isMenuOpen && (
-        <div className="absolute right-0 top-full mt-1 w-48 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-50">
-          <div className="py-1">
-            <button
-              onClick={() => openDialog('edit')}
-              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
-            >
-              <EditIcon />
-              Edit Session
-            </button>
-            <button
-              onClick={() => openDialog('restart')}
-              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
-            >
-              <RefreshIcon />
-              Restart Session
-            </button>
-            <div className="border-t border-slate-700 my-1" />
-            <button
-              onClick={handleOpenInFinder}
-              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
-            >
-              <FolderIcon />
-              Open in Finder
-            </button>
-            <button
-              onClick={handleCopyPath}
-              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
-            >
-              <CopyIcon />
-              {copySuccess ? 'Copied!' : 'Copy Path'}
-            </button>
-            <div className="border-t border-slate-700 my-1" />
-            <button
-              onClick={() => openDialog('close')}
-              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
-            >
-              <CloseIcon />
-              Close Session
-            </button>
-            <button
-              onClick={() => openDialog('delete-worktree')}
-              className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2"
-            >
-              <TrashIcon />
-              Delete Worktree
-            </button>
-          </div>
-        </div>
-      )}
+      <EditSessionDialog
+        open={activeDialog === 'edit'}
+        onOpenChange={(open) => !open && closeDialog()}
+        sessionId={sessionId}
+        currentBranch={currentBranch}
+        currentTitle={currentTitle}
+        onBranchChange={onBranchChange}
+        onTitleChange={onTitleChange}
+        onSessionRestart={onSessionRestart}
+      />
 
-      {/* Edit Session Dialog */}
-      <Dialog open={activeDialog === 'edit'} onOpenChange={(open) => !open && handleCloseDialog()}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit Session</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm text-gray-400 mb-2">
-                Title
-              </label>
-              <input
-                type="text"
-                value={sessionTitle}
-                onChange={(e) => setSessionTitle(e.target.value)}
-                className="input w-full"
-                placeholder="Session title (optional)"
-                autoFocus
-              />
-            </div>
-            <div>
-              <label className="block text-sm text-gray-400 mb-2">
-                Branch Name
-              </label>
-              <input
-                type="text"
-                value={branchName}
-                onChange={(e) => setBranchName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !isSubmitting) {
-                    handleEditSaveClick();
-                  }
-                }}
-                className="input w-full"
-                placeholder="Enter branch name"
-              />
-              {error && <p className="text-sm text-red-400 mt-1">{error}</p>}
-            </div>
-          </div>
-          <DialogFooter>
-            <button
-              onClick={handleCloseDialog}
-              className="btn bg-slate-600 hover:bg-slate-500"
-              disabled={isSubmitting}
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleEditSaveClick}
-              className="btn btn-primary"
-              disabled={isSubmitting}
-            >
-              {isSubmitting ? 'Saving...' : 'Save'}
-            </button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <RestartSessionDialog
+        open={activeDialog === 'restart'}
+        onOpenChange={(open) => !open && closeDialog()}
+        sessionId={sessionId}
+        onSessionRestart={onSessionRestart}
+      />
 
-      {/* Confirm Restart Dialog (shown when branch is changed) */}
-      <AlertDialog open={activeDialog === 'confirm-restart'} onOpenChange={(open) => !open && setActiveDialog('edit')}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Restart Required</AlertDialogTitle>
-            <AlertDialogDescription>
-              Branch name change requires restarting the agent. Do you want to continue?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          {error && <p className="text-sm text-red-400">{error}</p>}
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isSubmitting}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction onClick={handleEditSubmit} disabled={isSubmitting}>
-              {isSubmitting ? 'Saving...' : 'Restart & Save'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <CloseSessionDialog
+        open={activeDialog === 'close'}
+        onOpenChange={(open) => !open && closeDialog()}
+        sessionId={sessionId}
+      />
 
-      {/* Restart Session Dialog */}
-      <AlertDialog open={activeDialog === 'restart'} onOpenChange={(open) => !open && handleCloseDialog()}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Restart Session</AlertDialogTitle>
-            <AlertDialogDescription>
-              How would you like to restart this session?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          {error && <p className="text-sm text-red-400">{error}</p>}
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isSubmitting}>
-              Cancel
-            </AlertDialogCancel>
-            <button
-              onClick={() => handleRestart(false)}
-              className="btn bg-slate-600 hover:bg-slate-500"
-              disabled={isSubmitting}
-            >
-              New Session
-            </button>
-            <AlertDialogAction onClick={() => handleRestart(true)} disabled={isSubmitting}>
-              {isSubmitting ? 'Restarting...' : 'Continue (-c)'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Close Session Dialog */}
-      <AlertDialog open={activeDialog === 'close'} onOpenChange={(open) => !open && handleCloseDialog()}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Close Session</AlertDialogTitle>
-            <AlertDialogDescription asChild>
-              <div className="space-y-2">
-                <p>Are you sure you want to close this session?</p>
-                <p className="text-xs text-gray-500">
-                  This will stop the Claude process. The worktree will remain and
-                  you can start a new session from it later.
-                </p>
-              </div>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          {error && <p className="text-sm text-red-400">{error}</p>}
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isSubmitting}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction onClick={handleCloseSession} disabled={isSubmitting}>
-              {isSubmitting ? 'Closing...' : 'Close'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Delete Worktree Dialog */}
-      <AlertDialog open={activeDialog === 'delete-worktree'} onOpenChange={(open) => !open && handleCloseDialog()}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle className="text-red-400">Delete Worktree</AlertDialogTitle>
-            <AlertDialogDescription asChild>
-              <div className="space-y-2">
-                <p>Are you sure you want to delete this worktree?</p>
-                <p className="text-xs text-gray-500">
-                  This will permanently delete the worktree directory and all its contents.
-                </p>
-                <p className="text-xs text-red-400">
-                  This action cannot be undone.
-                </p>
-              </div>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          {error && <p className="text-sm text-red-400">{error}</p>}
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isSubmitting}>
-              Cancel
-            </AlertDialogCancel>
-            {error?.includes('untracked') ? (
-              <button
-                onClick={() => handleDeleteWorktree(true)}
-                className="btn btn-danger"
-                disabled={isSubmitting}
-              >
-                {isSubmitting ? 'Deleting...' : 'Force Delete'}
-              </button>
-            ) : (
-              <button
-                onClick={() => handleDeleteWorktree(false)}
-                className="btn btn-danger"
-                disabled={isSubmitting}
-              >
-                {isSubmitting ? 'Deleting...' : 'Delete Worktree'}
-              </button>
-            )}
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </div>
+      <DeleteWorktreeDialog
+        open={activeDialog === 'delete-worktree'}
+        onOpenChange={(open) => !open && closeDialog()}
+        repositoryId={repositoryId}
+        worktreePath={worktreePath}
+      />
+    </>
   );
 }

--- a/packages/client/src/components/session-settings/CloseSessionDialog.tsx
+++ b/packages/client/src/components/session-settings/CloseSessionDialog.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from '../ui/alert-dialog';
+import { deleteSession } from '../../lib/api';
+
+export interface CloseSessionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sessionId: string;
+}
+
+export function CloseSessionDialog({
+  open,
+  onOpenChange,
+  sessionId,
+}: CloseSessionDialogProps) {
+  const navigate = useNavigate();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCloseSession = async () => {
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await deleteSession(sessionId);
+      onOpenChange(false);
+      navigate({ to: '/' });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to close session');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    setError(null);
+    onOpenChange(false);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleClose}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Close Session</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p>Are you sure you want to close this session?</p>
+              <p className="text-xs text-gray-500">
+                This will stop the Claude process. The worktree will remain and
+                you can start a new session from it later.
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isSubmitting}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={handleCloseSession} disabled={isSubmitting}>
+            {isSubmitting ? 'Closing...' : 'Close'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/client/src/components/session-settings/DeleteWorktreeDialog.tsx
+++ b/packages/client/src/components/session-settings/DeleteWorktreeDialog.tsx
@@ -1,0 +1,109 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+} from '../ui/alert-dialog';
+import { deleteWorktree } from '../../lib/api';
+
+export interface DeleteWorktreeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  repositoryId: string;
+  worktreePath: string;
+}
+
+export function DeleteWorktreeDialog({
+  open,
+  onOpenChange,
+  repositoryId,
+  worktreePath,
+}: DeleteWorktreeDialogProps) {
+  const navigate = useNavigate();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset error when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setError(null);
+    }
+  }, [open]);
+
+  const handleDeleteWorktree = async (force: boolean = false) => {
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      // Server-side deleteWorktree also terminates any running sessions
+      await deleteWorktree(repositoryId, worktreePath, force);
+      onOpenChange(false);
+      navigate({ to: '/' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete worktree';
+      // If deletion failed without force and error mentions untracked files, show retry option
+      if (!force && message.includes('untracked')) {
+        setError('Worktree has untracked files. Click "Force Delete" to proceed anyway.');
+      } else {
+        setError(message);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const showForceDelete = error?.includes('untracked');
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleClose}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-red-400">Delete Worktree</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p>Are you sure you want to delete this worktree?</p>
+              <p className="text-xs text-gray-500">
+                This will permanently delete the worktree directory and all its contents.
+              </p>
+              <p className="text-xs text-red-400">
+                This action cannot be undone.
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isSubmitting}>
+            Cancel
+          </AlertDialogCancel>
+          {showForceDelete ? (
+            <button
+              onClick={() => handleDeleteWorktree(true)}
+              className="btn btn-danger"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? 'Deleting...' : 'Force Delete'}
+            </button>
+          ) : (
+            <button
+              onClick={() => handleDeleteWorktree(false)}
+              className="btn btn-danger"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? 'Deleting...' : 'Delete Worktree'}
+            </button>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/client/src/components/session-settings/EditSessionDialog.tsx
+++ b/packages/client/src/components/session-settings/EditSessionDialog.tsx
@@ -1,0 +1,225 @@
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '../ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from '../ui/alert-dialog';
+import { updateSessionMetadata } from '../../lib/api';
+
+export interface EditSessionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sessionId: string;
+  currentBranch: string;
+  currentTitle?: string;
+  onBranchChange: (newBranch: string) => void;
+  onTitleChange?: (newTitle: string) => void;
+  onSessionRestart?: () => void;
+}
+
+type DialogMode = 'edit' | 'confirm-restart';
+
+export function EditSessionDialog({
+  open,
+  onOpenChange,
+  sessionId,
+  currentBranch,
+  currentTitle,
+  onBranchChange,
+  onTitleChange,
+  onSessionRestart,
+}: EditSessionDialogProps) {
+  const [mode, setMode] = useState<DialogMode>('edit');
+  const [branchName, setBranchName] = useState(currentBranch);
+  const [sessionTitle, setSessionTitle] = useState(currentTitle ?? '');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Sync with current values when they change externally
+  useEffect(() => {
+    setBranchName(currentBranch);
+  }, [currentBranch]);
+
+  useEffect(() => {
+    setSessionTitle(currentTitle ?? '');
+  }, [currentTitle]);
+
+  // Reset state when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setMode('edit');
+      setBranchName(currentBranch);
+      setSessionTitle(currentTitle ?? '');
+      setError(null);
+    }
+  }, [open, currentBranch, currentTitle]);
+
+  const branchChanged = branchName.trim() !== currentBranch;
+  const titleChanged = sessionTitle.trim() !== (currentTitle ?? '');
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const handleSaveClick = () => {
+    const trimmedBranch = branchName.trim();
+
+    if (!trimmedBranch) {
+      setError('Branch name is required');
+      return;
+    }
+
+    // Validate branch name (basic git branch name rules)
+    if (!/^[a-zA-Z0-9._/-]+$/.test(trimmedBranch)) {
+      setError(
+        'Invalid branch name. Use alphanumeric, dots, underscores, slashes, or hyphens.'
+      );
+      return;
+    }
+
+    // If no changes, just close
+    if (!branchChanged && !titleChanged) {
+      handleClose();
+      return;
+    }
+
+    // If branch changed, show confirmation dialog
+    if (branchChanged) {
+      setMode('confirm-restart');
+      return;
+    }
+
+    // Only title changed - save directly
+    handleSubmit();
+  };
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const updates: { title?: string; branch?: string } = {};
+
+      if (titleChanged) {
+        updates.title = sessionTitle.trim();
+      }
+      if (branchChanged) {
+        updates.branch = branchName.trim();
+      }
+
+      const result = await updateSessionMetadata(sessionId, updates);
+
+      if (result.title !== undefined && onTitleChange) {
+        onTitleChange(result.title);
+      }
+      if (result.branch) {
+        onBranchChange(result.branch);
+      }
+      onOpenChange(false);
+
+      // Notify parent that session was restarted (server does this automatically when branch changes)
+      if (branchChanged && onSessionRestart) {
+        onSessionRestart();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update session');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (mode === 'confirm-restart') {
+    return (
+      <AlertDialog open={open} onOpenChange={() => setMode('edit')}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restart Required</AlertDialogTitle>
+            <AlertDialogDescription>
+              Branch name change requires restarting the agent. Do you want to continue?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {error && <p className="text-sm text-red-400">{error}</p>}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isSubmitting}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={handleSubmit} disabled={isSubmitting}>
+              {isSubmitting ? 'Saving...' : 'Restart & Save'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Session</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-2">
+              Title
+            </label>
+            <input
+              type="text"
+              value={sessionTitle}
+              onChange={(e) => setSessionTitle(e.target.value)}
+              className="input w-full"
+              placeholder="Session title (optional)"
+              autoFocus
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-2">
+              Branch Name
+            </label>
+            <input
+              type="text"
+              value={branchName}
+              onChange={(e) => setBranchName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !isSubmitting) {
+                  handleSaveClick();
+                }
+              }}
+              className="input w-full"
+              placeholder="Enter branch name"
+            />
+            {error && <p className="text-sm text-red-400 mt-1">{error}</p>}
+          </div>
+        </div>
+        <DialogFooter>
+          <button
+            onClick={handleClose}
+            className="btn bg-slate-600 hover:bg-slate-500"
+            disabled={isSubmitting}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSaveClick}
+            className="btn btn-primary"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Saving...' : 'Save'}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/session-settings/RestartSessionDialog.tsx
+++ b/packages/client/src/components/session-settings/RestartSessionDialog.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from '../ui/alert-dialog';
+import { restartAgentWorker, getSession } from '../../lib/api';
+
+export interface RestartSessionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sessionId: string;
+  onSessionRestart?: () => void;
+}
+
+export function RestartSessionDialog({
+  open,
+  onOpenChange,
+  sessionId,
+  onSessionRestart,
+}: RestartSessionDialogProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleRestart = async (continueConversation: boolean) => {
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      // Get the session to find the first agent worker
+      const session = await getSession(sessionId);
+      if (!session) {
+        throw new Error('Session not found');
+      }
+      const agentWorker = session.workers.find(w => w.type === 'agent');
+      if (!agentWorker) {
+        throw new Error('No agent worker found');
+      }
+      await restartAgentWorker(sessionId, agentWorker.id, continueConversation);
+      onOpenChange(false);
+      if (onSessionRestart) {
+        onSessionRestart();
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to restart session'
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    setError(null);
+    onOpenChange(false);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleClose}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Restart Session</AlertDialogTitle>
+          <AlertDialogDescription>
+            How would you like to restart this session?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isSubmitting}>
+            Cancel
+          </AlertDialogCancel>
+          <button
+            onClick={() => handleRestart(false)}
+            className="btn bg-slate-600 hover:bg-slate-500"
+            disabled={isSubmitting}
+          >
+            New Session
+          </button>
+          <AlertDialogAction onClick={() => handleRestart(true)} disabled={isSubmitting}>
+            {isSubmitting ? 'Restarting...' : 'Continue (-c)'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/client/src/components/session-settings/SessionSettingsMenu.tsx
+++ b/packages/client/src/components/session-settings/SessionSettingsMenu.tsx
@@ -1,0 +1,145 @@
+import { useState, useEffect } from 'react';
+import {
+  SettingsIcon,
+  EditIcon,
+  RefreshIcon,
+  FolderIcon,
+  CopyIcon,
+  CloseIcon,
+  TrashIcon,
+} from '../Icons';
+import { openPath } from '../../lib/api';
+
+export type MenuAction = 'edit' | 'restart' | 'close' | 'delete-worktree';
+
+export interface SessionSettingsMenuProps {
+  worktreePath: string;
+  onMenuAction: (action: MenuAction) => void;
+}
+
+export function SessionSettingsMenu({
+  worktreePath,
+  onMenuAction,
+}: SessionSettingsMenuProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [copySuccess, setCopySuccess] = useState(false);
+
+  // Close menu on escape key or clicking outside
+  useEffect(() => {
+    if (!isMenuOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsMenuOpen(false);
+      }
+    };
+
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest('[data-settings-menu]')) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    const timeout = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 0);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      clearTimeout(timeout);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isMenuOpen]);
+
+  const handleOpenInFinder = async () => {
+    setIsMenuOpen(false);
+    try {
+      await openPath(worktreePath);
+    } catch (err) {
+      console.error('Failed to open path:', err);
+    }
+  };
+
+  const handleCopyPath = async () => {
+    try {
+      await navigator.clipboard.writeText(worktreePath);
+      setCopySuccess(true);
+      setTimeout(() => setCopySuccess(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy path:', err);
+    }
+    setIsMenuOpen(false);
+  };
+
+  const handleMenuAction = (action: MenuAction) => {
+    setIsMenuOpen(false);
+    onMenuAction(action);
+  };
+
+  return (
+    <div className="relative" data-settings-menu>
+      {/* Settings button */}
+      <button
+        onClick={() => setIsMenuOpen(!isMenuOpen)}
+        className="text-gray-400 hover:text-white p-1.5 hover:bg-slate-700 rounded"
+        title="Session settings"
+      >
+        <SettingsIcon />
+      </button>
+
+      {/* Dropdown menu */}
+      {isMenuOpen && (
+        <div className="absolute right-0 top-full mt-1 w-48 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-50">
+          <div className="py-1">
+            <button
+              onClick={() => handleMenuAction('edit')}
+              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
+            >
+              <EditIcon />
+              Edit Session
+            </button>
+            <button
+              onClick={() => handleMenuAction('restart')}
+              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
+            >
+              <RefreshIcon />
+              Restart Session
+            </button>
+            <div className="border-t border-slate-700 my-1" />
+            <button
+              onClick={handleOpenInFinder}
+              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
+            >
+              <FolderIcon />
+              Open in Finder
+            </button>
+            <button
+              onClick={handleCopyPath}
+              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
+            >
+              <CopyIcon />
+              {copySuccess ? 'Copied!' : 'Copy Path'}
+            </button>
+            <div className="border-t border-slate-700 my-1" />
+            <button
+              onClick={() => handleMenuAction('close')}
+              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
+            >
+              <CloseIcon />
+              Close Session
+            </button>
+            <button
+              onClick={() => handleMenuAction('delete-worktree')}
+              className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2"
+            >
+              <TrashIcon />
+              Delete Worktree
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/session-settings/index.ts
+++ b/packages/client/src/components/session-settings/index.ts
@@ -1,0 +1,14 @@
+export { EditSessionDialog } from './EditSessionDialog';
+export type { EditSessionDialogProps } from './EditSessionDialog';
+
+export { RestartSessionDialog } from './RestartSessionDialog';
+export type { RestartSessionDialogProps } from './RestartSessionDialog';
+
+export { CloseSessionDialog } from './CloseSessionDialog';
+export type { CloseSessionDialogProps } from './CloseSessionDialog';
+
+export { DeleteWorktreeDialog } from './DeleteWorktreeDialog';
+export type { DeleteWorktreeDialogProps } from './DeleteWorktreeDialog';
+
+export { SessionSettingsMenu } from './SessionSettingsMenu';
+export type { SessionSettingsMenuProps, MenuAction } from './SessionSettingsMenu';


### PR DESCRIPTION
## Summary
- Extract `EditSessionDialog` component (with confirm-restart mode)
- Extract `RestartSessionDialog` component
- Extract `CloseSessionDialog` component
- Extract `DeleteWorktreeDialog` component
- Extract `SessionSettingsMenu` component
- Reduce `SessionSettings.tsx` from 518 lines to 84 lines
- Use shadcn/ui Dialog and AlertDialog components

## Test plan
- [x] Type check passes (`bun run typecheck`)
- [x] All tests pass (`bun run test:only`)
- [x] Manual verification: Edit Session dialog opens and displays correctly
- [x] Manual verification: Restart Session dialog opens with 3 options
- [x] Manual verification: Close Session dialog opens with confirmation message
- [x] Manual verification: Delete Worktree dialog opens with warning message

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)