### PR TITLE
fix: send empty string instead of null for repository env vars validation

### DIFF
--- a/packages/client/src/components/repositories/EditRepositoryForm.tsx
+++ b/packages/client/src/components/repositories/EditRepositoryForm.tsx
@@ -85,10 +85,11 @@ export function EditRepositoryForm({ repository, onSuccess, onCancel }: EditRepo
 
   const handleFormSubmit = (data: EditRepositoryFormData) => {
     setError(null);
-    // Convert empty string to null for the API
-    const setupCommand = data.setupCommand?.trim() || null;
-    const envVars = data.envVars?.trim() || null;
-    updateMutation.mutate({ setupCommand, envVars });
+    // Send empty string as-is; server will convert to null for database storage
+    updateMutation.mutate({
+      setupCommand: data.setupCommand?.trim() ?? '',
+      envVars: data.envVars?.trim() ?? '',
+    });
   };
 
   return (

--- a/packages/client/src/components/repositories/__tests__/EditRepositoryForm.test.tsx
+++ b/packages/client/src/components/repositories/__tests__/EditRepositoryForm.test.tsx
@@ -114,7 +114,7 @@ describe('EditRepositoryForm', () => {
       // Verify API was called with correct data
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const requestBody = getRequestBody(0);
-      expect(requestBody).toEqual({ setupCommand: 'bun install', envVars: null });
+      expect(requestBody).toEqual({ setupCommand: 'bun install', envVars: '' });
     });
 
     it('should submit with empty string (clears command)', async () => {
@@ -140,10 +140,10 @@ describe('EditRepositoryForm', () => {
         expect(props.onSuccess).toHaveBeenCalledTimes(1);
       });
 
-      // Verify API was called with null (empty string converted to null)
+      // Verify API was called with empty string (server will convert to null)
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const requestBody = getRequestBody(0);
-      expect(requestBody).toEqual({ setupCommand: null, envVars: null });
+      expect(requestBody).toEqual({ setupCommand: '', envVars: '' });
     });
 
     it('should trim whitespace from setupCommand', async () => {
@@ -170,7 +170,7 @@ describe('EditRepositoryForm', () => {
 
       // Verify API was called with trimmed value
       const requestBody = getRequestBody(0);
-      expect(requestBody).toEqual({ setupCommand: 'bun install', envVars: null });
+      expect(requestBody).toEqual({ setupCommand: 'bun install', envVars: '' });
     });
   });
 


### PR DESCRIPTION
## Summary
- リポジトリ設定で環境変数だけ入力した場合にバリデーションエラーが発生する問題を修正
- クライアント側で空文字を `null` ではなく空文字のまま送信するように変更
- サーバー側で既に空文字→null変換を実装済みなので、その既存ロジックを活用

## Background
- 元の実装: クライアントが `setupCommand: null` を送信
- 問題: サーバーのスキーマ `v.optional(v.string())` は `null` を許可しない
- 解決: 空文字を送信し、サーバー側で null に変換させる（PATCH セマンティクスに沿った設計）

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] Manual test: 環境変数だけ入力して保存できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)