### PR TITLE
feat: add session validation and recovery feature

### DIFF
--- a/packages/client/src/components/Icons.tsx
+++ b/packages/client/src/components/Icons.tsx
@@ -119,3 +119,29 @@ export function DiffIcon({ className = 'w-4 h-4' }: IconProps) {
     </svg>
   );
 }
+
+export function WarningIcon({ className = 'w-4 h-4' }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+      />
+    </svg>
+  );
+}
+
+export function CheckIcon({ className = 'w-4 h-4' }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M5 13l4 4L19 7"
+      />
+    </svg>
+  );
+}

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   AgentDefinition,
   CreateAgentRequest,
   UpdateAgentRequest,
+  SessionsValidationResponse,
 } from '@agent-console/shared';
 
 const API_BASE = '/api';
@@ -381,5 +382,24 @@ export async function openPath(path: string): Promise<void> {
   if (!res.ok) {
     const error = await res.json().catch(() => ({ error: res.statusText }));
     throw new Error(error.error || 'Failed to open path');
+  }
+}
+
+// Session validation
+export async function validateSessions(): Promise<SessionsValidationResponse> {
+  const res = await fetch(`${API_BASE}/sessions/validate`);
+  if (!res.ok) {
+    throw new Error(`Failed to validate sessions: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function deleteInvalidSession(sessionId: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/sessions/${sessionId}/invalid`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(error.error || 'Failed to delete invalid session');
   }
 }

--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -9,9 +9,15 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as MaintenanceRouteImport } from './routes/maintenance'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SessionsSessionIdRouteImport } from './routes/sessions/$sessionId'
 
+const MaintenanceRoute = MaintenanceRouteImport.update({
+  id: '/maintenance',
+  path: '/maintenance',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -25,32 +31,43 @@ const SessionsSessionIdRoute = SessionsSessionIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/maintenance': typeof MaintenanceRoute
   '/sessions/$sessionId': typeof SessionsSessionIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/maintenance': typeof MaintenanceRoute
   '/sessions/$sessionId': typeof SessionsSessionIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/maintenance': typeof MaintenanceRoute
   '/sessions/$sessionId': typeof SessionsSessionIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/sessions/$sessionId'
+  fullPaths: '/' | '/maintenance' | '/sessions/$sessionId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/sessions/$sessionId'
-  id: '__root__' | '/' | '/sessions/$sessionId'
+  to: '/' | '/maintenance' | '/sessions/$sessionId'
+  id: '__root__' | '/' | '/maintenance' | '/sessions/$sessionId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  MaintenanceRoute: typeof MaintenanceRoute
   SessionsSessionIdRoute: typeof SessionsSessionIdRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/maintenance': {
+      id: '/maintenance'
+      path: '/maintenance'
+      fullPath: '/maintenance'
+      preLoaderRoute: typeof MaintenanceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -70,6 +87,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  MaintenanceRoute: MaintenanceRoute,
   SessionsSessionIdRoute: SessionsSessionIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -1,4 +1,7 @@
 import { createRootRoute, Outlet, Link, useLocation } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { validateSessions } from '../lib/api';
+import { WarningIcon } from '../components/Icons';
 
 export const Route = createRootRoute({
   component: RootLayout,
@@ -41,10 +44,50 @@ function RootLayout() {
         >
           Agent Console
         </Link>
+        <ValidationWarningIndicator />
       </header>
       <main style={{ flex: 1, overflow: 'auto' }}>
         <Outlet />
       </main>
     </div>
+  );
+}
+
+function ValidationWarningIndicator() {
+  const { data } = useQuery({
+    queryKey: ['session-validation'],
+    queryFn: validateSessions,
+    // Only check once on initial load, don't refetch automatically
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    retry: false,
+  });
+
+  if (!data?.hasIssues) {
+    return null;
+  }
+
+  const invalidCount = data.results.filter(r => !r.valid).length;
+
+  return (
+    <Link
+      to="/maintenance"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '4px 8px',
+        borderRadius: '4px',
+        backgroundColor: 'rgba(234, 179, 8, 0.2)',
+        color: '#eab308',
+        fontSize: '0.75rem',
+        textDecoration: 'none',
+      }}
+      title={`${invalidCount} invalid session${invalidCount > 1 ? 's' : ''} found`}
+    >
+      <WarningIcon className="w-3.5 h-3.5" />
+      <span>{invalidCount}</span>
+    </Link>
   );
 }

--- a/packages/client/src/routes/maintenance.tsx
+++ b/packages/client/src/routes/maintenance.tsx
@@ -1,0 +1,209 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { validateSessions, deleteInvalidSession } from '../lib/api';
+import { formatPath } from '../lib/path';
+import { ConfirmDialog } from '../components/ui/confirm-dialog';
+import { CheckIcon, WarningIcon, CloseIcon } from '../components/Icons';
+import { useState } from 'react';
+import type { SessionValidationResult } from '@agent-console/shared';
+
+export const Route = createFileRoute('/maintenance')({
+  component: MaintenancePage,
+});
+
+function MaintenancePage() {
+  const queryClient = useQueryClient();
+  const [sessionToDelete, setSessionToDelete] = useState<SessionValidationResult | null>(null);
+  const [showDeleteAllConfirm, setShowDeleteAllConfirm] = useState(false);
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['session-validation'],
+    queryFn: validateSessions,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteInvalidSession,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['session-validation'] });
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+      setSessionToDelete(null);
+    },
+  });
+
+  const deleteAllMutation = useMutation({
+    mutationFn: async (sessionIds: string[]) => {
+      for (const id of sessionIds) {
+        await deleteInvalidSession(id);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['session-validation'] });
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+      setShowDeleteAllConfirm(false);
+    },
+  });
+
+  const invalidSessions = data?.results.filter(r => !r.valid) ?? [];
+
+  return (
+    <div className="py-6 px-6 max-w-4xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold">Maintenance</h1>
+          <p className="text-sm text-gray-400 mt-1">
+            Validate and clean up invalid sessions
+          </p>
+        </div>
+        <Link to="/" className="btn text-sm bg-slate-700 hover:bg-slate-600 no-underline">
+          Back to Dashboard
+        </Link>
+      </div>
+
+      <div className="card mb-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-medium">Session Validation</h2>
+          <button
+            onClick={() => refetch()}
+            disabled={isLoading}
+            className="btn text-sm bg-slate-700 hover:bg-slate-600"
+          >
+            {isLoading ? 'Validating...' : 'Validate All'}
+          </button>
+        </div>
+
+        {error && (
+          <div className="bg-red-500/20 text-red-400 px-4 py-3 rounded mb-4">
+            Failed to validate sessions: {error instanceof Error ? error.message : 'Unknown error'}
+          </div>
+        )}
+
+        {data && !data.hasIssues && (
+          <div className="bg-green-500/20 text-green-400 px-4 py-3 rounded flex items-center gap-2">
+            <CheckIcon className="w-5 h-5" />
+            All sessions are valid ({data.results.length} checked)
+          </div>
+        )}
+
+        {data && data.hasIssues && (
+          <>
+            <div className="bg-yellow-500/20 text-yellow-400 px-4 py-3 rounded mb-4 flex items-center gap-2">
+              <WarningIcon className="w-5 h-5" />
+              {invalidSessions.length} invalid session{invalidSessions.length > 1 ? 's' : ''} found
+            </div>
+
+            {invalidSessions.length > 1 && (
+              <div className="mb-4">
+                <button
+                  onClick={() => setShowDeleteAllConfirm(true)}
+                  disabled={deleteAllMutation.isPending}
+                  className="btn btn-danger text-sm"
+                >
+                  Delete All Invalid Sessions
+                </button>
+              </div>
+            )}
+
+            <div className="space-y-3">
+              {invalidSessions.map((result) => (
+                <InvalidSessionCard
+                  key={result.sessionId}
+                  result={result}
+                  onDelete={() => setSessionToDelete(result)}
+                  isDeleting={deleteMutation.isPending && sessionToDelete?.sessionId === result.sessionId}
+                />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Delete single session confirmation */}
+      <ConfirmDialog
+        open={sessionToDelete !== null}
+        onOpenChange={(open) => !open && setSessionToDelete(null)}
+        title="Delete Invalid Session"
+        description={`Delete session at "${sessionToDelete?.session.locationPath}"? This will remove the session from the configuration.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => sessionToDelete && deleteMutation.mutate(sessionToDelete.sessionId)}
+        isLoading={deleteMutation.isPending}
+      />
+
+      {/* Delete all confirmation */}
+      <ConfirmDialog
+        open={showDeleteAllConfirm}
+        onOpenChange={setShowDeleteAllConfirm}
+        title="Delete All Invalid Sessions"
+        description={`Delete all ${invalidSessions.length} invalid sessions? This cannot be undone.`}
+        confirmLabel="Delete All"
+        variant="danger"
+        onConfirm={() => deleteAllMutation.mutate(invalidSessions.map(r => r.sessionId))}
+        isLoading={deleteAllMutation.isPending}
+      />
+    </div>
+  );
+}
+
+interface InvalidSessionCardProps {
+  result: SessionValidationResult;
+  onDelete: () => void;
+  isDeleting: boolean;
+}
+
+function InvalidSessionCard({ result, onDelete, isDeleting }: InvalidSessionCardProps) {
+  const { session, issues } = result;
+
+  return (
+    <div className="bg-slate-800 rounded p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          {session.title && (
+            <div className="text-sm font-medium text-gray-200 mb-1 truncate" title={session.title}>
+              {session.title}
+            </div>
+          )}
+          <div className="text-sm text-gray-400 truncate" title={session.locationPath}>
+            {formatPath(session.locationPath)}
+          </div>
+          <div className="flex items-center gap-2 mt-1">
+            <span className="text-xs text-gray-500 capitalize">{session.type}</span>
+            {session.worktreeId && (
+              <>
+                <span className="text-xs text-gray-600">|</span>
+                <span className="text-xs text-gray-500">{session.worktreeId}</span>
+              </>
+            )}
+          </div>
+          <div className="mt-2 space-y-1">
+            {issues.map((issue, index) => (
+              <div key={index} className="flex items-center gap-2 text-xs text-red-400">
+                <CloseIcon className="w-3.5 h-3.5 shrink-0" />
+                <span>{getIssueMessage(issue.type)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <button
+          onClick={onDelete}
+          disabled={isDeleting}
+          className="btn btn-danger text-xs shrink-0"
+        >
+          {isDeleting ? 'Deleting...' : 'Delete'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function getIssueMessage(type: string): string {
+  switch (type) {
+    case 'directory_not_found':
+      return 'Directory does not exist';
+    case 'not_git_repository':
+      return 'Not a git repository';
+    case 'branch_not_found':
+      return 'Branch does not exist';
+    default:
+      return type;
+  }
+}

--- a/packages/server/src/services/__tests__/session-validation-service.test.ts
+++ b/packages/server/src/services/__tests__/session-validation-service.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { setupTestConfigDir, cleanupTestConfigDir, setupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
+import type { PersistedSession } from '../persistence-service.js';
+import type { SessionValidationResult } from '@agent-console/shared';
+
+// Mock gitRefExists to avoid actual git commands
+let mockGitRefExists: () => Promise<boolean> = () => Promise.resolve(true);
+
+mock.module('../../lib/git.js', () => ({
+  gitRefExists: () => mockGitRefExists(),
+}));
+
+describe('SessionValidationService', () => {
+  const TEST_CONFIG_DIR = '/test/config';
+  let importCounter = 0;
+
+  beforeEach(() => {
+    // Reset the mock
+    mockGitRefExists = () => Promise.resolve(true);
+  });
+
+  afterEach(() => {
+    cleanupTestConfigDir();
+  });
+
+  async function getServices() {
+    const module = await import(`../session-validation-service.js?v=${++importCounter}`);
+    const persistenceModule = await import(`../persistence-service.js?v=${importCounter}`);
+    return {
+      validationService: new module.SessionValidationService(),
+      persistenceService: new persistenceModule.PersistenceService(),
+    };
+  }
+
+  describe('validateSession', () => {
+    it('should pass validation for valid quick session with existing directory', async () => {
+      setupMemfs({
+        [`${TEST_CONFIG_DIR}/.keep`]: '',
+        '/projects/my-project/README.md': 'test',
+      });
+      process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+
+      const { validationService } = await getServices();
+
+      const session: PersistedSession = {
+        id: 'test-session',
+        type: 'quick',
+        locationPath: '/projects/my-project',
+        workers: [],
+        serverPid: 1234,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      const result = await validationService.validateSession(session);
+
+      expect(result.valid).toBe(true);
+      expect(result.issues).toHaveLength(0);
+      expect(result.sessionId).toBe('test-session');
+    });
+
+    it('should fail validation when directory does not exist', async () => {
+      setupTestConfigDir(TEST_CONFIG_DIR);
+
+      const { validationService } = await getServices();
+
+      const session: PersistedSession = {
+        id: 'test-session',
+        type: 'quick',
+        locationPath: '/non-existent/path',
+        workers: [],
+        serverPid: 1234,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      const result = await validationService.validateSession(session);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0].type).toBe('directory_not_found');
+    });
+
+    it('should fail validation for worktree session when not a git repository', async () => {
+      setupMemfs({
+        [`${TEST_CONFIG_DIR}/.keep`]: '',
+        '/projects/my-project/README.md': 'test',
+        // No .git directory
+      });
+      process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+
+      const { validationService } = await getServices();
+
+      const session: PersistedSession = {
+        id: 'test-session',
+        type: 'worktree',
+        locationPath: '/projects/my-project',
+        repositoryId: 'repo-1',
+        worktreeId: 'feature-branch',
+        workers: [],
+        serverPid: 1234,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      const result = await validationService.validateSession(session);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0].type).toBe('not_git_repository');
+    });
+
+    it('should fail validation when branch does not exist', async () => {
+      setupMemfs({
+        [`${TEST_CONFIG_DIR}/.keep`]: '',
+        '/projects/my-project/.git': 'gitdir: ...',
+        '/projects/my-project/README.md': 'test',
+      });
+      process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+
+      // Mock gitRefExists to return false for this test
+      mockGitRefExists = () => Promise.resolve(false);
+
+      const { validationService } = await getServices();
+
+      const session: PersistedSession = {
+        id: 'test-session',
+        type: 'worktree',
+        locationPath: '/projects/my-project',
+        repositoryId: 'repo-1',
+        worktreeId: 'non-existent-branch',
+        workers: [],
+        serverPid: 1234,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      const result = await validationService.validateSession(session);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0].type).toBe('branch_not_found');
+    });
+
+    it('should pass validation for worktree session with existing directory, git repo, and branch', async () => {
+      setupMemfs({
+        [`${TEST_CONFIG_DIR}/.keep`]: '',
+        '/projects/my-project/.git': 'gitdir: ...',
+        '/projects/my-project/README.md': 'test',
+      });
+      process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+
+      // Mock gitRefExists to return true
+      mockGitRefExists = () => Promise.resolve(true);
+
+      const { validationService } = await getServices();
+
+      const session: PersistedSession = {
+        id: 'test-session',
+        type: 'worktree',
+        locationPath: '/projects/my-project',
+        repositoryId: 'repo-1',
+        worktreeId: 'main',
+        workers: [],
+        serverPid: 1234,
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      const result = await validationService.validateSession(session);
+
+      expect(result.valid).toBe(true);
+      expect(result.issues).toHaveLength(0);
+    });
+
+    it('should include session info in result', async () => {
+      setupTestConfigDir(TEST_CONFIG_DIR);
+
+      const { validationService } = await getServices();
+
+      const session: PersistedSession = {
+        id: 'test-session',
+        type: 'worktree',
+        locationPath: '/non-existent/path',
+        repositoryId: 'repo-1',
+        worktreeId: 'feature-branch',
+        workers: [],
+        serverPid: 1234,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        title: 'My Session',
+      };
+
+      const result = await validationService.validateSession(session);
+
+      expect(result.session.type).toBe('worktree');
+      expect(result.session.locationPath).toBe('/non-existent/path');
+      expect(result.session.worktreeId).toBe('feature-branch');
+      expect(result.session.title).toBe('My Session');
+    });
+  });
+
+  describe('validateAllSessions', () => {
+    it('should return hasIssues=false when all sessions are valid', async () => {
+      setupMemfs({
+        [`${TEST_CONFIG_DIR}/sessions.json`]: JSON.stringify([
+          {
+            id: 's1',
+            type: 'quick',
+            locationPath: '/projects/p1',
+            workers: [],
+            serverPid: 1234,
+            createdAt: '2024-01-01T00:00:00.000Z',
+          },
+        ]),
+        '/projects/p1/README.md': 'test',
+      });
+      process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+
+      const { validationService } = await getServices();
+      const response = await validationService.validateAllSessions();
+
+      expect(response.hasIssues).toBe(false);
+      expect(response.results).toHaveLength(1);
+      expect(response.results[0].valid).toBe(true);
+    });
+
+    it('should return hasIssues=true when some sessions are invalid', async () => {
+      setupMemfs({
+        [`${TEST_CONFIG_DIR}/sessions.json`]: JSON.stringify([
+          {
+            id: 's1',
+            type: 'quick',
+            locationPath: '/projects/valid',
+            workers: [],
+            serverPid: 1234,
+            createdAt: '2024-01-01T00:00:00.000Z',
+          },
+          {
+            id: 's2',
+            type: 'quick',
+            locationPath: '/projects/invalid',
+            workers: [],
+            serverPid: 1234,
+            createdAt: '2024-01-01T00:00:00.000Z',
+          },
+        ]),
+        '/projects/valid/README.md': 'test',
+        // /projects/invalid does not exist
+      });
+      process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+
+      const { validationService } = await getServices();
+      const response = await validationService.validateAllSessions();
+
+      expect(response.hasIssues).toBe(true);
+      expect(response.results).toHaveLength(2);
+
+      const validResult = response.results.find((r: SessionValidationResult) => r.sessionId === 's1');
+      const invalidResult = response.results.find((r: SessionValidationResult) => r.sessionId === 's2');
+
+      expect(validResult?.valid).toBe(true);
+      expect(invalidResult?.valid).toBe(false);
+    });
+
+    it('should return empty results when no sessions exist', async () => {
+      setupTestConfigDir(TEST_CONFIG_DIR);
+
+      const { validationService } = await getServices();
+      const response = await validationService.validateAllSessions();
+
+      expect(response.hasIssues).toBe(false);
+      expect(response.results).toHaveLength(0);
+    });
+  });
+
+  describe('getInvalidSessions', () => {
+    it('should return only invalid sessions', async () => {
+      setupMemfs({
+        [`${TEST_CONFIG_DIR}/sessions.json`]: JSON.stringify([
+          {
+            id: 's1',
+            type: 'quick',
+            locationPath: '/projects/valid',
+            workers: [],
+            serverPid: 1234,
+            createdAt: '2024-01-01T00:00:00.000Z',
+          },
+          {
+            id: 's2',
+            type: 'quick',
+            locationPath: '/projects/invalid1',
+            workers: [],
+            serverPid: 1234,
+            createdAt: '2024-01-01T00:00:00.000Z',
+          },
+          {
+            id: 's3',
+            type: 'quick',
+            locationPath: '/projects/invalid2',
+            workers: [],
+            serverPid: 1234,
+            createdAt: '2024-01-01T00:00:00.000Z',
+          },
+        ]),
+        '/projects/valid/README.md': 'test',
+        // invalid1 and invalid2 do not exist
+      });
+      process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+
+      const { validationService } = await getServices();
+      const invalidSessions = await validationService.getInvalidSessions();
+
+      expect(invalidSessions).toHaveLength(2);
+      expect(invalidSessions.map((s: SessionValidationResult) => s.sessionId).sort()).toEqual(['s2', 's3']);
+    });
+  });
+});

--- a/packages/server/src/services/session-validation-service.ts
+++ b/packages/server/src/services/session-validation-service.ts
@@ -1,0 +1,141 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import type {
+  SessionValidationResult,
+  SessionValidationIssue,
+  SessionsValidationResponse,
+} from '@agent-console/shared';
+import {
+  persistenceService,
+  type PersistedSession,
+} from './persistence-service.js';
+import { gitRefExists } from '../lib/git.js';
+import { createLogger } from '../lib/logger.js';
+
+const logger = createLogger('session-validation');
+
+/**
+ * Service for validating session integrity.
+ *
+ * Checks:
+ * 1. locationPath exists (directory)
+ * 2. For worktree sessions: locationPath is a git repository
+ * 3. For worktree sessions: worktreeId (branch) exists
+ */
+export class SessionValidationService {
+  /**
+   * Validate a single session
+   */
+  async validateSession(session: PersistedSession): Promise<SessionValidationResult> {
+    const issues: SessionValidationIssue[] = [];
+
+    // Check 1: Directory exists
+    const directoryExists = await this.checkDirectoryExists(session.locationPath);
+    if (!directoryExists) {
+      issues.push({
+        type: 'directory_not_found',
+        message: `Directory does not exist: ${session.locationPath}`,
+      });
+      // If directory doesn't exist, we can't check further
+      return this.buildResult(session, issues);
+    }
+
+    // For worktree sessions, perform git-specific checks
+    if (session.type === 'worktree') {
+      // Check 2: Is a git repository
+      const isGitRepo = await this.checkIsGitRepository(session.locationPath);
+      if (!isGitRepo) {
+        issues.push({
+          type: 'not_git_repository',
+          message: `Not a git repository: ${session.locationPath}`,
+        });
+        // If not a git repo, we can't check branch
+        return this.buildResult(session, issues);
+      }
+
+      // Check 3: Branch exists
+      const branchExists = await this.checkBranchExists(session.worktreeId, session.locationPath);
+      if (!branchExists) {
+        issues.push({
+          type: 'branch_not_found',
+          message: `Branch does not exist: ${session.worktreeId}`,
+        });
+      }
+    }
+
+    return this.buildResult(session, issues);
+  }
+
+  /**
+   * Validate all persisted sessions
+   */
+  async validateAllSessions(): Promise<SessionsValidationResponse> {
+    const persistedSessions = persistenceService.loadSessions();
+    const results: SessionValidationResult[] = [];
+
+    for (const session of persistedSessions) {
+      const result = await this.validateSession(session);
+      results.push(result);
+    }
+
+    const hasIssues = results.some(r => !r.valid);
+
+    logger.info({
+      totalSessions: results.length,
+      invalidSessions: results.filter(r => !r.valid).length,
+      hasIssues,
+    }, 'Session validation completed');
+
+    return { results, hasIssues };
+  }
+
+  /**
+   * Get only invalid sessions
+   */
+  async getInvalidSessions(): Promise<SessionValidationResult[]> {
+    const response = await this.validateAllSessions();
+    return response.results.filter(r => !r.valid);
+  }
+
+  private async checkDirectoryExists(dirPath: string): Promise<boolean> {
+    try {
+      const stat = await fs.stat(dirPath);
+      return stat.isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
+  private async checkIsGitRepository(dirPath: string): Promise<boolean> {
+    // Check for .git file or directory (supports both regular repos and worktrees)
+    const gitPath = path.join(dirPath, '.git');
+    try {
+      await fs.access(gitPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async checkBranchExists(branch: string, cwd: string): Promise<boolean> {
+    // Use gitRefExists which checks if the ref can be resolved
+    return gitRefExists(branch, cwd);
+  }
+
+  private buildResult(session: PersistedSession, issues: SessionValidationIssue[]): SessionValidationResult {
+    return {
+      sessionId: session.id,
+      session: {
+        type: session.type,
+        locationPath: session.locationPath,
+        worktreeId: session.type === 'worktree' ? session.worktreeId : undefined,
+        title: session.title,
+      },
+      valid: issues.length === 0,
+      issues,
+    };
+  }
+}
+
+// Singleton instance
+export const sessionValidationService = new SessionValidationService();

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -68,3 +68,31 @@ export type DashboardServerMessage =
   | { type: 'session-updated'; session: Session }
   | { type: 'session-deleted'; sessionId: string }
   | { type: 'worker-activity'; sessionId: string; workerId: string; activityState: AgentActivityState };
+
+// Session validation types
+export type SessionValidationIssueType =
+  | 'directory_not_found'
+  | 'not_git_repository'
+  | 'branch_not_found';
+
+export interface SessionValidationIssue {
+  type: SessionValidationIssueType;
+  message: string;
+}
+
+export interface SessionValidationResult {
+  sessionId: string;
+  session: {
+    type: 'worktree' | 'quick';
+    locationPath: string;
+    worktreeId?: string;
+    title?: string;
+  };
+  valid: boolean;
+  issues: SessionValidationIssue[];
+}
+
+export interface SessionsValidationResponse {
+  results: SessionValidationResult[];
+  hasIssues: boolean;
+}


### PR DESCRIPTION
## Summary

- Add functionality to detect sessions with invalid state (non-existent directories, missing branches, deleted worktrees)
- Allow users to clean up invalid sessions from the configuration via a dedicated maintenance page
- Show a warning indicator in the header when validation issues exist

## Changes

- **SessionValidationService**: New service for validating sessions against filesystem/git state
- **API Endpoints**: 
  - `GET /api/sessions/validate` - Check all sessions for validity
  - `DELETE /api/sessions/:id/invalid` - Remove invalid session from persistence
- **Maintenance Page**: New `/maintenance` route showing invalid sessions with delete options
- **Header Indicator**: Subtle warning badge when validation issues exist

## Technical Details

Validation checks:
1. Directory exists (`fs.access(locationPath)`)
2. Is git repository (worktree sessions) - checks `.git` file/directory
3. Branch exists (worktree sessions) - uses `gitRefExists`

Only modifies `sessions.json` - does not touch actual files, directories, or git branches.

## Test plan

- [x] Unit tests for SessionValidationService (10 test cases)
- [x] All tests pass (client: 187, shared: 153, server: 276)
- [x] Manual testing via MCP browser verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)