### PR TITLE
feat: add initial prompt display feature

### DIFF
--- a/packages/client/src/components/Icons.tsx
+++ b/packages/client/src/components/Icons.tsx
@@ -153,3 +153,16 @@ export function GitHubIcon({ className = 'w-4 h-4' }: IconProps) {
     </svg>
   );
 }
+
+export function DocumentIcon({ className = 'w-4 h-4' }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+      />
+    </svg>
+  );
+}

--- a/packages/client/src/components/SessionSettings.tsx
+++ b/packages/client/src/components/SessionSettings.tsx
@@ -4,6 +4,7 @@ import {
   EditSessionDialog,
   RestartSessionDialog,
   DeleteWorktreeDialog,
+  InitialPromptDialog,
   type MenuAction,
 } from './sessions';
 
@@ -12,6 +13,7 @@ interface SessionSettingsProps {
   repositoryId: string;
   currentBranch: string;
   currentTitle?: string;
+  initialPrompt?: string;
   worktreePath: string;
   onBranchChange: (newBranch: string) => void;
   onTitleChange?: (newTitle: string) => void;
@@ -25,6 +27,7 @@ export function SessionSettings({
   repositoryId,
   currentBranch,
   currentTitle,
+  initialPrompt,
   worktreePath,
   onBranchChange,
   onTitleChange,
@@ -44,6 +47,7 @@ export function SessionSettings({
     <>
       <SessionSettingsMenu
         worktreePath={worktreePath}
+        initialPrompt={initialPrompt}
         onMenuAction={handleMenuAction}
       />
 
@@ -70,6 +74,12 @@ export function SessionSettings({
         onOpenChange={(open) => !open && closeDialog()}
         repositoryId={repositoryId}
         worktreePath={worktreePath}
+      />
+
+      <InitialPromptDialog
+        open={activeDialog === 'view-initial-prompt'}
+        onOpenChange={(open) => !open && closeDialog()}
+        initialPrompt={initialPrompt}
       />
     </>
   );

--- a/packages/client/src/components/sessions/InitialPromptDialog.tsx
+++ b/packages/client/src/components/sessions/InitialPromptDialog.tsx
@@ -1,0 +1,45 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '../ui/dialog';
+
+export interface InitialPromptDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialPrompt?: string;
+}
+
+export function InitialPromptDialog({
+  open,
+  onOpenChange,
+  initialPrompt,
+}: InitialPromptDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="left-16 right-16 -translate-x-0 w-auto max-w-none mx-0 p-4"
+        aria-describedby={initialPrompt ? 'initial-prompt-content' : undefined}
+      >
+        <DialogHeader className="mb-2">
+          <DialogTitle>Initial Prompt</DialogTitle>
+          {!initialPrompt && (
+            <DialogDescription>
+              No initial prompt available
+            </DialogDescription>
+          )}
+        </DialogHeader>
+        {initialPrompt && (
+          <pre
+            id="initial-prompt-content"
+            className="text-sm text-gray-300 bg-slate-900 rounded p-3 max-h-96 overflow-auto whitespace-pre-wrap break-words font-mono"
+          >
+            {initialPrompt}
+          </pre>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/sessions/SessionSettingsMenu.tsx
+++ b/packages/client/src/components/sessions/SessionSettingsMenu.tsx
@@ -6,18 +6,21 @@ import {
   FolderIcon,
   CopyIcon,
   TrashIcon,
+  DocumentIcon,
 } from '../Icons';
 import { openPath } from '../../lib/api';
 
-export type MenuAction = 'edit' | 'restart' | 'delete-worktree';
+export type MenuAction = 'edit' | 'restart' | 'delete-worktree' | 'view-initial-prompt';
 
 export interface SessionSettingsMenuProps {
   worktreePath: string;
+  initialPrompt?: string;
   onMenuAction: (action: MenuAction) => void;
 }
 
 export function SessionSettingsMenu({
   worktreePath,
+  initialPrompt,
   onMenuAction,
 }: SessionSettingsMenuProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -99,6 +102,15 @@ export function SessionSettingsMenu({
               <EditIcon />
               Edit Session
             </button>
+            {initialPrompt && (
+              <button
+                onClick={() => handleMenuAction('view-initial-prompt')}
+                className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
+              >
+                <DocumentIcon />
+                View Initial Prompt
+              </button>
+            )}
             <button
               onClick={() => handleMenuAction('restart')}
               className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"

--- a/packages/client/src/components/sessions/__tests__/InitialPromptDialog.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/InitialPromptDialog.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { screen, fireEvent, cleanup, act } from '@testing-library/react';
+import { renderWithRouter } from '../../../test/renderWithRouter';
+import { InitialPromptDialog } from '../InitialPromptDialog';
+
+describe('InitialPromptDialog', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const defaultProps = {
+    open: true,
+    onOpenChange: mock(() => {}),
+  };
+
+  it('should display the initial prompt when provided', async () => {
+    const testPrompt = 'This is a test prompt with content';
+    await act(async () => {
+      await renderWithRouter(
+        <InitialPromptDialog {...defaultProps} initialPrompt={testPrompt} />
+      );
+    });
+
+    expect(screen.getByText('Initial Prompt')).toBeTruthy();
+    // Use getById since the pre element has a specific id
+    const promptElement = document.getElementById('initial-prompt-content');
+    expect(promptElement).toBeTruthy();
+    expect(promptElement?.textContent).toBe(testPrompt);
+  });
+
+  it('should display "No initial prompt available" when no prompt is provided', async () => {
+    await act(async () => {
+      await renderWithRouter(
+        <InitialPromptDialog {...defaultProps} initialPrompt={undefined} />
+      );
+    });
+
+    expect(screen.getByText('Initial Prompt')).toBeTruthy();
+    expect(screen.getByText('No initial prompt available')).toBeTruthy();
+  });
+
+  it('should preserve whitespace formatting in the prompt', async () => {
+    const testPrompt = 'Line 1\n  Indented line\n    Double indented';
+    await act(async () => {
+      await renderWithRouter(
+        <InitialPromptDialog {...defaultProps} initialPrompt={testPrompt} />
+      );
+    });
+
+    // Use getById since the pre element has a specific id
+    const promptElement = document.getElementById('initial-prompt-content');
+    expect(promptElement).toBeTruthy();
+    expect(promptElement?.tagName.toLowerCase()).toBe('pre');
+    // The textContent should preserve the original whitespace
+    expect(promptElement?.textContent).toBe(testPrompt);
+  });
+
+  it('should call onOpenChange when close button is clicked', async () => {
+    const onOpenChange = mock(() => {});
+    await act(async () => {
+      await renderWithRouter(
+        <InitialPromptDialog
+          open={true}
+          onOpenChange={onOpenChange}
+          initialPrompt="test"
+        />
+      );
+    });
+
+    // Click the close button (sr-only text "Close")
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    await act(async () => {
+      fireEvent.click(closeButton);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('should not render content when dialog is closed', async () => {
+    await act(async () => {
+      await renderWithRouter(
+        <InitialPromptDialog
+          open={false}
+          onOpenChange={mock(() => {})}
+          initialPrompt="test prompt"
+        />
+      );
+    });
+
+    expect(screen.queryByText('Initial Prompt')).toBeNull();
+    expect(document.getElementById('initial-prompt-content')).toBeNull();
+  });
+});

--- a/packages/client/src/components/sessions/index.ts
+++ b/packages/client/src/components/sessions/index.ts
@@ -10,5 +10,8 @@ export type { RestartSessionDialogProps } from './RestartSessionDialog';
 export { DeleteWorktreeDialog } from './DeleteWorktreeDialog';
 export type { DeleteWorktreeDialogProps } from './DeleteWorktreeDialog';
 
+export { InitialPromptDialog } from './InitialPromptDialog';
+export type { InitialPromptDialogProps } from './InitialPromptDialog';
+
 export { SessionSettingsMenu } from './SessionSettingsMenu';
 export type { SessionSettingsMenuProps, MenuAction } from './SessionSettingsMenu';

--- a/packages/client/src/routes/sessions/$sessionId.tsx
+++ b/packages/client/src/routes/sessions/$sessionId.tsx
@@ -538,6 +538,7 @@ function TerminalPage() {
               repositoryId={repositoryId}
               currentBranch={branchName}
               currentTitle={sessionTitle}
+              initialPrompt={session.initialPrompt}
               worktreePath={session.locationPath}
               onBranchChange={setBranchName}
               onTitleChange={setSessionTitle}


### PR DESCRIPTION
## Summary
- Add ability to view session's initial prompt via settings menu
- Users can now see what prompt they used when creating a session

## Changes
- **New Component**: `InitialPromptDialog` - Modal dialog to display initial prompt text
- **Menu Item**: Added "View Initial Prompt" to session settings menu
- **Icon**: Added `DocumentIcon` for the menu item
- **Integration**: Wired dialog into `SessionSettings` and session page
- **Tests**: Added unit tests for `InitialPromptDialog`

## UI Design
- Dialog uses viewport width with fixed 64px left/right margins
- Minimal padding for better space utilization
- Preserves formatting (whitespace, line breaks) for Markdown prompts
- Menu item only appears when session has an initial prompt

## Test Plan
- [x] Manual testing via Chrome DevTools MCP
- [x] Verified dialog displays correctly with proper margins
- [x] Verified menu item appears only when initial prompt exists
- [x] Verified formatting preservation for long Markdown prompts
- [x] Unit tests pass
- [x] Type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "View Initial Prompt" menu option in session settings, allowing users to review initial prompts
  * New modal dialog displays initial prompts with optimized formatting and readability for better viewing experience

* **Tests**
  * Added comprehensive unit tests for the initial prompt dialog component

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->