### PR TITLE
feat: implement WebSocket & cache synchronization (Track B)

### DIFF
--- a/packages/client/src/hooks/useTerminalWebSocket.ts
+++ b/packages/client/src/hooks/useTerminalWebSocket.ts
@@ -9,6 +9,7 @@ interface UseTerminalWebSocketOptions {
   onExit: (exitCode: number, signal: string | null) => void;
   onConnectionChange: (connected: boolean) => void;
   onActivity?: (state: AgentActivityState) => void;
+  onOutputTruncated?: (message: string) => void;
 }
 
 export interface WorkerError {
@@ -29,7 +30,7 @@ export function useTerminalWebSocket(
   workerId: string,
   options: UseTerminalWebSocketOptions
 ): UseTerminalWebSocketReturn {
-  const { onOutput, onHistory, onExit, onConnectionChange, onActivity } = options;
+  const { onOutput, onHistory, onExit, onConnectionChange, onActivity, onOutputTruncated } = options;
 
   // Error state for worker activation failures
   const [error, setError] = useState<WorkerError | null>(null);
@@ -55,6 +56,7 @@ export function useTerminalWebSocket(
         onExit,
         onActivity,
         onError: handleError,
+        onOutputTruncated,
       });
     },
     disconnect: ({ sessionId, workerId }) => {
@@ -75,8 +77,9 @@ export function useTerminalWebSocket(
       onExit,
       onActivity,
       onError: handleError,
+      onOutputTruncated,
     });
-  }, [sessionId, workerId, onOutput, onHistory, onExit, onActivity, handleError]);
+  }, [sessionId, workerId, onOutput, onHistory, onExit, onActivity, handleError, onOutputTruncated]);
 
   // Notify connection changes
   useEffect(() => {

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -84,6 +84,7 @@ export const WORKER_SERVER_MESSAGE_TYPES = {
   'history': 3,
   'activity': 4,
   'error': 5,
+  'output-truncated': 6,
 } as const;
 
 export type WorkerServerMessageType = keyof typeof WORKER_SERVER_MESSAGE_TYPES;
@@ -96,14 +97,16 @@ export type WorkerErrorCode =
   | 'AGENT_NOT_FOUND'       // Agent definition deleted
   | 'ACTIVATION_FAILED'     // PTY spawn failed
   | 'WORKER_NOT_FOUND'      // Worker doesn't exist in session
-  | 'HISTORY_LOAD_FAILED';  // History retrieval failed (timeout or error)
+  | 'HISTORY_LOAD_FAILED'   // History retrieval failed (timeout or error)
+  | 'SESSION_DELETED';      // Session was deleted while WebSocket was connected
 
 export type WorkerServerMessage =
   | { type: 'output'; data: string; offset: number }
   | { type: 'exit'; exitCode: number; signal: string | null }
   | { type: 'history'; data: string; offset: number; timedOut?: boolean }
   | { type: 'activity'; state: AgentActivityState }  // Agent workers only
-  | { type: 'error'; message: string; code?: WorkerErrorCode };
+  | { type: 'error'; message: string; code?: WorkerErrorCode }
+  | { type: 'output-truncated'; message: string };
 
 export interface WorkerActivityInfo {
   sessionId: string;


### PR DESCRIPTION
## Summary

Implements Issue #206 Track B: WebSocket & Cache Synchronization

- **Session deletion notification**: Worker WebSocket connections now receive SESSION_DELETED error code when their session is deleted, enabling meaningful error display instead of generic disconnect
- **Worker restart cache invalidation**: Server broadcasts worker-restarted event, client clears IndexedDB cache and resets terminal state for fresh history
- **WebSocket reconnection event queuing**: Events are queued during client sync period and replayed after sync completes, preventing missed events
- **Output file truncation notification**: Server broadcasts output-truncated event when file is truncated, client resets offset tracking and shows warning banner after 5-second timeout

## Test plan

- [x] All 1,713 tests passing
- [x] TypeCheck passing
- [x] Code review completed (code-quality-reviewer, ux-architecture-reviewer, test-reviewer)
- [x] All CRITICAL/HIGH issues identified in review have been addressed

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal shows a dismissible warning banner when output is truncated (auto-dismisses after 10s).
  * Client API now supports a callback to receive output-truncation notifications.

* **Bug Fixes**
  * Improved terminal sync/recovery after truncation so history and display refresh reliably.
  * Clients are notified when sessions are deleted.
  * Broadcast queuing during client sync reduced dropped or out-of-order updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->