### PR TITLE
fix: prevent misclicks by always showing PR menu item with disabled state

### DIFF
--- a/packages/client/src/components/sessions/SessionSettingsMenu.tsx
+++ b/packages/client/src/components/sessions/SessionSettingsMenu.tsx
@@ -10,6 +10,7 @@ import {
   DocumentIcon,
   ExternalLinkIcon,
 } from '../Icons';
+import { Spinner } from '../ui/Spinner';
 import { openPath, fetchSessionPrLink } from '../../lib/api';
 
 export type MenuAction = 'edit' | 'restart' | 'delete-worktree' | 'view-initial-prompt';
@@ -130,15 +131,14 @@ export function SessionSettingsMenu({
                 View Initial Prompt
               </button>
             )}
-            {!isPrLinkLoading && prLinkData?.prUrl && (
-              <button
-                onClick={handleViewPullRequest}
-                className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
-              >
-                <ExternalLinkIcon />
-                View Pull Request
-              </button>
-            )}
+            <button
+              onClick={handleViewPullRequest}
+              disabled={isPrLinkLoading || !prLinkData?.prUrl}
+              className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-gray-300"
+            >
+              {isPrLinkLoading ? <Spinner size="sm" /> : <ExternalLinkIcon />}
+              View Pull Request
+            </button>
             <button
               onClick={() => handleMenuAction('restart')}
               className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"


### PR DESCRIPTION
## Summary
- PRメニュー項目が動的に追加されることによるユーザーの誤クリックを防止
- 「View Pull Request」を常に表示し、PR未取得時はdisabled状態にする
- ローディング中はスピナーを表示してフィードバックを提供

## Test plan
- [ ] セッション設定メニューを開き、「View Pull Request」が常に表示されることを確認
- [ ] PR未作成のセッションでメニュー項目がdisabled（opacity-50, cursor-not-allowed）であることを確認
- [ ] ローディング中にスピナーが表示されることを確認
- [ ] PRが存在するセッションでメニュー項目がクリック可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved "View Pull Request" menu item to remain visible with disabled state when URL is unavailable or loading, providing clearer user feedback with a loading spinner during retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->