### PR TITLE
feat: display repository name in session header breadcrumb

### DIFF
--- a/packages/client/src/components/Icons.tsx
+++ b/packages/client/src/components/Icons.tsx
@@ -211,3 +211,16 @@ export function StopIcon({ className = 'w-4 h-4' }: IconProps) {
     </svg>
   );
 }
+
+export function ChevronRightIcon({ className = 'w-4 h-4' }: IconProps) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M9 5l7 7-7 7"
+      />
+    </svg>
+  );
+}

--- a/packages/client/src/routes/sessions/$sessionId.tsx
+++ b/packages/client/src/routes/sessions/$sessionId.tsx
@@ -6,7 +6,7 @@ import { SessionSettings } from '../../components/SessionSettings';
 import { QuickSessionSettings } from '../../components/QuickSessionSettings';
 import { ErrorDialog, useErrorDialog } from '../../components/ui/error-dialog';
 import { ErrorBoundary } from '../../components/ui/ErrorBoundary';
-import { DiffIcon } from '../../components/Icons';
+import { DiffIcon, ChevronRightIcon } from '../../components/Icons';
 import { getSession, createWorker, deleteWorker, restartAgentWorker, openPath, ServerUnavailableError } from '../../lib/api';
 import { formatPath } from '../../lib/path';
 import { useAppWsEvent } from '../../hooks/useAppWs';
@@ -165,6 +165,13 @@ function TerminalPage() {
   const [branchName, setBranchName] = useState<string>('');
   // Local session title state (can be updated by settings dialog)
   const [sessionTitle, setSessionTitle] = useState<string>('');
+
+  // Get repository name directly from session (for worktree sessions)
+  const repositoryName =
+    (state.type === 'active' || state.type === 'disconnected') &&
+    state.session.type === 'worktree'
+      ? state.session.repositoryName
+      : undefined;
 
   // Sync branch name and title when state changes
   useEffect(() => {
@@ -562,19 +569,31 @@ function TerminalPage() {
     <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
       {/* Header with tabs */}
       <div className="bg-slate-900 border-b border-slate-700 flex items-center shrink-0">
-        {/* Title/Home link */}
-        <Link
-          to="/"
-          className="px-4 py-2 text-white font-bold text-sm hover:bg-slate-800 no-underline border-r border-slate-700"
-        >
-          Agent Console
-        </Link>
-        {/* Session title (if set) */}
-        {sessionTitle && (
-          <div className="px-4 py-2 text-gray-300 text-sm border-r border-slate-700 truncate max-w-xs" title={sessionTitle}>
-            {sessionTitle}
-          </div>
-        )}
+        {/* Breadcrumb navigation */}
+        <div className="flex items-center border-r border-slate-700">
+          <Link
+            to="/"
+            className="px-4 py-2 text-white font-bold text-sm hover:bg-slate-800 no-underline"
+          >
+            Agent Console
+          </Link>
+          {/* Repository name (for worktree sessions) */}
+          {repositoryName && (
+            <>
+              <ChevronRightIcon className="w-4 h-4 text-slate-500" />
+              <span className="px-2 py-2 text-slate-300 text-sm">{repositoryName}</span>
+            </>
+          )}
+          {/* Session title (if set) */}
+          {sessionTitle && (
+            <>
+              <ChevronRightIcon className="w-4 h-4 text-slate-500" />
+              <div className="px-2 py-2 text-slate-100 text-sm font-medium truncate max-w-[200px]" title={sessionTitle}>
+                {sessionTitle}
+              </div>
+            </>
+          )}
+        </div>
         {/* Tabs */}
         {tabButtons}
         <button

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -95,6 +95,8 @@ describe('SessionManager', () => {
       expect(session.locationPath).toBe('/test/path');
       if (session.type === 'worktree') {
         expect(session.repositoryId).toBe('repo-1');
+        // repositoryName is 'Unknown' when RepositoryManager is not initialized
+        expect(session.repositoryName).toBe('Unknown');
         expect(session.worktreeId).toBe('main');
       }
       expect(session.status).toBe('active');

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -1554,11 +1554,21 @@ export class SessionManager {
       .map(w => this.toPublicWorker(w));
 
     if (session.type === 'worktree') {
+      // Get repository name from RepositoryManager if available
+      let repositoryName = 'Unknown';
+      if (isRepositoryManagerInitialized()) {
+        const repository = getRepositoryManager().getRepository(session.repositoryId);
+        if (repository) {
+          repositoryName = repository.name;
+        }
+      }
+
       return {
         id: session.id,
         type: 'worktree',
         locationPath: session.locationPath,
         repositoryId: session.repositoryId,
+        repositoryName,
         worktreeId: session.worktreeId,
         status: session.status,
         createdAt: session.createdAt,

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -46,6 +46,7 @@ export interface SessionBase {
 export interface WorktreeSession extends SessionBase {
   type: 'worktree';
   repositoryId: string;
+  repositoryName: string;    // Human-readable repository name
   worktreeId: string;        // Worktree identifier (branch name)
 }
 


### PR DESCRIPTION
## Summary

- Display repository name in session header as breadcrumb navigation
- Format: `Agent Console > Repository Name > Session Title`

## Changes

- Add `repositoryName` field to `WorktreeSession` type
- Include repository name in session response from `SessionManager.toPublicSession()`
- Display breadcrumb with ChevronRightIcon separators in session header
- Add `ChevronRightIcon` component to Icons.tsx

## Notes

- Repository name is only displayed for worktree sessions (quick sessions do not have a repository ID)
- No additional API calls: repository name is included in the session response

## Test plan

- [x] `bun run test` - all tests pass
- [x] `bun run typecheck` - no type errors
- [ ] Manual verification: Repository name is displayed for worktree sessions
- [ ] Manual verification: Repository name is not displayed for quick sessions

Generated with [Claude Code](https://claude.com/claude-code)