### PR TITLE
fix: show correct connection status for non-agent workers

### DIFF
--- a/packages/client/src/components/sessions/__tests__/sessionStatus.test.ts
+++ b/packages/client/src/components/sessions/__tests__/sessionStatus.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'bun:test';
+import { getConnectionStatusColor, getConnectionStatusText } from '../sessionStatus';
+
+const exitInfo = { code: 1, signal: null };
+
+describe('Session status helpers', () => {
+  it('returns green/Connected for terminal when connected and activity unknown', () => {
+    expect(getConnectionStatusColor('connected', 'unknown', 'terminal')).toBe('bg-green-500');
+    expect(getConnectionStatusText('connected', 'unknown', null, 'terminal')).toBe('Connected');
+  });
+
+  it('keeps agent starting text when connected and activity unknown', () => {
+    expect(getConnectionStatusText('connected', 'unknown', null, 'agent')).toBe('Starting Claude...');
+  });
+
+  it('uses non-agent color rules for git-diff', () => {
+    expect(getConnectionStatusColor('connecting', 'unknown', 'git-diff')).toBe('bg-yellow-500');
+    expect(getConnectionStatusColor('disconnected', 'unknown', 'git-diff')).toBe('bg-gray-500');
+  });
+
+  it('renders exit details regardless of worker type', () => {
+    expect(getConnectionStatusText('exited', 'idle', exitInfo, 'terminal')).toBe('Exited (code: 1)');
+  });
+});

--- a/packages/client/src/components/sessions/sessionStatus.ts
+++ b/packages/client/src/components/sessions/sessionStatus.ts
@@ -1,0 +1,66 @@
+import type { ConnectionStatus } from '../Terminal';
+import type { AgentActivityState } from '@agent-console/shared';
+
+type WorkerType = 'agent' | 'terminal' | 'git-diff';
+
+function getNonAgentStatusColor(status: ConnectionStatus): string {
+  switch (status) {
+    case 'connected':
+      return 'bg-green-500';
+    case 'connecting':
+      return 'bg-yellow-500';
+    case 'exited':
+      return 'bg-red-500';
+    case 'disconnected':
+      return 'bg-gray-500';
+  }
+}
+
+export function getConnectionStatusColor(
+  status: ConnectionStatus,
+  activityState: AgentActivityState,
+  workerType: WorkerType
+): string {
+  if (workerType !== 'agent') {
+    return getNonAgentStatusColor(status);
+  }
+
+  // Connected with known activity state shows green (fully operational)
+  if (status === 'connected' && activityState !== 'unknown') {
+    return 'bg-green-500';
+  }
+
+  switch (status) {
+    case 'connected':
+    case 'connecting':
+      return 'bg-yellow-500';
+    case 'exited':
+      return 'bg-red-500';
+    case 'disconnected':
+      return 'bg-gray-500';
+  }
+}
+
+export function getConnectionStatusText(
+  status: ConnectionStatus,
+  activityState: AgentActivityState,
+  exitInfo: { code: number; signal: string | null } | null,
+  workerType: WorkerType
+): string {
+  switch (status) {
+    case 'connecting':
+      return 'Connecting...';
+    case 'connected':
+      if (workerType !== 'agent') {
+        return 'Connected';
+      }
+      return activityState === 'unknown' ? 'Starting Claude...' : 'Connected';
+    case 'disconnected':
+      return 'Disconnected';
+    case 'exited': {
+      const code = exitInfo?.code ?? 'unknown';
+      const signal = exitInfo?.signal ? `, signal: ${exitInfo.signal}` : '';
+      return `Exited (code: ${code}${signal})`;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Terminal/git-diff ワーカーで接続時に「Starting Claude...」と黄色インジケーターが表示されていた問題を修正
- 非エージェントワーカーでは「Connected」と緑インジケーターを正しく表示するように変更
- `getConnectionStatusColor`/`getConnectionStatusText` を `sessionStatus.ts` に分離し、`workerType` パラメータを追加

## Test plan
- [x] 型チェック通過
- [x] 全テスト通過（1,715 tests）
- [x] 開発サーバーで動作確認済み
  - エージェントワーカー: Idle + Connected（緑）✅
  - Terminal ワーカー: Connected（緑）✅

🤖 Generated with [Claude Code](https://claude.ai/code)