### PR TITLE
fix: emit session-deleted event locally for immediate UI update

### DIFF
--- a/packages/client/src/components/SessionSettings.tsx
+++ b/packages/client/src/components/SessionSettings.tsx
@@ -75,6 +75,7 @@ export function SessionSettings({
         onOpenChange={(open) => !open && closeDialog()}
         repositoryId={repositoryId}
         worktreePath={worktreePath}
+        sessionId={sessionId}
       />
 
       <InitialPromptDialog

--- a/packages/client/src/components/sessions/DeleteWorktreeDialog.tsx
+++ b/packages/client/src/components/sessions/DeleteWorktreeDialog.tsx
@@ -10,12 +10,14 @@ import {
   AlertDialogCancel,
 } from '../ui/alert-dialog';
 import { deleteWorktree } from '../../lib/api';
+import { emitSessionDeleted } from '../../lib/app-websocket';
 
 export interface DeleteWorktreeDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   repositoryId: string;
   worktreePath: string;
+  sessionId: string;
 }
 
 export function DeleteWorktreeDialog({
@@ -23,6 +25,7 @@ export function DeleteWorktreeDialog({
   onOpenChange,
   repositoryId,
   worktreePath,
+  sessionId,
 }: DeleteWorktreeDialogProps) {
   const navigate = useNavigate();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -42,6 +45,9 @@ export function DeleteWorktreeDialog({
     try {
       // Server-side deleteWorktree also terminates any running sessions
       await deleteWorktree(repositoryId, worktreePath, force);
+      // Emit session-deleted locally for immediate UI update
+      // WebSocket event will arrive later but will be processed idempotently
+      emitSessionDeleted(sessionId);
       onOpenChange(false);
       navigate({ to: '/' });
     } catch (err) {

--- a/packages/client/src/components/sessions/EndSessionDialog.tsx
+++ b/packages/client/src/components/sessions/EndSessionDialog.tsx
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { deleteSession } from '../../lib/api';
+import { emitSessionDeleted } from '../../lib/app-websocket';
 
 export interface EndSessionDialogProps {
   open: boolean;
@@ -19,6 +20,9 @@ export function EndSessionDialog({
   const deleteMutation = useMutation({
     mutationFn: () => deleteSession(sessionId),
     onSuccess: () => {
+      // Emit session-deleted locally for immediate UI update
+      // WebSocket event will arrive later but will be processed idempotently
+      emitSessionDeleted(sessionId);
       onOpenChange(false);
       navigate({ to: '/' });
     },

--- a/packages/client/src/lib/app-websocket.ts
+++ b/packages/client/src/lib/app-websocket.ts
@@ -222,6 +222,19 @@ function send(msg: AppClientMessage): boolean {
 }
 
 /**
+ * Emit a session-deleted event locally without waiting for WebSocket.
+ * Used for optimistic UI updates after successful API calls.
+ * This allows immediate UI feedback while the WebSocket event may arrive later.
+ * The event is processed idempotently - duplicate deletions are safely ignored.
+ *
+ * @param sessionId - The ID of the deleted session
+ */
+export function emitSessionDeleted(sessionId: string): void {
+  const msg: AppServerMessage = { type: 'session-deleted', sessionId };
+  messageListeners.forEach(fn => fn(msg));
+}
+
+/**
  * Request a full session sync from the server.
  * Use this when the Dashboard mounts and the WebSocket is already connected.
  * Resets sessionsSynced to false to show loading state until sync is received.


### PR DESCRIPTION
## Summary

- Fix race condition where deleted sessions would briefly appear on dashboard with missing data
- Fix occasional error dialog appearing even though deletion succeeded
- Add `emitSessionDeleted()` to emit session-deleted event locally after successful API call

## Problem

When deleting sessions/worktrees, the UI update relied on WebSocket events arriving after the API response. Due to timing differences, this caused:

1. Dashboard showing deleted sessions with missing content (workers, etc.)
2. Error dialogs appearing even though deletion actually succeeded
3. Sessions briefly visible before disappearing

## Solution

Emit the `session-deleted` event locally immediately after successful API deletion, without waiting for the WebSocket event. The existing event handler logic already handles duplicate deletions idempotently (using `filter`), so when the WebSocket event arrives later, it's safely ignored.

## Changes

- `packages/client/src/lib/app-websocket.ts`: Add `emitSessionDeleted()` function
- `packages/client/src/components/sessions/DeleteWorktreeDialog.tsx`: Call on successful deletion
- `packages/client/src/components/sessions/EndSessionDialog.tsx`: Call on successful deletion
- `packages/client/src/routes/index.tsx`: Call in `WorktreeRow` and `SessionCard` on successful deletion

## Test plan

- [ ] Delete a worktree session from the session page and verify immediate redirect without UI glitches
- [ ] Delete a quick session from the session page and verify immediate redirect
- [ ] Delete a worktree from the dashboard and verify immediate removal from list
- [ ] Stop a quick session from the dashboard and verify immediate removal from list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness of session and worktree deletion operations with immediate UI updates.
  * Enhanced error handling for deletion scenarios involving untracked files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->