### PR TITLE
feat: display actual agent name for Worker tabs

### DIFF
--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -390,7 +390,7 @@ export class SessionManager {
       this.createWorker(id, {
         type: 'agent',
         agentId: effectiveAgentId,
-        name: 'Claude',
+        // name is not specified; generateWorkerName will use the agent's name
       }, request.continueConversation ?? false, request.initialPrompt),
       this.createWorker(id, {
         type: 'git-diff',
@@ -483,7 +483,8 @@ export class SessionManager {
 
     const workerId = uuidv4();
     const createdAt = new Date().toISOString();
-    const workerName = request.name ?? this.generateWorkerName(session, request.type);
+    const agentIdForName = request.type === 'agent' ? request.agentId : undefined;
+    const workerName = request.name ?? this.generateWorkerName(session, request.type, agentIdForName);
 
     let worker: InternalWorker;
 
@@ -618,9 +619,12 @@ export class SessionManager {
     return true;
   }
 
-  private generateWorkerName(session: InternalSession, type: 'agent' | 'terminal' | 'git-diff'): string {
+  private generateWorkerName(session: InternalSession, type: 'agent' | 'terminal' | 'git-diff', agentId?: string): string {
     if (type === 'agent') {
-      return 'Claude';
+      // Get agent name from agentManager
+      const agent = agentId ? agentManager.getAgent(agentId) : undefined;
+      // Fall back to generic "AI" if agent not found
+      return agent?.name ?? 'AI';
     }
 
     if (type === 'git-diff') {


### PR DESCRIPTION
## Summary
- Changed Agent Worker tab display name from hardcoded "Claude" to the actual agent name
- Retrieves registered agent name from AgentManager
- Falls back to generic "AI" if agent is not found

## Changes
- Modified `generateWorkerName` method in `session-manager.ts` to look up actual agent name via `agentId`

## Test plan
- [ ] Verify new session Worker tab displays "Claude Code" instead of "Claude"
- [ ] Verify custom agents display their registered name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent workers now display with meaningful names based on their actual agents instead of generic defaults. This improves clarity when creating sessions and managing workers, making it easier to identify agents in your workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->