### PR TITLE
docs: add React best practices to code quality reviewer

### DIFF
--- a/.claude/agents/code-quality-reviewer.md
+++ b/.claude/agents/code-quality-reviewer.md
@@ -46,6 +46,14 @@ For each issue found:
 ### Recommendations
 Prioritized list of suggested improvements.
 
+## React-Specific Checks
+
+When reviewing React code, pay special attention to:
+
+1. **Suspense Usage** - Prefer Suspense for async operations and loading states over manual isLoading flags
+2. **useEffect Discipline** - Challenge every useEffect: could it be a derived value, event handler, or useMemo instead?
+3. **Icon Components** - SVG icons should be in `Icons.tsx`, not inline in View components
+
 ## Constraints
 
 - Do NOT modify any code files

--- a/.claude/skills/code-quality-standards/code-quality-standards.md
+++ b/.claude/skills/code-quality-standards/code-quality-standards.md
@@ -123,6 +123,24 @@ This document defines the evaluation criteria for code design and quality review
 - Are secrets handled securely (not in code, not logged)?
 - Is authentication/authorization checked at proper boundaries?
 
+## 9. React Best Practices
+
+### Suspense Usage
+- Is Suspense used for async data fetching and code splitting?
+- Are loading states handled declaratively with Suspense boundaries?
+- Is ErrorBoundary paired with Suspense for error handling?
+
+### useEffect Discipline
+- Is useEffect avoided when derived state or event handlers suffice?
+- Are effects truly for synchronization with external systems?
+- Could the logic be moved to event handlers, useMemo, or server components?
+- Are unnecessary re-subscriptions avoided?
+
+### Component Organization
+- Are SVG icons extracted to a dedicated Icons.tsx component?
+- Are View components kept clean of implementation details?
+- Is presentational logic separated from business logic?
+
 ## Evaluation Output Format
 
 For each aspect reviewed, provide:


### PR DESCRIPTION
## Summary
- Add React-specific checks to `code-quality-reviewer` agent for Suspense usage, useEffect discipline, and icon component organization
- Add "React Best Practices" section to code quality standards with detailed evaluation criteria
- Help identify common React anti-patterns during code reviews

## Test plan
- [ ] Verify the code-quality-reviewer agent references the new checks
- [ ] Confirm code-quality-standards.md includes the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)