### PR TITLE
fix: improve diff error handling with ErrorBoundary

### DIFF
--- a/packages/client/src/components/ui/ErrorBoundary.tsx
+++ b/packages/client/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,68 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode | ((error: Error, resetError: () => void) => ReactNode);
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Error boundary component that catches JavaScript errors in child components.
+ * Prevents errors from crashing the entire application.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  resetError = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError && this.state.error) {
+      const { fallback } = this.props;
+
+      if (typeof fallback === 'function') {
+        return fallback(this.state.error, this.resetError);
+      }
+
+      if (fallback) {
+        return fallback;
+      }
+
+      // Default fallback UI
+      return (
+        <div className="flex flex-col items-center justify-center h-full p-8 text-center bg-slate-900">
+          <div className="text-red-400 text-lg font-medium mb-2">Something went wrong</div>
+          <div className="text-gray-500 text-sm mb-4 max-w-md">
+            {this.state.error.message}
+          </div>
+          <button
+            onClick={this.resetError}
+            className="btn btn-primary text-sm"
+          >
+            Try Again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/client/src/components/ui/__tests__/ErrorBoundary.test.tsx
+++ b/packages/client/src/components/ui/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, mock, afterEach, spyOn } from 'bun:test';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+// Component that throws an error
+function ThrowingComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('Test error message');
+  }
+  return <div>Normal content</div>;
+}
+
+describe('ErrorBoundary', () => {
+  // Suppress console.error during tests since we expect errors
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  afterEach(() => {
+    cleanup();
+    consoleErrorSpy?.mockRestore();
+  });
+
+  it('renders children when there is no error', () => {
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <div>Test content</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Test content')).toBeTruthy();
+  });
+
+  it('renders default fallback UI when child throws an error', () => {
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+    expect(screen.getByText('Test error message')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeTruthy();
+  });
+
+  it('renders custom fallback ReactNode when provided', () => {
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary fallback={<div>Custom error UI</div>}>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Custom error UI')).toBeTruthy();
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+  });
+
+  it('renders custom fallback function with error and resetError', () => {
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    const fallbackFn = mock((error: Error, resetError: () => void) => (
+      <div>
+        <span>Error: {error.message}</span>
+        <button onClick={resetError}>Reset</button>
+      </div>
+    ));
+
+    render(
+      <ErrorBoundary fallback={fallbackFn}>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(fallbackFn).toHaveBeenCalled();
+    expect(screen.getByText('Error: Test error message')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Reset' })).toBeTruthy();
+  });
+
+  it('calls onError callback when error is caught', () => {
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onError = mock((_error: any, _errorInfo: any) => {});
+
+    render(
+      <ErrorBoundary onError={onError}>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [error, errorInfo] = onError.mock.calls[0];
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('Test error message');
+    expect(errorInfo).toHaveProperty('componentStack');
+  });
+
+  it('resets error state when resetError is called and component no longer throws', () => {
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    // Use a controllable throw flag
+    let shouldThrow = true;
+
+    function ConditionalThrow() {
+      if (shouldThrow) {
+        throw new Error('Conditional error');
+      }
+      return <div>Recovered content</div>;
+    }
+
+    const { rerender } = render(
+      <ErrorBoundary
+        fallback={(_error, resetError) => (
+          <div>
+            <span>Error occurred</span>
+            <button onClick={resetError}>Reset</button>
+          </div>
+        )}
+      >
+        <ConditionalThrow />
+      </ErrorBoundary>
+    );
+
+    // Should show error state
+    expect(screen.getByText('Error occurred')).toBeTruthy();
+
+    // Change the flag so component won't throw on next render
+    shouldThrow = false;
+
+    // Click reset button - this clears the error state
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+
+    // Force re-render to pick up the state change
+    rerender(
+      <ErrorBoundary
+        fallback={(_error, resetError) => (
+          <div>
+            <span>Error occurred</span>
+            <button onClick={resetError}>Reset</button>
+          </div>
+        )}
+      >
+        <ConditionalThrow />
+      </ErrorBoundary>
+    );
+
+    // Should show recovered content
+    expect(screen.getByText('Recovered content')).toBeTruthy();
+    expect(screen.queryByText('Error occurred')).toBeNull();
+  });
+
+  it('catches errors in nested components', () => {
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <div>
+          <div>
+            <ThrowingComponent shouldThrow={true} />
+          </div>
+        </div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+  });
+
+  it('isolates errors - sibling ErrorBoundaries do not affect each other', () => {
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <div>
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </ErrorBoundary>
+        <ErrorBoundary>
+          <div>Sibling content</div>
+        </ErrorBoundary>
+      </div>
+    );
+
+    // First boundary should show error
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+    // Second boundary should show normal content
+    expect(screen.getByText('Sibling content')).toBeTruthy();
+  });
+
+  it('logs error to console', () => {
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/components/workers/GitDiffWorkerView.tsx
+++ b/packages/client/src/components/workers/GitDiffWorkerView.tsx
@@ -3,6 +3,7 @@ import { useGitDiffWorker } from '../../hooks/useGitDiffWorker';
 import { RefreshIcon } from '../Icons';
 import { DiffViewer } from './DiffViewer';
 import { DiffFileList } from './DiffFileList';
+import { ErrorBoundary } from '../ui/ErrorBoundary';
 
 interface GitDiffWorkerViewProps {
   sessionId: string;
@@ -143,12 +144,31 @@ export function GitDiffWorkerView({ sessionId, workerId }: GitDiffWorkerViewProp
 
         {/* Right: Diff viewer - shows all files stacked */}
         <div className="flex-1 min-w-0 overflow-hidden">
-          <DiffViewer
-            rawDiff={rawDiff}
-            files={files}
-            scrollToFile={scrollToFile}
-            onFileVisible={handleFileVisible}
-          />
+          <ErrorBoundary
+            fallback={(error, resetError) => (
+              <div className="flex flex-col items-center justify-center h-full p-8 text-center bg-slate-900">
+                <div className="text-red-400 text-lg font-medium mb-2">Failed to parse diff</div>
+                <div className="text-gray-500 text-sm mb-4 max-w-md font-mono bg-slate-800 p-3 rounded">
+                  {error.message}
+                </div>
+                <div className="flex gap-3">
+                  <button onClick={resetError} className="btn btn-primary text-sm">
+                    Retry
+                  </button>
+                  <button onClick={refresh} className="btn bg-slate-600 hover:bg-slate-500 text-sm">
+                    Refresh Diff
+                  </button>
+                </div>
+              </div>
+            )}
+          >
+            <DiffViewer
+              rawDiff={rawDiff}
+              files={files}
+              scrollToFile={scrollToFile}
+              onFileVisible={handleFileVisible}
+            />
+          </ErrorBoundary>
         </div>
       </div>
 

--- a/packages/server/src/services/git-diff-service.ts
+++ b/packages/server/src/services/git-diff-service.ts
@@ -217,22 +217,26 @@ async function generateUntrackedFileDiff(
       return { diff, lineCount: 0, isBinary: false };
     }
 
+    // Build content lines with + prefix
+    const contentLines: string[] = [];
+    for (let i = 0; i < lineCount; i++) {
+      contentLines.push(`+${lines[i]}`);
+    }
+
     // Generate diff lines
+    // Note: The hunk header line count must match the actual number of added lines (lines starting with '+')
     const diffLines = [
       `diff --git a/${filePath} b/${filePath}`,
       'new file mode 100644',
       'index 0000000..0000000',
       '--- /dev/null',
       `+++ b/${filePath}`,
-      `@@ -0,0 +1,${lineCount} @@`,
+      `@@ -0,0 +1,${contentLines.length} @@`,
+      ...contentLines,
     ];
 
-    // Add content lines with + prefix
-    for (let i = 0; i < lineCount; i++) {
-      diffLines.push(`+${lines[i]}`);
-    }
-
     // Add "No newline at end of file" if applicable
+    // Note: This line does NOT count toward hunk line count - it's metadata
     if (!hasTrailingNewline && lineCount > 0) {
       diffLines.push('\\ No newline at end of file');
     }


### PR DESCRIPTION
## Summary
- Fix "Added line count did not match for hunk at line 5" error in diff parsing by ensuring hunk header line counts match actual content
- Add reusable ErrorBoundary component to isolate errors per worker tab
- Each tab (Agent, Terminal, Git Diff) now has independent error handling - errors in one tab don't crash others

## Changes
- `git-diff-service.ts`: Build content lines before hunk header to ensure count matches
- `ErrorBoundary.tsx`: New reusable component with custom fallback support
- `$sessionId.tsx`: Wrap all worker tabs with ErrorBoundary + WorkerErrorFallback
- `GitDiffWorkerView.tsx`: Add inner ErrorBoundary for DiffViewer (defense in depth)
- `ErrorBoundary.test.tsx`: 9 test cases covering error handling, reset, and isolation

## Test plan
- [x] Run `bun run test` - all tests pass including 9 new ErrorBoundary tests
- [x] Run `bun run typecheck` - no type errors
- [x] Manual test: Open Diff tab, verify diff displays without parsing error
- [x] Manual test: All worker tabs are isolated with individual error boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)