### PR TITLE
fix: use LLM for branch name generation when importing from GitHub Issue

### DIFF
--- a/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
+++ b/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
@@ -105,10 +105,8 @@ export function CreateWorktreeForm({
     if (!getValues('sessionTitle')?.trim()) {
       setValue('sessionTitle', issueState.issue.title, { shouldDirty: true });
     }
-    if (issueState.issue.suggestedBranch) {
-      setValue('branchNameMode', 'custom', { shouldDirty: true, shouldValidate: true });
-      setValue('customBranch', issueState.issue.suggestedBranch, { shouldDirty: true, shouldValidate: true });
-    }
+    // Use 'prompt' mode to let LLM generate a unique branch name from the issue content
+    setValue('branchNameMode', 'prompt', { shouldDirty: true, shouldValidate: true });
   };
 
   const handleFormSubmit = async (data: CreateWorktreeFormData) => {

--- a/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
@@ -343,7 +343,7 @@ describe('CreateWorktreeForm', () => {
   });
 
   describe('GitHub issue', () => {
-    it('should populate prompt and branch from issue', async () => {
+    it('should populate prompt from issue and use prompt mode for branch generation', async () => {
       const user = userEvent.setup();
       const issue = {
         org: 'owner',
@@ -389,8 +389,9 @@ describe('CreateWorktreeForm', () => {
       const promptInput = screen.getByPlaceholderText(/What do you want to work on/) as HTMLTextAreaElement;
       expect(promptInput.value).toBe(issue.body);
 
-      const branchInput = screen.getByPlaceholderText('New branch name') as HTMLInputElement;
-      expect(branchInput.value).toBe(issue.suggestedBranch);
+      // Verify 'prompt' mode is selected (Generate from prompt)
+      const promptRadio = screen.getByLabelText(/Generate from prompt/) as HTMLInputElement;
+      expect(promptRadio.checked).toBe(true);
     });
   });
 

--- a/packages/server/src/services/github-issue-service.ts
+++ b/packages/server/src/services/github-issue-service.ts
@@ -127,6 +127,7 @@ export async function fetchGitHubIssue(reference: string, repoPath: string): Pro
   }
 
   const responseText = await runGhApi(['api', `repos/${org}/${repo}/issues/${number}`], repoPath);
+
   let responseJson: { title?: string; body?: string | null; html_url?: string } | undefined;
   try {
     responseJson = JSON.parse(responseText) as { title?: string; body?: string | null; html_url?: string };


### PR DESCRIPTION
## Summary

- Changed branch name generation for Issue import to use LLM
- Unified duplicate avoidance logic by using the same `suggestSessionMetadata` as "Generate from prompt"
- Achieved by changing `branchNameMode` from `custom` to `prompt`

## Background

Previously, when importing from a GitHub Issue, the branch name was generated by simply slugifying the issue title (e.g., "Add user authentication" → `add-user-authentication`). This could cause duplication errors when a branch with the same name already existed.

## Solution

Changed the Issue import flow to use `prompt` mode instead of `custom` mode. This leverages the existing LLM-based branch name generation with duplicate avoidance that was already implemented for the "Generate from prompt" workflow.

**Before:**
1. Issue import → `suggestedBranch` (simple slug) → `branchNameMode: 'custom'`
2. Worktree creation → Uses the slug directly (no duplicate check)

**After:**
1. Issue import → Issue content set as `initialPrompt` → `branchNameMode: 'prompt'`
2. Worktree creation → LLM generates unique branch name via `suggestSessionMetadata`

## Test plan

- [x] All tests pass (`bun run test`)
- [x] Type check passes (`bun run typecheck`)
- [ ] Manual test: Import an Issue when a branch with the same slug already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)