### PR TITLE
fix: eliminate history initialization error on new worker/session creation

### DIFF
--- a/packages/client/src/lib/worker-websocket.ts
+++ b/packages/client/src/lib/worker-websocket.ts
@@ -303,24 +303,10 @@ function setupWebSocketHandlers(key: string, ws: WebSocket, callbacks: WorkerCal
     updateState(key, { connected: true });
     if (callbacks.type === 'git-diff') {
       updateState(key, { diffLoading: true });
-    } else {
-      // Request history for terminal/agent workers on connection
-      // Use debounce to prevent duplicate requests during React Strict Mode double render
-      const currentConn = connections.get(key);
-      if (currentConn) {
-        // Clear any pending history request
-        if (currentConn.historyRequestTimeout) {
-          clearTimeout(currentConn.historyRequestTimeout);
-        }
-        const HISTORY_REQUEST_DEBOUNCE_MS = 100;
-        currentConn.historyRequestTimeout = setTimeout(() => {
-          currentConn.historyRequestTimeout = null;
-          if (currentConn.ws.readyState === WebSocket.OPEN) {
-            currentConn.ws.send(JSON.stringify({ type: 'request-history' }));
-          }
-        }, HISTORY_REQUEST_DEBOUNCE_MS);
-      }
     }
+    // Note: Do NOT send request-history here on initial connection.
+    // The server automatically sends history when a client connects.
+    // Tab switch (remount with existing OPEN connection) handles history request in connect().
     console.log(`[WorkerWS] Connected: ${key}`);
   };
 

--- a/packages/server/src/lib/__tests__/worker-output-file.test.ts
+++ b/packages/server/src/lib/__tests__/worker-output-file.test.ts
@@ -198,9 +198,12 @@ describe('WorkerOutputFileManager', () => {
       expect(result!.offset).toBe(11);
     });
 
-    it('should return null for non-existent file', async () => {
+    it('should return empty history for non-existent file', async () => {
       const result = await manager.readHistoryWithOffset('nonexistent', 'worker-1');
-      expect(result).toBeNull();
+      // Returns empty history instead of null to support newly created workers
+      expect(result).not.toBeNull();
+      expect(result!.data).toBe('');
+      expect(result!.offset).toBe(0);
     });
 
     it('should return pending buffer when file does not exist', async () => {
@@ -786,9 +789,12 @@ describe('WorkerOutputFileManager', () => {
       expect(result!.data).toBe('\nline3\nline4');
     });
 
-    it('should return null for non-existent file with no buffer', async () => {
+    it('should return empty history for non-existent file with no buffer', async () => {
       const result = await manager.readLastNLines('nonexistent', 'worker-1', 5);
-      expect(result).toBeNull();
+      // Returns empty history instead of null to support newly created workers
+      expect(result).not.toBeNull();
+      expect(result!.data).toBe('');
+      expect(result!.offset).toBe(0);
     });
 
     it('should apply line limit to pending buffer', async () => {

--- a/packages/server/src/services/__tests__/worker-history-initialization.test.ts
+++ b/packages/server/src/services/__tests__/worker-history-initialization.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for worker history file initialization on worker creation.
+ *
+ * Problem: When a new worker is created and a WebSocket immediately connects,
+ * the history file does not exist yet, causing history retrieval to fail.
+ *
+ * Expected behavior after fix:
+ * - Worker creation should create an empty history file immediately
+ * - WebSocket connection should successfully retrieve history (even if empty)
+ * - No error messages should be sent to the client
+ *
+ * These tests are written to FAIL with the current implementation,
+ * following TDD methodology.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import type { CreateSessionRequest } from '@agent-console/shared';
+import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
+import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
+import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
+import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
+import { JobQueue } from '../../jobs/index.js';
+
+// Test config directory
+const TEST_CONFIG_DIR = '/test/config';
+
+// Test JobQueue instance (created fresh for each test)
+let testJobQueue: JobQueue | null = null;
+
+// Create mock PTY factory (will be reset in beforeEach)
+const ptyFactory = createMockPtyFactory(10000);
+
+let importCounter = 0;
+
+describe('Worker History File Initialization', () => {
+  beforeEach(async () => {
+    // Close any existing database connection first
+    await closeDatabase();
+
+    // Setup memfs with config directory structure
+    setupMemfs({
+      [`${TEST_CONFIG_DIR}/.keep`]: '',
+    });
+    process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+
+    // Initialize in-memory database (bypasses native file operations)
+    await initializeDatabase(':memory:');
+
+    // Create a test JobQueue with the shared database connection
+    testJobQueue = new JobQueue(getDatabase());
+
+    // Reset process mock and mark current process as alive
+    // This ensures sessions created with serverPid=process.pid are not cleaned up
+    resetProcessMock();
+    mockProcess.markAlive(process.pid);
+
+    // Reset PTY factory
+    ptyFactory.reset();
+  });
+
+  afterEach(async () => {
+    // Clean up test JobQueue
+    if (testJobQueue) {
+      await testJobQueue.stop();
+      testJobQueue = null;
+    }
+    await closeDatabase();
+    cleanupMemfs();
+  });
+
+  // Mock pathExists that always returns true (test paths don't exist on real filesystem)
+  const mockPathExists = async (_path: string): Promise<boolean> => true;
+
+  // Helper to get fresh module instance with DI using the factory pattern
+  async function getSessionManager() {
+    const module = await import(`../session-manager.js?v=${++importCounter}`);
+    // Use the factory pattern for async initialization with jobQueue
+    return module.SessionManager.create({
+      ptyProvider: ptyFactory.provider,
+      pathExists: mockPathExists,
+      jobQueue: testJobQueue,
+    });
+  }
+
+  describe('history file creation on worker creation', () => {
+    it('should create empty history file immediately when creating an agent worker', async () => {
+      const manager = await getSessionManager();
+
+      const request: CreateSessionRequest = {
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      };
+
+      const session = await manager.createSession(request);
+      const agentWorker = session.workers.find((w: { type: string }) => w.type === 'agent');
+      expect(agentWorker).toBeDefined();
+
+      // Immediately after creation, history should be available
+      // (not null, and not an error)
+      const history = await manager.getWorkerOutputHistory(
+        session.id,
+        agentWorker!.id,
+        0,
+        5000 // maxLines - simulating initial WebSocket connection
+      );
+
+      // The history should be a valid result, not null
+      expect(history).not.toBeNull();
+
+      // The data should be empty (no output yet)
+      expect(history!.data).toBe('');
+
+      // The offset should be 0 (file is empty)
+      expect(history!.offset).toBe(0);
+    });
+
+    it('should create empty history file immediately when creating a terminal worker', async () => {
+      const manager = await getSessionManager();
+
+      const request: CreateSessionRequest = {
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      };
+
+      const session = await manager.createSession(request);
+
+      // Create a terminal worker
+      const terminalWorker = await manager.createWorker(session.id, {
+        type: 'terminal',
+        name: 'Shell',
+      });
+      expect(terminalWorker).not.toBeNull();
+
+      // Immediately after creation, history should be available
+      const history = await manager.getWorkerOutputHistory(
+        session.id,
+        terminalWorker!.id,
+        0,
+        5000
+      );
+
+      // The history should be a valid result, not null
+      expect(history).not.toBeNull();
+
+      // The data should be empty
+      expect(history!.data).toBe('');
+
+      // The offset should be 0
+      expect(history!.offset).toBe(0);
+    });
+
+    it('should have history file exist on disk immediately after worker creation', async () => {
+      const manager = await getSessionManager();
+
+      const request: CreateSessionRequest = {
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      };
+
+      const session = await manager.createSession(request);
+      const agentWorker = session.workers.find((w: { type: string }) => w.type === 'agent');
+      expect(agentWorker).toBeDefined();
+
+      // The history file should exist on disk immediately
+      // Check both compressed and uncompressed paths
+      const outputsDir = `${TEST_CONFIG_DIR}/outputs/${session.id}`;
+      const uncompressedPath = `${outputsDir}/${agentWorker!.id}.log`;
+      const compressedPath = `${outputsDir}/${agentWorker!.id}.log.gz`;
+
+      // At least one of these files should exist
+      const fileExists =
+        fs.existsSync(uncompressedPath) || fs.existsSync(compressedPath);
+
+      expect(fileExists).toBe(true);
+    });
+  });
+
+  describe('WebSocket connection immediately after worker creation', () => {
+    it('should not return null from getWorkerOutputHistory for newly created worker', async () => {
+      const manager = await getSessionManager();
+
+      const request: CreateSessionRequest = {
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      };
+
+      const session = await manager.createSession(request);
+      const agentWorker = session.workers.find((w: { type: string }) => w.type === 'agent');
+      expect(agentWorker).toBeDefined();
+
+      // Simulate what WebSocket routes.ts does on connection:
+      // It calls getWorkerOutputHistory with maxLines parameter
+
+      // This simulates the first WebSocket connection immediately after session creation
+      const historyResult = await manager.getWorkerOutputHistory(
+        session.id,
+        agentWorker!.id,
+        0, // fromOffset
+        5000 // maxLines (WORKER_OUTPUT_INITIAL_HISTORY_LINES)
+      );
+
+      // This MUST NOT be null - null triggers fallback to in-memory buffer
+      // and potentially error messages to the client
+      expect(historyResult).not.toBeNull();
+    });
+
+    it('should return empty history with offset 0 for newly created worker without output', async () => {
+      const manager = await getSessionManager();
+
+      const request: CreateSessionRequest = {
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      };
+
+      const session = await manager.createSession(request);
+      const agentWorker = session.workers.find((w: { type: string }) => w.type === 'agent');
+      expect(agentWorker).toBeDefined();
+
+      // Before any PTY output, history should be empty but valid
+      const historyResult = await manager.getWorkerOutputHistory(
+        session.id,
+        agentWorker!.id,
+        0,
+        5000
+      );
+
+      expect(historyResult).not.toBeNull();
+      expect(historyResult!.data).toBe('');
+      expect(historyResult!.offset).toBe(0);
+    });
+
+    it('should allow subsequent output to append to the initialized history file', async () => {
+      const manager = await getSessionManager();
+
+      const request: CreateSessionRequest = {
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      };
+
+      const session = await manager.createSession(request);
+      const agentWorker = session.workers.find((w: { type: string }) => w.type === 'agent');
+      expect(agentWorker).toBeDefined();
+
+      // First, verify empty history is available
+      const initialHistory = await manager.getWorkerOutputHistory(
+        session.id,
+        agentWorker!.id,
+        0,
+        5000
+      );
+      expect(initialHistory).not.toBeNull();
+      expect(initialHistory!.data).toBe('');
+
+      // Now simulate PTY output
+      const pty = ptyFactory.instances[0];
+      pty.simulateData('Hello, World!\n');
+
+      // Wait for buffer flush (the worker-output-file uses 100ms flush interval in tests)
+      await new Promise(resolve => setTimeout(resolve, 150));
+
+      // Get history again
+      const afterOutput = await manager.getWorkerOutputHistory(
+        session.id,
+        agentWorker!.id,
+        0,
+        5000
+      );
+
+      expect(afterOutput).not.toBeNull();
+      expect(afterOutput!.data).toContain('Hello, World!');
+      expect(afterOutput!.offset).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getCurrentOutputOffset on newly created worker', () => {
+    it('should return 0 for newly created worker without any output', async () => {
+      const manager = await getSessionManager();
+
+      const request: CreateSessionRequest = {
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      };
+
+      const session = await manager.createSession(request);
+      const agentWorker = session.workers.find((w: { type: string }) => w.type === 'agent');
+      expect(agentWorker).toBeDefined();
+
+      // The offset should be 0 (file exists but is empty)
+      const offset = await manager.getCurrentOutputOffset(session.id, agentWorker!.id);
+      expect(offset).toBe(0);
+    });
+  });
+});

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -641,6 +641,13 @@ export class SessionManager {
     }
 
     session.workers.set(workerId, worker);
+
+    // Initialize output file immediately for PTY workers (agent/terminal)
+    // This prevents race conditions where WebSocket connects before any output is buffered
+    if (request.type === 'agent' || request.type === 'terminal') {
+      await workerOutputFileManager.initializeWorkerOutput(sessionId, workerId);
+    }
+
     await this.persistSession(session);
 
     logger.info({ workerId, workerType: request.type, sessionId }, 'Worker created');


### PR DESCRIPTION
## Summary

Fixes the "Terminal history not available" error that occurred when creating new workers or sessions. The error was caused by a race condition where WebSocket connections established immediately after worker creation would attempt to fetch history before the output file was flushed (100ms delay).

## Root Cause

Timeline of the issue:
1. New worker created with empty outputBuffer
2. `bufferOutput()` scheduled flush for 100ms later
3. WebSocket connection established almost simultaneously
4. `getWorkerOutputHistory()` called, but file doesn't exist yet
5. Error sent to client: "Terminal history not available"

After page reload, the file existed and everything worked normally.

## Technical Changes

### Backend (packages/server)

1. **Initialize empty output file on worker creation**
   - Added `initializeWorkerOutput()` method in `worker-output-file.ts`
   - Creates empty file (compressed or uncompressed based on config)
   - Called immediately after worker creation in `session-manager.ts`

2. **Consistent empty history handling**
   - Modified `readLastNLines()` to return `{ data: '', offset: 0 }` instead of `null`
   - Makes behavior consistent with `readHistoryWithOffset()`
   - Eliminates error paths for newly created workers

### Frontend (packages/client)

1. **Remove redundant request-history on initial connection**
   - Deleted `request-history` message sending in `ws.onopen` handler
   - Server automatically sends history when client connects
   - Eliminates double-send issue

2. **Preserve tab switch behavior**
   - Tab switch (remount with existing OPEN connection) still sends `request-history`
   - Debouncing mechanism preserved

### Tests

- Added `worker-history-initialization.test.ts` with 7 comprehensive tests
- Updated existing tests in `worker-output-file.test.ts` and `worker-websocket.test.ts`
- All 1,344 tests pass (770 server, 367 client, 204 shared, 3 integration)

## Test Plan

- [x] All automated tests pass (1,344 tests, 2,251 expect() calls)
- [x] Typecheck passes on all packages
- [x] Manual verification: Create new session - no error appears
- [x] Manual verification: Create new worker - no error appears
- [x] Manual verification: Tab switch still loads history correctly
- [x] Manual verification: Page refresh still works

## Breaking Changes

None. This is a bug fix with full backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented server-driven initial history delivery for worker terminals; client now requests history only on reconnect or remount.

* **Bug Fixes**
  * Initialize worker output files upfront to prevent race conditions between WebSocket connections and output buffering.
  * Standardized empty history responses, replacing null returns with consistent empty data objects.

* **Tests**
  * Added comprehensive test coverage for worker history initialization and debounced history request behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->