### PR TITLE
feat: add static SVG favicon with dynamic switching for asking state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Build outputs
 dist/
 public/
+!packages/client/public/
 *.tsbuildinfo
 
 # Editor

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Agent Console</title>
   </head>
   <body>

--- a/packages/client/public/favicon-waiting.svg
+++ b/packages/client/public/favicon-waiting.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="7" width="26" height="18" rx="4" fill="#854d0e" stroke="#fbbf24" stroke-width="1"/>
+  <text x="7" y="19" font-family="monospace" font-size="9" font-weight="bold" fill="#fef08a">&gt;_</text>
+  <polygon points="22,10 24.5,17.6 18,12.9 26,12.9 19.5,17.6" fill="#fef08a"/>
+</svg>

--- a/packages/client/public/favicon.svg
+++ b/packages/client/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e3a5f"/>
+      <stop offset="100%" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect x="3" y="7" width="26" height="18" rx="4" fill="url(#bg)" stroke="#3b82f6" stroke-width="0.5"/>
+  <text x="7" y="19" font-family="monospace" font-size="9" font-weight="bold" fill="#93c5fd">&gt;_</text>
+  <polygon points="22,10 24.5,17.6 18,12.9 26,12.9 19.5,17.6" fill="#fcd34d"/>
+</svg>

--- a/packages/client/src/lib/favicon-manager.ts
+++ b/packages/client/src/lib/favicon-manager.ts
@@ -1,0 +1,41 @@
+import type { AgentActivityState } from '@agent-console/shared';
+
+const FAVICON_NORMAL = '/favicon.svg';
+const FAVICON_WAITING = '/favicon-waiting.svg';
+
+let currentFaviconPath: string | null = null;
+
+/**
+ * Update favicon based on whether any worker is in 'asking' state
+ */
+export function updateFavicon(hasAskingWorker: boolean): void {
+  const newPath = hasAskingWorker ? FAVICON_WAITING : FAVICON_NORMAL;
+
+  // Skip if already set to this path
+  if (currentFaviconPath === newPath) {
+    return;
+  }
+
+  const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+  if (link) {
+    link.href = newPath;
+    currentFaviconPath = newPath;
+  }
+}
+
+/**
+ * Check if any worker across all sessions is in 'asking' state
+ */
+export function hasAnyAskingWorker(
+  workerActivityStates: Record<string, Record<string, AgentActivityState>>
+): boolean {
+  for (const sessionId of Object.keys(workerActivityStates)) {
+    const workers = workerActivityStates[sessionId];
+    for (const workerId of Object.keys(workers)) {
+      if (workers[workerId] === 'asking') {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from 'react';
 import { createRootRoute, Outlet, Link, useLocation } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { validateSessions } from '../lib/api';
+import { updateFavicon, hasAnyAskingWorker } from '../lib/favicon-manager';
 import { WarningIcon, ChevronRightIcon } from '../components/Icons';
 import { ConnectionBanner } from '../components/ui/ConnectionBanner';
 import { ActiveSessionsSidebar } from '../components/sidebar/ActiveSessionsSidebar';
@@ -49,6 +51,11 @@ function RootLayout() {
   // Sidebar state
   const { collapsed, toggle, width, setWidth } = useSidebarState();
   const activeSessions = useActiveSessionsWithActivity(sessions, workerActivityStates);
+
+  // Update favicon based on worker activity states
+  useEffect(() => {
+    updateFavicon(hasAnyAskingWorker(workerActivityStates));
+  }, [workerActivityStates]);
 
   // Find current session for breadcrumb display
   const currentSession: Session | undefined = currentSessionId


### PR DESCRIPTION
## Summary

- Add SVG favicon that changes based on worker activity state
- Normal state: Blue terminal icon with yellow star
- Asking state: Yellow/orange themed icon (indicates work stopped, needs attention)
- Replace old Canvas-based animated favicon with simpler static SVG approach
- Move favicon logic from SessionPage to RootLayout for app-wide monitoring

## Changes

- `packages/client/public/favicon.svg` - Normal state favicon
- `packages/client/public/favicon-waiting.svg` - Asking state favicon  
- `packages/client/src/lib/favicon-manager.ts` - Utility for switching favicon
- `packages/client/src/routes/__root.tsx` - Integration with workerActivityStates
- `packages/client/src/components/sessions/SessionPage.tsx` - Remove old Canvas code (~65 lines)
- `.gitignore` - Allow packages/client/public/ tracking

## Test plan

- [ ] Verify normal favicon displays on app load
- [ ] Verify favicon switches to waiting state when any worker enters 'asking' state
- [ ] Verify favicon returns to normal when no workers are in 'asking' state
- [ ] Verify all tests pass (`bun run test`)
- [ ] Verify typecheck passes (`bun run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Favicon now dynamically updates to indicate when workers are actively processing requests.

* **Bug Fixes**
  * Removed animated favicon behavior in favor of static state indicators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->