### PR TITLE
feat: add base commit and target ref selectors for git-diff worker

### DIFF
--- a/packages/client/src/components/workers/BaseCommitSelector.tsx
+++ b/packages/client/src/components/workers/BaseCommitSelector.tsx
@@ -1,0 +1,202 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchSessionBranches } from '../../lib/api';
+import { EditIcon } from '../Icons';
+
+interface BaseCommitSelectorProps {
+  sessionId: string;
+  currentBaseCommit: string | null;
+  onBaseCommitChange: (ref: string) => void;
+  disabled?: boolean;
+}
+
+export function BaseCommitSelector({
+  sessionId,
+  currentBaseCommit,
+  onBaseCommitChange,
+  disabled = false,
+}: BaseCommitSelectorProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const [showDropdown, setShowDropdown] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Fetch branches when editing starts
+  const { data: branchesData } = useQuery({
+    queryKey: ['sessionBranches', sessionId],
+    queryFn: () => fetchSessionBranches(sessionId),
+    enabled: isEditing,
+    staleTime: 30000, // Cache for 30 seconds
+  });
+
+  // Format display value - show commit hash clearly
+  const shortCommit = currentBaseCommit ? currentBaseCommit.substring(0, 7) : null;
+
+  // Filter branches based on input
+  const filteredBranches = branchesData
+    ? [
+        ...branchesData.local.filter(b => b.toLowerCase().includes(inputValue.toLowerCase())),
+        ...branchesData.remote
+          .filter(b => b.toLowerCase().includes(inputValue.toLowerCase()))
+          .filter(b => !branchesData.local.includes(b.replace(/^origin\//, ''))),
+      ].slice(0, 10)
+    : [];
+
+  const handleStartEdit = useCallback(() => {
+    if (disabled) return;
+    setIsEditing(true);
+    setInputValue('');
+    setShowDropdown(true);
+  }, [disabled]);
+
+  const handleCancel = useCallback(() => {
+    setIsEditing(false);
+    setShowDropdown(false);
+    setInputValue('');
+  }, []);
+
+  const handleSubmit = useCallback((value: string) => {
+    const trimmed = value.trim();
+    if (trimmed) {
+      onBaseCommitChange(trimmed);
+    }
+    setIsEditing(false);
+    setShowDropdown(false);
+    setInputValue('');
+  }, [onBaseCommitChange]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit(inputValue);
+    } else if (e.key === 'Escape') {
+      handleCancel();
+    }
+  }, [inputValue, handleSubmit, handleCancel]);
+
+  const handleSelectBranch = useCallback((branch: string) => {
+    handleSubmit(branch);
+  }, [handleSubmit]);
+
+  // Focus input when editing starts
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isEditing]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        inputRef.current &&
+        !inputRef.current.contains(event.target as Node)
+      ) {
+        handleCancel();
+      }
+    };
+
+    if (isEditing) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isEditing, handleCancel]);
+
+  if (isEditing) {
+    return (
+      <div className="relative inline-block">
+        <div className="flex items-center gap-1">
+          <input
+            ref={inputRef}
+            type="text"
+            value={inputValue}
+            onChange={(e) => {
+              setInputValue(e.target.value);
+              setShowDropdown(true);
+            }}
+            onKeyDown={handleKeyDown}
+            onFocus={() => setShowDropdown(true)}
+            placeholder="branch or commit..."
+            className="px-2 py-0.5 text-sm bg-slate-700 border border-slate-600 rounded text-gray-200 focus:outline-none focus:border-blue-500 w-48"
+          />
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="text-gray-400 hover:text-gray-200 text-xs px-1"
+          >
+            Cancel
+          </button>
+        </div>
+
+        {/* Dropdown */}
+        {showDropdown && filteredBranches.length > 0 && (
+          <div
+            ref={dropdownRef}
+            className="absolute top-full left-0 mt-1 w-64 max-h-60 overflow-y-auto bg-slate-800 border border-slate-600 rounded shadow-lg z-50"
+          >
+            {branchesData?.defaultBranch && !inputValue && (
+              <div className="px-2 py-1 text-xs text-gray-500 border-b border-slate-700">
+                Default branch
+              </div>
+            )}
+            {branchesData?.defaultBranch && !inputValue && (
+              <button
+                type="button"
+                onClick={() => handleSelectBranch(branchesData.defaultBranch!)}
+                className="w-full px-3 py-1.5 text-left text-sm text-blue-400 hover:bg-slate-700 flex items-center gap-2"
+              >
+                <span>{branchesData.defaultBranch}</span>
+                <span className="text-xs text-gray-500">(default)</span>
+              </button>
+            )}
+            {filteredBranches.length > 0 && (
+              <div className="px-2 py-1 text-xs text-gray-500 border-b border-slate-700">
+                {inputValue ? 'Matching branches' : 'Local branches'}
+              </div>
+            )}
+            {filteredBranches.map((branch) => (
+              <button
+                key={branch}
+                type="button"
+                onClick={() => handleSelectBranch(branch)}
+                className="w-full px-3 py-1.5 text-left text-sm text-gray-200 hover:bg-slate-700"
+              >
+                {branch}
+              </button>
+            ))}
+            {inputValue && (
+              <>
+                <div className="px-2 py-1 text-xs text-gray-500 border-t border-slate-700">
+                  Use custom ref
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleSubmit(inputValue)}
+                  className="w-full px-3 py-1.5 text-left text-sm text-gray-200 hover:bg-slate-700"
+                >
+                  Use &quot;{inputValue}&quot;
+                </button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleStartEdit}
+      disabled={disabled}
+      className="inline-flex items-center gap-1.5 px-2 py-0.5 bg-slate-700 hover:bg-slate-600 rounded text-sm font-mono disabled:opacity-50 disabled:cursor-not-allowed group"
+      title="Change base commit"
+    >
+      <span className="text-blue-400">{shortCommit || 'N/A'}</span>
+      <EditIcon className="w-3 h-3 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+    </button>
+  );
+}

--- a/packages/client/src/components/workers/TargetRefSelector.tsx
+++ b/packages/client/src/components/workers/TargetRefSelector.tsx
@@ -1,0 +1,184 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { GitDiffTarget } from '@agent-console/shared';
+import { fetchBranchCommits } from '../../lib/api';
+import { EditIcon } from '../Icons';
+
+interface TargetRefSelectorProps {
+  sessionId: string;
+  currentTargetRef: GitDiffTarget;
+  currentBaseCommit: string | null;
+  onTargetRefChange: (ref: GitDiffTarget) => void;
+  disabled?: boolean;
+}
+
+export function TargetRefSelector({
+  sessionId,
+  currentTargetRef,
+  currentBaseCommit,
+  onTargetRefChange,
+  disabled = false,
+}: TargetRefSelectorProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // Fetch commits since base commit when editing starts
+  const { data: commitsData } = useQuery({
+    queryKey: ['branchCommits', sessionId, currentBaseCommit],
+    queryFn: () => fetchBranchCommits(sessionId, currentBaseCommit!),
+    enabled: isEditing && !!currentBaseCommit,
+    staleTime: 10000, // Cache for 10 seconds
+  });
+
+  // Format display value
+  const isWorkingDir = currentTargetRef === 'working-dir';
+  const shortCommit = !isWorkingDir ? currentTargetRef.substring(0, 7) : null;
+
+  const handleStartEdit = useCallback(() => {
+    if (disabled) return;
+    setIsEditing(true);
+    setShowDropdown(true);
+  }, [disabled]);
+
+  const handleCancel = useCallback(() => {
+    setIsEditing(false);
+    setShowDropdown(false);
+  }, []);
+
+  const handleSelect = useCallback((value: GitDiffTarget) => {
+    onTargetRefChange(value);
+    setIsEditing(false);
+    setShowDropdown(false);
+  }, [onTargetRefChange]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        handleCancel();
+      }
+    };
+
+    if (isEditing) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isEditing, handleCancel]);
+
+  if (isEditing) {
+    return (
+      <div className="relative inline-block">
+        <button
+          ref={buttonRef}
+          type="button"
+          onClick={handleCancel}
+          className="inline-flex items-center gap-1.5 px-2 py-0.5 bg-slate-600 rounded text-sm font-mono"
+        >
+          {isWorkingDir ? (
+            <span className="text-green-400">Working Dir</span>
+          ) : (
+            <span className="text-yellow-400">{shortCommit}</span>
+          )}
+          <span className="text-gray-400 text-xs">▲</span>
+        </button>
+
+        {/* Dropdown */}
+        {showDropdown && (
+          <div
+            ref={dropdownRef}
+            className="absolute top-full left-0 mt-1 w-80 max-h-72 overflow-y-auto bg-slate-800 border border-slate-600 rounded shadow-lg z-50"
+          >
+            {/* Working Directory option - always show first */}
+            <div className="px-2 py-1 text-xs text-gray-500 border-b border-slate-700">
+              Current state
+            </div>
+            <button
+              type="button"
+              onClick={() => handleSelect('working-dir')}
+              className={`w-full px-3 py-1.5 text-left text-sm hover:bg-slate-700 flex items-center gap-2 ${
+                isWorkingDir ? 'text-green-400 bg-slate-700/50' : 'text-gray-200'
+              }`}
+            >
+              <span>Working Directory</span>
+              <span className="text-xs text-gray-500">(uncommitted changes)</span>
+            </button>
+
+            {/* HEAD option */}
+            <button
+              type="button"
+              onClick={() => handleSelect('HEAD')}
+              className={`w-full px-3 py-1.5 text-left text-sm hover:bg-slate-700 flex items-center gap-2 ${
+                currentTargetRef === 'HEAD' ? 'text-yellow-400 bg-slate-700/50' : 'text-gray-200'
+              }`}
+            >
+              <span>HEAD</span>
+              <span className="text-xs text-gray-500">(latest commit)</span>
+            </button>
+
+            {/* Commits created in this branch */}
+            {commitsData && commitsData.commits.length > 0 && (
+              <>
+                <div className="px-2 py-1 text-xs text-gray-500 border-t border-b border-slate-700">
+                  Commits in this branch ({commitsData.commits.length})
+                </div>
+                {commitsData.commits.map((commit) => (
+                  <button
+                    key={commit.hash}
+                    type="button"
+                    onClick={() => handleSelect(commit.hash)}
+                    className={`w-full px-3 py-1.5 text-left text-sm hover:bg-slate-700 ${
+                      currentTargetRef === commit.hash ? 'text-yellow-400 bg-slate-700/50' : 'text-gray-200'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-yellow-400">{commit.shortHash}</span>
+                      <span className="truncate flex-1">{commit.message}</span>
+                    </div>
+                  </button>
+                ))}
+              </>
+            )}
+
+            {/* No commits message */}
+            {commitsData && commitsData.commits.length === 0 && (
+              <div className="px-3 py-2 text-xs text-gray-500 border-t border-slate-700">
+                No commits yet in this branch
+              </div>
+            )}
+
+            {/* Loading state */}
+            {!commitsData && currentBaseCommit && (
+              <div className="px-3 py-2 text-xs text-gray-500 border-t border-slate-700">
+                Loading commits...
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleStartEdit}
+      disabled={disabled}
+      className="inline-flex items-center gap-1.5 px-2 py-0.5 bg-slate-700 hover:bg-slate-600 rounded text-sm font-mono disabled:opacity-50 disabled:cursor-not-allowed group"
+      title="Change target"
+    >
+      {isWorkingDir ? (
+        <span className="text-green-400">Working Dir</span>
+      ) : (
+        <span className="text-yellow-400">{shortCommit}</span>
+      )}
+      <EditIcon className="w-3 h-3 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+    </button>
+  );
+}

--- a/packages/client/src/hooks/__tests__/useGitDiffWorker.test.ts
+++ b/packages/client/src/hooks/__tests__/useGitDiffWorker.test.ts
@@ -83,6 +83,7 @@ describe('useGitDiffWorker', () => {
   const mockDiffData: GitDiffData = {
     summary: {
       baseCommit: 'abc123',
+      targetRef: 'working-dir',
       files: [
         {
           path: 'src/test.ts',
@@ -232,6 +233,54 @@ describe('useGitDiffWorker', () => {
 
     expect(ws?.send).toHaveBeenCalledWith(
       JSON.stringify({ type: 'set-base-commit', ref: 'main' })
+    );
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('should send set-target-commit message', async () => {
+    const { result } = renderHook(() =>
+      useGitDiffWorker({ sessionId: 'session1', workerId: 'worker1' })
+    );
+
+    await act(async () => {
+      await waitForNextTick();
+    });
+
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+    });
+
+    act(() => {
+      result.current.setTargetCommit('HEAD');
+    });
+
+    expect(ws?.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'set-target-commit', ref: 'HEAD' })
+    );
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('should send set-target-commit message with working-dir', async () => {
+    const { result } = renderHook(() =>
+      useGitDiffWorker({ sessionId: 'session1', workerId: 'worker1' })
+    );
+
+    await act(async () => {
+      await waitForNextTick();
+    });
+
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+    });
+
+    act(() => {
+      result.current.setTargetCommit('working-dir');
+    });
+
+    expect(ws?.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'set-target-commit', ref: 'working-dir' })
     );
     expect(result.current.loading).toBe(true);
   });

--- a/packages/client/src/hooks/useGitDiffWorker.ts
+++ b/packages/client/src/hooks/useGitDiffWorker.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
-import type { GitDiffServerMessage, GitDiffClientMessage, GitDiffData } from '@agent-console/shared';
+import type { GitDiffServerMessage, GitDiffClientMessage, GitDiffData, GitDiffTarget } from '@agent-console/shared';
 
 interface UseGitDiffWorkerOptions {
   sessionId: string;
@@ -14,6 +14,7 @@ interface UseGitDiffWorkerReturn {
   connected: boolean;
   refresh: () => void;
   setBaseCommit: (ref: string) => void;
+  setTargetCommit: (ref: GitDiffTarget) => void;
 }
 
 export function useGitDiffWorker(options: UseGitDiffWorkerOptions): UseGitDiffWorkerReturn {
@@ -112,6 +113,14 @@ export function useGitDiffWorker(options: UseGitDiffWorkerOptions): UseGitDiffWo
     }
   }, []);
 
+  const setTargetCommit = useCallback((ref: GitDiffTarget) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      const msg: GitDiffClientMessage = { type: 'set-target-commit', ref };
+      wsRef.current.send(JSON.stringify(msg));
+      setLoading(true);
+    }
+  }, []);
+
   return {
     diffData,
     error,
@@ -119,5 +128,6 @@ export function useGitDiffWorker(options: UseGitDiffWorkerOptions): UseGitDiffWo
     connected,
     refresh,
     setBaseCommit,
+    setTargetCommit,
   };
 }

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -250,6 +250,34 @@ export async function fetchBranches(repositoryId: string): Promise<BranchesRespo
   return res.json();
 }
 
+export async function fetchSessionBranches(sessionId: string): Promise<BranchesResponse> {
+  const res = await fetch(`${API_BASE}/sessions/${sessionId}/branches`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch session branches: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export interface CommitInfo {
+  hash: string;
+  shortHash: string;
+  message: string;
+  author: string;
+  date: string;
+}
+
+export interface BranchCommitsResponse {
+  commits: CommitInfo[];
+}
+
+export async function fetchBranchCommits(sessionId: string, baseRef: string): Promise<BranchCommitsResponse> {
+  const res = await fetch(`${API_BASE}/sessions/${sessionId}/commits?base=${encodeURIComponent(baseRef)}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch branch commits: ${res.statusText}`);
+  }
+  return res.json();
+}
+
 export async function createWorktree(
   repositoryId: string,
   request: CreateWorktreeRequest

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -365,3 +365,41 @@ export async function getOrgRepoFromPath(repoPath: string): Promise<string | nul
   }
   return parseOrgRepo(remoteUrl);
 }
+
+// ============================================================
+// Commit Log Operations
+// ============================================================
+
+export interface CommitInfo {
+  hash: string;
+  shortHash: string;
+  message: string;
+  author: string;
+  date: string;
+}
+
+/**
+ * Get commits between a base ref and HEAD (commits created in this branch).
+ * Uses `git log <baseRef>..HEAD` to get commits that are in HEAD but not in baseRef.
+ *
+ * @example
+ * const commits = await getBranchCommits('main', repoPath);
+ */
+export async function getBranchCommits(baseRef: string, cwd: string): Promise<CommitInfo[]> {
+  try {
+    // Format: hash|shortHash|message|author|date
+    const format = '%H|%h|%s|%an|%ai';
+    const output = await git(['log', `${baseRef}..HEAD`, `--format=${format}`], cwd);
+
+    if (!output) {
+      return [];
+    }
+
+    return output.split('\n').filter(Boolean).map((line) => {
+      const [hash, shortHash, message, author, date] = line.split('|');
+      return { hash, shortHash, message, author, date };
+    });
+  } catch {
+    return [];
+  }
+}

--- a/packages/shared/src/types/git-diff.ts
+++ b/packages/shared/src/types/git-diff.ts
@@ -47,9 +47,13 @@ export interface GitDiffLine {
   newLineNumber?: number;
 }
 
+/** Target reference for diff comparison */
+export type GitDiffTarget = 'working-dir' | string;  // 'working-dir' or commit hash
+
 /** Diff summary (sent via WebSocket) */
 export interface GitDiffSummary {
   baseCommit: string;        // Comparison base commit hash
+  targetRef: GitDiffTarget;  // Target: 'working-dir' or commit hash
   files: GitDiffFile[];
   totalAdditions: number;
   totalDeletions: number;
@@ -81,4 +85,5 @@ export type GitDiffServerMessage =
 /** Client → Server messages */
 export type GitDiffClientMessage =
   | { type: 'refresh' }
-  | { type: 'set-base-commit'; ref: string };
+  | { type: 'set-base-commit'; ref: string }
+  | { type: 'set-target-commit'; ref: GitDiffTarget };  // 'working-dir' or commit/branch ref


### PR DESCRIPTION
## Summary
- Add BaseCommitSelector component to change the base commit for diff comparison
- Add TargetRefSelector component to select comparison target (Working Directory, HEAD, or specific commits in the branch)
- Add `/sessions/:id/commits?base=` API endpoint to fetch commits since base ref
- Add `getBranchCommits()` git utility function

## Test plan
- [x] Typecheck passes
- [x] All 619 tests pass
- [x] Manual verification: dropdown shows commits created in the branch correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)