### PR TITLE
fix: update asking pattern to detect Claude Code Ask feature

### DIFF
--- a/packages/server/src/services/__tests__/activity-detector.test.ts
+++ b/packages/server/src/services/__tests__/activity-detector.test.ts
@@ -3,10 +3,10 @@ import { ActivityDetector } from '../activity-detector.js';
 import type { AgentActivityState, AgentActivityPatterns } from '@agent-console/shared';
 import { travel } from '../../test/time-travel.js';
 
-// Claude Code asking patterns (same as in agent-manager.ts)
+// Claude Code asking patterns (same as in claude-code.ts)
 const CLAUDE_CODE_PATTERNS: AgentActivityPatterns = {
   askingPatterns: [
-    'Enter to select.*Tab.*navigate.*Esc to cancel',
+    'Enter to select.*to navigate.*Esc to cancel',
     'Do you want to.*\\?',
     '\\[y\\].*\\[n\\]',
     '\\[a\\].*always',
@@ -90,6 +90,16 @@ describe('ActivityDetector', () => {
     it('should detect asking state from Enter/Tab/Esc menu pattern', () => {
       travel(new Date('2025-01-01T00:00:00Z'), (c) => {
         detector.processOutput('Enter to select, Tab to navigate, Esc to cancel');
+
+        c.tick(TEST_TIMEOUTS.debounceMs + 50);
+
+        expect(detector.getState()).toBe('asking');
+      });
+    });
+
+    it('should detect asking state from Enter/arrow/Esc menu pattern', () => {
+      travel(new Date('2025-01-01T00:00:00Z'), (c) => {
+        detector.processOutput('Enter to select · ↑/↓ to navigate · Esc to cancel');
 
         c.tick(TEST_TIMEOUTS.debounceMs + 50);
 

--- a/packages/server/src/services/agents/claude-code.ts
+++ b/packages/server/src/services/agents/claude-code.ts
@@ -13,7 +13,8 @@ export const CLAUDE_CODE_AGENT_ID = 'claude-code-builtin';
  */
 const ASKING_PATTERNS: string[] = [
   // Selection menu footer (most reliable - appears on all permission prompts)
-  'Enter to select.*Tab.*navigate.*Esc to cancel',
+  // Matches both "Enter to select · ↑/↓ to navigate" and "Enter to select, Tab to navigate"
+  'Enter to select.*to navigate.*Esc to cancel',
 
   // Permission prompts - Claude Code style
   'Do you want to.*\\?', // "Do you want to create/edit/run..." prompts

--- a/packages/shared/src/schemas/__tests__/agent.test.ts
+++ b/packages/shared/src/schemas/__tests__/agent.test.ts
@@ -118,7 +118,7 @@ describe('AgentActivityPatternsSchema', () => {
         'Do you want to.*\\?',
         '\\[y\\].*\\[n\\]',
         '^Please confirm:',
-        'Enter to select.*Tab.*navigate.*Esc to cancel',
+        'Enter to select.*to navigate.*Esc to cancel',
       ],
     });
     expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary
- Fixed the asking pattern detection for Claude Code's `AskUserQuestion` feature
- The previous pattern expected `Tab to navigate` but Claude Code actually displays `↑/↓ to navigate`
- Updated pattern to be more general: `Enter to select.*to navigate.*Esc to cancel`

## Test plan
- [x] All existing tests pass
- [x] Added new test case for arrow key navigation pattern
- [ ] Manual verification: Run Claude Code with Ask feature and confirm "asking" state is detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pattern recognition for detecting when Claude code is waiting for user input by making the detection more flexible to handle different navigation prompt variations.

* **Tests**
  * Updated test cases to validate the improved pattern matching behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->