### PR TITLE
fix: preserve DiffViewer scroll position across tab switches

### DIFF
--- a/packages/client/src/hooks/__tests__/useDiffScrollPosition.test.ts
+++ b/packages/client/src/hooks/__tests__/useDiffScrollPosition.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, spyOn } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+import { useDiffScrollPosition } from '../useDiffScrollPosition';
+
+describe('useDiffScrollPosition', () => {
+  const sessionId = 'test-session';
+  const workerId = 'test-worker';
+  const storageKey = `agent-console:diff-scroll:${sessionId}:${workerId}`;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('initial state', () => {
+    it('should return null for visibleFile and initialScrollTarget when no stored value', () => {
+      const { result } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      expect(result.current.visibleFile).toBe(null);
+      expect(result.current.initialScrollTarget).toBe(null);
+    });
+
+    it('should read initialScrollTarget from localStorage', () => {
+      localStorage.setItem(storageKey, 'src/components/Button.tsx');
+
+      const { result } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      expect(result.current.initialScrollTarget).toBe('src/components/Button.tsx');
+      // visibleFile should still be null initially
+      expect(result.current.visibleFile).toBe(null);
+    });
+  });
+
+  describe('setVisibleFile', () => {
+    it('should update visibleFile but NOT persist to localStorage', () => {
+      const { result } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      act(() => {
+        result.current.setVisibleFile('src/utils/helpers.ts');
+      });
+
+      expect(result.current.visibleFile).toBe('src/utils/helpers.ts');
+      // Should NOT persist to localStorage
+      expect(localStorage.getItem(storageKey)).toBe(null);
+    });
+
+    it('should update when file changes without persisting', () => {
+      const { result } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      act(() => {
+        result.current.setVisibleFile('file1.ts');
+      });
+      expect(result.current.visibleFile).toBe('file1.ts');
+      expect(localStorage.getItem(storageKey)).toBe(null);
+
+      act(() => {
+        result.current.setVisibleFile('file2.ts');
+      });
+      expect(result.current.visibleFile).toBe('file2.ts');
+      expect(localStorage.getItem(storageKey)).toBe(null);
+    });
+  });
+
+  describe('saveScrollPosition', () => {
+    it('should update visibleFile and persist to localStorage', () => {
+      const { result } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      act(() => {
+        result.current.saveScrollPosition('src/utils/helpers.ts');
+      });
+
+      expect(result.current.visibleFile).toBe('src/utils/helpers.ts');
+      expect(localStorage.getItem(storageKey)).toBe('src/utils/helpers.ts');
+    });
+
+    it('should update and persist when file changes', () => {
+      const { result } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      act(() => {
+        result.current.saveScrollPosition('file1.ts');
+      });
+      expect(result.current.visibleFile).toBe('file1.ts');
+      expect(localStorage.getItem(storageKey)).toBe('file1.ts');
+
+      act(() => {
+        result.current.saveScrollPosition('file2.ts');
+      });
+      expect(result.current.visibleFile).toBe('file2.ts');
+      expect(localStorage.getItem(storageKey)).toBe('file2.ts');
+    });
+  });
+
+  describe('clearInitialScrollTarget', () => {
+    it('should clear initialScrollTarget', () => {
+      localStorage.setItem(storageKey, 'src/components/Button.tsx');
+
+      const { result } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+      expect(result.current.initialScrollTarget).toBe('src/components/Button.tsx');
+
+      act(() => {
+        result.current.clearInitialScrollTarget();
+      });
+
+      expect(result.current.initialScrollTarget).toBe(null);
+    });
+
+    it('should not affect visibleFile or localStorage', () => {
+      localStorage.setItem(storageKey, 'src/components/Button.tsx');
+
+      const { result } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      act(() => {
+        result.current.saveScrollPosition('file.ts');
+        result.current.clearInitialScrollTarget();
+      });
+
+      expect(result.current.initialScrollTarget).toBe(null);
+      expect(result.current.visibleFile).toBe('file.ts');
+      expect(localStorage.getItem(storageKey)).toBe('file.ts');
+    });
+  });
+
+  describe('different session/worker combinations', () => {
+    it('should use different storage keys for different sessions', () => {
+      const key1 = 'agent-console:diff-scroll:session1:worker1';
+      const key2 = 'agent-console:diff-scroll:session2:worker1';
+
+      localStorage.setItem(key1, 'file1.ts');
+      localStorage.setItem(key2, 'file2.ts');
+
+      const { result: result1 } = renderHook(() => useDiffScrollPosition('session1', 'worker1'));
+      const { result: result2 } = renderHook(() => useDiffScrollPosition('session2', 'worker1'));
+
+      expect(result1.current.initialScrollTarget).toBe('file1.ts');
+      expect(result2.current.initialScrollTarget).toBe('file2.ts');
+    });
+
+    it('should use different storage keys for different workers', () => {
+      const key1 = 'agent-console:diff-scroll:session1:worker1';
+      const key2 = 'agent-console:diff-scroll:session1:worker2';
+
+      localStorage.setItem(key1, 'file1.ts');
+      localStorage.setItem(key2, 'file2.ts');
+
+      const { result: result1 } = renderHook(() => useDiffScrollPosition('session1', 'worker1'));
+      const { result: result2 } = renderHook(() => useDiffScrollPosition('session1', 'worker2'));
+
+      expect(result1.current.initialScrollTarget).toBe('file1.ts');
+      expect(result2.current.initialScrollTarget).toBe('file2.ts');
+    });
+  });
+
+  describe('localStorage error handling', () => {
+    it('should return null when localStorage.getItem throws', () => {
+      const getItemSpy = spyOn(localStorage, 'getItem').mockImplementation(() => {
+        throw new Error('Storage error');
+      });
+
+      const { result } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      expect(result.current.initialScrollTarget).toBe(null);
+
+      getItemSpy.mockRestore();
+    });
+
+    it('should handle localStorage.setItem throwing an error gracefully', () => {
+      const setItemSpy = spyOn(localStorage, 'setItem').mockImplementation(() => {
+        throw new Error('Storage quota exceeded');
+      });
+
+      const { result } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      // Should not throw, state should still update
+      act(() => {
+        result.current.saveScrollPosition('file.ts');
+      });
+
+      expect(result.current.visibleFile).toBe('file.ts');
+
+      setItemSpy.mockRestore();
+    });
+  });
+
+  describe('persistence across remounts', () => {
+    it('should restore scroll position after unmount and remount', () => {
+      const { result, unmount } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      // Save scroll position (explicit user action)
+      act(() => {
+        result.current.saveScrollPosition('src/MyComponent.tsx');
+      });
+
+      expect(localStorage.getItem(storageKey)).toBe('src/MyComponent.tsx');
+
+      // Unmount
+      unmount();
+
+      // Remount - should restore the scroll target
+      const { result: newResult } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      expect(newResult.current.initialScrollTarget).toBe('src/MyComponent.tsx');
+    });
+
+    it('should NOT restore scroll position from setVisibleFile (non-persisted)', () => {
+      const { result, unmount } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      // Set visible file (IntersectionObserver update, NOT persisted)
+      act(() => {
+        result.current.setVisibleFile('src/MyComponent.tsx');
+      });
+
+      expect(localStorage.getItem(storageKey)).toBe(null);
+
+      // Unmount
+      unmount();
+
+      // Remount - should NOT have any scroll target
+      const { result: newResult } = renderHook(() => useDiffScrollPosition(sessionId, workerId));
+
+      expect(newResult.current.initialScrollTarget).toBe(null);
+    });
+  });
+});

--- a/packages/client/src/hooks/useDiffScrollPosition.ts
+++ b/packages/client/src/hooks/useDiffScrollPosition.ts
@@ -1,0 +1,109 @@
+import { useState, useCallback } from 'react';
+
+/**
+ * Generate a localStorage key for storing the visible file position
+ */
+function getStorageKey(sessionId: string, workerId: string): string {
+  return `agent-console:diff-scroll:${sessionId}:${workerId}`;
+}
+
+/**
+ * Read the stored visible file from localStorage
+ * Exported so callers can read directly when needed (e.g., on fresh mount)
+ */
+export function getStoredVisibleFile(sessionId: string, workerId: string): string | null {
+  try {
+    const key = getStorageKey(sessionId, workerId);
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the visible file to localStorage
+ */
+function persistVisibleFile(sessionId: string, workerId: string, filePath: string | null): void {
+  try {
+    const key = getStorageKey(sessionId, workerId);
+    if (filePath) {
+      localStorage.setItem(key, filePath);
+    } else {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // Ignore localStorage errors
+  }
+}
+
+interface UseDiffScrollPositionReturn {
+  /** The currently visible file path for UI highlighting (null if none) */
+  visibleFile: string | null;
+  /** The file to scroll to on initial load (null after consumed) */
+  initialScrollTarget: string | null;
+  /** Called when a file becomes visible in the diff viewer (UI update only, no persistence) */
+  setVisibleFile: (filePath: string) => void;
+  /** Called when user explicitly selects a file (persists to localStorage) */
+  saveScrollPosition: (filePath: string) => void;
+  /** Called after the initial scroll has been performed */
+  clearInitialScrollTarget: () => void;
+  /** Re-read initialScrollTarget from localStorage (useful after mount) */
+  refreshInitialScrollTarget: () => void;
+}
+
+/**
+ * Hook for managing diff viewer scroll position with localStorage persistence.
+ * Stores the visible file path and restores it when reopening the same worker.
+ *
+ * Important: Only saveScrollPosition persists to localStorage.
+ * setVisibleFile is for UI updates only (e.g., from IntersectionObserver).
+ * This prevents automatic scroll resets from overwriting user selections.
+ */
+export function useDiffScrollPosition(
+  sessionId: string,
+  workerId: string
+): UseDiffScrollPositionReturn {
+  // Read initial scroll target from localStorage once
+  const [initialScrollTarget, setInitialScrollTarget] = useState<string | null>(() => {
+    return getStoredVisibleFile(sessionId, workerId);
+  });
+
+  // Current visible file for UI highlighting (may be different from saved position)
+  const [visibleFile, setVisibleFileState] = useState<string | null>(null);
+
+  // Update visible file for UI only (no persistence)
+  const setVisibleFile = useCallback((filePath: string) => {
+    setVisibleFileState(filePath);
+  }, []);
+
+  // Save scroll position to localStorage (called on explicit user selection)
+  const saveScrollPosition = useCallback(
+    (filePath: string) => {
+      setVisibleFileState(filePath);
+      persistVisibleFile(sessionId, workerId, filePath);
+    },
+    [sessionId, workerId]
+  );
+
+  const clearInitialScrollTarget = useCallback(() => {
+    setInitialScrollTarget(null);
+  }, []);
+
+  // Re-read from localStorage and update state
+  // Useful when the component needs to refresh the target (e.g., after confirming mount)
+  const refreshInitialScrollTarget = useCallback(() => {
+    const stored = getStoredVisibleFile(sessionId, workerId);
+    if (stored) {
+      setInitialScrollTarget(stored);
+    }
+  }, [sessionId, workerId]);
+
+  return {
+    visibleFile,
+    initialScrollTarget,
+    setVisibleFile,
+    saveScrollPosition,
+    clearInitialScrollTarget,
+    refreshInitialScrollTarget,
+  };
+}

--- a/packages/client/src/test/setup.ts
+++ b/packages/client/src/test/setup.ts
@@ -2,3 +2,12 @@ import { GlobalRegistrator } from '@happy-dom/global-registrator';
 
 // Register happy-dom globals (window, document, etc.)
 GlobalRegistrator.register();
+
+// Ensure localStorage is available globally (Happy DOM provides it via window)
+if (typeof globalThis.localStorage === 'undefined' && typeof window !== 'undefined') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: window.localStorage,
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## Summary
- Fix scroll position not being preserved when switching between Worker tabs (Diff ↔ Claude Code)
- Introduce `activeScrollRef` to track scroll state independently of prop changes
- Extend cleanup timeout to allow rAF scroll loop completion
- Add `useDiffScrollPosition` hook for localStorage persistence

## Test plan
- [x] Open a session with a Diff tab containing multiple files
- [x] Click a file in the sidebar (e.g., logger.ts) to scroll to it
- [x] Switch to Claude Code tab
- [x] Switch back to Diff tab
- [x] Verify the scroll position is restored to the previously selected file
- [x] All tests pass (`bun run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diff viewer now remembers and restores your scroll position and the file you were previously viewing across sessions.
  * Enhanced scroll handling for improved performance when working with large diffs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->