### PR TITLE
feat: replace browser alert() with ErrorDialog component

### DIFF
--- a/packages/client/src/components/AgentManagement.tsx
+++ b/packages/client/src/components/AgentManagement.tsx
@@ -7,6 +7,7 @@ import { CreateAgentRequestSchema } from '@agent-console/shared';
 import { registerAgent, unregisterAgent } from '../lib/api';
 import { useAgents } from './AgentSelector';
 import { ConfirmDialog } from './ui/confirm-dialog';
+import { ErrorDialog, useErrorDialog } from './ui/error-dialog';
 import { FormField, Input } from './ui/FormField';
 
 export function AgentManagement() {
@@ -14,6 +15,7 @@ export function AgentManagement() {
   const { agents, isLoading } = useAgents();
   const [showAddForm, setShowAddForm] = useState(false);
   const [agentToDelete, setAgentToDelete] = useState<AgentDefinition | null>(null);
+  const { errorDialogProps, showError } = useErrorDialog();
 
   const unregisterMutation = useMutation({
     mutationFn: unregisterAgent,
@@ -25,7 +27,7 @@ export function AgentManagement() {
 
   const handleDelete = (agent: AgentDefinition) => {
     if (agent.isBuiltIn) {
-      alert('Built-in agents cannot be deleted');
+      showError('Cannot Delete', 'Built-in agents cannot be deleted');
       return;
     }
     setAgentToDelete(agent);
@@ -87,6 +89,7 @@ export function AgentManagement() {
         }}
         isLoading={unregisterMutation.isPending}
       />
+      <ErrorDialog {...errorDialogProps} />
     </div>
   );
 }

--- a/packages/client/src/components/ui/error-dialog.tsx
+++ b/packages/client/src/components/ui/error-dialog.tsx
@@ -1,0 +1,105 @@
+import { useState, useCallback } from 'react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogAction,
+} from './alert-dialog';
+
+export interface ErrorDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+  message: string;
+  actionLabel?: string;
+}
+
+/**
+ * A dialog component for displaying error messages.
+ * Use this to replace native alert() calls with a consistent UI.
+ */
+export function ErrorDialog({
+  open,
+  onOpenChange,
+  title = 'Error',
+  message,
+  actionLabel = 'OK',
+}: ErrorDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-red-400">{title}</AlertDialogTitle>
+          <AlertDialogDescription>{message}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogAction>{actionLabel}</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export interface ErrorDialogState {
+  open: boolean;
+  title: string;
+  message: string;
+}
+
+/**
+ * Hook to manage error dialog state.
+ * Returns state and handlers for the ErrorDialog component.
+ *
+ * @example
+ * const { errorDialogProps, showError } = useErrorDialog();
+ *
+ * // Show error
+ * showError('Something went wrong');
+ * showError('Custom title', 'Error message');
+ *
+ * // Render dialog
+ * <ErrorDialog {...errorDialogProps} />
+ */
+export function useErrorDialog() {
+  const [state, setState] = useState<ErrorDialogState>({
+    open: false,
+    title: 'Error',
+    message: '',
+  });
+
+  const showError = useCallback((titleOrMessage: string, message?: string) => {
+    if (message !== undefined) {
+      setState({
+        open: true,
+        title: titleOrMessage,
+        message,
+      });
+    } else {
+      setState({
+        open: true,
+        title: 'Error',
+        message: titleOrMessage,
+      });
+    }
+  }, []);
+
+  const hideError = useCallback(() => {
+    setState((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  return {
+    errorDialogProps: {
+      open: state.open,
+      title: state.title,
+      message: state.message,
+      onOpenChange: (open: boolean) => {
+        if (!open) hideError();
+      },
+    },
+    showError,
+    hideError,
+  };
+}

--- a/packages/client/src/routes/sessions/$sessionId.tsx
+++ b/packages/client/src/routes/sessions/$sessionId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { useState, useEffect, useCallback } from 'react';
 import { Terminal, type ConnectionStatus } from '../../components/Terminal';
 import { SessionSettings } from '../../components/SessionSettings';
+import { ErrorDialog, useErrorDialog } from '../../components/ui/error-dialog';
 import { getSession, createWorker, deleteWorker, restartAgentWorker, ServerUnavailableError } from '../../lib/api';
 import { formatPath } from '../../lib/path';
 import type { Session, Worker, AgentWorker, AgentActivityState } from '@agent-console/shared';
@@ -87,6 +88,7 @@ function TerminalPage() {
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('connecting');
   const [exitInfo, setExitInfo] = useState<{ code: number; signal: string | null } | undefined>();
   const [activityState, setActivityState] = useState<AgentActivityState>('unknown');
+  const { errorDialogProps, showError } = useErrorDialog();
 
   // Tab management
   const [tabs, setTabs] = useState<Tab[]>([]);
@@ -309,7 +311,7 @@ function TerminalPage() {
       }
     } catch (error) {
       console.error('Failed to restart session:', error);
-      alert(error instanceof Error ? error.message : 'Failed to restart session');
+      showError('Restart Failed', error instanceof Error ? error.message : 'Failed to restart session');
       setState({ type: 'disconnected', session });
     }
   };
@@ -553,6 +555,7 @@ function TerminalPage() {
           <span className={`inline-block w-2 h-2 rounded-full ${statusColor}`} />
         </span>
       </div>
+      <ErrorDialog {...errorDialogProps} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add `ErrorDialog` component and `useErrorDialog` hook for consistent error display
- Replace all `alert()` calls with the new `ErrorDialog` component
- Provides better UX with styled modal dialogs instead of browser native alerts

## Changes

### New Component
- `packages/client/src/components/ui/error-dialog.tsx`
  - `ErrorDialog` - Modal dialog for error messages (red title, OK button)
  - `useErrorDialog` - Hook to manage dialog state

### Updated Files
- `packages/client/src/routes/index.tsx` - WorktreeRow component (3 alert replacements)
- `packages/client/src/components/AgentManagement.tsx` - Built-in agent delete warning
- `packages/client/src/routes/sessions/$sessionId.tsx` - Session restart error

## Test plan

- [x] TypeCheck passes
- [x] All tests pass
- [x] Manual verification: ConfirmDialog displays correctly
- [ ] Manual verification: ErrorDialog displays on API errors

Note: ErrorDialog could not be fully tested as it requires actual API errors. The component uses the same AlertDialog base as ConfirmDialog which was verified to work correctly.

## Related

- Closes #48 (Step 2: Alert/Toast System)
- Toast notifications intentionally not implemented per user preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)