### PR TITLE
fix: invalidate worktrees cache when deleting worktree from session page

### DIFF
--- a/packages/client/src/components/sessions/DeleteWorktreeDialog.tsx
+++ b/packages/client/src/components/sessions/DeleteWorktreeDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from '@tanstack/react-router';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -28,6 +29,7 @@ export function DeleteWorktreeDialog({
   sessionId,
 }: DeleteWorktreeDialogProps) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -48,6 +50,8 @@ export function DeleteWorktreeDialog({
       // Emit session-deleted locally for immediate UI update
       // WebSocket event will arrive later but will be processed idempotently
       emitSessionDeleted(sessionId);
+      // Invalidate worktrees cache so Dashboard shows updated list
+      await queryClient.invalidateQueries({ queryKey: ['worktrees', repositoryId] });
       onOpenChange(false);
       navigate({ to: '/' });
     } catch (err) {


### PR DESCRIPTION
## Summary
- Fixed a bug where deleting a worktree from the session detail page would not immediately reflect in the Dashboard
- The Dashboard showed stale worktree data because TanStack Query cache was not invalidated in `DeleteWorktreeDialog`
- Added `queryClient.invalidateQueries` call to ensure cache is properly invalidated

## Test plan
- [ ] Delete a worktree from the session detail page (via Settings menu)
- [ ] Navigate to Dashboard
- [ ] Verify the deleted worktree is no longer displayed immediately (without needing to wait or refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Dashboard list now properly refreshes after deleting a worktree, ensuring the display stays up-to-date with the latest state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->