### PR TITLE
feat: add Start Session button for orphan worktrees

### DIFF
--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -648,14 +648,14 @@ function WorktreeRow({ worktree, session, repositoryId }: WorktreeRowProps) {
   const [deleteConfirmType, setDeleteConfirmType] = useState<'normal' | 'force' | null>(null);
   const { errorDialogProps, showError } = useErrorDialog();
 
-  const startSessionMutation = useMutation({
+  const restoreSessionMutation = useMutation({
     mutationFn: (request: CreateWorktreeSessionRequest) => createSession(request),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['sessions'] });
       navigate({ to: '/sessions/$sessionId', params: { sessionId: data.session.id } });
     },
     onError: (error: Error) => {
-      showError('Start Session Failed', error.message);
+      showError('Restore Failed', error.message);
     },
   });
 
@@ -677,12 +677,13 @@ function WorktreeRow({ worktree, session, repositoryId }: WorktreeRowProps) {
     },
   });
 
-  const handleStartSession = () => {
-    startSessionMutation.mutate({
+  const handleRestoreSession = () => {
+    restoreSessionMutation.mutate({
       type: 'worktree',
       repositoryId: worktree.repositoryId,
       worktreeId: worktree.branch,
       locationPath: worktree.path,
+      continueConversation: true,
     });
   };
 
@@ -738,11 +739,11 @@ function WorktreeRow({ worktree, session, repositoryId }: WorktreeRowProps) {
           </Link>
         ) : (
           <button
-            onClick={handleStartSession}
-            disabled={startSessionMutation.isPending}
+            onClick={handleRestoreSession}
+            disabled={restoreSessionMutation.isPending}
             className="btn btn-primary text-xs"
           >
-            {startSessionMutation.isPending ? 'Starting...' : 'Start Session'}
+            {restoreSessionMutation.isPending ? 'Restoring...' : 'Restore'}
           </button>
         )}
         {!worktree.isMain && (


### PR DESCRIPTION
## Summary
- Add "Start Session" button for worktrees that have no associated session (orphan worktrees)
- When clicked, creates a new session pointing to the existing worktree and navigates to it
- Previously orphan worktrees only had a "Delete" button, now users can recover them

## Background
Orphan worktrees can occur when:
1. A session is deleted (session data removed from SQLite, but worktree directory remains)
2. A worktree is created with `autoStartSession=false`

This change allows users to restore sessions for existing worktrees instead of being forced to delete them.

## Test plan
- [ ] Create a worktree with a session
- [ ] Delete the session (not the worktree)
- [ ] Verify the worktree now shows "Start Session" button instead of "Open"
- [ ] Click "Start Session" and verify a new session is created and navigated to
- [ ] Verify the worktree now shows "Open" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a Restore Session button for worktrees without an active session (replaces the previous conditional Open link in that case).
  * Button shows a loading label ("Restoring...") during the operation, provides error feedback on failure, and automatically opens the new session on success.
  * Existing Open links for active sessions remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->