### PR TITLE
docs: add Design Review Mindset section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,36 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Speak up about issues.** When you notice something inappropriate or problematic outside the current task scope, mention it as a supplementary note. Do not silently ignore issues just because they are not directly related to the task at hand.
 
+**Ask when uncertain.** When uncertain about a design decision, do not decide arbitrarily. Ask the user for confirmation.
+
+## Design Review Mindset
+
+The following are perspectives to revisit repeatedly during design. This is not a one-way checklist.
+
+- Is the existing pattern truly appropriate?
+  - Are you following it just because other code does so?
+  - When uncertain, ask the user
+
+- Have you considered abstraction? Have you judged whether it is truly necessary after attempting it?
+  - Do not avoid abstraction; judge its necessity after considering it
+
+- Is the placement appropriate?
+  - Module-specific or shared?
+  - Does it align with the scope of responsibility?
+
+- Is the interface actually usable?
+  - Is the design such that callers cannot pass the information they need?
+
+- Does the naming cause misunderstanding in context?
+  - Can you predict the value from the name?
+  - Is it consistent with existing naming conventions in the codebase?
+
+- Do default values contradict state?
+  - Does the default value make sense when other fields are unset?
+
+- Is there anything unnecessary? Can it be deleted?
+  - Prioritize deletion over addition
+
 ## Subagent and Skill Usage Policy
 
 **Primary agent as coordinator.** The primary agent (first launched) MUST NOT write code directly. Instead:


### PR DESCRIPTION
## Summary

- Add "Ask when uncertain" principle to Working Principles section
- Add new "Design Review Mindset" section with 7 perspectives for design review

The design review perspectives are meant to be revisited repeatedly during implementation, not as a one-way checklist:

1. Is the existing pattern truly appropriate?
2. Have you considered abstraction and judged its necessity?
3. Is the placement appropriate?
4. Is the interface actually usable?
5. Does the naming cause misunderstanding in context?
6. Do default values contradict state?
7. Is there anything unnecessary that can be deleted?

## Background

These guidelines emerged from a conversation where design issues were identified:
- An interface was defined but unusable in practice
- A naming convention caused confusion with existing patterns
- Unnecessary features were added without UI to configure them

## Test plan

- [x] CLAUDE.md syntax is valid markdown
- [x] Content integrates properly with existing sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal guidance documentation with enhanced design review principles and structured delegation framework.

**Note:** This release contains internal documentation updates with no visible user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->