### PR TITLE
fix: preserve trailing newlines in git diff output

### DIFF
--- a/packages/server/src/__tests__/utils/mock-git-helper.ts
+++ b/packages/server/src/__tests__/utils/mock-git-helper.ts
@@ -32,6 +32,7 @@ type AsyncVoidFn = (...args: unknown[]) => Promise<void>;
 export const mockGit = {
   // Low-level
   git: mock(() => Promise.resolve('')) as Mock<AsyncStringFn>,
+  gitRaw: mock(() => Promise.resolve('')) as Mock<AsyncStringFn>,
   gitSafe: mock(() => Promise.resolve(null)) as Mock<AsyncStringNullFn>,
   gitRefExists: mock(() => Promise.resolve(false)) as Mock<(ref: string, cwd: string) => Promise<boolean>>,
 
@@ -91,6 +92,7 @@ mock.module('../../lib/git.js', () => ({
  */
 export function resetGitMocks(): void {
   mockGit.git.mockReset();
+  mockGit.gitRaw.mockReset();
   mockGit.gitSafe.mockReset();
   mockGit.gitRefExists.mockReset();
   mockGit.getCurrentBranch.mockReset();
@@ -121,6 +123,7 @@ export function resetGitMocks(): void {
 
   // Set default implementations
   mockGit.git.mockImplementation(() => Promise.resolve(''));
+  mockGit.gitRaw.mockImplementation(() => Promise.resolve(''));
   mockGit.gitSafe.mockImplementation(() => Promise.resolve(null));
   mockGit.gitRefExists.mockImplementation(() => Promise.resolve(false));
   mockGit.getCurrentBranch.mockImplementation(() => Promise.resolve('main'));


### PR DESCRIPTION
## Summary
- Add `gitRaw()` function that preserves trailing whitespace (uses `.trimStart()` instead of `.trim()`)
- Update `getDiff()` and `getDiffNumstat()` to use `gitRaw()` instead of `git()`
- Add comprehensive tests for trailing newline preservation

## Root Cause
The `git()` function used `.trim()` on stdout, which stripped trailing newlines from diff output. This broke the client-side diff parser (`diff` library's `parsePatch()`) because unified diff format relies on exact line counts in hunk headers.

## Test plan
- [x] All 865 server tests pass
- [x] Typecheck passes
- [x] Bug reproduction test verifies exact diff format preservation
- [x] Edge case tests cover empty output, no trailing newline, whitespace-only changes

Closes #184

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `gitRaw` function that preserves trailing whitespace when executing git commands, enabling accurate representation of git output in scenarios where whitespace is significant.

* **Bug Fixes**
  * Fixed handling of trailing newlines and whitespace in git diff operations to ensure accurate diff output preservation.

* **Tests**
  * Added comprehensive test coverage for git command execution, whitespace handling, and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->