### PR TITLE
feat: integrate valibot schema validation with React Hook Form

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@agent-console/shared": "*",
+        "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@tanstack/react-query": "^5.62.2",
@@ -24,7 +25,9 @@
         "clsx": "^2.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.68.0",
         "tailwind-merge": "^3.4.0",
+        "valibot": "^1.2.0",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.0.11",
@@ -53,6 +56,7 @@
         "hono": "^4.6.13",
         "open": "^11.0.0",
         "uuid": "^11.0.3",
+        "valibot": "^1.2.0",
       },
       "devDependencies": {
         "@types/bun": "^1.1.14",
@@ -67,7 +71,11 @@
     "packages/shared": {
       "name": "@agent-console/shared",
       "version": "0.1.0",
+      "dependencies": {
+        "valibot": "^1.2.0",
+      },
       "devDependencies": {
+        "@types/bun": "^1.3.4",
         "typescript": "^5.7.2",
       },
     },
@@ -197,6 +205,8 @@
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.11", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.11" } }, "sha512-GqNqiShBT/lzkHTMC/slKBrvN0DsD4Di8ssBk4aDaVgEn+2WMzE6DXxq701ndSXj7/0cJ8mNT71pM7Bnrr6JRw=="],
 
+    "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -300,6 +310,8 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.17", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.17" } }, "sha512-csIkHIgLb3JisEFQ0vxr2Y57GUNYh447C8xzwj89U/8fdW8LhProdxvnVH6U8M2Y73QKiTIH+LWbK3V2BBZsAg=="],
 
@@ -591,6 +603,8 @@
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
+    "react-hook-form": ["react-hook-form@7.68.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q=="],
+
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
@@ -660,6 +674,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@agent-console/shared": "*",
+    "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@tanstack/react-query": "^5.62.2",
@@ -24,7 +25,9 @@
     "clsx": "^2.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "tailwind-merge": "^3.4.0"
+    "react-hook-form": "^7.68.0",
+    "tailwind-merge": "^3.4.0",
+    "valibot": "^1.2.0"
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "^20.0.11",

--- a/packages/client/src/components/forms/AddRepositoryForm.tsx
+++ b/packages/client/src/components/forms/AddRepositoryForm.tsx
@@ -1,0 +1,74 @@
+import { useForm } from 'react-hook-form';
+import { valibotResolver } from '@hookform/resolvers/valibot';
+import { FormField, Input } from '../ui/FormField';
+import type { CreateRepositoryRequest } from '@agent-console/shared';
+import { CreateRepositoryRequestSchema } from '@agent-console/shared';
+
+export interface AddRepositoryFormProps {
+  isPending: boolean;
+  onSubmit: (data: CreateRepositoryRequest) => Promise<void>;
+  onCancel: () => void;
+}
+
+export function AddRepositoryForm({
+  isPending,
+  onSubmit,
+  onCancel,
+}: AddRepositoryFormProps) {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<CreateRepositoryRequest>({
+    resolver: valibotResolver(CreateRepositoryRequestSchema),
+    defaultValues: { path: '' },
+    mode: 'onBlur',
+  });
+
+  const handleFormSubmit = async (data: CreateRepositoryRequest) => {
+    try {
+      await onSubmit(data);
+    } catch (err) {
+      setError('root', {
+        message: err instanceof Error ? err.message : 'Failed to register repository',
+      });
+    }
+  };
+
+  return (
+    <div className="card mb-5">
+      <h2 className="mb-3 text-lg font-medium">Add Repository</h2>
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        <div className="flex gap-3 items-start">
+          <div className="flex-1">
+            <FormField error={errors.path}>
+              <Input
+                {...register('path')}
+                placeholder="Repository path (e.g., /path/to/repo)"
+                error={errors.path}
+              />
+            </FormField>
+            {errors.root && (
+              <p className="text-sm text-red-400 mt-1" role="alert">{errors.root.message}</p>
+            )}
+          </div>
+          <button
+            type="submit"
+            disabled={isPending}
+            className="btn btn-primary"
+          >
+            {isPending ? 'Adding...' : 'Add'}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="btn btn-danger"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/packages/client/src/components/forms/CreateWorktreeForm.tsx
+++ b/packages/client/src/components/forms/CreateWorktreeForm.tsx
@@ -1,0 +1,205 @@
+import { useForm } from 'react-hook-form';
+import { valibotResolver } from '@hookform/resolvers/valibot';
+import { FormField, Input, Textarea } from '../ui/FormField';
+import { AgentSelector } from '../AgentSelector';
+import type { CreateWorktreeFormData } from '../../schemas/worktree-form';
+import { CreateWorktreeFormSchema } from '../../schemas/worktree-form';
+import type { CreateWorktreeRequest } from '@agent-console/shared';
+
+export interface CreateWorktreeFormProps {
+  defaultBranch: string;
+  isPending: boolean;
+  onSubmit: (request: CreateWorktreeRequest) => Promise<void>;
+  onCancel: () => void;
+}
+
+export function CreateWorktreeForm({
+  defaultBranch,
+  isPending,
+  onSubmit,
+  onCancel,
+}: CreateWorktreeFormProps) {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<CreateWorktreeFormData>({
+    resolver: valibotResolver(CreateWorktreeFormSchema),
+    defaultValues: {
+      branchNameMode: 'prompt',
+      initialPrompt: '',
+      customBranch: '',
+      baseBranch: '',
+      sessionTitle: '',
+      agentId: undefined,
+    },
+    mode: 'onBlur',
+  });
+
+  const branchNameMode = watch('branchNameMode');
+  const initialPrompt = watch('initialPrompt');
+
+  const handleFormSubmit = async (data: CreateWorktreeFormData) => {
+    try {
+      let request: CreateWorktreeRequest;
+
+      switch (data.branchNameMode) {
+        case 'prompt':
+          request = {
+            mode: 'prompt',
+            initialPrompt: data.initialPrompt!.trim(),
+            baseBranch: data.baseBranch?.trim() || undefined,
+            autoStartSession: true,
+            agentId: data.agentId,
+            title: data.sessionTitle?.trim() || undefined,
+          };
+          break;
+        case 'custom':
+          request = {
+            mode: 'custom',
+            branch: data.customBranch!.trim(),
+            baseBranch: data.baseBranch?.trim() || undefined,
+            autoStartSession: true,
+            agentId: data.agentId,
+            initialPrompt: data.initialPrompt?.trim() || undefined,
+            title: data.sessionTitle?.trim() || undefined,
+          };
+          break;
+        case 'existing':
+          request = {
+            mode: 'existing',
+            branch: data.customBranch!.trim(),
+            autoStartSession: true,
+            agentId: data.agentId,
+            initialPrompt: data.initialPrompt?.trim() || undefined,
+            title: data.sessionTitle?.trim() || undefined,
+          };
+          break;
+      }
+      await onSubmit(request);
+    } catch (err) {
+      setError('root', {
+        message: err instanceof Error ? err.message : 'Failed to create worktree',
+      });
+    }
+  };
+
+  return (
+    <div className={`bg-slate-800 p-4 rounded mb-4 ${isPending ? 'opacity-70' : ''}`}>
+      <h3 className="text-sm font-medium mb-3">
+        {isPending ? 'Creating Worktree...' : 'Create Worktree'}
+      </h3>
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        <fieldset disabled={isPending} className="flex flex-col gap-3">
+          {/* Initial prompt input (available for all modes) */}
+          <FormField label="Initial prompt (optional)" error={errors.initialPrompt}>
+            <Textarea
+              {...register('initialPrompt')}
+              placeholder="What do you want to work on? (e.g., 'Add a dark mode toggle to the settings page')"
+              className="w-full min-h-[80px] resize-y"
+              rows={3}
+              error={errors.initialPrompt}
+            />
+          </FormField>
+
+          {/* Session title input */}
+          <FormField label="Title (optional)" error={errors.sessionTitle}>
+            <Input
+              {...register('sessionTitle')}
+              placeholder="Session title"
+              className="w-full"
+              error={errors.sessionTitle}
+            />
+            {initialPrompt?.trim() && (
+              <p className="text-xs text-gray-500 mt-1">Leave empty to generate from prompt</p>
+            )}
+          </FormField>
+
+          {/* Branch name mode selection */}
+          <fieldset className="flex flex-col gap-2 border-0 p-0 m-0">
+            <legend className="text-sm text-gray-400 mb-1">Branch name:</legend>
+            <label className={`text-sm flex items-center gap-2 ${!initialPrompt?.trim() ? 'text-gray-600' : 'text-gray-400'}`}>
+              <input
+                {...register('branchNameMode')}
+                type="radio"
+                value="prompt"
+                disabled={!initialPrompt?.trim()}
+              />
+              Generate from prompt {initialPrompt?.trim() ? '(recommended)' : '(requires prompt)'}
+            </label>
+            <label className="text-sm text-gray-400 flex items-center gap-2">
+              <input
+                {...register('branchNameMode')}
+                type="radio"
+                value="custom"
+              />
+              Custom name (new branch)
+            </label>
+            <label className="text-sm text-gray-400 flex items-center gap-2">
+              <input
+                {...register('branchNameMode')}
+                type="radio"
+                value="existing"
+              />
+              Use existing branch
+            </label>
+          </fieldset>
+
+          {/* Branch name input (only for custom/existing) */}
+          {(branchNameMode === 'custom' || branchNameMode === 'existing') && (
+            <FormField error={errors.customBranch}>
+              <Input
+                {...register('customBranch')}
+                placeholder={branchNameMode === 'custom' ? 'New branch name' : 'Existing branch name'}
+                error={errors.customBranch}
+              />
+            </FormField>
+          )}
+
+          {/* Base branch input (only for new branches) */}
+          {branchNameMode !== 'existing' && (
+            <FormField error={errors.baseBranch}>
+              <Input
+                {...register('baseBranch')}
+                placeholder={`Base branch (default: ${defaultBranch})`}
+                error={errors.baseBranch}
+              />
+            </FormField>
+          )}
+
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-400">Agent:</span>
+            <AgentSelector
+              value={watch('agentId')}
+              onChange={(value) => setValue('agentId', value)}
+              className="flex-1"
+            />
+          </div>
+
+          {errors.root && (
+            <p className="text-sm text-red-400" role="alert">{errors.root.message}</p>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="btn btn-primary text-sm"
+            >
+              {isPending ? 'Creating...' : 'Create & Start Session'}
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              className="btn btn-danger text-sm"
+            >
+              Cancel
+            </button>
+          </div>
+        </fieldset>
+      </form>
+    </div>
+  );
+}

--- a/packages/client/src/components/forms/QuickSessionForm.tsx
+++ b/packages/client/src/components/forms/QuickSessionForm.tsx
@@ -1,0 +1,91 @@
+import { useForm } from 'react-hook-form';
+import { valibotResolver } from '@hookform/resolvers/valibot';
+import { FormField, Input } from '../ui/FormField';
+import { AgentSelector } from '../AgentSelector';
+import type { CreateQuickSessionRequest } from '@agent-console/shared';
+import { CreateQuickSessionRequestSchema } from '@agent-console/shared';
+
+export interface QuickSessionFormProps {
+  isPending: boolean;
+  onSubmit: (data: CreateQuickSessionRequest) => Promise<void>;
+  onCancel: () => void;
+}
+
+export function QuickSessionForm({
+  isPending,
+  onSubmit,
+  onCancel,
+}: QuickSessionFormProps) {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<CreateQuickSessionRequest>({
+    resolver: valibotResolver(CreateQuickSessionRequestSchema),
+    defaultValues: {
+      type: 'quick',
+      locationPath: '',
+      agentId: undefined,
+    },
+    mode: 'onBlur',
+  });
+
+  const handleFormSubmit = async (data: CreateQuickSessionRequest) => {
+    try {
+      await onSubmit(data);
+    } catch (err) {
+      setError('root', {
+        message: err instanceof Error ? err.message : 'Failed to start session',
+      });
+    }
+  };
+
+  return (
+    <div className="card mb-4 bg-slate-800">
+      <h3 className="text-sm font-medium mb-3">Start Session in Any Directory</h3>
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        <input type="hidden" {...register('type')} value="quick" />
+        <div className="flex flex-col gap-3">
+          <FormField error={errors.locationPath}>
+            <Input
+              {...register('locationPath')}
+              placeholder="Path (e.g., /path/to/project)"
+              autoFocus
+              error={errors.locationPath}
+            />
+          </FormField>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-400">Agent:</span>
+            <AgentSelector
+              value={watch('agentId')}
+              onChange={(value) => setValue('agentId', value)}
+              className="flex-1"
+            />
+          </div>
+          {errors.root && (
+            <p className="text-sm text-red-400" role="alert">{errors.root.message}</p>
+          )}
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              disabled={isPending}
+              className="btn btn-primary text-sm"
+            >
+              {isPending ? 'Starting...' : 'Start'}
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              className="btn btn-danger text-sm"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/packages/client/src/components/forms/index.ts
+++ b/packages/client/src/components/forms/index.ts
@@ -1,0 +1,8 @@
+export { AddRepositoryForm } from './AddRepositoryForm';
+export type { AddRepositoryFormProps } from './AddRepositoryForm';
+
+export { CreateWorktreeForm } from './CreateWorktreeForm';
+export type { CreateWorktreeFormProps } from './CreateWorktreeForm';
+
+export { QuickSessionForm } from './QuickSessionForm';
+export type { QuickSessionFormProps } from './QuickSessionForm';

--- a/packages/client/src/components/ui/FormField.tsx
+++ b/packages/client/src/components/ui/FormField.tsx
@@ -1,0 +1,110 @@
+import type { FieldError } from 'react-hook-form';
+import type { InputHTMLAttributes, TextareaHTMLAttributes, SelectHTMLAttributes, ReactElement, ReactNode } from 'react';
+import { forwardRef, useId, isValidElement, cloneElement } from 'react';
+
+interface FormFieldProps {
+  label?: string;
+  error?: FieldError;
+  children: ReactNode;
+  /** Optional custom ID for the field. If not provided, one will be auto-generated. */
+  fieldId?: string;
+}
+
+/**
+ * Form field wrapper with label and error display.
+ * Provides accessibility features including:
+ * - Label association via htmlFor/id
+ * - Error message association via aria-describedby
+ * - Invalid state indication via aria-invalid
+ */
+export function FormField({ label, error, children, fieldId }: FormFieldProps) {
+  const generatedId = useId();
+  const id = fieldId ?? generatedId;
+  const errorId = `${id}-error`;
+
+  // Clone child element to inject accessibility props
+  const enhancedChildren = isValidElement(children)
+    ? cloneElement(children as ReactElement<{ id?: string; 'aria-invalid'?: boolean; 'aria-describedby'?: string }>, {
+        id,
+        'aria-invalid': error ? true : undefined,
+        'aria-describedby': error ? errorId : undefined,
+      })
+    : children;
+
+  return (
+    <div className="flex flex-col gap-1">
+      {label && (
+        <label htmlFor={id} className="text-sm text-gray-400">{label}</label>
+      )}
+      {enhancedChildren}
+      {error && (
+        <p id={errorId} className="text-sm text-red-400" role="alert">{error.message}</p>
+      )}
+    </div>
+  );
+}
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  error?: FieldError;
+}
+
+/**
+ * Input with error styling and accessibility support
+ */
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ error, className = '', 'aria-invalid': ariaInvalid, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        className={`input ${error ? 'border-red-500' : ''} ${className}`}
+        aria-invalid={ariaInvalid ?? (error ? true : undefined)}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  error?: FieldError;
+}
+
+/**
+ * Textarea with error styling and accessibility support
+ */
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ error, className = '', 'aria-invalid': ariaInvalid, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        className={`input ${error ? 'border-red-500' : ''} ${className}`}
+        aria-invalid={ariaInvalid ?? (error ? true : undefined)}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = 'Textarea';
+
+interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  error?: FieldError;
+}
+
+/**
+ * Select with error styling and accessibility support
+ */
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  ({ error, className = '', children, 'aria-invalid': ariaInvalid, ...props }, ref) => {
+    return (
+      <select
+        ref={ref}
+        className={`input ${error ? 'border-red-500' : ''} ${className}`}
+        aria-invalid={ariaInvalid ?? (error ? true : undefined)}
+        {...props}
+      >
+        {children}
+      </select>
+    );
+  }
+);
+Select.displayName = 'Select';

--- a/packages/client/src/schemas/__tests__/edit-session-form.test.ts
+++ b/packages/client/src/schemas/__tests__/edit-session-form.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'bun:test';
+import * as v from 'valibot';
+import { valibotResolver } from '@hookform/resolvers/valibot';
+import { EditSessionFormSchema } from '../edit-session-form';
+
+describe('EditSessionFormSchema', () => {
+  it('should validate with title only', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      title: 'New Title',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.title).toBe('New Title');
+      expect(result.output.branch).toBeUndefined();
+    }
+  });
+
+  it('should validate with branch only', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: 'feature/new-feature',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.branch).toBe('feature/new-feature');
+      expect(result.output.title).toBeUndefined();
+    }
+  });
+
+  it('should validate with both title and branch', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      title: 'New Title',
+      branch: 'feature/new-feature',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.title).toBe('New Title');
+      expect(result.output.branch).toBe('feature/new-feature');
+    }
+  });
+
+  it('should reject empty object (no fields)', () => {
+    const result = v.safeParse(EditSessionFormSchema, {});
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject when both fields are undefined', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      title: undefined,
+      branch: undefined,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should trim whitespace from title', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      title: '  New Title  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.title).toBe('New Title');
+    }
+  });
+
+  it('should trim whitespace from branch', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: '  feature/test  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.branch).toBe('feature/test');
+    }
+  });
+
+  it('should reject empty branch name', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject whitespace-only branch name', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept valid branch with slashes', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: 'feature/sub/branch',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept valid branch with dots', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: 'release-1.2.3',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept valid branch with underscores', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: 'feature_branch',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept valid branch with hyphens', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: 'feature-branch',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject branch with spaces', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: 'feature branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with special characters', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: 'feature@branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with unicode characters', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: 'feature/日本語',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // Type mismatch tests
+  it('should reject number for branch field', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      branch: 123,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject number for title field', () => {
+    const result = v.safeParse(EditSessionFormSchema, {
+      title: 456,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // valibotResolver integration tests
+  describe('valibotResolver behavior', () => {
+    it('should map v.forward() error to title field when both fields are undefined', async () => {
+      const resolver = valibotResolver(EditSessionFormSchema);
+      const result = await resolver(
+        {},
+        undefined,
+        { fields: {}, shouldUseNativeValidation: false }
+      );
+
+      // With v.forward(), the error should be mapped to the title field
+      expect(Object.keys(result.errors).length).toBeGreaterThan(0);
+      expect(result.errors.title).toBeDefined();
+      expect(result.errors.title?.message).toBe(
+        'At least one of title or branch must be provided'
+      );
+    });
+
+    it('should pass validation when title is provided', async () => {
+      const resolver = valibotResolver(EditSessionFormSchema);
+      const result = await resolver(
+        { title: 'Test Title' },
+        undefined,
+        { fields: {}, shouldUseNativeValidation: false }
+      );
+
+      expect(Object.keys(result.errors).length).toBe(0);
+      expect(result.values).toBeDefined();
+    });
+
+    it('should pass validation when branch is provided', async () => {
+      const resolver = valibotResolver(EditSessionFormSchema);
+      const result = await resolver(
+        { branch: 'feature/test' },
+        undefined,
+        { fields: {}, shouldUseNativeValidation: false }
+      );
+
+      expect(Object.keys(result.errors).length).toBe(0);
+      expect(result.values).toBeDefined();
+    });
+
+    it('should map branch validation error correctly', async () => {
+      const resolver = valibotResolver(EditSessionFormSchema);
+      const result = await resolver(
+        { branch: '' },
+        undefined,
+        { fields: {}, shouldUseNativeValidation: false }
+      );
+
+      expect(result.errors.branch).toBeDefined();
+      expect(result.errors.branch?.message).toBe('Branch name cannot be empty');
+    });
+  });
+});

--- a/packages/client/src/schemas/__tests__/worktree-form.test.ts
+++ b/packages/client/src/schemas/__tests__/worktree-form.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'bun:test';
+import * as v from 'valibot';
+import { valibotResolver } from '@hookform/resolvers/valibot';
+import { CreateWorktreeFormSchema } from '../worktree-form';
+
+describe('CreateWorktreeFormSchema', () => {
+  describe('prompt mode', () => {
+    it('should validate when prompt mode has initialPrompt', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'prompt',
+        initialPrompt: 'Add dark mode feature',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject when prompt mode has empty initialPrompt', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'prompt',
+        initialPrompt: '',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        // Check that the error is forwarded to initialPrompt field
+        expect(result.issues[0]?.message).toBe(
+          'Initial prompt is required when using "Generate from prompt" mode'
+        );
+        expect(result.issues[0]?.path?.[0]?.key).toBe('initialPrompt');
+      }
+    });
+
+    it('should reject when prompt mode has whitespace-only initialPrompt', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'prompt',
+        initialPrompt: '   ',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject when prompt mode has no initialPrompt', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'prompt',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('custom mode', () => {
+    it('should validate when custom mode has customBranch', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'custom',
+        customBranch: 'feature/new-feature',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject when custom mode has empty customBranch', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'custom',
+        customBranch: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject when custom mode has no customBranch', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'custom',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('existing mode', () => {
+    it('should validate when existing mode has customBranch', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'existing',
+        customBranch: 'main',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject when existing mode has empty customBranch', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'existing',
+        customBranch: '',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('branch name validation', () => {
+    it('should accept valid branch names', () => {
+      const validBranches = [
+        'feature/new-feature',
+        'fix/bug-123',
+        'release-1.2.3',
+        'feature_branch',
+        'main',
+      ];
+      for (const branch of validBranches) {
+        const result = v.safeParse(CreateWorktreeFormSchema, {
+          branchNameMode: 'custom',
+          customBranch: branch,
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it('should reject branch names with spaces', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'custom',
+        customBranch: 'feature branch',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject branch names with special characters', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'custom',
+        customBranch: 'feature@branch',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject branch names with Japanese characters', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'custom',
+        customBranch: 'feature/日本語',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should trim whitespace from branch names', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'custom',
+        customBranch: '  feature/test  ',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.output.customBranch).toBe('feature/test');
+      }
+    });
+  });
+
+  describe('v.forward() error path', () => {
+    it('should have field path for forwarded v.check() error', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'prompt',
+        initialPrompt: '',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        // v.forward() maps the error to the specified field path
+        const issue = result.issues[0];
+        expect(issue?.path).toBeDefined();
+        expect(issue?.path?.[0]?.key).toBe('initialPrompt');
+      }
+    });
+
+    it('should have customBranch path for custom mode error', () => {
+      const result = v.safeParse(CreateWorktreeFormSchema, {
+        branchNameMode: 'custom',
+        customBranch: '',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.issues[0];
+        expect(issue?.path).toBeDefined();
+        expect(issue?.path?.[0]?.key).toBe('customBranch');
+      }
+    });
+  });
+
+  describe('valibotResolver behavior', () => {
+    it('should map v.forward() error to field in React Hook Form', async () => {
+      const resolver = valibotResolver(CreateWorktreeFormSchema);
+      const result = await resolver(
+        {
+          branchNameMode: 'prompt',
+          initialPrompt: '',
+        },
+        undefined,
+        { fields: {}, shouldUseNativeValidation: false }
+      );
+
+      // With v.forward(), the error should now be mapped to the initialPrompt field
+      expect(Object.keys(result.errors).length).toBeGreaterThan(0);
+      expect(result.errors.initialPrompt).toBeDefined();
+      expect(result.errors.initialPrompt?.message).toBe(
+        'Initial prompt is required when using "Generate from prompt" mode'
+      );
+    });
+
+    it('should map customBranch required error when undefined', async () => {
+      const resolver = valibotResolver(CreateWorktreeFormSchema);
+      const result = await resolver(
+        {
+          branchNameMode: 'custom',
+          // customBranch is undefined
+        },
+        undefined,
+        { fields: {}, shouldUseNativeValidation: false }
+      );
+
+      expect(Object.keys(result.errors).length).toBeGreaterThan(0);
+      expect(result.errors.customBranch).toBeDefined();
+      expect(result.errors.customBranch?.message).toBe('Branch name is required');
+    });
+
+    it('should map customBranch regex error when invalid', async () => {
+      const resolver = valibotResolver(CreateWorktreeFormSchema);
+      const result = await resolver(
+        {
+          branchNameMode: 'custom',
+          customBranch: 'invalid branch@name',
+        },
+        undefined,
+        { fields: {}, shouldUseNativeValidation: false }
+      );
+
+      expect(Object.keys(result.errors).length).toBeGreaterThan(0);
+      expect(result.errors.customBranch).toBeDefined();
+      expect(result.errors.customBranch?.message).toContain('Invalid branch name');
+    });
+
+    it('should pass validation when data is valid', async () => {
+      const resolver = valibotResolver(CreateWorktreeFormSchema);
+      const result = await resolver(
+        {
+          branchNameMode: 'prompt',
+          initialPrompt: 'Add dark mode feature',
+        },
+        undefined,
+        { fields: {}, shouldUseNativeValidation: false }
+      );
+
+      expect(Object.keys(result.errors).length).toBe(0);
+      expect(result.values).toBeDefined();
+    });
+  });
+});

--- a/packages/client/src/schemas/edit-session-form.ts
+++ b/packages/client/src/schemas/edit-session-form.ts
@@ -1,0 +1,42 @@
+import * as v from 'valibot';
+import { branchNamePattern, branchNameErrorMessage } from '@agent-console/shared';
+
+/**
+ * Schema for the edit session form.
+ * At least one of title or branch must be provided.
+ *
+ * IMPORTANT: Cross-field validation with v.forward()
+ *
+ * When using v.check() at the pipe level for cross-field validation, the error has
+ * `path: undefined` (root-level error). However, @hookform/resolvers/valibot (v5.2.2)
+ * does not map root-level errors to React Hook Form's errors object - they are silently
+ * ignored, causing the form to submit despite validation failure.
+ *
+ * Workaround: Use v.forward() to explicitly assign errors to a specific field path.
+ * This is also the recommended approach in Valibot documentation for cross-field validation.
+ *
+ * @see https://valibot.dev/api/forward/
+ */
+export const EditSessionFormSchema = v.pipe(
+  v.object({
+    title: v.optional(v.pipe(v.string(), v.trim())),
+    branch: v.optional(
+      v.pipe(
+        v.string(),
+        v.trim(),
+        v.minLength(1, 'Branch name cannot be empty'),
+        v.regex(branchNamePattern, branchNameErrorMessage)
+      )
+    ),
+  }),
+  // Forward to 'title' field since it's the first field in the form
+  v.forward(
+    v.check(
+      (input) => input.title !== undefined || input.branch !== undefined,
+      'At least one of title or branch must be provided'
+    ),
+    ['title']
+  )
+);
+
+export type EditSessionFormData = v.InferOutput<typeof EditSessionFormSchema>;

--- a/packages/client/src/schemas/worktree-form.ts
+++ b/packages/client/src/schemas/worktree-form.ts
@@ -1,0 +1,54 @@
+import * as v from 'valibot';
+import { branchNamePattern, branchNameErrorMessage } from '@agent-console/shared';
+
+/**
+ * Client-side schema for Create Worktree form
+ * This schema handles the unified form state with conditional validation based on branchNameMode
+ *
+ * IMPORTANT: Cross-field validation with v.forward()
+ *
+ * When using v.check() at the pipe level for cross-field validation, the error has
+ * `path: undefined` (root-level error). However, @hookform/resolvers/valibot (v5.2.2)
+ * does not map root-level errors to React Hook Form's errors object - they are silently
+ * ignored, causing the form to submit despite validation failure.
+ *
+ * Workaround: Use v.forward() to explicitly assign errors to a specific field path.
+ * This is also the recommended approach in Valibot documentation for cross-field validation.
+ *
+ * @see https://valibot.dev/api/forward/
+ */
+export const CreateWorktreeFormSchema = v.pipe(
+  v.object({
+    branchNameMode: v.picklist(['prompt', 'custom', 'existing']),
+    initialPrompt: v.optional(v.string()),
+    customBranch: v.optional(
+      v.pipe(
+        v.string(),
+        v.trim(),
+        v.regex(branchNamePattern, branchNameErrorMessage)
+      )
+    ),
+    baseBranch: v.optional(v.string()),
+    sessionTitle: v.optional(v.string()),
+    agentId: v.optional(v.string()),
+  }),
+  // Validate initialPrompt is required when mode is 'prompt'
+  v.forward(
+    v.check(
+      (data) => data.branchNameMode !== 'prompt' || !!data.initialPrompt?.trim(),
+      'Initial prompt is required when using "Generate from prompt" mode'
+    ),
+    ['initialPrompt']
+  ),
+  // Validate customBranch is required when mode is 'custom' or 'existing'
+  v.forward(
+    v.check(
+      (data) =>
+        data.branchNameMode === 'prompt' || !!data.customBranch?.trim(),
+      'Branch name is required'
+    ),
+    ['customBranch']
+  )
+);
+
+export type CreateWorktreeFormData = v.InferOutput<typeof CreateWorktreeFormSchema>;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,8 @@
     "bun-pty": "^0.4.2",
     "hono": "^4.6.13",
     "open": "^11.0.0",
-    "uuid": "^11.0.3"
+    "uuid": "^11.0.3",
+    "valibot": "^1.2.0"
   },
   "devDependencies": {
     "@types/bun": "^1.1.14",

--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -316,6 +316,34 @@ describe('API Routes Integration', () => {
         expect(savedData.length).toBe(1);
         expect(savedData[0].locationPath).toBe('/test/path');
       });
+
+      it('should return 400 for invalid JSON body', async () => {
+        const app = await createApp();
+
+        const res = await app.request('/api/sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: 'invalid json',
+        });
+        expect(res.status).toBe(400);
+
+        const body = (await res.json()) as { error: string };
+        expect(body.error).toBe('Invalid JSON body');
+      });
+
+      it('should return 400 for empty request body', async () => {
+        const app = await createApp();
+
+        const res = await app.request('/api/sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '',
+        });
+        expect(res.status).toBe(400);
+
+        const body = (await res.json()) as { error: string };
+        expect(body.error).toBe('Invalid JSON body');
+      });
     });
 
     describe('GET /api/sessions/:id', () => {
@@ -460,7 +488,7 @@ describe('API Routes Integration', () => {
         expect(patchRes.status).toBe(400);
 
         const body = (await patchRes.json()) as { error: string };
-        expect(body.error).toContain('branch cannot be empty');
+        expect(body.error).toContain('Branch name cannot be empty');
       });
 
       it('should return 404 for non-existent session', async () => {
@@ -887,7 +915,7 @@ describe('API Routes Integration', () => {
         expect(res.status).toBe(400);
 
         const body = (await res.json()) as { error: string };
-        expect(body.error).toContain('initialPrompt is required for prompt mode');
+        expect(body.error).toContain('Initial prompt is required for prompt mode');
       });
 
       it('should return 404 for non-existent repository', async () => {

--- a/packages/server/src/middleware/validation.ts
+++ b/packages/server/src/middleware/validation.ts
@@ -1,0 +1,43 @@
+import type { Context, Next } from 'hono';
+import * as v from 'valibot';
+import { ValidationError } from '../lib/errors.js';
+
+/**
+ * Valibot validation middleware for Hono
+ * Validates request body against a schema and sets validated data in context
+ */
+export function validateBody<TSchema extends v.GenericSchema>(schema: TSchema) {
+  return async (c: Context, next: Next) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      throw new ValidationError('Invalid JSON body');
+    }
+    const result = v.safeParse(schema, body);
+
+    if (!result.success) {
+      const firstIssue = result.issues[0];
+      const path = firstIssue?.path
+        ?.map((p) => ('key' in p ? String(p.key) : ''))
+        .filter(Boolean)
+        .join('.') || '';
+      const message = path
+        ? `${path}: ${firstIssue?.message}`
+        : firstIssue?.message || 'Validation failed';
+      throw new ValidationError(message);
+    }
+
+    // Store validated data in context for handlers
+    c.set('validatedBody', result.output);
+    await next();
+  };
+}
+
+/**
+ * Get validated body from context
+ * Type-safe helper to retrieve validated data
+ */
+export function getValidatedBody<T>(c: Context): T {
+  return c.get('validatedBody') as T;
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,9 +14,14 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test src/"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.4",
     "typescript": "^5.7.2"
+  },
+  "dependencies": {
+    "valibot": "^1.2.0"
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './types/agent.js';
 export * from './types/worker.js';
 export * from './types/session.js';
+export * from './schemas/index.js';
 
 export interface Repository {
   id: string;           // UUID
@@ -15,46 +16,6 @@ export interface Worktree {
   isMain: boolean;      // Is main worktree
   repositoryId: string; // Parent repository ID
   index?: number;       // Index number (starting from 1, not assigned to main)
-}
-
-export interface CreateRepositoryRequest {
-  path: string;
-}
-
-interface CreateWorktreeBaseRequest {
-  autoStartSession?: boolean;
-  agentId?: string;
-  /** Initial prompt to send to the agent after starting */
-  initialPrompt?: string;
-  /** Human-readable title for the session */
-  title?: string;
-}
-
-interface CreateWorktreePromptRequest extends CreateWorktreeBaseRequest {
-  mode: 'prompt';
-  /** Required for prompt mode - the prompt to generate branch name from */
-  initialPrompt: string;
-  baseBranch?: string;
-}
-
-interface CreateWorktreeCustomRequest extends CreateWorktreeBaseRequest {
-  mode: 'custom';
-  branch: string;
-  baseBranch?: string;
-}
-
-interface CreateWorktreeExistingRequest extends CreateWorktreeBaseRequest {
-  mode: 'existing';
-  branch: string;
-}
-
-export type CreateWorktreeRequest =
-  | CreateWorktreePromptRequest
-  | CreateWorktreeCustomRequest
-  | CreateWorktreeExistingRequest;
-
-export interface DeleteWorktreeRequest {
-  force?: boolean;          // Force delete with session termination
 }
 
 export interface ApiError {

--- a/packages/shared/src/schemas/__tests__/agent.test.ts
+++ b/packages/shared/src/schemas/__tests__/agent.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect } from 'bun:test';
+import * as v from 'valibot';
+import {
+  CreateAgentRequestSchema,
+  UpdateAgentRequestSchema,
+  AgentActivityPatternsSchema,
+  InitialPromptModeSchema,
+} from '../agent';
+
+describe('InitialPromptModeSchema', () => {
+  it('should accept "stdin"', () => {
+    const result = v.safeParse(InitialPromptModeSchema, 'stdin');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output).toBe('stdin');
+    }
+  });
+
+  it('should accept "arg"', () => {
+    const result = v.safeParse(InitialPromptModeSchema, 'arg');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output).toBe('arg');
+    }
+  });
+
+  it('should reject invalid value', () => {
+    const result = v.safeParse(InitialPromptModeSchema, 'invalid');
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('AgentActivityPatternsSchema', () => {
+  it('should accept empty object', () => {
+    const result = v.safeParse(AgentActivityPatternsSchema, {});
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept object with askingPatterns', () => {
+    const result = v.safeParse(AgentActivityPatternsSchema, {
+      askingPatterns: ['pattern1', 'pattern2'],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.askingPatterns).toEqual(['pattern1', 'pattern2']);
+    }
+  });
+
+  it('should accept empty askingPatterns array', () => {
+    const result = v.safeParse(AgentActivityPatternsSchema, {
+      askingPatterns: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject non-array askingPatterns', () => {
+    const result = v.safeParse(AgentActivityPatternsSchema, {
+      askingPatterns: 'not-an-array',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject askingPatterns array with non-string elements', () => {
+    const result = v.safeParse(AgentActivityPatternsSchema, {
+      askingPatterns: ['valid', 123, 'also-valid'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject askingPatterns array with null elements', () => {
+    const result = v.safeParse(AgentActivityPatternsSchema, {
+      askingPatterns: ['valid', null],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject askingPatterns array with object elements', () => {
+    const result = v.safeParse(AgentActivityPatternsSchema, {
+      askingPatterns: ['valid', { pattern: 'test' }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CreateAgentRequestSchema', () => {
+  it('should validate valid request with required fields only', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '/bin/agent',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.name).toBe('Test Agent');
+      expect(result.output.command).toBe('/bin/agent');
+    }
+  });
+
+  it('should validate valid request with all fields', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '/bin/agent',
+      description: 'A test agent',
+      icon: 'icon.png',
+      activityPatterns: { askingPatterns: ['pattern'] },
+      continueArgs: ['--continue'],
+      initialPromptMode: 'stdin',
+      initialPromptDelayMs: 100,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject empty name', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: '',
+      command: '/bin/agent',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty command', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject whitespace-only name', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: '   ',
+      command: '/bin/agent',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject whitespace-only command', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should trim whitespace from name', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: '  Test Agent  ',
+      command: '/bin/agent',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.name).toBe('Test Agent');
+    }
+  });
+
+  it('should trim whitespace from command', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '  /bin/agent  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.command).toBe('/bin/agent');
+    }
+  });
+
+  it('should reject missing name', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      command: '/bin/agent',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing command', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject negative initialPromptDelayMs', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '/bin/agent',
+      initialPromptDelayMs: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject non-integer initialPromptDelayMs', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '/bin/agent',
+      initialPromptDelayMs: 100.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept zero initialPromptDelayMs', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '/bin/agent',
+      initialPromptDelayMs: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid initialPromptMode', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '/bin/agent',
+      initialPromptMode: 'invalid',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // Type mismatch tests
+  it('should reject number for name field', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 123,
+      command: '/bin/agent',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject number for command field', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: 456,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject object for name field', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: { value: 'Test Agent' },
+      command: '/bin/agent',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject null for name field', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: null,
+      command: '/bin/agent',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // continueArgs array validation
+  it('should accept valid continueArgs array', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '/bin/agent',
+      continueArgs: ['--continue', '-y'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept empty continueArgs array', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '/bin/agent',
+      continueArgs: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject continueArgs with non-string elements', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '/bin/agent',
+      continueArgs: ['--continue', 123],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject continueArgs with null elements', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '/bin/agent',
+      continueArgs: ['--continue', null],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject non-array continueArgs', () => {
+    const result = v.safeParse(CreateAgentRequestSchema, {
+      name: 'Test Agent',
+      command: '/bin/agent',
+      continueArgs: '--continue',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('UpdateAgentRequestSchema', () => {
+  it('should validate update with name only', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {
+      name: 'Updated Agent',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.name).toBe('Updated Agent');
+    }
+  });
+
+  it('should validate update with command only', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {
+      command: '/bin/updated-agent',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.command).toBe('/bin/updated-agent');
+    }
+  });
+
+  it('should validate update with all fields', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {
+      name: 'Updated Agent',
+      command: '/bin/updated-agent',
+      description: 'Updated description',
+      icon: 'new-icon.png',
+      activityPatterns: { askingPatterns: ['new-pattern'] },
+      continueArgs: ['--new-continue'],
+      initialPromptMode: 'arg',
+      initialPromptDelayMs: 200,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate empty update object', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {});
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject empty name', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {
+      name: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty command', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {
+      command: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject whitespace-only name', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {
+      name: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject whitespace-only command', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {
+      command: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should trim whitespace from name', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {
+      name: '  Updated Agent  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.name).toBe('Updated Agent');
+    }
+  });
+
+  it('should trim whitespace from command', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {
+      command: '  /bin/updated-agent  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.command).toBe('/bin/updated-agent');
+    }
+  });
+
+  it('should reject negative initialPromptDelayMs', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {
+      initialPromptDelayMs: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject non-integer initialPromptDelayMs', () => {
+    const result = v.safeParse(UpdateAgentRequestSchema, {
+      initialPromptDelayMs: 100.5,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/__tests__/repository.test.ts
+++ b/packages/shared/src/schemas/__tests__/repository.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect } from 'bun:test';
+import * as v from 'valibot';
+import {
+  CreateRepositoryRequestSchema,
+  CreateWorktreeRequestSchema,
+  CreateWorktreePromptRequestSchema,
+  CreateWorktreeCustomRequestSchema,
+  CreateWorktreeExistingRequestSchema,
+  DeleteWorktreeRequestSchema,
+} from '../repository';
+
+describe('CreateRepositoryRequestSchema', () => {
+  it('should validate valid repository request', () => {
+    const result = v.safeParse(CreateRepositoryRequestSchema, {
+      path: '/path/to/repository',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.path).toBe('/path/to/repository');
+    }
+  });
+
+  it('should trim whitespace from path', () => {
+    const result = v.safeParse(CreateRepositoryRequestSchema, {
+      path: '  /path/to/repository  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.path).toBe('/path/to/repository');
+    }
+  });
+
+  it('should reject missing path', () => {
+    const result = v.safeParse(CreateRepositoryRequestSchema, {});
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty path', () => {
+    const result = v.safeParse(CreateRepositoryRequestSchema, {
+      path: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject whitespace-only path', () => {
+    const result = v.safeParse(CreateRepositoryRequestSchema, {
+      path: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CreateWorktreePromptRequestSchema', () => {
+  it('should validate valid prompt mode request', () => {
+    const result = v.safeParse(CreateWorktreePromptRequestSchema, {
+      mode: 'prompt',
+      initialPrompt: 'Fix login bug',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.mode).toBe('prompt');
+      expect(result.output.initialPrompt).toBe('Fix login bug');
+    }
+  });
+
+  it('should validate with all optional fields', () => {
+    const result = v.safeParse(CreateWorktreePromptRequestSchema, {
+      mode: 'prompt',
+      initialPrompt: 'Fix login bug',
+      baseBranch: 'develop',
+      autoStartSession: true,
+      agentId: 'agent-123',
+      title: 'Login Fix',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.baseBranch).toBe('develop');
+      expect(result.output.autoStartSession).toBe(true);
+      expect(result.output.agentId).toBe('agent-123');
+      expect(result.output.title).toBe('Login Fix');
+    }
+  });
+
+  it('should trim whitespace from initialPrompt', () => {
+    const result = v.safeParse(CreateWorktreePromptRequestSchema, {
+      mode: 'prompt',
+      initialPrompt: '  Fix login bug  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.initialPrompt).toBe('Fix login bug');
+    }
+  });
+
+  it('should reject missing initialPrompt', () => {
+    const result = v.safeParse(CreateWorktreePromptRequestSchema, {
+      mode: 'prompt',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty initialPrompt', () => {
+    const result = v.safeParse(CreateWorktreePromptRequestSchema, {
+      mode: 'prompt',
+      initialPrompt: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject whitespace-only initialPrompt', () => {
+    const result = v.safeParse(CreateWorktreePromptRequestSchema, {
+      mode: 'prompt',
+      initialPrompt: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject wrong mode', () => {
+    const result = v.safeParse(CreateWorktreePromptRequestSchema, {
+      mode: 'custom',
+      initialPrompt: 'Fix login bug',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept valid baseBranch', () => {
+    const result = v.safeParse(CreateWorktreePromptRequestSchema, {
+      mode: 'prompt',
+      initialPrompt: 'Fix login bug',
+      baseBranch: 'develop',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.baseBranch).toBe('develop');
+    }
+  });
+
+  it('should reject baseBranch with spaces', () => {
+    const result = v.safeParse(CreateWorktreePromptRequestSchema, {
+      mode: 'prompt',
+      initialPrompt: 'Fix login bug',
+      baseBranch: 'my branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject baseBranch with special characters', () => {
+    const result = v.safeParse(CreateWorktreePromptRequestSchema, {
+      mode: 'prompt',
+      initialPrompt: 'Fix login bug',
+      baseBranch: 'feature@branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept empty baseBranch (treated as undefined)', () => {
+    const result = v.safeParse(CreateWorktreePromptRequestSchema, {
+      mode: 'prompt',
+      initialPrompt: 'Fix login bug',
+      baseBranch: '',
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('CreateWorktreeCustomRequestSchema', () => {
+  it('should validate valid custom mode request', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'custom',
+      branch: 'feature/custom-branch',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.mode).toBe('custom');
+      expect(result.output.branch).toBe('feature/custom-branch');
+    }
+  });
+
+  it('should validate with all optional fields', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'custom',
+      branch: 'feature/custom-branch',
+      baseBranch: 'main',
+      autoStartSession: false,
+      agentId: 'agent-456',
+      initialPrompt: 'Start coding',
+      title: 'Custom Branch Work',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.baseBranch).toBe('main');
+      expect(result.output.autoStartSession).toBe(false);
+      expect(result.output.agentId).toBe('agent-456');
+      expect(result.output.initialPrompt).toBe('Start coding');
+      expect(result.output.title).toBe('Custom Branch Work');
+    }
+  });
+
+  it('should trim whitespace from branch', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'custom',
+      branch: '  feature/test  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.branch).toBe('feature/test');
+    }
+  });
+
+  it('should reject missing branch', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'custom',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty branch', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'custom',
+      branch: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject whitespace-only branch', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'custom',
+      branch: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject wrong mode', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'existing',
+      branch: 'feature/custom-branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with spaces', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'custom',
+      branch: 'feature branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with special characters', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'custom',
+      branch: 'feature@branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with unicode characters', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'custom',
+      branch: 'feature/日本語',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept valid baseBranch', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'custom',
+      branch: 'feature/new',
+      baseBranch: 'develop',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.baseBranch).toBe('develop');
+    }
+  });
+
+  it('should reject baseBranch with spaces', () => {
+    const result = v.safeParse(CreateWorktreeCustomRequestSchema, {
+      mode: 'custom',
+      branch: 'feature/new',
+      baseBranch: 'my branch',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CreateWorktreeExistingRequestSchema', () => {
+  it('should validate valid existing mode request', () => {
+    const result = v.safeParse(CreateWorktreeExistingRequestSchema, {
+      mode: 'existing',
+      branch: 'existing-branch',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.mode).toBe('existing');
+      expect(result.output.branch).toBe('existing-branch');
+    }
+  });
+
+  it('should validate with all optional fields', () => {
+    const result = v.safeParse(CreateWorktreeExistingRequestSchema, {
+      mode: 'existing',
+      branch: 'existing-branch',
+      autoStartSession: true,
+      agentId: 'agent-789',
+      initialPrompt: 'Review code',
+      title: 'Code Review',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.autoStartSession).toBe(true);
+      expect(result.output.agentId).toBe('agent-789');
+      expect(result.output.initialPrompt).toBe('Review code');
+      expect(result.output.title).toBe('Code Review');
+    }
+  });
+
+  it('should trim whitespace from branch', () => {
+    const result = v.safeParse(CreateWorktreeExistingRequestSchema, {
+      mode: 'existing',
+      branch: '  main  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.branch).toBe('main');
+    }
+  });
+
+  it('should reject missing branch', () => {
+    const result = v.safeParse(CreateWorktreeExistingRequestSchema, {
+      mode: 'existing',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty branch', () => {
+    const result = v.safeParse(CreateWorktreeExistingRequestSchema, {
+      mode: 'existing',
+      branch: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject whitespace-only branch', () => {
+    const result = v.safeParse(CreateWorktreeExistingRequestSchema, {
+      mode: 'existing',
+      branch: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject wrong mode', () => {
+    const result = v.safeParse(CreateWorktreeExistingRequestSchema, {
+      mode: 'prompt',
+      branch: 'existing-branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with spaces', () => {
+    const result = v.safeParse(CreateWorktreeExistingRequestSchema, {
+      mode: 'existing',
+      branch: 'my branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with special characters', () => {
+    const result = v.safeParse(CreateWorktreeExistingRequestSchema, {
+      mode: 'existing',
+      branch: 'branch@name',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with unicode characters', () => {
+    const result = v.safeParse(CreateWorktreeExistingRequestSchema, {
+      mode: 'existing',
+      branch: '日本語ブランチ',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CreateWorktreeRequestSchema', () => {
+  it('should accept prompt mode', () => {
+    const result = v.safeParse(CreateWorktreeRequestSchema, {
+      mode: 'prompt',
+      initialPrompt: 'Fix bug',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept custom mode', () => {
+    const result = v.safeParse(CreateWorktreeRequestSchema, {
+      mode: 'custom',
+      branch: 'feature/new',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept existing mode', () => {
+    const result = v.safeParse(CreateWorktreeRequestSchema, {
+      mode: 'existing',
+      branch: 'main',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid mode', () => {
+    const result = v.safeParse(CreateWorktreeRequestSchema, {
+      mode: 'invalid',
+      branch: 'test',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject prompt mode without initialPrompt', () => {
+    const result = v.safeParse(CreateWorktreeRequestSchema, {
+      mode: 'prompt',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject custom mode without branch', () => {
+    const result = v.safeParse(CreateWorktreeRequestSchema, {
+      mode: 'custom',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject existing mode without branch', () => {
+    const result = v.safeParse(CreateWorktreeRequestSchema, {
+      mode: 'existing',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('DeleteWorktreeRequestSchema', () => {
+  it('should validate empty request', () => {
+    const result = v.safeParse(DeleteWorktreeRequestSchema, {});
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate with force true', () => {
+    const result = v.safeParse(DeleteWorktreeRequestSchema, {
+      force: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.force).toBe(true);
+    }
+  });
+
+  it('should validate with force false', () => {
+    const result = v.safeParse(DeleteWorktreeRequestSchema, {
+      force: false,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.force).toBe(false);
+    }
+  });
+
+  it('should reject non-boolean force', () => {
+    const result = v.safeParse(DeleteWorktreeRequestSchema, {
+      force: 'yes',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/__tests__/session.test.ts
+++ b/packages/shared/src/schemas/__tests__/session.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect } from 'bun:test';
+import * as v from 'valibot';
+import {
+  CreateSessionRequestSchema,
+  CreateWorktreeSessionRequestSchema,
+  CreateQuickSessionRequestSchema,
+  UpdateSessionRequestSchema,
+} from '../session';
+
+describe('CreateWorktreeSessionRequestSchema', () => {
+  it('should validate valid worktree session request', () => {
+    const result = v.safeParse(CreateWorktreeSessionRequestSchema, {
+      type: 'worktree',
+      repositoryId: 'repo-123',
+      worktreeId: 'wt-456',
+      locationPath: '/path/to/worktree',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.type).toBe('worktree');
+      expect(result.output.repositoryId).toBe('repo-123');
+      expect(result.output.worktreeId).toBe('wt-456');
+      expect(result.output.locationPath).toBe('/path/to/worktree');
+    }
+  });
+
+  it('should validate with optional fields', () => {
+    const result = v.safeParse(CreateWorktreeSessionRequestSchema, {
+      type: 'worktree',
+      repositoryId: 'repo-123',
+      worktreeId: 'wt-456',
+      locationPath: '/path/to/worktree',
+      agentId: 'agent-789',
+      continueConversation: true,
+      initialPrompt: 'Start working',
+      title: 'My Session',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.agentId).toBe('agent-789');
+      expect(result.output.continueConversation).toBe(true);
+      expect(result.output.initialPrompt).toBe('Start working');
+      expect(result.output.title).toBe('My Session');
+    }
+  });
+
+  it('should reject missing repositoryId', () => {
+    const result = v.safeParse(CreateWorktreeSessionRequestSchema, {
+      type: 'worktree',
+      worktreeId: 'wt-456',
+      locationPath: '/path/to/worktree',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty repositoryId', () => {
+    const result = v.safeParse(CreateWorktreeSessionRequestSchema, {
+      type: 'worktree',
+      repositoryId: '',
+      worktreeId: 'wt-456',
+      locationPath: '/path/to/worktree',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing worktreeId', () => {
+    const result = v.safeParse(CreateWorktreeSessionRequestSchema, {
+      type: 'worktree',
+      repositoryId: 'repo-123',
+      locationPath: '/path/to/worktree',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty worktreeId', () => {
+    const result = v.safeParse(CreateWorktreeSessionRequestSchema, {
+      type: 'worktree',
+      repositoryId: 'repo-123',
+      worktreeId: '',
+      locationPath: '/path/to/worktree',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing locationPath', () => {
+    const result = v.safeParse(CreateWorktreeSessionRequestSchema, {
+      type: 'worktree',
+      repositoryId: 'repo-123',
+      worktreeId: 'wt-456',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty locationPath', () => {
+    const result = v.safeParse(CreateWorktreeSessionRequestSchema, {
+      type: 'worktree',
+      repositoryId: 'repo-123',
+      worktreeId: 'wt-456',
+      locationPath: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject wrong type', () => {
+    const result = v.safeParse(CreateWorktreeSessionRequestSchema, {
+      type: 'quick',
+      repositoryId: 'repo-123',
+      worktreeId: 'wt-456',
+      locationPath: '/path/to/worktree',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CreateQuickSessionRequestSchema', () => {
+  it('should validate valid quick session request', () => {
+    const result = v.safeParse(CreateQuickSessionRequestSchema, {
+      type: 'quick',
+      locationPath: '/path/to/directory',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.type).toBe('quick');
+      expect(result.output.locationPath).toBe('/path/to/directory');
+    }
+  });
+
+  it('should validate with optional fields', () => {
+    const result = v.safeParse(CreateQuickSessionRequestSchema, {
+      type: 'quick',
+      locationPath: '/path/to/directory',
+      agentId: 'agent-789',
+      continueConversation: false,
+      initialPrompt: 'Quick task',
+      title: 'Quick Session',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.agentId).toBe('agent-789');
+      expect(result.output.continueConversation).toBe(false);
+      expect(result.output.initialPrompt).toBe('Quick task');
+      expect(result.output.title).toBe('Quick Session');
+    }
+  });
+
+  it('should trim whitespace from locationPath', () => {
+    const result = v.safeParse(CreateQuickSessionRequestSchema, {
+      type: 'quick',
+      locationPath: '  /path/to/directory  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.locationPath).toBe('/path/to/directory');
+    }
+  });
+
+  it('should reject missing locationPath', () => {
+    const result = v.safeParse(CreateQuickSessionRequestSchema, {
+      type: 'quick',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty locationPath', () => {
+    const result = v.safeParse(CreateQuickSessionRequestSchema, {
+      type: 'quick',
+      locationPath: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject whitespace-only locationPath', () => {
+    const result = v.safeParse(CreateQuickSessionRequestSchema, {
+      type: 'quick',
+      locationPath: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject wrong type', () => {
+    const result = v.safeParse(CreateQuickSessionRequestSchema, {
+      type: 'worktree',
+      locationPath: '/path/to/directory',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CreateSessionRequestSchema', () => {
+  it('should accept worktree session', () => {
+    const result = v.safeParse(CreateSessionRequestSchema, {
+      type: 'worktree',
+      repositoryId: 'repo-123',
+      worktreeId: 'wt-456',
+      locationPath: '/path/to/worktree',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept quick session', () => {
+    const result = v.safeParse(CreateSessionRequestSchema, {
+      type: 'quick',
+      locationPath: '/path/to/directory',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid type', () => {
+    const result = v.safeParse(CreateSessionRequestSchema, {
+      type: 'invalid',
+      locationPath: '/path/to/directory',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('UpdateSessionRequestSchema', () => {
+  it('should validate update with title only', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      title: 'New Title',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.title).toBe('New Title');
+    }
+  });
+
+  it('should validate update with branch only', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature/new-feature',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.branch).toBe('feature/new-feature');
+    }
+  });
+
+  it('should validate update with both title and branch', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      title: 'New Title',
+      branch: 'feature/new-feature',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject empty object (no fields)', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {});
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty branch name', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject whitespace-only branch name', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: '   ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should trim whitespace from branch', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: '  feature/test  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.branch).toBe('feature/test');
+    }
+  });
+
+  it('should accept valid branch with slashes', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature/sub/branch',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept valid branch with dots', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'release-1.2.3',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept valid branch with underscores', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature_branch',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept valid branch with hyphens', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature-branch',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept valid branch with mixed valid characters', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature/test-1.0_beta',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject branch with spaces', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with special characters', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature@branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with hash', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature#branch',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // Branch name boundary tests
+  it('should accept branch starting with slash', () => {
+    // Git allows branches starting with slash
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: '/feature',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept branch ending with slash', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature/',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept branch with double slashes', () => {
+    // The regex allows // - this is valid per current implementation
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature//test',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject branch with unicode characters', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature/日本語',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with emoji', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature/🚀',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept branch starting with dot', () => {
+    // The regex allows branches starting with dot
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: '.hidden-branch',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject branch with backslash', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature\\test',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject branch with asterisk', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 'feature*',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // Type mismatch tests
+  it('should reject number for branch field', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: 123,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject number for title field', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      title: 456,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject object for branch field', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: { name: 'feature/test' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject null for branch field', () => {
+    const result = v.safeParse(UpdateSessionRequestSchema, {
+      branch: null,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/__tests__/worker.test.ts
+++ b/packages/shared/src/schemas/__tests__/worker.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'bun:test';
+import * as v from 'valibot';
+import {
+  CreateWorkerRequestSchema,
+  CreateAgentWorkerRequestSchema,
+  CreateTerminalWorkerRequestSchema,
+  RestartWorkerRequestSchema,
+} from '../worker';
+
+describe('CreateAgentWorkerRequestSchema', () => {
+  it('should validate valid agent worker request', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'agent',
+      agentId: 'agent-123',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.type).toBe('agent');
+      expect(result.output.agentId).toBe('agent-123');
+    }
+  });
+
+  it('should validate with optional name', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'agent',
+      agentId: 'agent-123',
+      name: 'My Agent Worker',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.name).toBe('My Agent Worker');
+    }
+  });
+
+  it('should reject missing agentId', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'agent',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty agentId', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'agent',
+      agentId: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject wrong type', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'terminal',
+      agentId: 'agent-123',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing type', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      agentId: 'agent-123',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // Type mismatch tests
+  it('should reject number for agentId field', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'agent',
+      agentId: 123,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject object for agentId field', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'agent',
+      agentId: { id: 'agent-123' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject null for agentId field', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'agent',
+      agentId: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject number for name field', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'agent',
+      agentId: 'agent-123',
+      name: 456,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // Optional field tests
+  it('should accept undefined name', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'agent',
+      agentId: 'agent-123',
+      name: undefined,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept continueConversation option', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'agent',
+      agentId: 'agent-123',
+      continueConversation: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.continueConversation).toBe(true);
+    }
+  });
+
+  it('should reject non-boolean continueConversation', () => {
+    const result = v.safeParse(CreateAgentWorkerRequestSchema, {
+      type: 'agent',
+      agentId: 'agent-123',
+      continueConversation: 'yes',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CreateTerminalWorkerRequestSchema', () => {
+  it('should validate valid terminal worker request', () => {
+    const result = v.safeParse(CreateTerminalWorkerRequestSchema, {
+      type: 'terminal',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.type).toBe('terminal');
+    }
+  });
+
+  it('should validate with optional name', () => {
+    const result = v.safeParse(CreateTerminalWorkerRequestSchema, {
+      type: 'terminal',
+      name: 'My Terminal',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.name).toBe('My Terminal');
+    }
+  });
+
+  it('should reject wrong type', () => {
+    const result = v.safeParse(CreateTerminalWorkerRequestSchema, {
+      type: 'agent',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing type', () => {
+    const result = v.safeParse(CreateTerminalWorkerRequestSchema, {
+      name: 'My Terminal',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CreateWorkerRequestSchema', () => {
+  it('should accept agent worker', () => {
+    const result = v.safeParse(CreateWorkerRequestSchema, {
+      type: 'agent',
+      agentId: 'agent-123',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept terminal worker', () => {
+    const result = v.safeParse(CreateWorkerRequestSchema, {
+      type: 'terminal',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid type', () => {
+    const result = v.safeParse(CreateWorkerRequestSchema, {
+      type: 'invalid',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject agent worker without agentId', () => {
+    const result = v.safeParse(CreateWorkerRequestSchema, {
+      type: 'agent',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('RestartWorkerRequestSchema', () => {
+  it('should validate empty request', () => {
+    const result = v.safeParse(RestartWorkerRequestSchema, {});
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate with continueConversation true', () => {
+    const result = v.safeParse(RestartWorkerRequestSchema, {
+      continueConversation: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.continueConversation).toBe(true);
+    }
+  });
+
+  it('should validate with continueConversation false', () => {
+    const result = v.safeParse(RestartWorkerRequestSchema, {
+      continueConversation: false,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.continueConversation).toBe(false);
+    }
+  });
+
+  it('should reject non-boolean continueConversation', () => {
+    const result = v.safeParse(RestartWorkerRequestSchema, {
+      continueConversation: 'yes',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -1,0 +1,55 @@
+import * as v from 'valibot';
+
+/**
+ * Initial prompt mode - how to pass the initial prompt to the agent
+ */
+export const InitialPromptModeSchema = v.picklist(['stdin', 'arg']);
+
+/**
+ * Agent activity patterns for detection
+ */
+export const AgentActivityPatternsSchema = v.object({
+  askingPatterns: v.optional(v.array(v.string())),
+});
+
+/**
+ * Schema for creating a new agent
+ */
+export const CreateAgentRequestSchema = v.object({
+  name: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'Name is required')
+  ),
+  command: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'Command is required')
+  ),
+  description: v.optional(v.string()),
+  icon: v.optional(v.string()),
+  activityPatterns: v.optional(AgentActivityPatternsSchema),
+  continueArgs: v.optional(v.array(v.string())),
+  initialPromptMode: v.optional(InitialPromptModeSchema),
+  initialPromptDelayMs: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
+});
+
+/**
+ * Schema for updating an existing agent
+ */
+export const UpdateAgentRequestSchema = v.object({
+  name: v.optional(v.pipe(v.string(), v.trim(), v.minLength(1, 'Name cannot be empty'))),
+  command: v.optional(v.pipe(v.string(), v.trim(), v.minLength(1, 'Command cannot be empty'))),
+  description: v.optional(v.string()),
+  icon: v.optional(v.string()),
+  activityPatterns: v.optional(AgentActivityPatternsSchema),
+  continueArgs: v.optional(v.array(v.string())),
+  initialPromptMode: v.optional(InitialPromptModeSchema),
+  initialPromptDelayMs: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
+});
+
+// Inferred types from schemas
+export type CreateAgentRequest = v.InferOutput<typeof CreateAgentRequestSchema>;
+export type UpdateAgentRequest = v.InferOutput<typeof UpdateAgentRequestSchema>;
+export type AgentActivityPatterns = v.InferOutput<typeof AgentActivityPatternsSchema>;
+export type InitialPromptMode = v.InferOutput<typeof InitialPromptModeSchema>;

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -1,0 +1,53 @@
+// Agent schemas
+export {
+  InitialPromptModeSchema,
+  AgentActivityPatternsSchema,
+  CreateAgentRequestSchema,
+  UpdateAgentRequestSchema,
+  type CreateAgentRequest,
+  type UpdateAgentRequest,
+  type AgentActivityPatterns,
+  type InitialPromptMode,
+} from './agent.js';
+
+// Worker schemas
+export {
+  CreateAgentWorkerRequestSchema,
+  CreateTerminalWorkerRequestSchema,
+  CreateWorkerRequestSchema,
+  RestartWorkerRequestSchema,
+  type CreateAgentWorkerRequest,
+  type CreateTerminalWorkerRequest,
+  type CreateWorkerRequest,
+  type RestartWorkerRequest,
+} from './worker.js';
+
+// Session schemas
+export {
+  CreateWorktreeSessionRequestSchema,
+  CreateQuickSessionRequestSchema,
+  CreateSessionRequestSchema,
+  UpdateSessionRequestSchema,
+  branchNamePattern,
+  branchNameErrorMessage,
+  type CreateWorktreeSessionRequest,
+  type CreateQuickSessionRequest,
+  type CreateSessionRequest,
+  type UpdateSessionRequest,
+} from './session.js';
+
+// Repository schemas
+export {
+  CreateRepositoryRequestSchema,
+  CreateWorktreePromptRequestSchema,
+  CreateWorktreeCustomRequestSchema,
+  CreateWorktreeExistingRequestSchema,
+  CreateWorktreeRequestSchema,
+  DeleteWorktreeRequestSchema,
+  type CreateRepositoryRequest,
+  type CreateWorktreePromptRequest,
+  type CreateWorktreeCustomRequest,
+  type CreateWorktreeExistingRequest,
+  type CreateWorktreeRequest,
+  type DeleteWorktreeRequest,
+} from './repository.js';

--- a/packages/shared/src/schemas/repository.ts
+++ b/packages/shared/src/schemas/repository.ts
@@ -1,0 +1,104 @@
+import * as v from 'valibot';
+import { branchNamePattern, branchNameErrorMessage } from './session';
+
+/**
+ * Schema for creating a repository
+ */
+export const CreateRepositoryRequestSchema = v.object({
+  path: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'Path is required')
+  ),
+});
+
+/**
+ * Optional branch name schema - validates format only when provided and non-empty
+ */
+const OptionalBranchSchema = v.optional(
+  v.pipe(
+    v.string(),
+    v.trim(),
+    v.check(
+      (val) => val === '' || branchNamePattern.test(val),
+      branchNameErrorMessage
+    )
+  )
+);
+
+/**
+ * Required branch name schema - validates format and requires non-empty value
+ */
+const RequiredBranchSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1, 'Branch name is required'),
+  v.regex(branchNamePattern, branchNameErrorMessage)
+);
+
+/**
+ * Base schema for worktree creation requests
+ */
+const CreateWorktreeBaseSchema = v.object({
+  autoStartSession: v.optional(v.boolean()),
+  agentId: v.optional(v.string()),
+  initialPrompt: v.optional(v.string()),
+  title: v.optional(v.string()),
+});
+
+/**
+ * Schema for creating worktree with prompt-based branch name
+ */
+export const CreateWorktreePromptRequestSchema = v.object({
+  ...CreateWorktreeBaseSchema.entries,
+  mode: v.literal('prompt'),
+  initialPrompt: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'Initial prompt is required for prompt mode')
+  ),
+  baseBranch: OptionalBranchSchema,
+});
+
+/**
+ * Schema for creating worktree with custom branch name
+ */
+export const CreateWorktreeCustomRequestSchema = v.object({
+  ...CreateWorktreeBaseSchema.entries,
+  mode: v.literal('custom'),
+  branch: RequiredBranchSchema,
+  baseBranch: OptionalBranchSchema,
+});
+
+/**
+ * Schema for creating worktree from existing branch
+ */
+export const CreateWorktreeExistingRequestSchema = v.object({
+  ...CreateWorktreeBaseSchema.entries,
+  mode: v.literal('existing'),
+  branch: RequiredBranchSchema,
+});
+
+/**
+ * Schema for creating any worktree (union)
+ */
+export const CreateWorktreeRequestSchema = v.union([
+  CreateWorktreePromptRequestSchema,
+  CreateWorktreeCustomRequestSchema,
+  CreateWorktreeExistingRequestSchema,
+]);
+
+/**
+ * Schema for deleting a worktree
+ */
+export const DeleteWorktreeRequestSchema = v.object({
+  force: v.optional(v.boolean()),
+});
+
+// Inferred types from schemas
+export type CreateRepositoryRequest = v.InferOutput<typeof CreateRepositoryRequestSchema>;
+export type CreateWorktreePromptRequest = v.InferOutput<typeof CreateWorktreePromptRequestSchema>;
+export type CreateWorktreeCustomRequest = v.InferOutput<typeof CreateWorktreeCustomRequestSchema>;
+export type CreateWorktreeExistingRequest = v.InferOutput<typeof CreateWorktreeExistingRequestSchema>;
+export type CreateWorktreeRequest = v.InferOutput<typeof CreateWorktreeRequestSchema>;
+export type DeleteWorktreeRequest = v.InferOutput<typeof DeleteWorktreeRequestSchema>;

--- a/packages/shared/src/schemas/session.ts
+++ b/packages/shared/src/schemas/session.ts
@@ -1,0 +1,89 @@
+import * as v from 'valibot';
+
+/**
+ * Schema for creating a worktree session
+ */
+export const CreateWorktreeSessionRequestSchema = v.object({
+  type: v.literal('worktree'),
+  repositoryId: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'Repository ID is required')
+  ),
+  worktreeId: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'Worktree ID is required')
+  ),
+  locationPath: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'Location path is required')
+  ),
+  agentId: v.optional(v.string()),
+  continueConversation: v.optional(v.boolean()),
+  initialPrompt: v.optional(v.string()),
+  title: v.optional(v.string()),
+});
+
+/**
+ * Schema for creating a quick session
+ */
+export const CreateQuickSessionRequestSchema = v.object({
+  type: v.literal('quick'),
+  locationPath: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'Location path is required')
+  ),
+  agentId: v.optional(v.string()),
+  continueConversation: v.optional(v.boolean()),
+  initialPrompt: v.optional(v.string()),
+  title: v.optional(v.string()),
+});
+
+/**
+ * Schema for creating any session (union)
+ */
+export const CreateSessionRequestSchema = v.union([
+  CreateWorktreeSessionRequestSchema,
+  CreateQuickSessionRequestSchema,
+]);
+
+/**
+ * Branch name validation regex pattern
+ * Valid: alphanumeric, dots, underscores, slashes, hyphens
+ */
+export const branchNamePattern = /^[a-zA-Z0-9._/-]+$/;
+
+/**
+ * Branch name validation error message
+ */
+export const branchNameErrorMessage = 'Invalid branch name. Use alphanumeric, dots, underscores, slashes, or hyphens.';
+
+/**
+ * Schema for updating a session
+ */
+export const UpdateSessionRequestSchema = v.pipe(
+  v.object({
+    title: v.optional(v.string()),
+    branch: v.optional(
+      v.pipe(
+        v.string(),
+        v.trim(),
+        v.minLength(1, 'Branch name cannot be empty'),
+        v.regex(branchNamePattern, branchNameErrorMessage)
+      )
+    ),
+  }),
+  v.check(
+    (input) => input.title !== undefined || input.branch !== undefined,
+    'At least one of title or branch must be provided'
+  )
+);
+
+// Inferred types from schemas
+export type CreateWorktreeSessionRequest = v.InferOutput<typeof CreateWorktreeSessionRequestSchema>;
+export type CreateQuickSessionRequest = v.InferOutput<typeof CreateQuickSessionRequestSchema>;
+export type CreateSessionRequest = v.InferOutput<typeof CreateSessionRequestSchema>;
+export type UpdateSessionRequest = v.InferOutput<typeof UpdateSessionRequestSchema>;

--- a/packages/shared/src/schemas/worker.ts
+++ b/packages/shared/src/schemas/worker.ts
@@ -1,0 +1,50 @@
+import * as v from 'valibot';
+
+/**
+ * Base options for worker creation
+ */
+const WorkerOptionsSchema = v.object({
+  name: v.optional(v.string()),
+  continueConversation: v.optional(v.boolean()),
+});
+
+/**
+ * Schema for creating an agent worker
+ */
+export const CreateAgentWorkerRequestSchema = v.object({
+  ...WorkerOptionsSchema.entries,
+  type: v.literal('agent'),
+  agentId: v.pipe(
+    v.string(),
+    v.minLength(1, 'Agent ID is required')
+  ),
+});
+
+/**
+ * Schema for creating a terminal worker
+ */
+export const CreateTerminalWorkerRequestSchema = v.object({
+  ...WorkerOptionsSchema.entries,
+  type: v.literal('terminal'),
+});
+
+/**
+ * Schema for creating any worker (union)
+ */
+export const CreateWorkerRequestSchema = v.union([
+  CreateAgentWorkerRequestSchema,
+  CreateTerminalWorkerRequestSchema,
+]);
+
+/**
+ * Schema for restarting a worker
+ */
+export const RestartWorkerRequestSchema = v.object({
+  continueConversation: v.optional(v.boolean()),
+});
+
+// Inferred types from schemas
+export type CreateAgentWorkerRequest = v.InferOutput<typeof CreateAgentWorkerRequestSchema>;
+export type CreateTerminalWorkerRequest = v.InferOutput<typeof CreateTerminalWorkerRequestSchema>;
+export type CreateWorkerRequest = v.InferOutput<typeof CreateWorkerRequestSchema>;
+export type RestartWorkerRequest = v.InferOutput<typeof RestartWorkerRequestSchema>;

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1,17 +1,13 @@
-/**
- * Agent-specific patterns for activity detection
- */
-export interface AgentActivityPatterns {
-  /** Regex patterns (as strings) that indicate "asking" state */
-  askingPatterns?: string[];
-}
+// Import types for local use
+import type { AgentActivityPatterns, InitialPromptMode } from '../schemas/agent.js';
 
-/**
- * How to pass the initial prompt to the agent
- * - 'stdin': Write the prompt to stdin after the agent starts (default)
- * - 'arg': Pass as command line argument
- */
-export type InitialPromptMode = 'stdin' | 'arg';
+// Re-export schema-derived types
+export type {
+  AgentActivityPatterns,
+  InitialPromptMode,
+  CreateAgentRequest,
+  UpdateAgentRequest,
+} from '../schemas/agent.js';
 
 /**
  * Agent definition - stored and managed by AgentManager
@@ -40,32 +36,4 @@ export interface AgentDefinition {
    * If not set, the agent does not support non-interactive mode.
    */
   printModeArgs?: string[];
-}
-
-/**
- * Request to create a new agent
- */
-export interface CreateAgentRequest {
-  name: string;
-  command: string;
-  description?: string;
-  icon?: string;
-  activityPatterns?: AgentActivityPatterns;
-  continueArgs?: string[];
-  initialPromptMode?: InitialPromptMode;
-  initialPromptDelayMs?: number;
-}
-
-/**
- * Request to update an existing agent
- */
-export interface UpdateAgentRequest {
-  name?: string;
-  command?: string;
-  description?: string;
-  icon?: string;
-  activityPatterns?: AgentActivityPatterns;
-  continueArgs?: string[];
-  initialPromptMode?: InitialPromptMode;
-  initialPromptDelayMs?: number;
 }

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -1,5 +1,20 @@
 import type { Worker, AgentActivityState } from './worker.js';
 
+// Re-export schema-derived types
+export type {
+  CreateWorktreeSessionRequest,
+  CreateQuickSessionRequest,
+  CreateSessionRequest,
+  UpdateSessionRequest,
+} from '../schemas/session.js';
+
+export type {
+  CreateAgentWorkerRequest,
+  CreateTerminalWorkerRequest,
+  CreateWorkerRequest,
+  RestartWorkerRequest,
+} from '../schemas/worker.js';
+
 export type SessionStatus = 'active' | 'inactive';
 
 export interface SessionBase {
@@ -24,49 +39,9 @@ export interface QuickSession extends SessionBase {
 
 export type Session = WorktreeSession | QuickSession;
 
-interface CreateWorktreeSessionRequest {
-  type: 'worktree';
-  repositoryId: string;
-  worktreeId: string;
-  locationPath: string;
-  agentId?: string;              // If provided, create initial agent worker
-  continueConversation?: boolean;
-  /** Initial prompt to send to the agent after starting */
-  initialPrompt?: string;
-  /** Human-readable title for the session */
-  title?: string;
-}
-
-interface CreateQuickSessionRequest {
-  type: 'quick';
-  locationPath: string;
-  agentId?: string;
-  continueConversation?: boolean;
-  /** Initial prompt to send to the agent after starting */
-  initialPrompt?: string;
-  /** Human-readable title for the session */
-  title?: string;
-}
-
-export type CreateSessionRequest = CreateWorktreeSessionRequest | CreateQuickSessionRequest;
-
 export interface CreateSessionResponse {
   session: Session;
 }
-
-// Worker creation
-interface CreateAgentWorkerRequest {
-  type: 'agent';
-  name?: string;
-  agentId: string;
-}
-
-interface CreateTerminalWorkerRequest {
-  type: 'terminal';
-  name?: string;
-}
-
-export type CreateWorkerRequest = CreateAgentWorkerRequest | CreateTerminalWorkerRequest;
 
 export interface CreateWorkerResponse {
   worker: Worker;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["bun"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary

- Add valibot schemas for form validation across client, server, and shared packages
- Integrate React Hook Form with valibot resolver for type-safe form handling
- Add `v.forward()` for cross-field validation to work around `@hookform/resolvers/valibot` limitation with root-level errors
- Add server-side `validateBody()` middleware with proper JSON parse error handling
- Extract form components (AddRepositoryForm, CreateWorktreeForm, QuickSessionForm) for maintainability
- Add comprehensive test coverage for all schemas and validation scenarios

## Test plan

- [x] Run `bun run test` - all 529 tests pass
- [x] Run `bun run typecheck` - no type errors
- [ ] Manual testing: Submit CreateWorktree form with empty input (should show validation error, not JSON parse error)
- [ ] Manual testing: Submit EditSession form with invalid branch name (should show validation error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)