### PR TITLE
fix: inherit sessions on server restart instead of deleting them

### DIFF
--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -650,8 +650,11 @@ describe('SessionManager', () => {
       const savedDataBefore = JSON.parse(fs.readFileSync(`${TEST_CONFIG_DIR}/sessions.json`, 'utf-8'));
       expect(savedDataBefore.length).toBe(1);
 
-      // Simulate server restart: create new manager that loads from persistence
-      // but doesn't have internal workers
+      // Simulate server restart: mark the previous server as dead
+      // so the new manager will inherit the session
+      mockProcess.markDead(process.pid);
+
+      // Create new manager that loads from persistence
       const manager2 = await getSessionManager();
 
       // Session exists but internal worker map is empty
@@ -691,7 +694,9 @@ describe('SessionManager', () => {
       });
       const terminalWorkerId = terminalWorker!.id;
 
-      // Simulate server restart
+      // Simulate server restart: mark the previous server as dead
+      mockProcess.markDead(process.pid);
+
       const manager2 = await getSessionManager();
 
       // PTY count before restore
@@ -724,7 +729,9 @@ describe('SessionManager', () => {
       });
       expect(gitDiffWorker).toBeDefined();
 
-      // Simulate server restart
+      // Simulate server restart: mark the previous server as dead
+      mockProcess.markDead(process.pid);
+
       const manager2 = await getSessionManager();
 
       // Restore should return null for git-diff worker
@@ -748,7 +755,9 @@ describe('SessionManager', () => {
         agentId: 'claude-code',
       });
 
-      // Simulate server restart
+      // Simulate server restart: mark the previous server as dead
+      mockProcess.markDead(process.pid);
+
       const manager2 = await getSessionManager();
 
       // Try to restore non-existent worker
@@ -771,7 +780,9 @@ describe('SessionManager', () => {
       const originalPid = savedDataBefore[0].workers.find((w: { id: string }) => w.id === workerId)?.pid;
       expect(originalPid).toBeDefined();
 
-      // Simulate server restart
+      // Simulate server restart: mark the previous server as dead
+      mockProcess.markDead(process.pid);
+
       const manager2 = await getSessionManager();
 
       // Restore worker


### PR DESCRIPTION
## Summary

- Fix bug introduced by PR #86 where all sessions were deleted on server restart
- Sessions are now inherited (not deleted) when their `serverPid` is dead
- Orphan worker processes are killed during inheritance
- `serverPid` is updated to current server's PID when inheriting

## Background

PR #86 added logic to delete orphan sessions from `sessions.json` when `serverPid` was dead. However, this caused all sessions to be deleted on server restart because the previous server's PID is naturally dead after restart.

## Changes

- Swap execution order: `initializeSessions()` → `cleanupOrphanProcesses()`
- `initializeSessions()` now handles session inheritance:
  - Skip sessions with alive `serverPid` (other server instances)
  - Inherit sessions with dead/missing `serverPid`
  - Kill orphan worker processes
  - Update `serverPid` to current server PID
- Update tests to expect inheritance instead of deletion
- Add documentation in `docs/design/session-worker-design.md`

## Test plan

- [x] All existing tests pass
- [x] Orphan worker processes are killed on inheritance
- [x] Sessions from other live servers are not touched
- [x] `serverPid` is correctly updated on inheritance

🤖 Generated with [Claude Code](https://claude.com/claude-code)