### PR TITLE
docs: add task assumption validation to Working Principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Ask when uncertain.** When uncertain about a design decision, do not decide arbitrarily. Ask the user for confirmation.
 
+**Validate task assumptions before implementing.** Before implementing any task, understand WHY the task is needed. If a task assumes existing behavior that seems questionable, verify whether that assumption is correct. Do not implement a "fix" for behavior that may not actually need fixing. When in doubt, ask the user to confirm the underlying assumption.
+
 ## Design Review Mindset
 
 The following are perspectives to revisit repeatedly during design. This is not a one-way checklist.


### PR DESCRIPTION
## Summary

Add guidance to CLAUDE.md Working Principles section to validate WHY a task is needed before implementing it.

## Background

During WebSocket cache sync implementation (PR #214), a task assumed that output files must be reset on worker restart. This led to implementing client-side cache invalidation logic (`worker-restarted` event) that was ultimately unnecessary because the underlying assumption was incorrect.

## Change

Added to Working Principles:

> **Validate task assumptions before implementing.** Before implementing any task, understand WHY the task is needed. If a task assumes existing behavior that seems questionable, verify whether that assumption is correct. Do not implement a "fix" for behavior that may not actually need fixing. When in doubt, ask the user to confirm the underlying assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines to include a new working principle: validate task assumptions before implementing. This ensures more thorough understanding of requirements and helps prevent misaligned implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->