### PR TITLE
feat: add QuickSession end functionality and improve robustness

### DIFF
--- a/packages/client/src/components/Icons.tsx
+++ b/packages/client/src/components/Icons.tsx
@@ -192,3 +192,22 @@ export function ChevronDownIcon({ className = 'w-4 h-4' }: IconProps) {
     </svg>
   );
 }
+
+export function StopIcon({ className = 'w-4 h-4' }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"
+      />
+    </svg>
+  );
+}

--- a/packages/client/src/components/QuickSessionSettings.tsx
+++ b/packages/client/src/components/QuickSessionSettings.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import {
+  QuickSessionSettingsMenu,
+  InitialPromptDialog,
+  EndSessionDialog,
+  type QuickMenuAction,
+} from './sessions';
+
+interface QuickSessionSettingsProps {
+  sessionId: string;
+  initialPrompt?: string;
+}
+
+type DialogType = QuickMenuAction | null;
+
+export function QuickSessionSettings({
+  sessionId,
+  initialPrompt,
+}: QuickSessionSettingsProps) {
+  const [activeDialog, setActiveDialog] = useState<DialogType>(null);
+
+  const handleMenuAction = (action: QuickMenuAction) => {
+    setActiveDialog(action);
+  };
+
+  const closeDialog = () => {
+    setActiveDialog(null);
+  };
+
+  return (
+    <>
+      <QuickSessionSettingsMenu
+        initialPrompt={initialPrompt}
+        onMenuAction={handleMenuAction}
+      />
+
+      <InitialPromptDialog
+        open={activeDialog === 'view-initial-prompt'}
+        onOpenChange={(open) => !open && closeDialog()}
+        initialPrompt={initialPrompt}
+      />
+
+      <EndSessionDialog
+        open={activeDialog === 'end-session'}
+        onOpenChange={(open) => !open && closeDialog()}
+        sessionId={sessionId}
+      />
+    </>
+  );
+}

--- a/packages/client/src/components/sessions/EndSessionDialog.tsx
+++ b/packages/client/src/components/sessions/EndSessionDialog.tsx
@@ -1,0 +1,39 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { ConfirmDialog } from '../ui/confirm-dialog';
+import { deleteSession } from '../../lib/api';
+
+export interface EndSessionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sessionId: string;
+}
+
+export function EndSessionDialog({
+  open,
+  onOpenChange,
+  sessionId,
+}: EndSessionDialogProps) {
+  const navigate = useNavigate();
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteSession(sessionId),
+    onSuccess: () => {
+      onOpenChange(false);
+      navigate({ to: '/' });
+    },
+  });
+
+  return (
+    <ConfirmDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="End Session"
+      description="Are you sure you want to end this session? This will stop all workers and cannot be undone."
+      confirmLabel="End Session"
+      variant="danger"
+      onConfirm={() => deleteMutation.mutate()}
+      isLoading={deleteMutation.isPending}
+    />
+  );
+}

--- a/packages/client/src/components/sessions/QuickSessionForm.tsx
+++ b/packages/client/src/components/sessions/QuickSessionForm.tsx
@@ -28,7 +28,7 @@ export function QuickSessionForm({
     resolver: valibotResolver(CreateQuickSessionRequestSchema),
     defaultValues: {
       type: 'quick',
-      locationPath: '',
+      locationPath: '/tmp',
       agentId: undefined,
     },
     mode: 'onBlur',

--- a/packages/client/src/components/sessions/QuickSessionSettingsMenu.tsx
+++ b/packages/client/src/components/sessions/QuickSessionSettingsMenu.tsx
@@ -1,0 +1,94 @@
+import { useState, useEffect } from 'react';
+import {
+  SettingsIcon,
+  DocumentIcon,
+  StopIcon,
+} from '../Icons';
+
+export type QuickMenuAction = 'view-initial-prompt' | 'end-session';
+
+export interface QuickSessionSettingsMenuProps {
+  initialPrompt?: string;
+  onMenuAction: (action: QuickMenuAction) => void;
+}
+
+export function QuickSessionSettingsMenu({
+  initialPrompt,
+  onMenuAction,
+}: QuickSessionSettingsMenuProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  // Close menu on escape key or clicking outside
+  useEffect(() => {
+    if (!isMenuOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsMenuOpen(false);
+      }
+    };
+
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest('[data-settings-menu]')) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    const timeout = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 0);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      clearTimeout(timeout);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isMenuOpen]);
+
+  const handleMenuAction = (action: QuickMenuAction) => {
+    setIsMenuOpen(false);
+    onMenuAction(action);
+  };
+
+  return (
+    <div className="relative" data-settings-menu>
+      {/* Settings button */}
+      <button
+        onClick={() => setIsMenuOpen(!isMenuOpen)}
+        className="text-gray-400 hover:text-white p-1.5 hover:bg-slate-700 rounded"
+        title="Session settings"
+      >
+        <SettingsIcon />
+      </button>
+
+      {/* Dropdown menu */}
+      {isMenuOpen && (
+        <div className="absolute right-0 top-full mt-1 w-48 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-50">
+          <div className="py-1">
+            {initialPrompt && (
+              <button
+                onClick={() => handleMenuAction('view-initial-prompt')}
+                className="w-full px-4 py-2 text-left text-sm text-gray-300 hover:bg-slate-700 hover:text-white flex items-center gap-2"
+              >
+                <DocumentIcon />
+                View Initial Prompt
+              </button>
+            )}
+            {initialPrompt && (
+              <div className="border-t border-slate-700 my-1" />
+            )}
+            <button
+              onClick={() => handleMenuAction('end-session')}
+              className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2"
+            >
+              <StopIcon />
+              End Session
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/sessions/__tests__/QuickSessionForm.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/QuickSessionForm.test.tsx
@@ -81,8 +81,9 @@ describe('QuickSessionForm', () => {
         expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
       });
 
-      // Fill in location path
+      // Clear default value and fill in location path
       const pathInput = screen.getByPlaceholderText(/Path.*e\.g\./);
+      await user.clear(pathInput);
       await user.type(pathInput, '/path/to/project');
 
       // Submit form
@@ -144,6 +145,10 @@ describe('QuickSessionForm', () => {
         expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
       });
 
+      // Clear the default value to make path empty
+      const pathInput = screen.getByPlaceholderText(/Path.*e\.g\./);
+      await user.clear(pathInput);
+
       // Submit without filling anything
       const submitButton = screen.getByText('Start');
       await user.click(submitButton);
@@ -160,11 +165,11 @@ describe('QuickSessionForm', () => {
     });
 
     /**
-     * This test ensures form submission validation works correctly when
-     * locationPath field has empty string as default value.
-     * The form uses defaultValues: { locationPath: '' }
+     * This test ensures form submission works correctly with the default
+     * locationPath value of '/tmp'.
+     * The form uses defaultValues: { locationPath: '/tmp' }
      */
-    it('should show validation error when submitting with empty default value', async () => {
+    it('should submit successfully with default locationPath value', async () => {
       const user = userEvent.setup();
       const { props } = renderQuickSessionForm();
 
@@ -173,18 +178,19 @@ describe('QuickSessionForm', () => {
         expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
       });
 
-      // Submit immediately - locationPath is '' from defaultValues
+      // Submit immediately - locationPath is '/tmp' from defaultValues
       const submitButton = screen.getByText('Start');
       await user.click(submitButton);
 
-      // onSubmit should NOT be called
+      // onSubmit should be called with default path
       await waitFor(() => {
-        expect(props.onSubmit).not.toHaveBeenCalled();
+        expect(props.onSubmit).toHaveBeenCalledTimes(1);
       });
 
-      // Error should be displayed
-      await waitFor(() => {
-        expect(screen.getByText(/Location path is required/)).toBeTruthy();
+      const submitCall = (props.onSubmit as ReturnType<typeof mock>).mock.calls[0];
+      expect(submitCall[0]).toMatchObject({
+        type: 'quick',
+        locationPath: '/tmp',
       });
     });
   });

--- a/packages/client/src/components/sessions/index.ts
+++ b/packages/client/src/components/sessions/index.ts
@@ -13,5 +13,11 @@ export type { DeleteWorktreeDialogProps } from './DeleteWorktreeDialog';
 export { InitialPromptDialog } from './InitialPromptDialog';
 export type { InitialPromptDialogProps } from './InitialPromptDialog';
 
+export { EndSessionDialog } from './EndSessionDialog';
+export type { EndSessionDialogProps } from './EndSessionDialog';
+
 export { SessionSettingsMenu } from './SessionSettingsMenu';
 export type { SessionSettingsMenuProps, MenuAction } from './SessionSettingsMenu';
+
+export { QuickSessionSettingsMenu } from './QuickSessionSettingsMenu';
+export type { QuickSessionSettingsMenuProps, QuickMenuAction } from './QuickSessionSettingsMenu';

--- a/packages/client/src/lib/__tests__/server-id.test.ts
+++ b/packages/client/src/lib/__tests__/server-id.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { setServerId, getServerId } from '../server-id';
+
+describe('server-id', () => {
+  beforeEach(() => {
+    // Reset server ID between tests by setting to a known state
+    // Note: This relies on the module's internal state being mutable
+    // In a real scenario, we might want a resetServerId function for testing
+  });
+
+  describe('setServerId and getServerId', () => {
+    it('should store and retrieve server ID', () => {
+      setServerId('test-server-123');
+      expect(getServerId()).toBe('test-server-123');
+    });
+
+    it('should overwrite previous server ID', () => {
+      setServerId('server-1');
+      setServerId('server-2');
+      expect(getServerId()).toBe('server-2');
+    });
+
+    it('should handle empty string', () => {
+      setServerId('');
+      expect(getServerId()).toBe('');
+    });
+  });
+});

--- a/packages/client/src/lib/__tests__/terminal-state-cache.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-state-cache.test.ts
@@ -71,6 +71,7 @@ import {
   loadTerminalState,
   clearTerminalState,
   cleanupOldStates,
+  clearAllTerminalStates,
   isValidForServer,
 } from '../terminal-state-cache';
 
@@ -272,6 +273,38 @@ describe('terminal-state-cache', () => {
 
       // Should complete without error
       expect(mockStore.keys().length).toBe(0);
+    });
+  });
+
+  describe('clearAllTerminalStates', () => {
+    it('should clear all terminal entries', async () => {
+      const state1 = createValidState();
+      const state2 = createValidState();
+
+      mockStore.set('terminal:session-1:worker-1', state1);
+      mockStore.set('terminal:session-2:worker-2', state2);
+      mockStore.set('other-key', { foo: 'bar' }); // Non-terminal key
+
+      await clearAllTerminalStates();
+
+      // All terminal entries should be deleted
+      expect(mockStore.get('terminal:session-1:worker-1')).toBeUndefined();
+      expect(mockStore.get('terminal:session-2:worker-2')).toBeUndefined();
+      // Non-terminal key should be untouched
+      expect(mockStore.get('other-key')).toEqual({ foo: 'bar' });
+    });
+
+    it('should handle empty store', async () => {
+      await clearAllTerminalStates();
+
+      // Should complete without error
+      expect(mockStore.keys().length).toBe(0);
+    });
+
+    it('should handle keys() error gracefully', async () => {
+      keysMockThrows = true;
+      // Should not throw
+      await expect(clearAllTerminalStates()).resolves.toBeUndefined();
     });
   });
 

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -559,3 +559,25 @@ export async function fetchSessionPrLink(sessionId: string): Promise<SessionPrLi
   }
   return res.json();
 }
+
+// ===========================================================================
+// Server ID
+// ===========================================================================
+
+export interface ServerIdResponse {
+  serverId: string;
+}
+
+/**
+ * Fetch the server instance ID.
+ * This ID is unique per server process and is used to detect server restarts.
+ * When the server restarts, terminal caches become invalid because the server
+ * loses its in-memory history buffers.
+ */
+export async function fetchServerId(): Promise<ServerIdResponse> {
+  const res = await fetch(`${API_BASE}/server/id`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch server ID: ${res.statusText}`);
+  }
+  return res.json();
+}

--- a/packages/client/src/lib/server-id.ts
+++ b/packages/client/src/lib/server-id.ts
@@ -1,0 +1,25 @@
+/**
+ * Module for managing the current server instance ID.
+ *
+ * The server ID is used to detect server restarts and invalidate stale terminal caches.
+ * When the server restarts, its in-memory history buffers are lost, so cached terminal
+ * states with offsets from the old server instance become invalid.
+ */
+
+let currentServerId: string | undefined;
+
+/**
+ * Set the current server ID.
+ * Called during app initialization after fetching from the server.
+ */
+export function setServerId(serverId: string): void {
+  currentServerId = serverId;
+}
+
+/**
+ * Get the current server ID.
+ * Returns undefined if not yet initialized.
+ */
+export function getServerId(): string | undefined {
+  return currentServerId;
+}

--- a/packages/client/src/lib/terminal-state-cache.ts
+++ b/packages/client/src/lib/terminal-state-cache.ts
@@ -207,3 +207,26 @@ export async function cleanupOldStates(): Promise<void> {
     console.warn('Failed to cleanup old terminal states:', error);
   }
 }
+
+/**
+ * Clear all terminal state entries from IndexedDB.
+ *
+ * This is used when a server restart is detected to invalidate all cached states,
+ * since the server's in-memory history buffers are lost on restart.
+ */
+export async function clearAllTerminalStates(): Promise<void> {
+  try {
+    const allKeys = await keys();
+    const terminalKeys = allKeys.filter(
+      (key): key is string =>
+        typeof key === 'string' && key.startsWith(PREFIX)
+    );
+
+    const deletePromises = terminalKeys.map((key) => del(key));
+    await Promise.all(deletePromises);
+
+    console.info(`[TerminalCache] Cleared ${terminalKeys.length} cached terminal states`);
+  } catch (error) {
+    console.warn('Failed to clear all terminal states:', error);
+  }
+}

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -3,8 +3,10 @@ import { createRoot } from 'react-dom/client';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { routeTree } from './routeTree.gen';
-import { fetchConfig } from './lib/api';
+import { fetchConfig, fetchServerId } from './lib/api';
 import { setHomeDir } from './lib/path';
+import { setServerId } from './lib/server-id';
+import { clearAllTerminalStates } from './lib/terminal-state-cache';
 import './styles.css';
 
 // Create a new router instance
@@ -119,6 +121,9 @@ function showConnectionError(error: unknown) {
   document.getElementById('retry-button')?.addEventListener('click', initApp);
 }
 
+// Key for storing server ID in localStorage
+const SERVER_ID_STORAGE_KEY = 'agent-console:server-id';
+
 // Initialize app with config from server
 async function initApp() {
   showLoadingIndicator();
@@ -130,6 +135,25 @@ async function initApp() {
     console.error('Failed to fetch config:', e);
     showConnectionError(e);
     return;
+  }
+
+  // Fetch server ID and check for server restart
+  try {
+    const { serverId } = await fetchServerId();
+    setServerId(serverId);
+
+    // Check if server has restarted by comparing with stored server ID
+    const storedServerId = localStorage.getItem(SERVER_ID_STORAGE_KEY);
+    if (storedServerId && storedServerId !== serverId) {
+      // Server has restarted - clear all terminal caches since history buffers are lost
+      console.info('[App] Server restart detected, clearing terminal caches');
+      await clearAllTerminalStates();
+    }
+    localStorage.setItem(SERVER_ID_STORAGE_KEY, serverId);
+  } catch (e) {
+    // Server ID endpoint not available (older server version) - continue without it
+    // Terminal cache validation will be skipped, maintaining backward compatibility
+    console.warn('Server ID endpoint not available, terminal cache validation disabled:', e);
   }
 
   createRoot(rootElement).render(

--- a/packages/server/src/websocket/git-diff-handler.ts
+++ b/packages/server/src/websocket/git-diff-handler.ts
@@ -196,6 +196,13 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies = default
           await sendDiffData(ws, locationPath, currentBaseCommit, targetRef);
           break;
         }
+
+        default: {
+          // Exhaustive check: TypeScript will error if a new message type is added but not handled
+          const _exhaustive: never = parsed;
+          log.error({ messageType: (_exhaustive as GitDiffClientMessage).type }, 'Unknown git-diff message type');
+          sendError(ws, 'Unknown message type');
+        }
       }
     } catch (e) {
       log.error({ err: e }, 'Invalid git-diff message');

--- a/packages/server/src/websocket/worker-handler.ts
+++ b/packages/server/src/websocket/worker-handler.ts
@@ -202,6 +202,19 @@ export function createWorkerMessageHandler(
           sessionManager.writeWorkerInput(sessionId, workerId, filePath);
           break;
         }
+
+        case 'request-history':
+          // request-history is handled separately in routes.ts before this handler is called.
+          // If it reaches here, it means validation allowed it but routing didn't intercept it.
+          // This should not happen in normal operation.
+          logger.warn({ sessionId, workerId }, 'request-history message reached worker handler (should be handled by routes.ts)');
+          break;
+
+        default: {
+          // Exhaustive check: TypeScript will error if a new message type is added but not handled
+          const _exhaustive: never = parsed;
+          logger.warn({ messageType: (_exhaustive as WorkerClientMessage).type, sessionId, workerId }, 'Unknown worker message type');
+        }
       }
     } catch (e) {
       logger.warn({ err: e, sessionId, workerId }, 'Invalid worker message');


### PR DESCRIPTION
## Summary

- Add ability to end QuickSession from session screen via gear icon menu (QuickSessionSettingsMenu, EndSessionDialog)
- Set default directory for QuickSession to `/tmp`
- Add exhaustive type checks in WebSocket handlers to prevent silent failures when new message types are added
- Fix race condition during initial WebSocket sync by tracking syncing clients
- Make session deletion atomic with rollback on failure to prevent phantom sessions
- Add server ID tracking for terminal cache invalidation after server restart
- Improve worker restoration error reporting with specific error codes (PATH_NOT_FOUND, AGENT_NOT_FOUND, etc.)
- Pre-generate all favicon frames at module initialization to bound cache size

## Test plan

- [x] All existing tests pass (1,432 tests)
- [ ] Manual verification: Create a QuickSession and verify default directory is `/tmp`
- [ ] Manual verification: End a QuickSession from the gear icon menu and confirm navigation to dashboard
- [ ] Manual verification: Restart server and verify terminal cache is properly invalidated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session settings menu with quick actions to view initial prompt and end sessions
  * Added stop icon component to UI library
  * Implemented server instance detection to invalidate terminal caches on server restarts

* **Bug Fixes**
  * Fixed terminal state cache to validate against server restarts, clearing stale data automatically
  * Improved WebSocket client synchronization to prevent broadcast race conditions
  * Enhanced worker restoration error handling with structured error codes and messages

* **Improvements**
  * Updated default session path to `/tmp`
  * Optimized favicon animation caching for better performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->