### PR TITLE
feat: add remote branch status check in worktree creation

### DIFF
--- a/docs/design/main-branch-pull-ux.md
+++ b/docs/design/main-branch-pull-ux.md
@@ -1,0 +1,150 @@
+# Main Branch Pull UX Design
+
+## Problem
+
+When creating a new worktree, users often branch from an outdated main branch. This leads to:
+- Merge conflicts when creating PRs
+- Missing recent changes from other developers
+- Need for rebasing before merge
+
+The real need is not "I want to pull main" but "I want to branch from the latest main."
+
+## Git Worktree Constraint
+
+Git does not allow the same branch to be checked out in multiple worktrees. Since main is already checked out in worktree 0, we cannot pull main from another location.
+
+**Solution**: Instead of pulling, we fetch and branch directly from `origin/main`.
+
+## Solution
+
+Integrate the fetch operation into the worktree creation flow. Check the base branch status when the form opens and offer to create from the latest remote state.
+
+## UX Flow
+
+### 1. Form Opens
+- Fetch remote status in background (async)
+- Show "Checking remote status..." while fetching
+- User can start filling the form immediately
+
+### 2. If Base Branch is Behind
+- Show warning: `⚠️ X commits behind origin/main`
+- Show `[Fetch & Create]` button
+- User chooses:
+  - **Cancel**: Close form
+  - **Create**: Branch from local base branch (may be outdated)
+  - **Fetch & Create**: Fetch remote, then branch from `origin/<base>` (latest)
+
+### 3. If Base Branch is Up to Date
+- No warning shown (or optional "✓ Up to date")
+- Normal flow with Cancel/Create buttons
+
+## Form Layout
+
+```
+Agent: [Claude Code ▼]              [Import from Issue]
+────────────────────────────────────────────────────────
+Initial prompt
+  [textarea]
+
+Title (optional)
+  [input]
+
+Branch name:
+  ○ Generate from prompt (recommended)
+  ○ Custom name (new branch)
+  ○ Use existing branch
+
+Branch name (if custom/existing)
+  [input]
+
+Base branch: [input] [Refresh]
+⚠️ 5 commits behind                    [Fetch & Create]
+
+                                    [Cancel]  [Create]
+```
+
+### Layout Decisions
+
+1. **Agent selector at top-left**: Same row as "Import from Issue" for compact layout
+2. **Branch settings grouped together**: Branch name mode, name input, and base branch are related
+3. **Behind warning near base branch**: Contextually relevant placement
+4. **Cancel/Create buttons fixed position**: Right-bottom, never moves regardless of warning state
+5. **Fetch & Create appears conditionally**: Only when behind, positioned above the main action buttons
+
+## Button Behavior
+
+| Button | Position | Visibility | Action |
+|--------|----------|------------|--------|
+| Cancel | Bottom-right (fixed) | Always | Close form |
+| Create | Bottom-right (fixed) | Always | Create from local base branch |
+| Fetch & Create | Above Create | Only when behind | Fetch remote, create from `origin/<base>` |
+
+### Why Fixed Positions?
+
+- Users who want to quickly create a worktree can always click Create in the same spot
+- No accidental misclicks from buttons shifting
+- Fetch & Create is an additional option, not a replacement
+
+## Technical Implementation
+
+### API Endpoints
+
+```
+GET  /api/repositories/:id/branches/:branch/remote-status
+Response: { behind: number, ahead: number }
+
+POST /api/repositories/:id/fetch
+Response: { success: boolean, error?: string }
+```
+
+### Git Commands
+
+```bash
+# Check how far behind local is from remote
+git fetch origin <branch>
+git rev-list --count <branch>..origin/<branch>
+
+# Create worktree from origin (latest)
+git worktree add <path> -b <new-branch> origin/<base-branch>
+
+# Create worktree from local (may be outdated)
+git worktree add <path> -b <new-branch> <base-branch>
+```
+
+### Frontend Flow
+
+```typescript
+// In CreateWorktreeForm
+const { data: remoteStatus, isLoading } = useQuery({
+  queryKey: ['remote-status', repositoryId, baseBranch],
+  queryFn: () => fetchRemoteStatus(repositoryId, baseBranch),
+  enabled: isFormOpen,
+});
+
+// Show warning if behind > 0
+// Show loading indicator while checking
+// Fetch & Create passes useRemote: true to create worktree API
+```
+
+### Create Worktree API Change
+
+Add `useRemote` option to create worktree request:
+
+```typescript
+interface CreateWorktreeRequest {
+  // ... existing fields
+  useRemote?: boolean;  // If true, branch from origin/<base> instead of local <base>
+}
+```
+
+### Edge Cases
+
+1. **Fetch fails (network error)**: Show error message, allow Create anyway
+2. **Remote branch doesn't exist**: Fall back to local branch
+3. **User changes base branch**: Re-fetch remote status for new branch
+
+## Future Enhancements
+
+- Show commit details (what's new in remote)
+- Background periodic fetch on dashboard
+- "Always use remote" user preference

--- a/packages/server/src/__tests__/utils/mock-git-helper.ts
+++ b/packages/server/src/__tests__/utils/mock-git-helper.ts
@@ -16,17 +16,11 @@
  */
 import { mock, type Mock } from 'bun:test';
 
-// GitError class for tests
-export class GitError extends Error {
-  constructor(
-    message: string,
-    public readonly exitCode: number,
-    public readonly stderr: string
-  ) {
-    super(message);
-    this.name = 'GitError';
-  }
-}
+// Import and re-export the real GitError class from the git module.
+// This ensures instanceof checks work correctly in tests, because both the test code
+// and the mocked module use the same GitError class.
+import { GitError } from '../../lib/git.js';
+export { GitError };
 
 // Type definitions for mock functions
 type AsyncStringFn = (cwd: string) => Promise<string>;
@@ -68,6 +62,12 @@ export const mockGit = {
   }) as Mock<(remoteUrl: string) => string | null>,
   getOrgRepoFromPath: mock(() => Promise.resolve('owner/repo')) as Mock<AsyncStringNullFn>,
 
+  // Remote fetch operations
+  fetchRemote: mock(() => Promise.resolve()) as Mock<(branch: string, cwd: string) => Promise<void>>,
+  fetchAllRemote: mock(() => Promise.resolve()) as Mock<(cwd: string) => Promise<void>>,
+  getCommitsBehind: mock(() => Promise.resolve(0)) as Mock<(branch: string, cwd: string) => Promise<number>>,
+  getCommitsAhead: mock(() => Promise.resolve(0)) as Mock<(branch: string, cwd: string) => Promise<number>>,
+
   // Diff operations
   getMergeBase: mock(() => Promise.resolve('abc1234')) as Mock<(ref1: string, ref2: string, cwd: string) => Promise<string>>,
   getMergeBaseSafe: mock(() => Promise.resolve('abc1234')) as Mock<(ref1: string, ref2: string, cwd: string) => Promise<string | null>>,
@@ -106,6 +106,10 @@ export function resetGitMocks(): void {
   mockGit.removeWorktree.mockReset();
   mockGit.parseOrgRepo.mockReset();
   mockGit.getOrgRepoFromPath.mockReset();
+  mockGit.fetchRemote.mockReset();
+  mockGit.fetchAllRemote.mockReset();
+  mockGit.getCommitsBehind.mockReset();
+  mockGit.getCommitsAhead.mockReset();
   mockGit.getMergeBase.mockReset();
   mockGit.getMergeBaseSafe.mockReset();
   mockGit.getDiff.mockReset();
@@ -138,6 +142,10 @@ export function resetGitMocks(): void {
     return null;
   });
   mockGit.getOrgRepoFromPath.mockImplementation(() => Promise.resolve('owner/repo'));
+  mockGit.fetchRemote.mockImplementation(() => Promise.resolve());
+  mockGit.fetchAllRemote.mockImplementation(() => Promise.resolve());
+  mockGit.getCommitsBehind.mockImplementation(() => Promise.resolve(0));
+  mockGit.getCommitsAhead.mockImplementation(() => Promise.resolve(0));
   mockGit.getMergeBase.mockImplementation(() => Promise.resolve('abc1234'));
   mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve('abc1234'));
   mockGit.getDiff.mockImplementation(() => Promise.resolve(''));

--- a/packages/server/src/lib/__tests__/git.test.ts
+++ b/packages/server/src/lib/__tests__/git.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
+
+/**
+ * Tests for remote git operations.
+ *
+ * These tests mock Bun.spawn to avoid actual git operations.
+ * The approach mirrors the pattern used in worktree-service.test.ts.
+ */
+
+// Store original Bun.spawn to restore after tests
+const originalBunSpawn = Bun.spawn;
+
+// Track spawn calls for assertions
+let spawnCalls: Array<{ args: string[]; options: Record<string, unknown> }> = [];
+
+// Mock result to be returned by Bun.spawn
+let mockSpawnResult: {
+  exited: Promise<number>;
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+};
+
+/**
+ * Helper to set mock spawn result.
+ */
+function setMockSpawnResult(stdout: string, exitCode = 0, stderr = '') {
+  mockSpawnResult = {
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(stdout));
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(stderr));
+        controller.close();
+      },
+    }),
+  };
+}
+
+// Import counter for dynamic module loading
+let importCounter = 0;
+
+/**
+ * Get fresh git module instance.
+ * Dynamic import ensures we get a fresh module that uses our mocked Bun.spawn.
+ */
+async function getGitModule() {
+  const module = await import(`../git.js?v=${++importCounter}`);
+  return module;
+}
+
+describe('git remote operations', () => {
+  beforeEach(() => {
+    // Reset spawn tracking
+    spawnCalls = [];
+
+    // Default mock result (successful command with empty output)
+    setMockSpawnResult('');
+
+    // Mock Bun.spawn
+    (Bun as { spawn: typeof Bun.spawn }).spawn = ((args: string[], options?: Record<string, unknown>) => {
+      spawnCalls.push({ args, options: options || {} });
+      return mockSpawnResult;
+    }) as typeof Bun.spawn;
+  });
+
+  afterAll(() => {
+    // Restore original Bun.spawn
+    (Bun as { spawn: typeof Bun.spawn }).spawn = originalBunSpawn;
+  });
+
+  describe('fetchRemote', () => {
+    it('should call git with correct arguments for specific branch', async () => {
+      setMockSpawnResult('');
+      const { fetchRemote } = await getGitModule();
+
+      await fetchRemote('main', '/repo');
+
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args).toEqual(['git', 'fetch', 'origin', 'main']);
+      expect(spawnCalls[0].options.cwd).toBe('/repo');
+    });
+
+    it('should call git with correct arguments for feature branch', async () => {
+      setMockSpawnResult('');
+      const { fetchRemote } = await getGitModule();
+
+      await fetchRemote('feature/my-branch', '/workspace/project');
+
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args).toEqual(['git', 'fetch', 'origin', 'feature/my-branch']);
+      expect(spawnCalls[0].options.cwd).toBe('/workspace/project');
+    });
+
+    it('should throw GitError on failure', async () => {
+      setMockSpawnResult('', 128, 'fatal: Could not read from remote repository');
+      const { fetchRemote, GitError } = await getGitModule();
+
+      await expect(fetchRemote('nonexistent', '/repo')).rejects.toBeInstanceOf(GitError);
+    });
+  });
+
+  describe('fetchAllRemote', () => {
+    it('should call git fetch origin without branch argument', async () => {
+      setMockSpawnResult('');
+      const { fetchAllRemote } = await getGitModule();
+
+      await fetchAllRemote('/repo');
+
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args).toEqual(['git', 'fetch', 'origin']);
+      expect(spawnCalls[0].options.cwd).toBe('/repo');
+    });
+
+    it('should work with different working directories', async () => {
+      setMockSpawnResult('');
+      const { fetchAllRemote } = await getGitModule();
+
+      await fetchAllRemote('/home/user/projects/my-app');
+
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args).toEqual(['git', 'fetch', 'origin']);
+      expect(spawnCalls[0].options.cwd).toBe('/home/user/projects/my-app');
+    });
+
+    it('should throw GitError on failure', async () => {
+      setMockSpawnResult('', 128, 'fatal: Could not read from remote repository');
+      const { fetchAllRemote, GitError } = await getGitModule();
+
+      await expect(fetchAllRemote('/repo')).rejects.toBeInstanceOf(GitError);
+    });
+  });
+
+  describe('getCommitsBehind', () => {
+    it('should return correct count when local is behind remote', async () => {
+      setMockSpawnResult('5\n');
+      const { getCommitsBehind } = await getGitModule();
+
+      const result = await getCommitsBehind('main', '/repo');
+
+      expect(result).toBe(5);
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args).toEqual(['git', 'rev-list', '--count', 'main..origin/main']);
+    });
+
+    it('should return 0 when up to date', async () => {
+      setMockSpawnResult('0\n');
+      const { getCommitsBehind } = await getGitModule();
+
+      const result = await getCommitsBehind('develop', '/repo');
+
+      expect(result).toBe(0);
+      expect(spawnCalls[0].args).toEqual(['git', 'rev-list', '--count', 'develop..origin/develop']);
+    });
+
+    it('should return 0 on error (e.g., no remote tracking branch)', async () => {
+      setMockSpawnResult('', 128, 'fatal: bad revision');
+      const { getCommitsBehind } = await getGitModule();
+
+      const result = await getCommitsBehind('local-only-branch', '/repo');
+
+      expect(result).toBe(0);
+    });
+
+    it('should handle large commit counts', async () => {
+      setMockSpawnResult('1234\n');
+      const { getCommitsBehind } = await getGitModule();
+
+      const result = await getCommitsBehind('main', '/repo');
+
+      expect(result).toBe(1234);
+    });
+  });
+
+  describe('getCommitsAhead', () => {
+    it('should return correct count when local is ahead of remote', async () => {
+      setMockSpawnResult('3\n');
+      const { getCommitsAhead } = await getGitModule();
+
+      const result = await getCommitsAhead('main', '/repo');
+
+      expect(result).toBe(3);
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args).toEqual(['git', 'rev-list', '--count', 'origin/main..main']);
+    });
+
+    it('should return 0 when up to date', async () => {
+      setMockSpawnResult('0\n');
+      const { getCommitsAhead } = await getGitModule();
+
+      const result = await getCommitsAhead('feature-branch', '/repo');
+
+      expect(result).toBe(0);
+      expect(spawnCalls[0].args).toEqual(['git', 'rev-list', '--count', 'origin/feature-branch..feature-branch']);
+    });
+
+    it('should return 0 on error (e.g., no remote tracking branch)', async () => {
+      setMockSpawnResult('', 128, 'fatal: bad revision');
+      const { getCommitsAhead } = await getGitModule();
+
+      const result = await getCommitsAhead('local-only-branch', '/repo');
+
+      expect(result).toBe(0);
+    });
+
+    it('should handle large commit counts', async () => {
+      setMockSpawnResult('567\n');
+      const { getCommitsAhead } = await getGitModule();
+
+      const result = await getCommitsAhead('main', '/repo');
+
+      expect(result).toBe(567);
+    });
+  });
+
+  describe('GitError', () => {
+    it('should be instanceof Error', async () => {
+      const { GitError } = await getGitModule();
+      const error = new GitError('test message', 128, 'stderr content');
+
+      expect(error).toBeInstanceOf(Error);
+    });
+
+    it('should have correct name', async () => {
+      const { GitError } = await getGitModule();
+      const error = new GitError('test message', 128, 'stderr content');
+
+      expect(error.name).toBe('GitError');
+    });
+
+    it('should have correct properties', async () => {
+      const { GitError } = await getGitModule();
+      const error = new GitError('test message', 128, 'stderr content');
+
+      expect(error.message).toBe('test message');
+      expect(error.exitCode).toBe(128);
+      expect(error.stderr).toBe('stderr content');
+    });
+  });
+});

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -441,6 +441,55 @@ export interface CommitInfo {
   date: string;
 }
 
+// ============================================================
+// Remote Operations
+// ============================================================
+
+/**
+ * Fetch a specific branch from remote origin.
+ */
+export async function fetchRemote(branch: string, cwd: string): Promise<void> {
+  await git(['fetch', 'origin', branch], cwd);
+}
+
+/**
+ * Fetch all branches from remote origin.
+ */
+export async function fetchAllRemote(cwd: string): Promise<void> {
+  await git(['fetch', 'origin'], cwd);
+}
+
+/**
+ * Get how many commits the local branch is behind the remote branch.
+ * Returns 0 if up to date, positive number if behind.
+ */
+export async function getCommitsBehind(branch: string, cwd: string): Promise<number> {
+  try {
+    // Count commits in origin/branch that are not in local branch
+    const output = await git(['rev-list', '--count', `${branch}..origin/${branch}`], cwd);
+    return parseInt(output, 10);
+  } catch {
+    return 0; // If the comparison fails, assume up to date
+  }
+}
+
+/**
+ * Get how many commits the local branch is ahead of the remote branch.
+ */
+export async function getCommitsAhead(branch: string, cwd: string): Promise<number> {
+  try {
+    // Count commits in local branch that are not in origin/branch
+    const output = await git(['rev-list', '--count', `origin/${branch}..${branch}`], cwd);
+    return parseInt(output, 10);
+  } catch {
+    return 0;
+  }
+}
+
+// ============================================================
+// Commit Log Operations
+// ============================================================
+
 /**
  * Get commits between a base ref and HEAD (commits created in this branch).
  * Uses `git log <baseRef>..HEAD` to get commits that are in HEAD but not in baseRef.

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -60,6 +60,7 @@ export {
   FetchGitHubIssueRequestSchema,
   GitHubIssueSummarySchema,
   RefreshDefaultBranchResponseSchema,
+  RemoteBranchStatusSchema,
   type CreateRepositoryRequest,
   type CreateWorktreePromptRequest,
   type CreateWorktreeCustomRequest,
@@ -70,6 +71,7 @@ export {
   type FetchGitHubIssueRequest,
   type GitHubIssueSummary,
   type RefreshDefaultBranchResponse,
+  type RemoteBranchStatus,
 } from './repository.js';
 
 // System schemas

--- a/packages/shared/src/schemas/repository.ts
+++ b/packages/shared/src/schemas/repository.ts
@@ -58,6 +58,7 @@ export const CreateWorktreePromptRequestSchema = v.object({
     v.minLength(1, 'Initial prompt is required for prompt mode')
   ),
   baseBranch: OptionalBranchSchema,
+  useRemote: v.optional(v.boolean()), // If true, branch from origin/<base> instead of local <base>
 });
 
 /**
@@ -68,6 +69,7 @@ export const CreateWorktreeCustomRequestSchema = v.object({
   mode: v.literal('custom'),
   branch: RequiredBranchSchema,
   baseBranch: OptionalBranchSchema,
+  useRemote: v.optional(v.boolean()), // If true, branch from origin/<base> instead of local <base>
 });
 
 /**
@@ -134,6 +136,14 @@ export const RefreshDefaultBranchResponseSchema = v.object({
   defaultBranch: v.pipe(v.string(), v.minLength(1, 'Default branch name is required')),
 });
 
+/**
+ * Schema for remote branch status response
+ */
+export const RemoteBranchStatusSchema = v.object({
+  behind: v.number(),
+  ahead: v.number(),
+});
+
 // Inferred types from schemas
 export type CreateRepositoryRequest = v.InferOutput<typeof CreateRepositoryRequestSchema>;
 export type CreateWorktreePromptRequest = v.InferOutput<typeof CreateWorktreePromptRequestSchema>;
@@ -145,3 +155,4 @@ export type UpdateRepositoryRequest = v.InferOutput<typeof UpdateRepositoryReque
 export type FetchGitHubIssueRequest = v.InferOutput<typeof FetchGitHubIssueRequestSchema>;
 export type GitHubIssueSummary = v.InferOutput<typeof GitHubIssueSummarySchema>;
 export type RefreshDefaultBranchResponse = v.InferOutput<typeof RefreshDefaultBranchResponseSchema>;
+export type RemoteBranchStatus = v.InferOutput<typeof RemoteBranchStatusSchema>;


### PR DESCRIPTION
## Summary

- Show warning when local base branch is behind remote during worktree creation
- Add "Fetch & Create" button to create worktree from latest remote state (`origin/<base>`)
- Add "Refresh" button to update default branch information from remote
- Add backend API endpoints for remote status checking and fetching

## Problem

When creating a new worktree, users often branch from an outdated main branch. This leads to:
- Merge conflicts when creating PRs
- Missing recent changes from other developers
- Need for rebasing before merge

## Solution

Integrate remote status checking into the worktree creation flow:
1. Check base branch status when form opens (async background query)
2. Show warning if local is behind remote: "⚠️ X commits behind origin/main"
3. Offer "Fetch & Create" button to fetch and branch from `origin/<base>`

## UX Changes

| State | UI |
|-------|-----|
| Checking status | "Checking remote status..." |
| Up to date | No warning shown |
| Behind remote | Yellow warning + "Fetch & Create" button |
| Network error | "Could not check remote status" warning |

## Test plan

- [ ] Verify "Checking remote status..." appears while loading
- [ ] Verify warning appears when local branch is behind
- [ ] Verify "Fetch & Create" button creates worktree from remote
- [ ] Verify normal "Create" button still works (uses local branch)
- [ ] Verify "Refresh" button updates default branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows remote branch status (ahead/behind) and adds a conditional "Fetch & Create" action when your base is behind origin.
* **UI**
  * Two-sided action layout keeps Cancel/Create visible and surfaces remote status near base branch controls.
* **Documentation**
  * Added design doc describing remote-based worktree creation UX and flows.
* **Tests**
  * Expanded tests covering remote-status checks, fetch/fallback behavior, and worktree creation paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->