### PR TITLE
feat: add frontend/backend specialist agents and standardize skills

### DIFF
--- a/.claude/agents/backend-specialist.md
+++ b/.claude/agents/backend-specialist.md
@@ -1,0 +1,60 @@
+---
+name: backend-specialist
+description: Implement backend features and fixes. Use for API endpoints, WebSocket handlers, services, and server-side logic in packages/server.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: opus
+skills: development-workflow-standards, code-quality-standards, backend-standards
+---
+
+You are a backend specialist. Your responsibility is to implement backend features, fix bugs, and maintain code quality in the Bun/Hono server application.
+
+## Scope
+
+Your primary scope is:
+- `packages/server/` - Bun backend application
+- `packages/shared/` - Type definitions and shared utilities (primary owner)
+
+## Key Principles
+- **Server is the source of truth** - Backend manages all session/worker state
+- **Structured logging** - Use Pino with context objects
+- **Resource cleanup** - Always clean up PTY processes and connections
+- **Type safety** - Define types in shared package, validate at boundaries
+
+## How to Use This Agent
+
+Invoke with specific implementation tasks:
+- "Add an API endpoint to export session history"
+- "Implement automatic session cleanup for idle workers"
+- "Add support for custom agent configuration"
+- "Fix the WebSocket reconnection issue"
+
+## Implementation Process
+
+1. **Understand Requirements** - Clarify what needs to be built
+2. **Explore Existing Code** - Find related patterns in the codebase
+3. **Plan Changes** - Identify files to modify or create
+4. **Implement** - Write code following backend standards
+5. **Verify** - Run typecheck and tests
+
+## Tech Stack Reference
+
+- **Bun** runtime with native APIs
+- **Hono** web framework
+- **bun-pty** for pseudo-terminal management
+- **Pino** for structured logging
+- **Valibot** for request validation
+
+## Core Services
+
+- **SessionManager** - Central service for session/worker lifecycle
+- **WorktreeService** - Git worktree operations
+- **PersistenceService** - State persistence
+- **ActivityDetector** - Agent activity state detection
+
+## Constraints
+
+- Follow the patterns in backend-standards
+- Run `bun run typecheck` after changes to verify types
+- Maintain backward compatibility with existing WebSocket protocol
+- Don't break existing functionality
+- Clean up resources properly (PTY processes, file watchers)

--- a/.claude/agents/code-quality-reviewer.md
+++ b/.claude/agents/code-quality-reviewer.md
@@ -3,6 +3,7 @@ name: code-quality-reviewer
 description: Review code design and quality. Use when evaluating code architecture, design patterns, maintainability, or identifying potential issues before or after implementation.
 tools: Read, Grep, Glob
 model: sonnet
+skills: development-workflow-standards, code-quality-standards, frontend-standards, backend-standards
 ---
 
 You are a code quality specialist. Your responsibility is to evaluate code design and quality, identifying strengths and areas for improvement.
@@ -13,10 +14,6 @@ Invoke with specific context:
 - "Review the design of the new authentication module"
 - "Evaluate the API error handling patterns"
 - "Check the session management code for potential issues"
-
-## Knowledge Base
-
-Refer to the code quality standards defined in `.claude/skills/code-quality-standards/code-quality-standards.md` for evaluation criteria.
 
 ## Review Process
 

--- a/.claude/agents/frontend-specialist.md
+++ b/.claude/agents/frontend-specialist.md
@@ -1,0 +1,53 @@
+---
+name: frontend-specialist
+description: Implement frontend features and fixes. Use for React components, hooks, routes, styling, and client-side logic in packages/client.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: opus
+skills: development-workflow-standards, code-quality-standards, frontend-standards
+---
+
+You are a frontend specialist. Your responsibility is to implement frontend features, fix bugs, and maintain code quality in the React client application.
+
+## Scope
+
+Your primary scope is:
+- `packages/client/` - React frontend application
+- `packages/shared/` - When changes are driven by frontend needs (e.g., adding types for new UI features)
+
+## Key Principles
+- **Avoid useEffect** - Use TanStack Query, useSyncExternalStore, or event handlers instead
+- **Prefer Suspense** - For loading states and async boundaries
+- **useSyncExternalStore** - For external state subscriptions
+- **Server is the source of truth** - Don't maintain conflicting client state
+
+## How to Use This Agent
+
+Invoke with specific implementation tasks:
+- "Add a confirmation dialog to the delete session button"
+- "Implement keyboard shortcuts for terminal navigation"
+- "Create a new route for agent configuration"
+- "Fix the terminal resize issue when switching tabs"
+
+## Implementation Process
+
+1. **Understand Requirements** - Clarify what needs to be built
+2. **Explore Existing Code** - Find related patterns in the codebase
+3. **Plan Changes** - Identify files to modify or create
+4. **Implement** - Write code following frontend standards
+5. **Verify** - Run typecheck and tests
+
+## Tech Stack Reference
+
+- **React 18** with function components and hooks
+- **TanStack Router** for file-based routing
+- **TanStack Query** for server state
+- **Tailwind CSS** for styling
+- **xterm.js** for terminal rendering
+- **Valibot** for schema validation
+
+## Constraints
+
+- Follow the patterns in frontend-standards
+- Run `bun run typecheck` after changes to verify types
+- Keep components focused on single responsibility
+- Don't break existing functionality

--- a/.claude/agents/test-reviewer.md
+++ b/.claude/agents/test-reviewer.md
@@ -3,6 +3,7 @@ name: test-reviewer
 description: Review test quality and coverage. Use when evaluating whether tests are adequate, well-designed, or need improvement after tests are added or modified.
 tools: Read, Grep, Glob
 model: sonnet
+skills: development-workflow-standards, code-quality-standards
 ---
 
 You are a test quality specialist. Your responsibility is to evaluate the adequacy and quality of tests.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -3,6 +3,7 @@ name: test-runner
 description: Execute tests and analyze failures. Use when running tests, investigating test failures, or verifying that code changes pass tests.
 tools: Read, Grep, Glob, Bash
 model: haiku
+skills: development-workflow-standards
 ---
 
 You are a test execution specialist. Your responsibility is to run tests and analyze results.

--- a/.claude/agents/ux-architecture-reviewer.md
+++ b/.claude/agents/ux-architecture-reviewer.md
@@ -3,6 +3,7 @@ name: ux-architecture-reviewer
 description: Review UX architecture for state consistency and edge case handling. Use when implementing features involving persistence, state synchronization, WebSocket/REST API contracts, or session/worker lifecycle changes.
 tools: Read, Grep, Glob
 model: sonnet
+skills: frontend-standards, backend-standards
 ---
 
 You are a UX architecture specialist. Your responsibility is to ensure that user-visible state accurately reflects actual system state, and that edge cases are properly handled from a user experience perspective.

--- a/.claude/skills/backend-standards/SKILL.md
+++ b/.claude/skills/backend-standards/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: backend-standards
+description: Hono/Bun patterns and backend best practices for this project. Use when implementing API endpoints, WebSocket handlers, services, or server-side logic in packages/server.
+---
+
+# Backend Standards
+
+Refer to [backend-standards.md](backend-standards.md) for detailed patterns.
+
+## Key Principles
+
+- **Server is the source of truth** - Backend manages all session/worker state
+- **Structured logging** - Use Pino with context objects
+- **Resource cleanup** - Always clean up PTY processes and connections
+- **Type safety** - Define types in shared package, validate at boundaries
+
+## Tech Stack
+
+- Bun, Hono, bun-pty, Pino, Valibot

--- a/.claude/skills/backend-standards/backend-standards.md
+++ b/.claude/skills/backend-standards/backend-standards.md
@@ -1,0 +1,300 @@
+# Backend Standards
+
+This document defines backend-specific knowledge and patterns for the agent-console project.
+
+## Tech Stack
+
+- **Bun** - JavaScript runtime
+- **Hono** - Web framework
+- **bun-pty** - Pseudo-terminal for spawning processes
+- **Pino** - Structured logging
+- **Valibot** - Schema validation (shared with frontend)
+
+## Directory Structure
+
+```
+packages/server/src/
+├── __tests__/      # Unit tests
+├── lib/            # Utilities (logger, config, error handler)
+├── middleware/     # Hono middleware
+├── routes/         # API route handlers
+├── services/       # Business logic (session manager, workers, etc.)
+└── websocket/      # WebSocket handlers
+```
+
+## Core Concepts
+
+### Session Manager
+
+Central service managing all sessions and workers. Responsibilities:
+- Create/delete sessions
+- Spawn/manage workers (agent, terminal, git-diff)
+- Track worker activity states
+- Persist session state
+- Broadcast lifecycle events
+
+### Workers
+
+Three types of workers:
+- **Agent Worker**: PTY process running AI agent (Claude Code, etc.)
+- **Terminal Worker**: Plain PTY shell
+- **Git-Diff Worker**: Non-PTY worker for real-time diff viewing
+
+### PTY Management
+
+- Use `bun-pty` for spawning interactive processes
+- Workers persist across WebSocket reconnections (tmux-like behavior)
+- Buffer output for history replay on reconnection
+
+## Hono Framework
+
+### Route Organization
+
+```typescript
+// routes/api.ts
+const api = new Hono();
+api.route('/sessions', sessions);
+api.route('/agents', agents);
+export { api };
+
+// index.ts
+app.route('/api', api);
+```
+
+### Request Validation
+
+Use Valibot with Hono's validator:
+
+```typescript
+import * as v from 'valibot';
+import { vValidator } from '@hono/valibot-validator';
+
+const schema = v.object({
+  name: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'Name is required'),
+  ),
+});
+
+app.post('/items', vValidator('json', schema), (c) => {
+  const data = c.req.valid('json');
+  // data is typed
+});
+```
+
+### Error Handling
+
+Use centralized error handler:
+
+```typescript
+// lib/error-handler.ts
+export function onApiError(err: Error, c: Context): Response {
+  // Log and return appropriate HTTP response
+}
+
+// index.ts
+app.onError(onApiError);
+```
+
+## WebSocket Patterns
+
+### Dual WebSocket Architecture
+
+1. **App WebSocket (`/ws/app`)**: Single connection for app-wide state sync
+   - Broadcasts session/worker lifecycle events
+   - Client uses singleton pattern
+
+2. **Worker WebSocket (`/ws/session/:id/worker/:id`)**: Per-worker connections
+   - Handles terminal I/O, resize, image upload
+   - Tied to specific session/worker
+
+### Message Protocol
+
+Server → Client messages are typed:
+
+```typescript
+type WorkerServerMessage =
+  | { type: 'output'; data: string }
+  | { type: 'history'; data: string }
+  | { type: 'exit'; exitCode: number; signal: string | null }
+  | { type: 'activity'; state: AgentActivityState };
+```
+
+### Broadcasting
+
+For app-wide events, use broadcast pattern:
+
+```typescript
+const appClients = new Set<WSContext>();
+
+function broadcastToApp(msg: AppServerMessage): void {
+  const msgStr = JSON.stringify(msg);
+  for (const client of appClients) {
+    client.send(msgStr);
+  }
+}
+```
+
+### Output Buffering
+
+Buffer rapid PTY output to reduce WebSocket message count:
+
+```typescript
+let outputBuffer = '';
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+const FLUSH_INTERVAL = 50; // ms
+
+const flushBuffer = () => {
+  if (outputBuffer.length > 0) {
+    ws.send(JSON.stringify({ type: 'output', data: outputBuffer }));
+    outputBuffer = '';
+  }
+  flushTimer = null;
+};
+```
+
+## Logging
+
+Use Pino with structured logging:
+
+```typescript
+import { createLogger } from './lib/logger.js';
+
+const logger = createLogger('service-name');
+
+// Structured data first, message second
+logger.info({ sessionId, workerId }, 'Worker created');
+logger.error({ err: error, context }, 'Operation failed');
+```
+
+### Log Levels
+
+- `fatal`: Application crash, unrecoverable errors
+- `error`: Errors that need attention
+- `warn`: Potentially problematic situations
+- `info`: Normal operational messages
+- `debug`: Detailed debugging information
+
+## Service Design
+
+### Singleton Services
+
+Use module-level singletons for shared services:
+
+```typescript
+// services/session-manager.ts
+class SessionManager {
+  // ...implementation
+}
+
+export const sessionManager = new SessionManager();
+```
+
+### Callback Patterns
+
+For async notifications, use callback registration:
+
+```typescript
+class SessionManager {
+  private activityCallback?: (sessionId: string, workerId: string, state: AgentActivityState) => void;
+
+  setGlobalActivityCallback(callback: typeof this.activityCallback) {
+    this.activityCallback = callback;
+  }
+}
+```
+
+### Resource Cleanup
+
+Always clean up resources:
+
+```typescript
+// Process termination handlers
+process.on('SIGTERM', () => cleanup());
+process.on('SIGINT', () => cleanup());
+
+// Worker cleanup
+onClose() {
+  sessionManager.detachWorkerCallbacks(sessionId, workerId);
+}
+```
+
+## Configuration
+
+Use typed configuration with environment variables:
+
+```typescript
+// lib/server-config.ts
+export const serverConfig = {
+  PORT: process.env.PORT || '3001',
+  NODE_ENV: process.env.NODE_ENV || 'development',
+  AGENT_CONSOLE_HOME: process.env.AGENT_CONSOLE_HOME || path.join(homedir(), '.agent-console'),
+};
+```
+
+## Testing
+
+### Unit Tests
+
+- Place tests in `__tests__/` directories
+- Use Vitest
+- Mock external dependencies (file system, processes)
+
+### Integration Tests
+
+- Test API endpoints with real HTTP requests
+- Test WebSocket connections
+
+### Test Patterns
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('ServiceName', () => {
+  beforeEach(() => {
+    // Setup
+  });
+
+  afterEach(() => {
+    // Cleanup
+  });
+
+  it('should do something', () => {
+    // Test
+  });
+});
+```
+
+## Security
+
+### Input Validation
+
+- Validate all API inputs at boundaries
+- Use Valibot schemas
+- Never trust client-provided data
+
+### Process Spawning
+
+- Sanitize environment variables before spawning
+- Don't expose sensitive env vars to child processes
+
+### File System Access
+
+- Validate paths to prevent directory traversal
+- Use absolute paths
+- Check file existence before operations
+
+## Performance
+
+### PTY Output Handling
+
+- Buffer output to reduce message frequency
+- Use efficient string concatenation
+- Limit history buffer size
+
+### Connection Management
+
+- Clean up dead WebSocket connections
+- Use timeouts for operations
+- Handle reconnection gracefully

--- a/.claude/skills/code-quality-standards/SKILL.md
+++ b/.claude/skills/code-quality-standards/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: code-quality-standards
+description: Code quality evaluation criteria for reviews. Use when reviewing code design, architecture, maintainability, or identifying potential issues.
+---
+
+# Code Quality Standards
+
+Refer to [code-quality-standards.md](code-quality-standards.md) for detailed evaluation criteria.
+
+## Evaluation Aspects
+
+1. **Robustness to Change** - Open-closed principle, dependency management, encapsulation
+2. **Bug Resistance** - Type safety, null safety, error handling, input validation
+3. **Readability** - Naming, function design, code organization
+4. **Simplicity** - YAGNI, avoid accidental complexity, minimize cognitive load
+5. **Consistency** - Patterns, API design
+6. **Testability** - Isolation, observability
+7. **Performance Awareness** - Algorithmic efficiency, resource management
+8. **Security Mindset** - OWASP top 10, least privilege

--- a/.claude/skills/development-workflow-standards/SKILL.md
+++ b/.claude/skills/development-workflow-standards/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: development-workflow-standards
+description: Development process rules for this project including testing, branching, and commit standards. Use when implementing features, fixing bugs, or making any code changes.
+---
+
+# Development Workflow Standards
+
+Refer to [development-workflow-standards.md](development-workflow-standards.md) for detailed rules.
+
+## Key Rules
+
+- **Testing with code changes**: Always update or add tests. Code without tests is incomplete.
+- **TDD for bug fixes**: Write a failing test first, then implement the fix.
+- **GitHub-Flow**: Fetch latest `origin/main` and create feature branches from it.
+- **Verification**: Run `bun run test` and `bun run typecheck` before completing changes.

--- a/.claude/skills/development-workflow-standards/development-workflow-standards.md
+++ b/.claude/skills/development-workflow-standards/development-workflow-standards.md
@@ -1,0 +1,80 @@
+# Development Workflow Standards
+
+This document defines the development process rules that all implementation work must follow.
+
+## Working Principles
+
+**Purpose over speed.** Do not rush to finish quickly at the expense of losing sight of the original purpose. Code that fails to achieve its purpose wastes more time than code written correctly from the start.
+
+**Do not blindly follow existing patterns.** Existing code is not automatically correct. Evaluate whether patterns in the codebase are appropriate before adopting them.
+
+**Think before you act.** When facing a problem, first consider the correct approach rather than immediately implementing the easiest solution.
+
+**Speak up about issues.** When you notice something inappropriate or problematic outside the current task scope, mention it as a supplementary note. Do not silently ignore issues just because they are not directly related to the task at hand.
+
+## Branching Strategy (GitHub-Flow)
+
+Follow GitHub-Flow:
+
+1. Fetch the latest `origin/main` and create a feature branch from it
+2. Make changes with descriptive commits
+3. Open pull requests for review
+4. Merge after approval
+
+The `main` branch is always kept GREEN (all tests and type checks pass).
+
+## Testing Requirements
+
+**Testing with code changes.** When modifying code, always update or add corresponding tests. Code changes without test coverage are incomplete.
+
+**TDD for bug fixes.** When fixing bugs, apply Test-Driven Development where feasible:
+1. Write a failing test that reproduces the bug
+2. Implement the fix
+3. Verify the test passes
+
+## Verification Checklist
+
+Before completing any code changes, always verify:
+
+1. **Run tests:** Execute `bun run test` and ensure all tests pass
+2. **Run type check:** Execute `bun run typecheck` and ensure no type errors
+3. **Review test quality:** When tests are added or modified, evaluate adequacy and coverage
+
+If any verification fails, assume it is caused by your changes and fix it before proceeding.
+
+## Commit Standards
+
+Use conventional commit format: `type: description`
+
+- `feat:` new feature
+- `fix:` bug fix
+- `refactor:` code change without feature/fix
+- `test:` adding or updating tests
+- `docs:` documentation changes
+
+## Code Quality
+
+**Avoid over-engineering.** Only make changes that are directly requested or clearly necessary. Keep solutions simple and focused.
+
+- Don't add features, refactor code, or make "improvements" beyond what was asked
+- A bug fix doesn't need surrounding code cleaned up
+- A simple feature doesn't need extra configurability
+- Don't add docstrings, comments, or type annotations to code you didn't change
+- Only add comments where the logic isn't self-evident
+
+**Avoid unnecessary complexity.**
+
+- Don't add error handling, fallbacks, or validation for scenarios that can't happen
+- Trust internal code and framework guarantees
+- Only validate at system boundaries (user input, external APIs)
+- Don't create helpers, utilities, or abstractions for one-time operations
+- Don't design for hypothetical future requirements
+
+**Clean up properly.**
+
+- Avoid backwards-compatibility hacks like renaming unused `_vars`, re-exporting types, adding `// removed` comments
+- If something is unused, delete it completely
+
+## Language Policy
+
+**Code and documentation:** Write all code comments, commit messages, and documentation in English.

--- a/.claude/skills/frontend-standards/SKILL.md
+++ b/.claude/skills/frontend-standards/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: frontend-standards
+description: React patterns and frontend best practices for this project. Use when implementing React components, hooks, routes, styling, or client-side logic in packages/client.
+---
+
+# Frontend Standards
+
+Refer to [frontend-standards.md](frontend-standards.md) for detailed patterns.
+
+## Key Principles
+
+- **Avoid useEffect** - Use TanStack Query, useSyncExternalStore, or event handlers instead
+- **Prefer Suspense** - For loading states and async boundaries
+- **useSyncExternalStore** - For external state subscriptions (WebSocket, global stores)
+- **Server is the source of truth** - Don't maintain conflicting client state
+
+## Tech Stack
+
+- React 18, TanStack Router, TanStack Query, Tailwind CSS, xterm.js, Valibot

--- a/.claude/skills/frontend-standards/frontend-standards.md
+++ b/.claude/skills/frontend-standards/frontend-standards.md
@@ -1,0 +1,253 @@
+# Frontend Standards
+
+This document defines frontend-specific knowledge and patterns for the agent-console project.
+
+## Tech Stack
+
+- **React 18** - UI framework
+- **Vite** - Build tool and dev server
+- **TanStack Router** - File-based routing with type safety
+- **TanStack Query** - Server state management
+- **Tailwind CSS** - Utility-first styling
+- **xterm.js** - Terminal emulator
+- **Valibot** - Schema validation
+
+## Directory Structure
+
+```
+packages/client/src/
+├── components/     # React components
+├── hooks/          # Custom React hooks
+├── lib/            # Utilities and API clients
+├── routes/         # TanStack Router file-based routes
+├── schemas/        # Valibot validation schemas
+└── test/           # Test utilities and setup
+```
+
+## React Patterns (Critical)
+
+### Avoid useEffect - Use Alternatives
+
+**useEffect should be a last resort.** Most use cases have better alternatives:
+
+| Instead of useEffect for... | Use this |
+|----------------------------|----------|
+| Fetching data | TanStack Query (`useQuery`) |
+| Subscribing to external store | `useSyncExternalStore` |
+| Derived state | Compute during render or `useMemo` |
+| Responding to user events | Event handlers |
+| Syncing with parent component | Lift state up or use context |
+
+**When useEffect is acceptable:**
+- Component-scoped WebSocket connections (tied to component lifecycle)
+- Third-party library integration (xterm.js, etc.)
+- Browser API subscriptions (resize observers, etc.)
+
+### useSyncExternalStore for External State
+
+When subscribing to external state (global stores, singletons), use `useSyncExternalStore`:
+
+```typescript
+// lib/app-websocket.ts - External store with subscribe/getState pattern
+export function subscribeState(listener: () => void): () => void {
+  stateListeners.add(listener);
+  return () => stateListeners.delete(listener);
+}
+
+export function getState(): AppWebSocketState {
+  return state;
+}
+
+// hooks/useAppWs.ts - Hook using useSyncExternalStore
+export function useAppWsState<T>(selector: (state: AppWebSocketState) => T): T {
+  return useSyncExternalStore(subscribeState, () => selector(getState()));
+}
+```
+
+**Why this pattern:**
+- React-safe synchronization with external state
+- Automatic subscription cleanup
+- Works with concurrent rendering
+- No stale closure issues
+
+### Suspense for Async Operations
+
+**Prefer Suspense** for handling loading states:
+
+```typescript
+// Route-level Suspense with TanStack Router
+export const Route = createFileRoute('/sessions/$sessionId')({
+  pendingComponent: () => <LoadingSpinner />,
+  errorComponent: ({ error }) => <ErrorDisplay error={error} />,
+})
+
+// Component-level Suspense
+<Suspense fallback={<Skeleton />}>
+  <AsyncComponent />
+</Suspense>
+```
+
+**Benefits:**
+- Cleaner component code (no loading state management)
+- Better UX with coordinated loading states
+- Enables streaming and progressive rendering
+
+### Component Design
+
+- Prefer function components with hooks
+- Keep components focused on single responsibility
+- Extract complex logic into custom hooks
+- Use composition over inheritance
+
+### State Management Hierarchy
+
+1. **Server state**: TanStack Query (`useQuery`, `useMutation`)
+2. **External state**: `useSyncExternalStore`
+3. **Local UI state**: `useState`, `useReducer`
+4. **Shared client state**: React Context (sparingly)
+
+Avoid prop drilling; prefer composition or context.
+
+## TanStack Router
+
+### File-Based Routing
+
+- Routes are defined in `src/routes/` directory
+- `__root.tsx` - Root layout
+- `index.tsx` - Home route (`/`)
+- `$param.tsx` - Dynamic segments
+
+### Route Types
+
+```typescript
+// Route params are automatically typed
+const { sessionId } = Route.useParams()
+
+// Search params with validation
+const { tab } = Route.useSearch()
+```
+
+### Navigation
+
+```typescript
+// Use Link component for navigation
+<Link to="/sessions/$sessionId" params={{ sessionId }}>
+
+// Programmatic navigation
+const navigate = useNavigate()
+navigate({ to: '/sessions/$sessionId', params: { sessionId } })
+```
+
+## TanStack Query
+
+### Query Keys
+
+Use consistent key factories for related queries:
+
+```typescript
+const sessionKeys = {
+  all: ['sessions'] as const,
+  detail: (id: string) => ['sessions', id] as const,
+}
+```
+
+### Mutations
+
+Always invalidate related queries after mutations:
+
+```typescript
+const mutation = useMutation({
+  mutationFn: createSession,
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: sessionKeys.all })
+  },
+})
+```
+
+## WebSocket Integration
+
+### Choose the Right Pattern
+
+**Singleton pattern** - For app-wide connections that persist across navigation:
+- Example: `/ws/app` for session/worker lifecycle events
+- Use module-level state with `useSyncExternalStore`
+
+**Hook-based pattern** - For component-scoped connections:
+- Example: `/ws/session/:id/worker/:id` for terminal I/O
+- Use `useEffect` with cleanup, tied to component lifecycle
+
+### State Synchronization
+
+- Server is the source of truth
+- Update UI based on server messages
+- Don't maintain conflicting client state
+
+## xterm.js Integration
+
+### Terminal Setup
+
+- Initialize with appropriate options (font, theme, scrollback)
+- Attach fit addon for responsive sizing
+- Handle resize events
+
+### Input/Output
+
+- Send user input via WebSocket
+- Write received output to terminal
+- Handle special keys appropriately
+
+## Styling with Tailwind CSS
+
+### Class Organization
+
+Group related utilities: layout → spacing → sizing → colors → typography
+
+### Responsive Design
+
+Mobile-first approach (`sm:`, `md:`, `lg:` breakpoints)
+
+## Form Handling with Valibot
+
+### Validation Patterns
+
+**Always add minLength before regex:**
+
+```typescript
+const schema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1, 'Field is required'),
+  v.regex(pattern, errorMessage)
+)
+```
+
+## Testing
+
+### Component Testing
+
+- Use `@testing-library/react`
+- Test user interactions, not implementation
+- Mock API calls appropriately
+
+### Hook Testing
+
+- Test all state transitions
+- Mock dependencies appropriately
+
+## Performance
+
+- Memoize expensive computations with `useMemo`
+- Use `useCallback` only when passing to optimized children
+- Avoid inline object/array literals in JSX props
+
+## Error Handling
+
+### Error Boundaries
+
+- Wrap major sections in error boundaries
+- Provide meaningful fallback UI
+
+### API Errors
+
+- Display user-friendly error messages
+- Provide retry mechanisms where appropriate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,18 @@ User-defined subagents (in `~/.claude/agents/`):
 - **Web research:** Use `web-research-specialist` subagent for technical documentation lookup
 
 Project-defined subagents (in `.claude/agents/`):
+- **Frontend implementation:** Use `frontend-specialist` subagent for React components, hooks, routes, and client-side logic
+- **Backend implementation:** Use `backend-specialist` subagent for API endpoints, WebSocket handlers, services, and server-side logic
 - **Test execution:** Use `test-runner` subagent for running tests and analyzing failures
 - **Test quality review:** Use `test-reviewer` subagent for evaluating test adequacy and coverage
 - **Code quality review:** Use `code-quality-reviewer` subagent for evaluating design, maintainability, and identifying potential issues
 - **UX architecture review:** Use `ux-architecture-reviewer` subagent for verifying state consistency and edge case handling in client-server interactions
+
+Project-defined skills (in `.claude/skills/`):
+- **Development workflow standards:** `.claude/skills/development-workflow-standards/` - Development process rules (testing, branching, commits)
+- **Code quality standards:** `.claude/skills/code-quality-standards/` - Evaluation criteria for code reviews
+- **Frontend standards:** `.claude/skills/frontend-standards/` - React patterns and frontend best practices
+- **Backend standards:** `.claude/skills/backend-standards/` - Hono/Bun patterns and backend best practices
 
 **Propose missing subagents or skills.** When you identify a recurring task pattern that would benefit from a specialized subagent or skill but none exists, propose it to the user with a ready-to-use definition file.
 
@@ -215,7 +223,7 @@ Before completing any code changes, always verify the following:
 2. **Run type check:** Execute `bun run typecheck` and ensure no type errors.
 3. **Review test quality:** When tests are added or modified, use `test-reviewer` to evaluate adequacy and coverage.
 4. **Manual verification (UI changes only):** When modifying UI components and Chrome DevTools MCP is available, perform manual testing through the browser to verify the changes work as expected.
-5. **Code quality review (before push):** For significant changes (new features, architectural changes, security-related code), use `code-quality-reviewer` to evaluate design and identify potential issues. Refer to `.claude/skills/code-quality-standards/code-quality-standards.md` for evaluation criteria.
+5. **Code quality review (before push):** For significant changes (new features, architectural changes, security-related code), use `code-quality-reviewer` to evaluate design and identify potential issues.
 6. **UX architecture review (state sync features):** When implementing features involving persistence, state synchronization, or WebSocket/REST API changes, use `ux-architecture-reviewer` to verify state consistency and edge case handling.
 
 **Important:** The main branch is always kept GREEN (all tests and type checks pass). If any verification fails, assume it is caused by your changes on the current branch and fix it before proceeding.


### PR DESCRIPTION
## Summary

- Add specialized coding agents (`frontend-specialist`, `backend-specialist`) for delegating implementation tasks
- Create Claude Code compliant skills with `SKILL.md` frontmatter for automatic discovery
- Standardize skill references across all agents using the `skills` field

## New Agents

| Agent | Purpose | Model | Skills |
|-------|---------|-------|--------|
| `frontend-specialist` | React/client implementation | opus | dev-workflow, code-quality, frontend |
| `backend-specialist` | Hono/server implementation | opus | dev-workflow, code-quality, backend |

## New Skills

| Skill | Content |
|-------|---------|
| `development-workflow-standards` | Testing requirements, GitHub-Flow, commit standards |
| `frontend-standards` | React patterns (useEffect alternatives, Suspense, useSyncExternalStore) |
| `backend-standards` | Hono/Bun patterns, PTY management, structured logging |

## Updated Agents

All existing agents now have `skills` field for automatic skill loading:

| Agent | Added Skills |
|-------|-------------|
| `code-quality-reviewer` | dev-workflow, code-quality, frontend, backend |
| `test-reviewer` | dev-workflow, code-quality |
| `test-runner` | dev-workflow |
| `ux-architecture-reviewer` | frontend, backend |

## Agent × Skill Matrix

| Agent | dev-workflow | code-quality | frontend | backend |
|-------|:------------:|:------------:|:--------:|:-------:|
| frontend-specialist | ✅ | ✅ | ✅ | |
| backend-specialist | ✅ | ✅ | | ✅ |
| code-quality-reviewer | ✅ | ✅ | ✅ | ✅ |
| test-runner | ✅ | | | |
| test-reviewer | ✅ | ✅ | | |
| ux-architecture-reviewer | | | ✅ | ✅ |

## Test plan

- [ ] Verify skills are auto-discovered by Claude Code
- [ ] Test frontend-specialist with a React implementation task
- [ ] Test backend-specialist with a server implementation task
- [ ] Verify code-quality-reviewer uses all skill standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)