### PR TITLE
feat: add repository setup commands feature

### DIFF
--- a/packages/client/src/components/repositories/EditRepositoryForm.tsx
+++ b/packages/client/src/components/repositories/EditRepositoryForm.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { valibotResolver } from '@hookform/resolvers/valibot';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as v from 'valibot';
+import type { Repository } from '@agent-console/shared';
+import { updateRepository, type UpdateRepositoryRequest } from '../../lib/api';
+import { FormField, Textarea } from '../ui/FormField';
+import { FormOverlay } from '../ui/Spinner';
+
+// Form data schema - setup command is optional, can be empty
+const EditRepositoryFormSchema = v.object({
+  setupCommand: v.optional(
+    v.pipe(
+      v.string(),
+      v.trim()
+    )
+  ),
+});
+
+type EditRepositoryFormData = v.InferOutput<typeof EditRepositoryFormSchema>;
+
+export interface EditRepositoryFormProps {
+  repository: Repository & { setupCommand?: string | null };
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export function EditRepositoryForm({ repository, onSuccess, onCancel }: EditRepositoryFormProps) {
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<EditRepositoryFormData>({
+    resolver: valibotResolver(EditRepositoryFormSchema),
+    defaultValues: {
+      setupCommand: repository.setupCommand ?? '',
+    },
+    mode: 'onBlur',
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (data: UpdateRepositoryRequest) => updateRepository(repository.id, data),
+    onMutate: async (data) => {
+      // Cancel any outgoing refetches to prevent overwriting optimistic update
+      await queryClient.cancelQueries({ queryKey: ['repositories'] });
+
+      // Snapshot the previous value for rollback
+      const previousRepositories = queryClient.getQueryData<{ repositories: Repository[] }>(['repositories']);
+
+      // Optimistically update the cache
+      queryClient.setQueryData<{ repositories: Repository[] } | undefined>(['repositories'], (old) => {
+        if (!old) return old;
+        return {
+          repositories: old.repositories.map((r) =>
+            r.id === repository.id ? { ...r, setupCommand: data.setupCommand } : r
+          ),
+        };
+      });
+
+      return { previousRepositories };
+    },
+    onSuccess: () => {
+      // Server WebSocket broadcast will handle cache update, but call onSuccess callback
+      onSuccess();
+    },
+    onError: (err, _data, context) => {
+      // Rollback to previous value on error
+      if (context?.previousRepositories) {
+        queryClient.setQueryData(['repositories'], context.previousRepositories);
+      }
+      setError(err instanceof Error ? err.message : 'Failed to update repository');
+    },
+  });
+
+  const handleFormSubmit = (data: EditRepositoryFormData) => {
+    setError(null);
+    // Convert empty string to null for the API
+    const setupCommand = data.setupCommand?.trim() || null;
+    updateMutation.mutate({ setupCommand });
+  };
+
+  return (
+    <div className="relative card mb-4">
+      <FormOverlay isVisible={updateMutation.isPending} message="Saving changes..." />
+      <h3 className="text-lg font-medium mb-2">{repository.name}</h3>
+      <p className="text-sm text-gray-500 mb-4 font-mono">{repository.path}</p>
+
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        <fieldset disabled={updateMutation.isPending} className="flex flex-col gap-4">
+          <FormField label="Setup Command (optional)" error={errors.setupCommand}>
+            <Textarea
+              {...register('setupCommand')}
+              placeholder="e.g., bun install && bun run build"
+              rows={3}
+              className="font-mono text-sm"
+              error={errors.setupCommand}
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              This command runs automatically after creating a new worktree. Available template variables:
+            </p>
+            <ul className="text-xs text-gray-500 mt-1 ml-4 list-disc">
+              <li><code className="bg-slate-700 px-1 rounded">{'{{WORKTREE_NUM}}'}</code> - Worktree number (e.g., "3")</li>
+              <li><code className="bg-slate-700 px-1 rounded">{'{{BRANCH}}'}</code> - Branch name</li>
+              <li><code className="bg-slate-700 px-1 rounded">{'{{REPO}}'}</code> - Repository name</li>
+              <li><code className="bg-slate-700 px-1 rounded">{'{{WORKTREE_PATH}}'}</code> - Full path to the worktree</li>
+            </ul>
+          </FormField>
+
+          {error && (
+            <p className="text-sm text-red-400">{error}</p>
+          )}
+
+          <div className="flex gap-2">
+            <button type="submit" className="btn btn-primary text-sm">
+              Save Changes
+            </button>
+            <button type="button" onClick={onCancel} className="btn btn-danger text-sm">
+              Cancel
+            </button>
+          </div>
+        </fieldset>
+      </form>
+    </div>
+  );
+}

--- a/packages/client/src/components/repositories/RepositoryList.tsx
+++ b/packages/client/src/components/repositories/RepositoryList.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import type { Repository } from '@agent-console/shared';
+import { useRepositories } from '../../hooks/use-repositories';
+import { Spinner } from '../ui/Spinner';
+import { EditRepositoryForm } from './EditRepositoryForm';
+
+// Extended Repository type that includes setupCommand
+type RepositoryWithSetup = Repository & { setupCommand?: string | null };
+
+export function RepositoryList() {
+  const { repositories, isLoading, error, refetch } = useRepositories();
+  const [editingRepoId, setEditingRepoId] = useState<string | null>(null);
+
+  // Show loading state only while initial fetch is in progress
+  const showLoading = isLoading;
+
+  if (showLoading) {
+    return (
+      <div className="flex items-center gap-2 text-gray-500">
+        <Spinner size="sm" />
+        <span>Loading repositories...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="card text-center py-10">
+        <p className="text-red-400 mb-4">Failed to load repositories</p>
+        <button onClick={() => refetch()} className="btn btn-primary">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (repositories.length === 0) {
+    return (
+      <div className="card text-center py-10">
+        <p className="text-gray-500 mb-4">No repositories registered</p>
+        <p className="text-sm text-gray-600">
+          Register repositories from the Dashboard to manage their setup commands.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {repositories.map((repo) => {
+        const repoWithSetup = repo as RepositoryWithSetup;
+        const isEditing = editingRepoId === repo.id;
+
+        if (isEditing) {
+          return (
+            <EditRepositoryForm
+              key={repo.id}
+              repository={repoWithSetup}
+              onSuccess={() => setEditingRepoId(null)}
+              onCancel={() => setEditingRepoId(null)}
+            />
+          );
+        }
+
+        return (
+          <RepositoryCard
+            key={repo.id}
+            repository={repoWithSetup}
+            onEdit={() => setEditingRepoId(repo.id)}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+interface RepositoryCardProps {
+  repository: RepositoryWithSetup;
+  onEdit: () => void;
+}
+
+function RepositoryCard({ repository, onEdit }: RepositoryCardProps) {
+  const { setupCommand } = repository;
+  const hasSetupCommand = Boolean(setupCommand?.trim());
+
+  return (
+    <div className="card">
+      <div className="flex items-start gap-4">
+        <div className="flex-1 min-w-0">
+          {/* Name */}
+          <div className="text-lg font-medium mb-1">{repository.name}</div>
+
+          {/* Path */}
+          <div className="text-sm text-gray-400 font-mono mb-2">{repository.path}</div>
+
+          {/* Setup command */}
+          <div className="text-sm">
+            <span className="text-gray-500">Setup command: </span>
+            {hasSetupCommand ? (
+              <span
+                className="font-mono text-gray-300 truncate inline-block max-w-[400px] align-bottom"
+                title={setupCommand || undefined}
+              >
+                {truncateCommand(setupCommand!, 60)}
+              </span>
+            ) : (
+              <span className="text-gray-600 italic">Not configured</span>
+            )}
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex gap-2 shrink-0">
+          <button
+            onClick={onEdit}
+            className="btn btn-primary text-sm"
+          >
+            Edit
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Truncate a command string to a maximum length with ellipsis.
+ * Preserves the beginning of the command which is most informative.
+ */
+function truncateCommand(command: string, maxLength: number): string {
+  if (command.length <= maxLength) {
+    return command;
+  }
+  return command.slice(0, maxLength - 3) + '...';
+}

--- a/packages/client/src/components/repositories/__tests__/EditRepositoryForm.test.tsx
+++ b/packages/client/src/components/repositories/__tests__/EditRepositoryForm.test.tsx
@@ -1,0 +1,517 @@
+import { describe, it, expect, mock, beforeEach, afterEach, afterAll } from 'bun:test';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { Repository } from '@agent-console/shared';
+import { EditRepositoryForm } from '../EditRepositoryForm';
+
+// Save original fetch and set up mock
+const originalFetch = globalThis.fetch;
+const mockFetch = mock((_input: RequestInfo | URL, _init?: RequestInit) => Promise.resolve(new Response()));
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+// Helper to get request body from mockFetch calls
+function getRequestBody(callIndex: number): Record<string, unknown> {
+  const calls = mockFetch.mock.calls as Array<[RequestInfo | URL, RequestInit | undefined]>;
+  const init = calls[callIndex]?.[1];
+  return JSON.parse(init?.body as string);
+}
+
+// Restore original fetch after all tests
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// Clean up after each test
+afterEach(() => {
+  cleanup();
+});
+
+function createMockResponse(body: unknown, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 400,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function createTestRepository(overrides: Partial<Repository & { setupCommand?: string | null }> = {}): Repository & { setupCommand?: string | null } {
+  return {
+    id: 'repo-1',
+    name: 'test-repo',
+    path: '/path/to/test-repo',
+    createdAt: new Date().toISOString(),
+    remoteUrl: 'https://github.com/test/test-repo.git',
+    setupCommand: null,
+    ...overrides,
+  };
+}
+
+// Wrapper component with QueryClientProvider
+function TestWrapper({ children, queryClient }: { children: React.ReactNode; queryClient: QueryClient }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function renderEditRepositoryForm(
+  props: Partial<React.ComponentProps<typeof EditRepositoryForm>> = {},
+  options: { queryClient?: QueryClient } = {}
+) {
+  const queryClient = options.queryClient ?? new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const defaultProps = {
+    repository: createTestRepository(),
+    onSuccess: mock(() => {}),
+    onCancel: mock(() => {}),
+  };
+
+  const mergedProps = { ...defaultProps, ...props };
+
+  return {
+    ...render(
+      <TestWrapper queryClient={queryClient}>
+        <EditRepositoryForm {...mergedProps} />
+      </TestWrapper>
+    ),
+    props: mergedProps,
+    queryClient,
+  };
+}
+
+describe('EditRepositoryForm', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe('form submission', () => {
+    it('should submit with valid setup command', async () => {
+      const user = userEvent.setup();
+      const repository = createTestRepository();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ repository: { ...repository, setupCommand: 'bun install' } })
+      );
+
+      const { props } = renderEditRepositoryForm({ repository });
+
+      // Fill in setup command
+      const commandInput = screen.getByPlaceholderText(/bun install/);
+      await user.type(commandInput, 'bun install');
+
+      // Submit form
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Wait for mutation to complete
+      await waitFor(() => {
+        expect(props.onSuccess).toHaveBeenCalledTimes(1);
+      });
+
+      // Verify API was called with correct data
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const requestBody = getRequestBody(0);
+      expect(requestBody).toEqual({ setupCommand: 'bun install' });
+    });
+
+    it('should submit with empty string (clears command)', async () => {
+      const user = userEvent.setup();
+      const repository = createTestRepository({ setupCommand: 'bun install' });
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ repository: { ...repository, setupCommand: null } })
+      );
+
+      const { props } = renderEditRepositoryForm({ repository });
+
+      // Clear the setup command
+      const commandInput = screen.getByPlaceholderText(/bun install/) as HTMLTextAreaElement;
+      expect(commandInput.value).toBe('bun install');
+      await user.clear(commandInput);
+
+      // Submit form
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Wait for mutation to complete
+      await waitFor(() => {
+        expect(props.onSuccess).toHaveBeenCalledTimes(1);
+      });
+
+      // Verify API was called with null (empty string converted to null)
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const requestBody = getRequestBody(0);
+      expect(requestBody).toEqual({ setupCommand: null });
+    });
+
+    it('should trim whitespace from setupCommand', async () => {
+      const user = userEvent.setup();
+      const repository = createTestRepository();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ repository: { ...repository, setupCommand: 'bun install' } })
+      );
+
+      const { props } = renderEditRepositoryForm({ repository });
+
+      // Fill in setup command with whitespace
+      const commandInput = screen.getByPlaceholderText(/bun install/);
+      await user.type(commandInput, '  bun install  ');
+
+      // Submit form
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Wait for mutation to complete
+      await waitFor(() => {
+        expect(props.onSuccess).toHaveBeenCalledTimes(1);
+      });
+
+      // Verify API was called with trimmed value
+      const requestBody = getRequestBody(0);
+      expect(requestBody).toEqual({ setupCommand: 'bun install' });
+    });
+  });
+
+  describe('optimistic updates', () => {
+    it('should optimistically update repository in cache', async () => {
+      const user = userEvent.setup();
+      const repository = createTestRepository();
+
+      // Set up query client with initial data
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      queryClient.setQueryData(['repositories'], {
+        repositories: [repository],
+      });
+
+      // Make fetch hang to observe optimistic state
+      let resolveFetch: (value: Response) => void;
+      mockFetch.mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+      );
+
+      renderEditRepositoryForm({ repository }, { queryClient });
+
+      // Fill in setup command
+      const commandInput = screen.getByPlaceholderText(/bun install/);
+      await user.type(commandInput, 'npm install');
+
+      // Submit form
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Check optimistic update was applied immediately
+      await waitFor(() => {
+        const cached = queryClient.getQueryData<{ repositories: Repository[] }>(['repositories']);
+        expect(cached?.repositories[0].setupCommand).toBe('npm install');
+      });
+
+      // Resolve the fetch
+      resolveFetch!(createMockResponse({ repository: { ...repository, setupCommand: 'npm install' } }));
+    });
+
+    it('should rollback cache on mutation error', async () => {
+      const user = userEvent.setup();
+      const repository = createTestRepository({ setupCommand: 'original command' });
+
+      // Set up query client with initial data
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      queryClient.setQueryData(['repositories'], {
+        repositories: [repository],
+      });
+
+      // Mock fetch to fail
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ error: 'Server error' }, false)
+      );
+
+      renderEditRepositoryForm({ repository }, { queryClient });
+
+      // Modify setup command
+      const commandInput = screen.getByPlaceholderText(/bun install/) as HTMLTextAreaElement;
+      await user.clear(commandInput);
+      await user.type(commandInput, 'new command');
+
+      // Submit form
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Wait for error to appear
+      await waitFor(() => {
+        expect(screen.getByText(/Server error|Failed to update/)).toBeTruthy();
+      });
+
+      // Cache should be rolled back to original value
+      const cached = queryClient.getQueryData<{ repositories: Repository[] }>(['repositories']);
+      expect(cached?.repositories[0].setupCommand).toBe('original command');
+    });
+
+    it('should cancel in-flight queries before optimistic update', async () => {
+      const user = userEvent.setup();
+      const repository = createTestRepository();
+
+      // Set up query client with initial data
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      queryClient.setQueryData(['repositories'], {
+        repositories: [repository],
+      });
+
+      // Spy on cancelQueries
+      const cancelQueriesSpy = mock(() => Promise.resolve());
+      const originalCancelQueries = queryClient.cancelQueries.bind(queryClient);
+      queryClient.cancelQueries = cancelQueriesSpy as typeof queryClient.cancelQueries;
+
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ repository: { ...repository, setupCommand: 'bun install' } })
+      );
+
+      renderEditRepositoryForm({ repository }, { queryClient });
+
+      // Fill in setup command
+      const commandInput = screen.getByPlaceholderText(/bun install/);
+      await user.type(commandInput, 'bun install');
+
+      // Submit form
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Verify cancelQueries was called
+      await waitFor(() => {
+        expect(cancelQueriesSpy).toHaveBeenCalled();
+      });
+
+      // Verify it was called with the correct query key
+      type CancelQueriesCall = Parameters<typeof queryClient.cancelQueries>;
+      const cancelCalls = cancelQueriesSpy.mock.calls as CancelQueriesCall[];
+      expect(cancelCalls[0][0]).toEqual({ queryKey: ['repositories'] });
+
+      // Restore original cancelQueries
+      queryClient.cancelQueries = originalCancelQueries;
+    });
+  });
+
+  describe('validation', () => {
+    it('should accept multi-line commands', async () => {
+      const user = userEvent.setup();
+      const repository = createTestRepository();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ repository: { ...repository, setupCommand: 'bun install\nbun run build' } })
+      );
+
+      const { props } = renderEditRepositoryForm({ repository });
+
+      // Fill in multi-line setup command
+      const commandInput = screen.getByPlaceholderText(/bun install/);
+      await user.type(commandInput, 'bun install{enter}bun run build');
+
+      // Submit form
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Wait for mutation to complete
+      await waitFor(() => {
+        expect(props.onSuccess).toHaveBeenCalledTimes(1);
+      });
+
+      // Verify API was called with multi-line command
+      const requestBody = getRequestBody(0);
+      expect(requestBody.setupCommand).toContain('\n');
+    });
+
+    it('should accept template variables', async () => {
+      const user = userEvent.setup();
+      const commandWithTemplate = 'cd {{WORKTREE_PATH}} && bun install';
+      // Pre-populate the repository with the template command to avoid userEvent escaping issues
+      const repository = createTestRepository({ setupCommand: commandWithTemplate });
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ repository: { ...repository, setupCommand: commandWithTemplate } })
+      );
+
+      const { props } = renderEditRepositoryForm({ repository });
+
+      // Verify the template variable is displayed correctly
+      const commandInput = screen.getByPlaceholderText(/bun install/) as HTMLTextAreaElement;
+      expect(commandInput.value).toBe(commandWithTemplate);
+
+      // Submit form without modifying
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Wait for mutation to complete
+      await waitFor(() => {
+        expect(props.onSuccess).toHaveBeenCalledTimes(1);
+      });
+
+      // Verify API was called with template variable preserved
+      const requestBody = getRequestBody(0);
+      expect(requestBody.setupCommand).toBe(commandWithTemplate);
+    });
+  });
+
+  describe('UI state', () => {
+    it('should show FormOverlay when mutation is pending', async () => {
+      const user = userEvent.setup();
+      const repository = createTestRepository();
+
+      // Make fetch hang indefinitely
+      mockFetch.mockReturnValueOnce(new Promise(() => {}));
+
+      renderEditRepositoryForm({ repository });
+
+      // Fill in setup command
+      const commandInput = screen.getByPlaceholderText(/bun install/);
+      await user.type(commandInput, 'bun install');
+
+      // Submit form
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Form overlay should be visible with loading message
+      await waitFor(() => {
+        expect(screen.getByText('Saving changes...')).toBeTruthy();
+      });
+
+      // Form fields should be disabled via fieldset
+      expect(commandInput.closest('fieldset')?.disabled).toBe(true);
+    });
+
+    it('should call onSuccess after successful mutation', async () => {
+      const user = userEvent.setup();
+      const repository = createTestRepository();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ repository: { ...repository, setupCommand: 'bun install' } })
+      );
+
+      const { props } = renderEditRepositoryForm({ repository });
+
+      // Fill in setup command
+      const commandInput = screen.getByPlaceholderText(/bun install/);
+      await user.type(commandInput, 'bun install');
+
+      // Submit form
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Wait for mutation to complete
+      await waitFor(() => {
+        expect(props.onSuccess).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should call onCancel when cancel button is clicked', async () => {
+      const user = userEvent.setup();
+      const { props } = renderEditRepositoryForm();
+
+      // Click cancel button
+      const cancelButton = screen.getByText('Cancel');
+      await user.click(cancelButton);
+
+      expect(props.onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('should display error message on mutation failure', async () => {
+      const user = userEvent.setup();
+      const repository = createTestRepository();
+
+      // Mock fetch to fail with specific error
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ error: 'Invalid setup command' }, false)
+      );
+
+      const { props } = renderEditRepositoryForm({ repository });
+
+      // Fill in setup command
+      const commandInput = screen.getByPlaceholderText(/bun install/);
+      await user.type(commandInput, 'invalid command');
+
+      // Submit form
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Error should be displayed
+      await waitFor(() => {
+        expect(screen.getByText('Invalid setup command')).toBeTruthy();
+      });
+
+      // onSuccess should NOT be called
+      expect(props.onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should display default error message when error response has no error field', async () => {
+      const user = userEvent.setup();
+      const repository = createTestRepository();
+
+      // Mock fetch to fail without error field
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({}, false)
+      );
+
+      renderEditRepositoryForm({ repository });
+
+      // Fill in setup command
+      const commandInput = screen.getByPlaceholderText(/bun install/);
+      await user.type(commandInput, 'some command');
+
+      // Submit form
+      const submitButton = screen.getByText('Save Changes');
+      await user.click(submitButton);
+
+      // Default error message should be displayed
+      await waitFor(() => {
+        expect(screen.getByText('Failed to update repository')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('initial state', () => {
+    it('should display repository name and path', () => {
+      const repository = createTestRepository({
+        name: 'my-repo',
+        path: '/home/user/projects/my-repo',
+      });
+
+      renderEditRepositoryForm({ repository });
+
+      expect(screen.getByText('my-repo')).toBeTruthy();
+      expect(screen.getByText('/home/user/projects/my-repo')).toBeTruthy();
+    });
+
+    it('should pre-populate setupCommand from repository', () => {
+      const repository = createTestRepository({ setupCommand: 'npm install && npm run build' });
+
+      renderEditRepositoryForm({ repository });
+
+      const commandInput = screen.getByPlaceholderText(/bun install/) as HTMLTextAreaElement;
+      expect(commandInput.value).toBe('npm install && npm run build');
+    });
+
+    it('should handle null setupCommand gracefully', () => {
+      const repository = createTestRepository({ setupCommand: null });
+
+      renderEditRepositoryForm({ repository });
+
+      const commandInput = screen.getByPlaceholderText(/bun install/) as HTMLTextAreaElement;
+      expect(commandInput.value).toBe('');
+    });
+
+    it('should handle undefined setupCommand gracefully', () => {
+      const repository = createTestRepository();
+      // Explicitly set to undefined instead of null
+      delete (repository as { setupCommand?: string | null }).setupCommand;
+
+      renderEditRepositoryForm({ repository });
+
+      const commandInput = screen.getByPlaceholderText(/bun install/) as HTMLTextAreaElement;
+      expect(commandInput.value).toBe('');
+    });
+  });
+});

--- a/packages/client/src/hooks/use-repositories.ts
+++ b/packages/client/src/hooks/use-repositories.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchRepositories } from '../lib/api';
+
+/**
+ * Hook for fetching repositories list with TanStack Query.
+ * Returns loading, error state and refetch function along with data.
+ */
+export function useRepositories() {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['repositories'],
+    queryFn: fetchRepositories,
+  });
+
+  return {
+    repositories: data?.repositories ?? [],
+    isLoading,
+    error,
+    refetch,
+  };
+}

--- a/packages/client/src/hooks/useAppWs.ts
+++ b/packages/client/src/hooks/useAppWs.ts
@@ -44,6 +44,8 @@ interface UseAppWsEventOptions {
   onRepositoryCreated?: (repository: Repository) => void;
   /** Called when a repository is deleted */
   onRepositoryDeleted?: (repositoryId: string) => void;
+  /** Called when a repository is updated */
+  onRepositoryUpdated?: (repository: Repository) => void;
 }
 
 /**
@@ -124,6 +126,10 @@ export function useAppWsEvent(options: UseAppWsEventOptions = {}): void {
         case 'repository-deleted':
           console.log(`[WebSocket] repository-deleted: ${msg.repositoryId}`);
           optionsRef.current.onRepositoryDeleted?.(msg.repositoryId);
+          break;
+        case 'repository-updated':
+          console.log(`[WebSocket] repository-updated: ${msg.repository.id}`);
+          optionsRef.current.onRepositoryUpdated?.(msg.repository);
           break;
       }
     });

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   JobStats,
   JobStatus,
   JobType,
+  SetupCommandResult,
 } from '@agent-console/shared';
 
 const API_BASE = '/api';
@@ -215,6 +216,30 @@ export async function unregisterRepository(repositoryId: string): Promise<void> 
   }
 }
 
+export interface UpdateRepositoryRequest {
+  setupCommand?: string | null;
+}
+
+export interface UpdateRepositoryResponse {
+  repository: Repository;
+}
+
+export async function updateRepository(
+  repositoryId: string,
+  request: UpdateRepositoryRequest
+): Promise<UpdateRepositoryResponse> {
+  const res = await fetch(`${API_BASE}/repositories/${repositoryId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error(error.error || 'Failed to update repository');
+  }
+  return res.json();
+}
+
 export interface WorktreesResponse {
   worktrees: Worktree[];
 }
@@ -230,6 +255,8 @@ export interface CreateWorktreeResponse {
   session: Session | null;
   /** Present when AI-based branch name generation failed and a fallback name was used */
   branchNameFallback?: BranchNameFallback;
+  /** Present when a setup command was configured and executed */
+  setupCommandResult?: SetupCommandResult;
 }
 
 export async function fetchWorktrees(repositoryId: string): Promise<WorktreesResponse> {

--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -11,8 +11,10 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as MaintenanceRouteImport } from './routes/maintenance'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as JobsIndexRouteImport } from './routes/jobs/index'
 import { Route as AgentsIndexRouteImport } from './routes/agents/index'
+import { Route as SettingsRepositoriesRouteImport } from './routes/settings/repositories'
 import { Route as SessionsSessionIdRouteImport } from './routes/sessions/$sessionId'
 import { Route as JobsJobIdIndexRouteImport } from './routes/jobs/$jobId/index'
 import { Route as AgentsAgentIdIndexRouteImport } from './routes/agents/$agentId/index'
@@ -28,6 +30,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SettingsIndexRoute = SettingsIndexRouteImport.update({
+  id: '/settings/',
+  path: '/settings/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const JobsIndexRoute = JobsIndexRouteImport.update({
   id: '/jobs/',
   path: '/jobs/',
@@ -36,6 +43,11 @@ const JobsIndexRoute = JobsIndexRouteImport.update({
 const AgentsIndexRoute = AgentsIndexRouteImport.update({
   id: '/agents/',
   path: '/agents/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsRepositoriesRoute = SettingsRepositoriesRouteImport.update({
+  id: '/settings/repositories',
+  path: '/settings/repositories',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SessionsSessionIdRoute = SessionsSessionIdRouteImport.update({
@@ -63,8 +75,10 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/maintenance': typeof MaintenanceRoute
   '/sessions/$sessionId': typeof SessionsSessionIdRoute
+  '/settings/repositories': typeof SettingsRepositoriesRoute
   '/agents': typeof AgentsIndexRoute
   '/jobs': typeof JobsIndexRoute
+  '/settings': typeof SettingsIndexRoute
   '/agents/$agentId/edit': typeof AgentsAgentIdEditRoute
   '/agents/$agentId': typeof AgentsAgentIdIndexRoute
   '/jobs/$jobId': typeof JobsJobIdIndexRoute
@@ -73,8 +87,10 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/maintenance': typeof MaintenanceRoute
   '/sessions/$sessionId': typeof SessionsSessionIdRoute
+  '/settings/repositories': typeof SettingsRepositoriesRoute
   '/agents': typeof AgentsIndexRoute
   '/jobs': typeof JobsIndexRoute
+  '/settings': typeof SettingsIndexRoute
   '/agents/$agentId/edit': typeof AgentsAgentIdEditRoute
   '/agents/$agentId': typeof AgentsAgentIdIndexRoute
   '/jobs/$jobId': typeof JobsJobIdIndexRoute
@@ -84,8 +100,10 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/maintenance': typeof MaintenanceRoute
   '/sessions/$sessionId': typeof SessionsSessionIdRoute
+  '/settings/repositories': typeof SettingsRepositoriesRoute
   '/agents/': typeof AgentsIndexRoute
   '/jobs/': typeof JobsIndexRoute
+  '/settings/': typeof SettingsIndexRoute
   '/agents/$agentId/edit': typeof AgentsAgentIdEditRoute
   '/agents/$agentId/': typeof AgentsAgentIdIndexRoute
   '/jobs/$jobId/': typeof JobsJobIdIndexRoute
@@ -96,8 +114,10 @@ export interface FileRouteTypes {
     | '/'
     | '/maintenance'
     | '/sessions/$sessionId'
+    | '/settings/repositories'
     | '/agents'
     | '/jobs'
+    | '/settings'
     | '/agents/$agentId/edit'
     | '/agents/$agentId'
     | '/jobs/$jobId'
@@ -106,8 +126,10 @@ export interface FileRouteTypes {
     | '/'
     | '/maintenance'
     | '/sessions/$sessionId'
+    | '/settings/repositories'
     | '/agents'
     | '/jobs'
+    | '/settings'
     | '/agents/$agentId/edit'
     | '/agents/$agentId'
     | '/jobs/$jobId'
@@ -116,8 +138,10 @@ export interface FileRouteTypes {
     | '/'
     | '/maintenance'
     | '/sessions/$sessionId'
+    | '/settings/repositories'
     | '/agents/'
     | '/jobs/'
+    | '/settings/'
     | '/agents/$agentId/edit'
     | '/agents/$agentId/'
     | '/jobs/$jobId/'
@@ -127,8 +151,10 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   MaintenanceRoute: typeof MaintenanceRoute
   SessionsSessionIdRoute: typeof SessionsSessionIdRoute
+  SettingsRepositoriesRoute: typeof SettingsRepositoriesRoute
   AgentsIndexRoute: typeof AgentsIndexRoute
   JobsIndexRoute: typeof JobsIndexRoute
+  SettingsIndexRoute: typeof SettingsIndexRoute
   AgentsAgentIdEditRoute: typeof AgentsAgentIdEditRoute
   AgentsAgentIdIndexRoute: typeof AgentsAgentIdIndexRoute
   JobsJobIdIndexRoute: typeof JobsJobIdIndexRoute
@@ -150,6 +176,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/settings/': {
+      id: '/settings/'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/jobs/': {
       id: '/jobs/'
       path: '/jobs'
@@ -162,6 +195,13 @@ declare module '@tanstack/react-router' {
       path: '/agents'
       fullPath: '/agents'
       preLoaderRoute: typeof AgentsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/repositories': {
+      id: '/settings/repositories'
+      path: '/settings/repositories'
+      fullPath: '/settings/repositories'
+      preLoaderRoute: typeof SettingsRepositoriesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/sessions/$sessionId': {
@@ -199,8 +239,10 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   MaintenanceRoute: MaintenanceRoute,
   SessionsSessionIdRoute: SessionsSessionIdRoute,
+  SettingsRepositoriesRoute: SettingsRepositoriesRoute,
   AgentsIndexRoute: AgentsIndexRoute,
   JobsIndexRoute: JobsIndexRoute,
+  SettingsIndexRoute: SettingsIndexRoute,
   AgentsAgentIdEditRoute: AgentsAgentIdEditRoute,
   AgentsAgentIdIndexRoute: AgentsAgentIdIndexRoute,
   JobsJobIdIndexRoute: JobsJobIdIndexRoute,

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -52,6 +52,7 @@ function RootLayout() {
           <ValidationWarningIndicator />
           <JobsNavLink />
           <AgentsNavLink />
+          <RepositoriesNavLink />
         </div>
       </header>
       <ConnectionBanner connected={connected} />
@@ -100,6 +101,27 @@ function AgentsNavLink() {
       }}
     >
       Agents
+    </Link>
+  );
+}
+
+function RepositoriesNavLink() {
+  const location = useLocation();
+  const isActive = location.pathname === '/settings/repositories';
+
+  return (
+    <Link
+      to="/settings/repositories"
+      style={{
+        color: isActive ? '#fff' : '#94a3b8',
+        textDecoration: 'none',
+        fontSize: '0.875rem',
+        padding: '4px 8px',
+        borderRadius: '4px',
+        backgroundColor: isActive ? 'rgba(255, 255, 255, 0.1)' : 'transparent',
+      }}
+    >
+      Repositories
     </Link>
   );
 }

--- a/packages/client/src/routes/settings/index.tsx
+++ b/packages/client/src/routes/settings/index.tsx
@@ -1,0 +1,218 @@
+import { useState } from 'react';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AgentDefinition } from '@agent-console/shared';
+import { unregisterAgent } from '../../lib/api';
+import { useAgents } from '../../components/AgentSelector';
+import { AddAgentForm, CapabilityIndicator } from '../../components/agents';
+import { ConfirmDialog } from '../../components/ui/confirm-dialog';
+import { ErrorDialog, useErrorDialog } from '../../components/ui/error-dialog';
+import { Spinner } from '../../components/ui/Spinner';
+import { useAppWsState } from '../../hooks/useAppWs';
+
+export const Route = createFileRoute('/settings/')({
+  component: SettingsPage,
+});
+
+function SettingsPage() {
+  const queryClient = useQueryClient();
+  const agentsSynced = useAppWsState((s) => s.agentsSynced);
+  const { agents, isLoading, error, refetch } = useAgents();
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [agentToDelete, setAgentToDelete] = useState<AgentDefinition | null>(null);
+  const { errorDialogProps, showError } = useErrorDialog();
+
+  // Show loading state until WebSocket sync completes
+  const showLoading = isLoading || !agentsSynced;
+
+  const unregisterMutation = useMutation({
+    mutationFn: unregisterAgent,
+    onSuccess: (_response, deletedAgentId) => {
+      // Optimistic cache update
+      queryClient.setQueryData<{ agents: AgentDefinition[] } | undefined>(['agents'], (old) => {
+        if (!old) return old;
+        return { agents: old.agents.filter(a => a.id !== deletedAgentId) };
+      });
+      queryClient.invalidateQueries({ queryKey: ['agent', deletedAgentId] });
+      setAgentToDelete(null);
+    },
+    onError: (err) => {
+      setAgentToDelete(null);
+      showError('Cannot Delete Agent', err instanceof Error ? err.message : 'Unknown error');
+    },
+  });
+
+  const handleDelete = (agent: AgentDefinition) => {
+    if (agent.isBuiltIn) {
+      showError('Cannot Delete', 'Built-in agents cannot be deleted');
+      return;
+    }
+    setAgentToDelete(agent);
+  };
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
+        <Link to="/" className="hover:text-white">Agent Console</Link>
+        <span>/</span>
+        <span className="text-white">Settings</span>
+      </div>
+
+      {/* Header with Add button */}
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-semibold">Settings</h1>
+        <button
+          onClick={() => setShowAddForm(true)}
+          className="btn btn-primary text-sm"
+        >
+          + Add Agent
+        </button>
+      </div>
+
+      {/* Add Agent Form */}
+      {showAddForm && (
+        <AddAgentForm
+          onSuccess={() => setShowAddForm(false)}
+          onCancel={() => setShowAddForm(false)}
+        />
+      )}
+
+      {/* Loading State */}
+      {showLoading && (
+        <div className="flex items-center gap-2 text-gray-500">
+          <Spinner size="sm" />
+          <span>Loading agents...</span>
+        </div>
+      )}
+
+      {/* Error State */}
+      {!showLoading && error && (
+        <div className="card text-center py-10">
+          <p className="text-red-400 mb-4">Failed to load agents</p>
+          <button onClick={() => refetch()} className="btn btn-primary">
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Agent List */}
+      {!showLoading && !error && (
+        <div className="flex flex-col gap-3">
+          {agents.map((agent) => (
+            <AgentCard
+              key={agent.id}
+              agent={agent}
+              onDelete={() => handleDelete(agent)}
+              isDeleting={unregisterMutation.isPending && agentToDelete?.id === agent.id}
+            />
+          ))}
+        </div>
+      )}
+
+      {!showLoading && !error && agents.length === 0 && (
+        <div className="card text-center py-10">
+          <p className="text-gray-500 mb-4">No agents registered</p>
+          <button
+            onClick={() => setShowAddForm(true)}
+            className="btn btn-primary"
+          >
+            Add your first agent
+          </button>
+        </div>
+      )}
+
+      {/* Delete Agent Confirmation */}
+      <ConfirmDialog
+        open={agentToDelete !== null}
+        onOpenChange={(open) => !open && setAgentToDelete(null)}
+        title="Delete Agent"
+        description={`Are you sure you want to delete "${agentToDelete?.name}"?`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => {
+          if (agentToDelete) {
+            unregisterMutation.mutate(agentToDelete.id);
+          }
+        }}
+        isLoading={unregisterMutation.isPending}
+      />
+      <ErrorDialog {...errorDialogProps} />
+    </div>
+  );
+}
+
+interface AgentCardProps {
+  agent: AgentDefinition;
+  onDelete: () => void;
+  isDeleting: boolean;
+}
+
+function AgentCard({ agent, onDelete, isDeleting }: AgentCardProps) {
+  const { capabilities } = agent;
+
+  return (
+    <div className="card">
+      <div className="flex items-start gap-4">
+        <div className="flex-1 min-w-0">
+          {/* Name and badges */}
+          <div className="text-lg font-medium flex items-center gap-2 mb-1">
+            {agent.name}
+            {agent.isBuiltIn && (
+              <span className="text-xs px-1.5 py-0.5 bg-blue-500/20 text-blue-400 rounded">
+                built-in
+              </span>
+            )}
+          </div>
+
+          {/* Command template */}
+          <div className="text-sm text-gray-400 font-mono mb-2">
+            {agent.commandTemplate}
+          </div>
+
+          {/* Description */}
+          {agent.description && (
+            <p className="text-sm text-gray-500 mb-2">{agent.description}</p>
+          )}
+
+          {/* Capability indicators */}
+          <div className="flex gap-4 text-sm">
+            <CapabilityIndicator enabled={capabilities.supportsContinue} label="Continue" />
+            <CapabilityIndicator enabled={capabilities.supportsHeadlessMode} label="Headless" />
+            <CapabilityIndicator enabled={capabilities.supportsActivityDetection} label="Activity Detection" />
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex gap-2 shrink-0">
+          <Link
+            to="/agents/$agentId"
+            params={{ agentId: agent.id }}
+            className="btn text-sm bg-slate-700 hover:bg-slate-600 no-underline"
+          >
+            View
+          </Link>
+          {!agent.isBuiltIn && (
+            <>
+              <Link
+                to="/agents/$agentId/edit"
+                params={{ agentId: agent.id }}
+                className="btn btn-primary text-sm no-underline"
+              >
+                Edit
+              </Link>
+              <button
+                onClick={onDelete}
+                disabled={isDeleting}
+                className="btn btn-danger text-sm"
+              >
+                Delete
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/packages/client/src/routes/settings/repositories.tsx
+++ b/packages/client/src/routes/settings/repositories.tsx
@@ -1,0 +1,28 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { RepositoryList } from '../../components/repositories/RepositoryList';
+
+export const Route = createFileRoute('/settings/repositories')({
+  component: RepositoriesPage,
+});
+
+function RepositoriesPage() {
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
+        <Link to="/" className="hover:text-white">Agent Console</Link>
+        <span>/</span>
+        <span className="text-white">Repositories</span>
+      </div>
+
+      {/* Header */}
+      <h1 className="text-2xl font-semibold mb-2">Repository Settings</h1>
+      <p className="text-gray-400 mb-8">
+        Configure setup commands that run automatically after creating a new worktree for each repository.
+      </p>
+
+      {/* Repository List */}
+      <RepositoryList />
+    </div>
+  );
+}

--- a/packages/server/src/database/__tests__/mappers.test.ts
+++ b/packages/server/src/database/__tests__/mappers.test.ts
@@ -475,6 +475,7 @@ describe('mappers', () => {
         path: '/opt/repos/another-project',
         created_at: '2024-02-20T14:00:00.000Z',
         updated_at: '2024-02-20T14:00:00.000Z',
+        setup_command: null,
       };
 
       const repository = toRepository(row);
@@ -483,6 +484,7 @@ describe('mappers', () => {
       expect(repository.name).toBe('another-project');
       expect(repository.path).toBe('/opt/repos/another-project');
       expect(repository.createdAt).toBe('2024-02-20T14:00:00.000Z');
+      expect(repository.setupCommand).toBeNull();
     });
 
     it('should handle created_at correctly', () => {
@@ -492,12 +494,28 @@ describe('mappers', () => {
         path: '/tmp/test-repo',
         created_at: '2024-12-01T00:00:00.000Z',
         updated_at: '2024-12-01T00:00:00.000Z',
+        setup_command: null,
       };
 
       const repository = toRepository(row);
 
       // Verify createdAt is correctly mapped from created_at
       expect(repository.createdAt).toBe('2024-12-01T00:00:00.000Z');
+    });
+
+    it('should map setup_command to setupCommand', () => {
+      const row: RepositoryRow = {
+        id: 'repo-4',
+        name: 'test-repo',
+        path: '/tmp/test-repo',
+        created_at: '2024-12-01T00:00:00.000Z',
+        updated_at: '2024-12-01T00:00:00.000Z',
+        setup_command: 'npm install',
+      };
+
+      const repository = toRepository(row);
+
+      expect(repository.setupCommand).toBe('npm install');
     });
   });
 

--- a/packages/server/src/database/connection.ts
+++ b/packages/server/src/database/connection.ts
@@ -150,6 +150,10 @@ async function runMigrations(database: Kysely<Database>): Promise<void> {
   if (currentVersion < 3) {
     await migrateToV3(database);
   }
+
+  if (currentVersion < 4) {
+    await migrateToV4(database);
+  }
 }
 
 /**
@@ -319,6 +323,25 @@ async function migrateToV3(database: Kysely<Database>): Promise<void> {
   await sql`PRAGMA user_version = 3`.execute(database);
 
   logger.info('Migration to v3 completed');
+}
+
+/**
+ * Migration v4: Add setup_command column to repositories table.
+ * This column stores shell commands to run after creating worktrees.
+ */
+async function migrateToV4(database: Kysely<Database>): Promise<void> {
+  logger.info('Running migration to v4: Adding setup_command column to repositories');
+
+  // Add setup_command column to repositories table
+  await database.schema
+    .alterTable('repositories')
+    .addColumn('setup_command', 'text')
+    .execute();
+
+  // Update schema version
+  await sql`PRAGMA user_version = 4`.execute(database);
+
+  logger.info('Migration to v4 completed');
 }
 
 /**

--- a/packages/server/src/database/mappers.ts
+++ b/packages/server/src/database/mappers.ts
@@ -261,6 +261,7 @@ export function toRepositoryRow(repository: PersistedRepository): NewRepository 
     path: repository.path,
     created_at: repository.createdAt,
     updated_at: now,
+    setup_command: repository.setupCommand ?? null,
   };
 }
 
@@ -276,6 +277,7 @@ export function toRepository(row: RepositoryRow): Repository {
     name: row.name,
     path: row.path,
     createdAt: row.created_at,
+    setupCommand: row.setup_command ?? null,
   };
 }
 

--- a/packages/server/src/database/schema.ts
+++ b/packages/server/src/database/schema.ts
@@ -95,6 +95,8 @@ export interface RepositoriesTable {
   created_at: Generated<string>;
   /** Last update timestamp as ISO 8601 string (has DEFAULT) */
   updated_at: Generated<string>;
+  /** Shell command to run after creating worktrees (added in v4) */
+  setup_command: string | null;
 }
 
 /** Repository row as returned from SELECT queries */

--- a/packages/server/src/repositories/repository-repository.ts
+++ b/packages/server/src/repositories/repository-repository.ts
@@ -1,6 +1,13 @@
 import type { Repository } from '@agent-console/shared';
 
 /**
+ * Updates that can be applied to a repository.
+ */
+export interface RepositoryUpdates {
+  setupCommand?: string | null;
+}
+
+/**
  * Repository interface for persisting git repositories.
  * Provides an abstraction layer for repository storage operations.
  */
@@ -30,6 +37,14 @@ export interface RepositoryRepository {
    * @param repository - The repository to save
    */
   save(repository: Repository): Promise<void>;
+
+  /**
+   * Update specific fields of a repository.
+   * @param id - The repository ID to update
+   * @param updates - The fields to update
+   * @returns The updated repository if found, null otherwise
+   */
+  update(id: string, updates: RepositoryUpdates): Promise<Repository | null>;
 
   /**
    * Delete a repository by its ID.

--- a/packages/server/src/services/__tests__/repository-manager.test.ts
+++ b/packages/server/src/services/__tests__/repository-manager.test.ts
@@ -4,7 +4,7 @@ import type { Repository } from '@agent-console/shared';
 import { setupMemfs, cleanupMemfs, createMockGitRepoFiles } from '../../__tests__/utils/mock-fs-helper.js';
 import { mockGit } from '../../__tests__/utils/mock-git-helper.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
-import type { RepositoryRepository } from '../../repositories/repository-repository.js';
+import type { RepositoryRepository, RepositoryUpdates } from '../../repositories/repository-repository.js';
 import { JobQueue } from '../../jobs/index.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { resetSessionManager, initializeSessionManager } from '../session-manager.js';
@@ -36,6 +36,14 @@ class InMemoryRepositoryRepository implements RepositoryRepository {
 
   async save(repository: Repository): Promise<void> {
     this.repositories.set(repository.id, repository);
+  }
+
+  async update(id: string, updates: RepositoryUpdates): Promise<Repository | null> {
+    const repo = this.repositories.get(id);
+    if (!repo) return null;
+    const updated = { ...repo, ...updates };
+    this.repositories.set(id, updated);
+    return updated;
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/server/src/services/persistence-service.ts
+++ b/packages/server/src/services/persistence-service.ts
@@ -16,6 +16,7 @@ export interface PersistedRepository {
   name: string;
   path: string;
   createdAt: string;
+  setupCommand?: string | null;
 }
 
 // Base for all persisted workers

--- a/packages/server/src/websocket/routes.ts
+++ b/packages/server/src/websocket/routes.ts
@@ -127,6 +127,10 @@ export async function setupWebSocketRoutes(
       logger.debug({ repositoryId: repository.id }, 'Broadcasting repository-created');
       broadcastToApp({ type: 'repository-created', repository });
     },
+    onRepositoryUpdated: (repository) => {
+      logger.debug({ repositoryId: repository.id }, 'Broadcasting repository-updated');
+      broadcastToApp({ type: 'repository-updated', repository });
+    },
     onRepositoryDeleted: (repositoryId) => {
       logger.debug({ repositoryId }, 'Broadcasting repository-deleted');
       broadcastToApp({ type: 'repository-deleted', repositoryId });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,6 +12,16 @@ export interface Repository {
   path: string;         // Absolute path
   createdAt: string;    // Creation date (ISO 8601)
   remoteUrl?: string;   // Git remote URL for origin (if available)
+  setupCommand?: string | null; // Shell command to run after creating worktrees
+}
+
+/**
+ * Result of executing a setup command after worktree creation
+ */
+export interface SetupCommandResult {
+  success: boolean;
+  output?: string;
+  error?: string;
 }
 
 export interface Worktree {

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -56,6 +56,7 @@ export {
   CreateWorktreeExistingRequestSchema,
   CreateWorktreeRequestSchema,
   DeleteWorktreeRequestSchema,
+  UpdateRepositoryRequestSchema,
   FetchGitHubIssueRequestSchema,
   GitHubIssueSummarySchema,
   type CreateRepositoryRequest,
@@ -64,6 +65,7 @@ export {
   type CreateWorktreeExistingRequest,
   type CreateWorktreeRequest,
   type DeleteWorktreeRequest,
+  type UpdateRepositoryRequest,
   type FetchGitHubIssueRequest,
   type GitHubIssueSummary,
 } from './repository.js';

--- a/packages/shared/src/schemas/repository.ts
+++ b/packages/shared/src/schemas/repository.ts
@@ -119,6 +119,13 @@ export const DeleteWorktreeRequestSchema = v.object({
   force: v.optional(v.boolean()),
 });
 
+/**
+ * Schema for updating a repository
+ */
+export const UpdateRepositoryRequestSchema = v.object({
+  setupCommand: v.optional(v.pipe(v.string(), v.trim())),
+});
+
 // Inferred types from schemas
 export type CreateRepositoryRequest = v.InferOutput<typeof CreateRepositoryRequestSchema>;
 export type CreateWorktreePromptRequest = v.InferOutput<typeof CreateWorktreePromptRequestSchema>;
@@ -126,5 +133,6 @@ export type CreateWorktreeCustomRequest = v.InferOutput<typeof CreateWorktreeCus
 export type CreateWorktreeExistingRequest = v.InferOutput<typeof CreateWorktreeExistingRequestSchema>;
 export type CreateWorktreeRequest = v.InferOutput<typeof CreateWorktreeRequestSchema>;
 export type DeleteWorktreeRequest = v.InferOutput<typeof DeleteWorktreeRequestSchema>;
+export type UpdateRepositoryRequest = v.InferOutput<typeof UpdateRepositoryRequestSchema>;
 export type FetchGitHubIssueRequest = v.InferOutput<typeof FetchGitHubIssueRequestSchema>;
 export type GitHubIssueSummary = v.InferOutput<typeof GitHubIssueSummarySchema>;

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -9,6 +9,7 @@ interface Repository {
   path: string;
   createdAt: string;
   remoteUrl?: string;
+  setupCommand?: string | null;
 }
 
 // Re-export schema-derived types
@@ -124,7 +125,8 @@ export const APP_SERVER_MESSAGE_TYPES = {
   'agent-deleted': 9,
   'repositories-sync': 10,
   'repository-created': 11,
-  'repository-deleted': 12,
+  'repository-updated': 12,
+  'repository-deleted': 13,
 } as const;
 
 /** @deprecated Use APP_SERVER_MESSAGE_TYPES instead */
@@ -144,6 +146,7 @@ export type AppServerMessage =
   | { type: 'agent-deleted'; agentId: string }
   | { type: 'repositories-sync'; repositories: Repository[] }
   | { type: 'repository-created'; repository: Repository }
+  | { type: 'repository-updated'; repository: Repository }
   | { type: 'repository-deleted'; repositoryId: string };
 
 /**


### PR DESCRIPTION
## Summary

Add support for configurable setup commands that run automatically after creating new worktrees. Users can configure shell commands per repository that execute after worktree creation (e.g., `bun install`, `npm ci`).

### Key Features
- Configure setup commands per repository via `/settings/repositories` UI
- Automatic execution after worktree creation
- Template variable support: `{{WORKTREE_NUM}}`, `{{BRANCH}}`, `{{REPO}}`, `{{WORKTREE_PATH}}`
- Arithmetic expressions: `{{WORKTREE_NUM + 3000}}`
- Setup failure feedback with error dialog
- Real-time synchronization across browser tabs via WebSocket

## Implementation Details

### Backend
- **Database**: Migration v4 adds `setup_command` column to repositories table
- **API**: PATCH `/api/repositories/:id` endpoint for updating setupCommand
- **Execution**: `WorktreeService.executeSetupCommand()` with template substitution
- **Broadcasting**: `repository-updated` WebSocket messages for real-time sync

### Frontend
- **Route**: `/settings/repositories` for repository management
- **Components**: `RepositoryList`, `EditRepositoryForm` with inline editing
- **UX**: Optimistic updates with automatic rollback on error
- **Feedback**: `SetupCommandFailureDialog` shows setup command results
- **Bug Fix**: Removed confusing Settings link from header

### Testing
- **Backend**: 35+ new tests
  - Template variable substitution (22 tests)
  - Repository CRUD operations (7 tests)
  - API endpoint integration (6 tests)
- **Frontend**: 17 new tests
  - Form submission and validation
  - Optimistic updates with rollback
  - UI state management
- **Total**: All 1296 tests passing

## Test Plan

- [x] Configure setupCommand via UI
- [x] Verify setupCommand persists to database
- [x] Create worktree and verify command executes
- [x] Test template variable substitution
- [x] Test arithmetic expressions
- [x] Verify setup failure shows error dialog
- [x] Test multi-tab synchronization
- [x] Verify optimistic update rollback on error
- [x] All automated tests passing
- [x] Manual UI testing completed

## Screenshots

Setup command configuration UI showing template variable help and inline editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings > Repositories page for managing repositories.
  * Configure an optional setup command per repository.
  * Setup commands run automatically when creating worktrees; failures show a detailed dialog.
  * Real-time repository updates via WebSocket sync.
  * Inline edit flow for repository setup command with save/cancel, loading states, and optimistic UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->