### PR TITLE
refactor: replace uuid package with Bun native crypto.randomUUID()

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,14 +84,12 @@
         "kysely-bun-sqlite": "^0.4.0",
         "open": "^11.0.0",
         "pino": "^10.1.0",
-        "uuid": "^11.0.3",
         "valibot": "^1.2.0",
       },
       "devDependencies": {
         "@types/bun": "^1.1.14",
         "@types/mock-fs": "^4.13.4",
         "@types/node": "^22.10.1",
-        "@types/uuid": "^10.0.0",
         "memfs": "^4.51.1",
         "mock-fs": "^5.4.1",
         "pino-pretty": "^13.1.3",
@@ -434,8 +432,6 @@
     "@types/react": ["@types/react@18.3.27", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w=="],
 
     "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
-
-    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
@@ -848,8 +844,6 @@
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
-
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,14 +24,12 @@
     "kysely-bun-sqlite": "^0.4.0",
     "open": "^11.0.0",
     "pino": "^10.1.0",
-    "uuid": "^11.0.3",
     "valibot": "^1.2.0"
   },
   "devDependencies": {
     "@types/bun": "^1.1.14",
     "@types/mock-fs": "^4.13.4",
     "@types/node": "^22.10.1",
-    "@types/uuid": "^10.0.0",
     "memfs": "^4.51.1",
     "mock-fs": "^5.4.1",
     "pino-pretty": "^13.1.3",

--- a/packages/server/src/database/__tests__/connection.isolated-test.ts
+++ b/packages/server/src/database/__tests__/connection.isolated-test.ts
@@ -19,7 +19,6 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import * as path from 'path';
 import * as os from 'os';
 import { sql } from 'kysely';
-import { v4 as uuid } from 'uuid';
 import {
   initializeDatabase,
   closeDatabase,
@@ -33,7 +32,7 @@ import {
  */
 function createTempDir(): string {
   const tmpBase = os.tmpdir();
-  const uniqueDir = path.join(tmpBase, `agent-console-db-test-${uuid()}`);
+  const uniqueDir = path.join(tmpBase, `agent-console-db-test-${crypto.randomUUID()}`);
   // Use Bun's native shell to create directory
   Bun.spawnSync(['mkdir', '-p', uniqueDir]);
   return uniqueDir;

--- a/packages/server/src/services/agent-manager.ts
+++ b/packages/server/src/services/agent-manager.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
 import {
   type AgentDefinition,
   type CreateAgentRequest,
@@ -97,7 +96,7 @@ export class AgentManager {
    * Register a new custom agent
    */
   async registerAgent(request: CreateAgentRequest): Promise<AgentDefinition> {
-    const id = uuidv4();
+    const id = crypto.randomUUID();
     const now = new Date().toISOString();
 
     const agentBase = {

--- a/packages/server/src/services/repository-manager.ts
+++ b/packages/server/src/services/repository-manager.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
 import * as fs from 'fs';
 import { access } from 'fs/promises';
 import * as path from 'path';
@@ -98,7 +97,7 @@ export class RepositoryManager {
       }
     }
 
-    const id = uuidv4();
+    const id = crypto.randomUUID();
     const name = path.basename(absolutePath);
 
     const repository: Repository = {

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import { v4 as uuidv4 } from 'uuid';
 import { access } from 'fs/promises';
 import type {
   Session,
@@ -394,7 +393,7 @@ export class SessionManager {
   // ========== Session Lifecycle ==========
 
   async createSession(request: CreateSessionRequest): Promise<Session> {
-    const id = uuidv4();
+    const id = crypto.randomUUID();
     const createdAt = new Date().toISOString();
 
     let internalSession: InternalSession;
@@ -574,7 +573,7 @@ export class SessionManager {
     const session = this.sessions.get(sessionId);
     if (!session) return null;
 
-    const workerId = uuidv4();
+    const workerId = crypto.randomUUID();
     const createdAt = new Date().toISOString();
     const agentIdForName = request.type === 'agent' ? request.agentId : undefined;
     const workerName = request.name ?? await this.generateWorkerName(session, request.type, agentIdForName);


### PR DESCRIPTION
## Summary
- Replace external `uuid` package with Bun's built-in `crypto.randomUUID()`
- Remove `uuid` and `@types/uuid` dependencies from packages/server
- Reduce external dependencies while maintaining full compatibility (UUIDv4 format)

## Test plan
- [x] All existing tests pass (`bun run test`)
- [x] Type check passes (`bun run typecheck`)
- [x] UUID generation works identically (crypto.randomUUID() returns UUIDv4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined server dependencies for improved installation performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->