### PR TITLE
feat: notify users when branch name generation falls back

### DIFF
--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   CreateAgentRequest,
   UpdateAgentRequest,
   SessionsValidationResponse,
+  BranchNameFallback,
 } from '@agent-console/shared';
 
 const API_BASE = '/api';
@@ -233,6 +234,8 @@ export interface BranchesResponse {
 export interface CreateWorktreeResponse {
   worktree: Worktree;
   session: Session | null;
+  /** Present when AI-based branch name generation failed and a fallback name was used */
+  branchNameFallback?: BranchNameFallback;
 }
 
 export async function fetchWorktrees(repositoryId: string): Promise<WorktreesResponse> {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,3 +24,14 @@ export interface ApiError {
   message: string;
 }
 
+/**
+ * Information about branch name generation fallback
+ * Returned when AI-based branch name generation fails and a fallback name is used
+ */
+export interface BranchNameFallback {
+  /** The fallback branch name that was used (e.g., "task-1702000000000") */
+  usedBranch: string;
+  /** The error message from the AI agent */
+  reason: string;
+}
+


### PR DESCRIPTION
## Summary

- Add notification dialog when AI-based branch name generation fails and a fallback name (`task-{timestamp}`) is used
- Display the fallback branch name and error reason from the AI agent
- Guide users that they can rename the branch later from session settings

## Changes

- **shared**: Add `BranchNameFallback` interface for type-safe fallback info
- **server**: Return `branchNameFallback` in API response when generation fails
- **client**: Add `BranchNameFallbackDialog` component to display the notification

## Test plan

- [x] Typecheck passes
- [x] All tests pass
- [x] Manual testing with forced fallback confirmed dialog displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)