### PR TITLE
perf: disable visibility change reconnection to preserve terminal history

### DIFF
--- a/packages/client/src/lib/__tests__/worker-websocket.test.ts
+++ b/packages/client/src/lib/__tests__/worker-websocket.test.ts
@@ -51,7 +51,10 @@ describe('worker-websocket', () => {
     onError: mock(() => {}),
   });
 
-  describe('visibility-based reconnection', () => {
+  // DISABLED: Visibility-based reconnection is currently disabled to avoid performance overhead.
+  // The event listener registration in worker-websocket.ts is commented out.
+  // These tests are skipped until the feature is re-enabled.
+  describe.skip('visibility-based reconnection', () => {
     let originalVisibilityState: PropertyDescriptor | undefined;
 
     beforeEach(() => {

--- a/packages/client/src/lib/worker-websocket.ts
+++ b/packages/client/src/lib/worker-websocket.ts
@@ -644,8 +644,11 @@ export function disconnectSession(sessionId: string): void {
  * Handle page visibility change.
  * Disconnects all worker WebSockets when page is hidden (to save resources).
  * Reconnects with full history when page becomes visible.
+ *
+ * NOTE: This function is currently disabled. See the event listener registration below.
  */
-function handleVisibilityChange(): void {
+// @ts-expect-error: Function intentionally unused - kept for potential re-enablement
+function _handleVisibilityChange(): void {
   if (document.visibilityState === 'hidden') {
     // Store connection info and disconnect all workers
     for (const [key, conn] of connections.entries()) {
@@ -703,7 +706,11 @@ function handleVisibilityChange(): void {
 
 // Register visibility change listener once
 if (typeof document !== 'undefined') {
-  document.addEventListener('visibilitychange', handleVisibilityChange);
+  // DISABLED: Preserve terminal history and avoid reconnection overhead
+  // Visibility disconnection was causing performance issues when switching browser tabs.
+  // Terminal history is preserved in xterm.js memory, so reconnection is unnecessary.
+  // To re-enable, uncomment and rename _handleVisibilityChange back to handleVisibilityChange:
+  // document.addEventListener('visibilitychange', _handleVisibilityChange);
 }
 
 /**


### PR DESCRIPTION
## Summary

Disable WebSocket reconnection on browser tab visibility changes to fix performance issues when switching tabs.

## Problem

When users switch browser tabs, the current implementation:
1. Disconnects all WebSocket connections when tab becomes hidden
2. Reconnects when tab becomes visible
3. Reloads 5000 lines of terminal history for each worker
4. With compression enabled, this involves:
   - Reading compressed file (~5MB+)
   - Decompressing with gunzip
   - Writing to xterm.js
   - High CPU and I/O overhead

This caused noticeable lag when switching back to the tab.

## Solution

- Commented out the `visibilitychange` event listener registration
- Preserved `handleVisibilityChange()` and `clearVisibilityTracking()` functions for easy re-enabling if needed
- Skipped visibility-based reconnection tests (expected behavior change)

## Benefits

- **Browser tab switch**: No WebSocket reconnection, no history reload, instant response ✅
- **Tab close and reopen**: History still restored from file (user requirement) ✅
- Terminal history preserved in xterm.js memory during tab switches
- Reduced server I/O and client rendering overhead

## Test Plan

Manual testing:
1. Open a session with terminal worker
2. Perform some operations to generate output
3. Switch to another browser tab
4. Switch back → Terminal should retain history without reloading
5. Performance should be noticeably better

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal refactoring of WebSocket reconnection mechanisms and test suite organization with no impact to existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->