### PR TITLE
fix: set initial activity state to idle on PTY activation

### DIFF
--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -316,6 +316,12 @@ export class WorkerManager {
     worker.activityDetector = activityDetector;
     worker.agentId = agentId;
 
+    // Set initial activity state to match ActivityDetector's initial state ('idle').
+    // The onStateChange callback only fires on state *changes*, not on initialization,
+    // so we must explicitly set the initial state here.
+    worker.activityState = 'idle';
+    this.globalActivityCallback?.(sessionId, worker.id, 'idle');
+
     this.setupWorkerEventHandlers(worker, sessionId);
   }
 


### PR DESCRIPTION
## Summary

- Fix bug where agent workers didn't appear in ACTIVE SESSIONS sidebar after PTY activation
- Set initial activity state to 'idle' immediately after creating ActivityDetector
- Notify global callback so clients receive the initial state via WebSocket

## Problem

`worker.activityState` remained `'unknown'` after PTY activation because `ActivityDetector.onStateChange` only fires on state **changes**, not on initialization. This caused:

1. Agent workers to not appear in ACTIVE SESSIONS sidebar
2. Status indicator showing "Starting Claude..." indefinitely (until new output occurred)

## Solution

Explicitly set `worker.activityState = 'idle'` and call `globalActivityCallback` after creating `ActivityDetector`, matching its initial state.

## Test plan

- [x] Existing tests updated to reflect correct behavior
- [x] New test added to verify global callback is called on PTY activation
- [x] All tests pass (`bun run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated activity state test expectations to reflect idle state initialization after PTY activation.
  * Added test coverage verifying global callback is properly invoked with idle state on PTY activation.

* **Bug Fixes**
  * Ensured worker activity state properly initializes to idle with immediate global callback notification to observers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->