### PR TITLE
refactor: migrate WebSocket state to useSyncExternalStore

### DIFF
--- a/packages/client/src/hooks/index.ts
+++ b/packages/client/src/hooks/index.ts
@@ -1,3 +1,3 @@
-export { useAppWebSocket } from './useAppWebSocket';
+export { useAppWsState, useAppWsEvent } from './useAppWs';
 export { useTerminalWebSocket } from './useTerminalWebSocket';
 export { useGitDiffWorker } from './useGitDiffWorker';


### PR DESCRIPTION
## Summary

- Adopt React 18's `useSyncExternalStore` for WebSocket state management
- Implement unified store + selector pattern (similar to Zustand/Redux)
- Separate concerns: `useAppWsState` for state, `useAppWsEvent` for events
- Fix memory leak in notification tracking refs cleanup
- Add generic state comparison and concurrent subscription test

## Changes

| File | Description |
|------|-------------|
| `useAppWs.ts` (renamed) | New hooks with selector pattern |
| `app-websocket.ts` | Unified store with `subscribeState`/`getState` |
| `routes/index.tsx` | Updated to use new hooks + memory leak fix |

## Test plan

- [x] All existing tests pass (41 tests)
- [x] New test for concurrent state subscriptions
- [x] TypeScript compilation passes
- [x] Manual verification in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)