### PR TITLE
feat: add APP_URL environment variable to plist configuration

### DIFF
--- a/scripts/com.agent-console.plist.template
+++ b/scripts/com.agent-console.plist.template
@@ -20,6 +20,8 @@
         <string>production</string>
         <key>PORT</key>
         <string>{{PORT}}</string>
+        <key>APP_URL</key>
+        <string>{{APP_URL}}</string>
         <key>PATH</key>
         <string>{{PATH}}</string>
     </dict>

--- a/scripts/update-and-deploy-for-mac.sh
+++ b/scripts/update-and-deploy-for-mac.sh
@@ -12,9 +12,11 @@ bun install
 echo "==> Installing plist..."
 COMMAND_PATH=$(which bun)
 PORT=${PORT:-6340}
+APP_URL=${APP_URL:-"http://localhost:$PORT"}
 sed -e "s|{{HOME}}|$HOME|g" \
     -e "s|{{COMMAND_PATH}}|$COMMAND_PATH|g" \
     -e "s|{{PORT}}|$PORT|g" \
+    -e "s|{{APP_URL}}|$APP_URL|g" \
     -e "s|{{PATH}}|$PATH|g" \
     "$SCRIPT_DIR/com.agent-console.plist.template" \
     > ~/Library/LaunchAgents/com.agent-console.plist


### PR DESCRIPTION
## Summary
- Add `APP_URL` environment variable to LaunchAgent plist template
- Default value is `http://localhost:$PORT` (e.g., `http://localhost:6340`)
- Can be customized via `APP_URL` environment variable when running deploy script

## Test plan
- [ ] Run `./scripts/update-and-deploy-for-mac.sh` and verify APP_URL is set in plist
- [ ] Verify default value works correctly with default PORT
- [ ] Test custom APP_URL override: `APP_URL="http://custom:8080" ./scripts/update-and-deploy-for-mac.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)