### PR TITLE
feat: add loading spinner for forms and app initialization

### DIFF
--- a/packages/client/src/components/AgentManagement.tsx
+++ b/packages/client/src/components/AgentManagement.tsx
@@ -9,6 +9,7 @@ import { useAgents } from './AgentSelector';
 import { ConfirmDialog } from './ui/confirm-dialog';
 import { ErrorDialog, useErrorDialog } from './ui/error-dialog';
 import { FormField, Input } from './ui/FormField';
+import { FormOverlay, Spinner } from './ui/Spinner';
 
 export function AgentManagement() {
   const queryClient = useQueryClient();
@@ -34,7 +35,12 @@ export function AgentManagement() {
   };
 
   if (isLoading) {
-    return <div className="text-gray-500">Loading agents...</div>;
+    return (
+      <div className="flex items-center gap-2 text-gray-500">
+        <Spinner size="sm" />
+        <span>Loading agents...</span>
+      </div>
+    );
   }
 
   return (
@@ -177,46 +183,50 @@ function AddAgentForm({ onSuccess, onCancel }: AddAgentFormProps) {
     }
   };
 
+  const isPending = registerMutation.isPending;
+
   return (
-    <div className="bg-slate-800 p-4 rounded mb-4">
+    <div className="relative bg-slate-800 p-4 rounded mb-4">
+      <FormOverlay isVisible={isPending} message="Adding agent..." />
       <h3 className="text-sm font-medium mb-3">Add New Agent</h3>
-      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-3">
-        <FormField label="Name" error={errors.name}>
-          <Input
-            {...register('name')}
-            placeholder="Agent name (e.g., My Custom Agent)"
-            error={errors.name}
-          />
-        </FormField>
-        <FormField label="Command" error={errors.command}>
-          <Input
-            {...register('command')}
-            placeholder="Command (e.g., my-agent, /usr/local/bin/agent)"
-            error={errors.command}
-          />
-        </FormField>
-        <FormField label="Description (optional)" error={errors.description}>
-          <Input
-            {...register('description')}
-            placeholder="Description"
-            error={errors.description}
-          />
-        </FormField>
-        {errors.root && (
-          <p className="text-sm text-red-400">{errors.root.message}</p>
-        )}
-        <div className="flex gap-2">
-          <button
-            type="submit"
-            disabled={registerMutation.isPending}
-            className="btn btn-primary text-sm"
-          >
-            {registerMutation.isPending ? 'Adding...' : 'Add Agent'}
-          </button>
-          <button type="button" onClick={onCancel} className="btn btn-danger text-sm">
-            Cancel
-          </button>
-        </div>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <fieldset disabled={isPending} className="flex flex-col gap-3">
+          <FormField label="Name" error={errors.name}>
+            <Input
+              {...register('name')}
+              placeholder="Agent name (e.g., My Custom Agent)"
+              error={errors.name}
+            />
+          </FormField>
+          <FormField label="Command" error={errors.command}>
+            <Input
+              {...register('command')}
+              placeholder="Command (e.g., my-agent, /usr/local/bin/agent)"
+              error={errors.command}
+            />
+          </FormField>
+          <FormField label="Description (optional)" error={errors.description}>
+            <Input
+              {...register('description')}
+              placeholder="Description"
+              error={errors.description}
+            />
+          </FormField>
+          {errors.root && (
+            <p className="text-sm text-red-400">{errors.root.message}</p>
+          )}
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="btn btn-primary text-sm"
+            >
+              Add Agent
+            </button>
+            <button type="button" onClick={onCancel} className="btn btn-danger text-sm">
+              Cancel
+            </button>
+          </div>
+        </fieldset>
       </form>
     </div>
   );

--- a/packages/client/src/components/forms/AddRepositoryForm.tsx
+++ b/packages/client/src/components/forms/AddRepositoryForm.tsx
@@ -1,6 +1,7 @@
 import { useForm } from 'react-hook-form';
 import { valibotResolver } from '@hookform/resolvers/valibot';
 import { FormField, Input } from '../ui/FormField';
+import { FormOverlay } from '../ui/Spinner';
 import type { CreateRepositoryRequest } from '@agent-console/shared';
 import { CreateRepositoryRequestSchema } from '@agent-console/shared';
 
@@ -37,10 +38,11 @@ export function AddRepositoryForm({
   };
 
   return (
-    <div className="card mb-5">
+    <div className="relative card mb-5">
+      <FormOverlay isVisible={isPending} message="Adding repository..." />
       <h2 className="mb-3 text-lg font-medium">Add Repository</h2>
       <form onSubmit={handleSubmit(handleFormSubmit)}>
-        <div className="flex gap-3 items-start">
+        <fieldset disabled={isPending} className="flex gap-3 items-start">
           <div className="flex-1">
             <FormField error={errors.path}>
               <Input
@@ -55,10 +57,9 @@ export function AddRepositoryForm({
           </div>
           <button
             type="submit"
-            disabled={isPending}
             className="btn btn-primary"
           >
-            {isPending ? 'Adding...' : 'Add'}
+            Add
           </button>
           <button
             type="button"
@@ -67,7 +68,7 @@ export function AddRepositoryForm({
           >
             Cancel
           </button>
-        </div>
+        </fieldset>
       </form>
     </div>
   );

--- a/packages/client/src/components/forms/CreateWorktreeForm.tsx
+++ b/packages/client/src/components/forms/CreateWorktreeForm.tsx
@@ -2,6 +2,7 @@ import { useForm } from 'react-hook-form';
 import { valibotResolver } from '@hookform/resolvers/valibot';
 import { FormField, Input, Textarea } from '../ui/FormField';
 import { AgentSelector } from '../AgentSelector';
+import { FormOverlay } from '../ui/Spinner';
 import type { CreateWorktreeFormData } from '../../schemas/worktree-form';
 import { CreateWorktreeFormSchema } from '../../schemas/worktree-form';
 import type { CreateWorktreeRequest } from '@agent-console/shared';
@@ -89,10 +90,9 @@ export function CreateWorktreeForm({
   };
 
   return (
-    <div className={`bg-slate-800 p-4 rounded mb-4 ${isPending ? 'opacity-70' : ''}`}>
-      <h3 className="text-sm font-medium mb-3">
-        {isPending ? 'Creating Worktree...' : 'Create Worktree'}
-      </h3>
+    <div className="relative bg-slate-800 p-4 rounded mb-4">
+      <FormOverlay isVisible={isPending} message="Creating worktree..." />
+      <h3 className="text-sm font-medium mb-3">Create Worktree</h3>
       <form onSubmit={handleSubmit(handleFormSubmit)}>
         <fieldset disabled={isPending} className="flex flex-col gap-3">
           {/* Initial prompt input (available for all modes) */}
@@ -189,7 +189,7 @@ export function CreateWorktreeForm({
               type="submit"
               className="btn btn-primary text-sm"
             >
-              {isPending ? 'Creating...' : 'Create & Start Session'}
+              Create & Start Session
             </button>
             <button
               type="button"

--- a/packages/client/src/components/forms/QuickSessionForm.tsx
+++ b/packages/client/src/components/forms/QuickSessionForm.tsx
@@ -2,6 +2,7 @@ import { useForm } from 'react-hook-form';
 import { valibotResolver } from '@hookform/resolvers/valibot';
 import { FormField, Input } from '../ui/FormField';
 import { AgentSelector } from '../AgentSelector';
+import { FormOverlay } from '../ui/Spinner';
 import type { CreateQuickSessionRequest } from '@agent-console/shared';
 import { CreateQuickSessionRequestSchema } from '@agent-console/shared';
 
@@ -44,11 +45,12 @@ export function QuickSessionForm({
   };
 
   return (
-    <div className="card mb-4 bg-slate-800">
+    <div className="relative card mb-4 bg-slate-800">
+      <FormOverlay isVisible={isPending} message="Starting session..." />
       <h3 className="text-sm font-medium mb-3">Start Session in Any Directory</h3>
       <form onSubmit={handleSubmit(handleFormSubmit)}>
         <input type="hidden" {...register('type')} value="quick" />
-        <div className="flex flex-col gap-3">
+        <fieldset disabled={isPending} className="flex flex-col gap-3">
           <FormField error={errors.locationPath}>
             <Input
               {...register('locationPath')}
@@ -71,10 +73,9 @@ export function QuickSessionForm({
           <div className="flex gap-3">
             <button
               type="submit"
-              disabled={isPending}
               className="btn btn-primary text-sm"
             >
-              {isPending ? 'Starting...' : 'Start'}
+              Start
             </button>
             <button
               type="button"
@@ -84,7 +85,7 @@ export function QuickSessionForm({
               Cancel
             </button>
           </div>
-        </div>
+        </fieldset>
       </form>
     </div>
   );

--- a/packages/client/src/components/forms/__tests__/AddRepositoryForm.test.tsx
+++ b/packages/client/src/components/forms/__tests__/AddRepositoryForm.test.tsx
@@ -143,12 +143,15 @@ describe('AddRepositoryForm', () => {
   });
 
   describe('UI state', () => {
-    it('should disable submit button when isPending is true', () => {
+    it('should disable form when isPending is true', () => {
       renderAddRepositoryForm({ isPending: true });
 
-      // Submit button should show "Adding..." and be disabled
-      const submitButton = screen.getByText('Adding...');
-      expect((submitButton as HTMLButtonElement).disabled).toBe(true);
+      // Form overlay should be visible with loading message
+      expect(screen.getByText('Adding repository...')).toBeTruthy();
+
+      // Form fields should be disabled via fieldset
+      const pathInput = screen.getByPlaceholderText(/Repository path/);
+      expect(pathInput.closest('fieldset')?.disabled).toBe(true);
     });
 
     it('should call onCancel when cancel button is clicked', async () => {

--- a/packages/client/src/components/forms/__tests__/CreateWorktreeForm.test.tsx
+++ b/packages/client/src/components/forms/__tests__/CreateWorktreeForm.test.tsx
@@ -350,8 +350,8 @@ describe('CreateWorktreeForm', () => {
         expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
       });
 
-      // Submit button should show "Creating..."
-      expect(screen.getByText('Creating...')).toBeTruthy();
+      // Form overlay should be visible with loading message
+      expect(screen.getByText('Creating worktree...')).toBeTruthy();
 
       // Form fields should be disabled
       const promptInput = screen.getByPlaceholderText(/What do you want to work on/);

--- a/packages/client/src/components/forms/__tests__/QuickSessionForm.test.tsx
+++ b/packages/client/src/components/forms/__tests__/QuickSessionForm.test.tsx
@@ -216,7 +216,7 @@ describe('QuickSessionForm', () => {
   });
 
   describe('UI state', () => {
-    it('should disable submit button when isPending is true', async () => {
+    it('should disable form when isPending is true', async () => {
       renderQuickSessionForm({ isPending: true });
 
       // Wait for agents to load
@@ -224,9 +224,12 @@ describe('QuickSessionForm', () => {
         expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
       });
 
-      // Submit button should show "Starting..." and be disabled
-      const submitButton = screen.getByText('Starting...');
-      expect((submitButton as HTMLButtonElement).disabled).toBe(true);
+      // Form overlay should be visible with loading message
+      expect(screen.getByText('Starting session...')).toBeTruthy();
+
+      // Form fields should be disabled via fieldset
+      const pathInput = screen.getByPlaceholderText(/Path/);
+      expect(pathInput.closest('fieldset')?.disabled).toBe(true);
     });
 
     it('should call onCancel when cancel button is clicked', async () => {

--- a/packages/client/src/components/ui/Spinner.tsx
+++ b/packages/client/src/components/ui/Spinner.tsx
@@ -1,0 +1,78 @@
+import { type ComponentProps } from 'react';
+
+export type SpinnerSize = 'sm' | 'md' | 'lg';
+
+interface SpinnerProps extends Omit<ComponentProps<'div'>, 'children'> {
+  size?: SpinnerSize;
+}
+
+const sizeClasses: Record<SpinnerSize, string> = {
+  sm: 'w-4 h-4 border-2',
+  md: 'w-6 h-6 border-2',
+  lg: 'w-8 h-8 border-3',
+};
+
+export function Spinner({ size = 'md', className = '', ...props }: SpinnerProps) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className={`inline-block rounded-full border-current border-r-transparent animate-spin ${sizeClasses[size]} ${className}`}
+      {...props}
+    />
+  );
+}
+
+interface LoadingOverlayProps {
+  message?: string;
+}
+
+export function LoadingOverlay({ message = 'Loading...' }: LoadingOverlayProps) {
+  return (
+    <div className="fixed inset-0 bg-slate-900/80 flex flex-col items-center justify-center z-50">
+      <Spinner size="lg" className="text-indigo-500" />
+      <p className="mt-4 text-gray-300">{message}</p>
+    </div>
+  );
+}
+
+interface ButtonSpinnerProps {
+  isPending: boolean;
+  pendingText: string;
+  children: React.ReactNode;
+}
+
+export function ButtonSpinner({ isPending, pendingText, children }: ButtonSpinnerProps) {
+  if (!isPending) {
+    return <>{children}</>;
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <Spinner size="sm" />
+      {pendingText}
+    </span>
+  );
+}
+
+interface FormOverlayProps {
+  isVisible: boolean;
+  message?: string;
+}
+
+/**
+ * An overlay that covers a form container during loading.
+ * The parent element must have `position: relative` set.
+ */
+export function FormOverlay({ isVisible, message }: FormOverlayProps) {
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div className="absolute inset-0 bg-slate-900/70 rounded flex flex-col items-center justify-center z-10">
+      <Spinner size="md" className="text-indigo-500" />
+      {message && <p className="mt-3 text-sm text-gray-300">{message}</p>}
+    </div>
+  );
+}

--- a/packages/client/src/components/ui/__tests__/Spinner.test.tsx
+++ b/packages/client/src/components/ui/__tests__/Spinner.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { render, screen, cleanup } from '@testing-library/react';
+import { Spinner, ButtonSpinner, FormOverlay, LoadingOverlay } from '../Spinner';
+
+describe('Spinner', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('Spinner component', () => {
+    it('renders with default size (md)', () => {
+      render(<Spinner />);
+
+      const spinner = screen.getByRole('status');
+      expect(spinner).toBeTruthy();
+      expect(spinner.getAttribute('aria-label')).toBe('Loading');
+      expect(spinner.className).toContain('w-6');
+      expect(spinner.className).toContain('h-6');
+    });
+
+    it('renders with small size', () => {
+      render(<Spinner size="sm" />);
+
+      const spinner = screen.getByRole('status');
+      expect(spinner.className).toContain('w-4');
+      expect(spinner.className).toContain('h-4');
+    });
+
+    it('renders with large size', () => {
+      render(<Spinner size="lg" />);
+
+      const spinner = screen.getByRole('status');
+      expect(spinner.className).toContain('w-8');
+      expect(spinner.className).toContain('h-8');
+    });
+
+    it('applies custom className', () => {
+      render(<Spinner className="text-red-500" />);
+
+      const spinner = screen.getByRole('status');
+      expect(spinner.className).toContain('text-red-500');
+    });
+
+    it('has spin animation class', () => {
+      render(<Spinner />);
+
+      const spinner = screen.getByRole('status');
+      expect(spinner.className).toContain('animate-spin');
+    });
+  });
+
+  describe('ButtonSpinner component', () => {
+    it('renders children when not pending', () => {
+      render(
+        <ButtonSpinner isPending={false} pendingText="Loading...">
+          Submit
+        </ButtonSpinner>
+      );
+
+      expect(screen.getByText('Submit')).toBeTruthy();
+      expect(screen.queryByText('Loading...')).toBeNull();
+      expect(screen.queryByRole('status')).toBeNull();
+    });
+
+    it('renders spinner and pending text when pending', () => {
+      render(
+        <ButtonSpinner isPending={true} pendingText="Loading...">
+          Submit
+        </ButtonSpinner>
+      );
+
+      expect(screen.getByText('Loading...')).toBeTruthy();
+      expect(screen.queryByText('Submit')).toBeNull();
+      expect(screen.getByRole('status')).toBeTruthy();
+    });
+  });
+
+  describe('FormOverlay component', () => {
+    it('renders nothing when not visible', () => {
+      const { container } = render(<FormOverlay isVisible={false} />);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders overlay when visible', () => {
+      render(<FormOverlay isVisible={true} />);
+
+      const spinner = screen.getByRole('status');
+      expect(spinner).toBeTruthy();
+    });
+
+    it('renders message when provided', () => {
+      render(<FormOverlay isVisible={true} message="Processing..." />);
+
+      expect(screen.getByText('Processing...')).toBeTruthy();
+    });
+
+    it('does not render message when not provided', () => {
+      render(<FormOverlay isVisible={true} />);
+
+      // Should only have spinner, no text
+      expect(screen.queryByText(/./)).toBeNull();
+    });
+
+    it('has correct positioning classes', () => {
+      const { container } = render(<FormOverlay isVisible={true} message="Test" />);
+
+      const overlay = container.firstChild as HTMLElement;
+      expect(overlay.className).toContain('absolute');
+      expect(overlay.className).toContain('inset-0');
+      expect(overlay.className).toContain('z-10');
+    });
+  });
+
+  describe('LoadingOverlay component', () => {
+    it('renders with default message', () => {
+      render(<LoadingOverlay />);
+
+      expect(screen.getByText('Loading...')).toBeTruthy();
+      expect(screen.getByRole('status')).toBeTruthy();
+    });
+
+    it('renders with custom message', () => {
+      render(<LoadingOverlay message="Connecting..." />);
+
+      expect(screen.getByText('Connecting...')).toBeTruthy();
+    });
+
+    it('has fixed positioning for full screen', () => {
+      const { container } = render(<LoadingOverlay />);
+
+      const overlay = container.firstChild as HTMLElement;
+      expect(overlay.className).toContain('fixed');
+      expect(overlay.className).toContain('inset-0');
+      expect(overlay.className).toContain('z-50');
+    });
+  });
+});

--- a/packages/client/src/components/ui/confirm-dialog.tsx
+++ b/packages/client/src/components/ui/confirm-dialog.tsx
@@ -9,6 +9,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel,
 } from './alert-dialog';
+import { ButtonSpinner } from './Spinner';
 
 export interface ConfirmDialogProps {
   open: boolean;
@@ -56,11 +57,15 @@ export function ConfirmDialog({
               className="btn btn-danger"
               disabled={isLoading}
             >
-              {isLoading ? 'Processing...' : confirmLabel}
+              <ButtonSpinner isPending={isLoading} pendingText="Processing...">
+                {confirmLabel}
+              </ButtonSpinner>
             </button>
           ) : (
             <AlertDialogAction onClick={onConfirm} disabled={isLoading}>
-              {isLoading ? 'Processing...' : confirmLabel}
+              <ButtonSpinner isPending={isLoading} pendingText="Processing...">
+                {confirmLabel}
+              </ButtonSpinner>
             </AlertDialogAction>
           )}
         </AlertDialogFooter>

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -29,13 +29,98 @@ const queryClient = new QueryClient({
 
 const rootElement = document.getElementById('root')!;
 
+// Show initial loading indicator
+function showLoadingIndicator() {
+  rootElement.innerHTML = `
+    <div style="
+      position: fixed;
+      inset: 0;
+      background-color: #0a0a14;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    ">
+      <div style="
+        width: 32px;
+        height: 32px;
+        border: 3px solid #6366f1;
+        border-right-color: transparent;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+      "></div>
+      <p style="margin-top: 16px; color: #9ca3af;">Connecting to server...</p>
+      <style>
+        @keyframes spin {
+          to { transform: rotate(360deg); }
+        }
+      </style>
+    </div>
+  `;
+}
+
+// Show connection error with retry button
+function showConnectionError(error: unknown) {
+  const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+  rootElement.innerHTML = `
+    <div style="
+      position: fixed;
+      inset: 0;
+      background-color: #0a0a14;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    ">
+      <div style="
+        color: #ef4444;
+        font-size: 48px;
+        margin-bottom: 16px;
+      ">⚠</div>
+      <h1 style="
+        color: #e5e7eb;
+        font-size: 20px;
+        font-weight: 600;
+        margin-bottom: 8px;
+      ">Failed to connect to server</h1>
+      <p style="
+        color: #9ca3af;
+        font-size: 14px;
+        margin-bottom: 24px;
+        text-align: center;
+      ">${errorMessage}</p>
+      <button
+        id="retry-button"
+        style="
+          background-color: #4338ca;
+          color: white;
+          padding: 8px 16px;
+          border-radius: 4px;
+          border: none;
+          font-weight: 500;
+          cursor: pointer;
+          transition: background-color 150ms ease;
+        "
+        onmouseover="this.style.backgroundColor='#4f46e5'"
+        onmouseout="this.style.backgroundColor='#4338ca'"
+      >Retry</button>
+    </div>
+  `;
+  document.getElementById('retry-button')?.addEventListener('click', initApp);
+}
+
 // Initialize app with config from server
 async function initApp() {
+  showLoadingIndicator();
+
   try {
     const config = await fetchConfig();
     setHomeDir(config.homeDir);
   } catch (e) {
-    console.warn('Failed to fetch config:', e);
+    console.error('Failed to fetch config:', e);
+    showConnectionError(e);
+    return;
   }
 
   createRoot(rootElement).render(


### PR DESCRIPTION
## Summary

- Add reusable Spinner component with multiple variants for different use cases
- Apply form overlay during form submissions to provide visual feedback
- Add loading indicator on app startup with error handling and retry capability

## Changes

### New Components (`packages/client/src/components/ui/Spinner.tsx`)
- `Spinner` - Basic spinning indicator (sm/md/lg sizes)
- `ButtonSpinner` - For use inside buttons (used in ConfirmDialog)
- `FormOverlay` - Covers form area during submission with message
- `LoadingOverlay` - Full-screen overlay (available for future use)

### Form Loading States
Forms now show an overlay covering the form area during submission:
- CreateWorktreeForm - "Creating worktree..."
- QuickSessionForm - "Starting session..."
- AddRepositoryForm - "Adding repository..."
- AddAgentForm - "Adding agent..."

### App Initialization
- Shows spinner while connecting to server on startup
- Displays error screen with retry button if connection fails

## Test plan
- [x] All existing tests pass
- [x] Added 15 new tests for Spinner components
- [ ] Manual testing: verify form overlays appear during submission
- [ ] Manual testing: verify app startup loading and error states

🤖 Generated with [Claude Code](https://claude.com/claude-code)