### PR TITLE
fix: prevent duplicate terminal output in React StrictMode

### DIFF
--- a/packages/client/src/components/Terminal.tsx
+++ b/packages/client/src/components/Terminal.tsx
@@ -33,6 +33,9 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
   }, []);
 
   const handleHistory = useCallback((data: string) => {
+    // Clear terminal before writing history to prevent duplicate output
+    // (e.g., when reconnecting or React StrictMode causes double connection)
+    terminalRef.current?.clear();
     terminalRef.current?.write(data);
   }, []);
 

--- a/packages/client/src/hooks/__tests__/useTerminalWebSocket.test.ts
+++ b/packages/client/src/hooks/__tests__/useTerminalWebSocket.test.ts
@@ -25,7 +25,9 @@ describe('useTerminalWebSocket', () => {
     onActivity: mock(() => {}),
   });
 
-  it('should connect on mount and disconnect on unmount', async () => {
+  it('should connect on mount and keep connection on unmount (singleton pattern)', async () => {
+    // Note: We don't disconnect on unmount to prevent duplicate output in React StrictMode.
+    // This follows the same pattern as useAppWsEvent.
     const options = createDefaultOptions();
     const { unmount } = renderHook(() =>
       useTerminalWebSocket('session-1', 'worker-1', options)
@@ -38,7 +40,8 @@ describe('useTerminalWebSocket', () => {
 
     unmount();
 
-    expect(ws?.close).toHaveBeenCalled();
+    // Connection should persist (singleton pattern) - close is NOT called on unmount
+    expect(ws?.close).not.toHaveBeenCalled();
   });
 
   it('should update connected state when WebSocket opens', async () => {


### PR DESCRIPTION
## Summary

- Fix duplicate terminal output caused by React StrictMode double mounting
- Apply the same singleton pattern used in `useAppWsEvent` to `useTerminalWebSocket`

## Root Cause

React StrictMode executes mount→unmount→mount in development mode:

1. First mount: WebSocket connected, data received via output callback
2. Unmount: `disconnect()` closes WebSocket
3. Second mount: New WebSocket connected, same data received as history

→ Same data displayed twice

## Changes

- **useTerminalWebSocket.ts**: Do not call `disconnect()` on cleanup (maintain singleton)
- **useTerminalWebSocket.ts**: Only disconnect old connection when `sessionId`/`workerId` changes
- **worker-websocket.ts**: Add `pendingListeners` for subscriptions before connection exists
- **worker-websocket.ts**: Add `DEFAULT_DISCONNECTED_STATE` to prevent useSyncExternalStore infinite loop
- **Terminal.tsx**: Call `clear()` before writing history (defensive measure)
- **routes.ts**: Send history before registering callbacks (ensure correct order)

## Test plan

- [x] `bun run test` - all tests pass
- [x] `bun run typecheck` - no type errors
- [x] Manual verification: duplicate output on Worktree open is resolved

## Related

- #121 (Issue for future refactoring/consolidation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)