### PR TITLE
refactor: consolidate websocket connection handling

### DIFF
--- a/packages/client/src/hooks/useGitDiffWorker.ts
+++ b/packages/client/src/hooks/useGitDiffWorker.ts
@@ -23,7 +23,7 @@ export function useGitDiffWorker(options: UseGitDiffWorkerOptions): UseGitDiffWo
 
   // Subscribe to connection state using useSyncExternalStore
   const state = useSyncExternalStore(
-    (callback) => workerWs.subscribeState(sessionId, workerId, callback),
+    (callback) => workerWs.subscribeState(callback),
     () => workerWs.getState(sessionId, workerId)
   );
 

--- a/packages/client/src/hooks/usePersistentWebSocket.ts
+++ b/packages/client/src/hooks/usePersistentWebSocket.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import type { DependencyList } from 'react';
+
+type UsePersistentWebSocketOptions<K> = {
+  key: K;
+  connect: (key: K) => void;
+  disconnect: (key: K) => void;
+  keyEquals?: (a: K, b: K) => boolean;
+  deps?: DependencyList;
+};
+
+/**
+ * Persist WebSocket singletons across unmounts, disconnecting only when the key changes.
+ */
+export function usePersistentWebSocket<K>({
+  key,
+  connect,
+  disconnect,
+  keyEquals = Object.is,
+  deps,
+}: UsePersistentWebSocketOptions<K>): void {
+  const prevRef = useRef<K | null>(null);
+  const effectDeps = deps ?? [key];
+
+  useEffect(() => {
+    const prev = prevRef.current;
+    if (prev && !keyEquals(prev, key)) {
+      disconnect(prev);
+    }
+    prevRef.current = key;
+    connect(key);
+    // Intentionally no cleanup to keep singleton connections alive across unmounts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, effectDeps);
+}

--- a/packages/client/src/hooks/useTerminalWebSocket.ts
+++ b/packages/client/src/hooks/useTerminalWebSocket.ts
@@ -1,6 +1,7 @@
-import { useEffect, useCallback, useSyncExternalStore, useRef, useState } from 'react';
+import { useEffect, useCallback, useSyncExternalStore, useState } from 'react';
 import type { AgentActivityState, WorkerErrorCode } from '@agent-console/shared';
 import * as workerWs from '../lib/worker-websocket.js';
+import { usePersistentWebSocket } from './usePersistentWebSocket';
 
 interface UseTerminalWebSocketOptions {
   onOutput: (data: string) => void;
@@ -40,38 +41,30 @@ export function useTerminalWebSocket(
 
   // Subscribe to connection state using useSyncExternalStore
   const state = useSyncExternalStore(
-    (callback) => workerWs.subscribeState(sessionId, workerId, callback),
+    (callback) => workerWs.subscribeState(callback),
     () => workerWs.getState(sessionId, workerId)
   );
 
-  // Track previous sessionId/workerId for cleanup on change
-  const prevRef = useRef<{ sessionId: string; workerId: string } | null>(null);
-
-  // Connect on mount, disconnect old connection when sessionId/workerId changes
-  // Note: We don't disconnect on cleanup (return function) because the singleton
-  // should persist (same pattern as useAppWsEvent). This prevents duplicate output
-  // in React StrictMode where mount→unmount→mount would cause two connections.
-  // Instead, we disconnect the OLD connection in the effect body when deps change.
-  useEffect(() => {
-    // If sessionId or workerId changed, disconnect the old connection
-    const prev = prevRef.current;
-    if (prev && (prev.sessionId !== sessionId || prev.workerId !== workerId)) {
-      workerWs.disconnect(prev.sessionId, prev.workerId);
-      // Clear error when switching workers
+  usePersistentWebSocket({
+    key: { sessionId, workerId },
+    connect: ({ sessionId, workerId }) => {
+      workerWs.connect(sessionId, workerId, {
+        type: 'terminal',
+        onOutput,
+        onHistory,
+        onExit,
+        onActivity,
+        onError: handleError,
+      });
+    },
+    disconnect: ({ sessionId, workerId }) => {
+      workerWs.disconnect(sessionId, workerId);
+      // Clear error when switching workers.
       setError(null);
-    }
-    prevRef.current = { sessionId, workerId };
-
-    workerWs.connect(sessionId, workerId, {
-      type: 'terminal',
-      onOutput,
-      onHistory,
-      onExit,
-      onActivity,
-      onError: handleError,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId, workerId]);
+    },
+    keyEquals: (a, b) => a.sessionId === b.sessionId && a.workerId === b.workerId,
+    deps: [sessionId, workerId],
+  });
 
   // Update callbacks without reconnecting when they change
   useEffect(() => {


### PR DESCRIPTION
## Summary
- introduce usePersistentWebSocket to share the persistent-connection pattern for app/terminal sockets
- simplify worker-websocket state listeners to a global subscriber model and drop pending listeners
- align worker hooks with the updated subscribeState API

## Testing
- bun run test:only