### PR TITLE
fix: detect asking state for Bash command confirmation prompts

### DIFF
--- a/packages/server/src/services/agents/claude-code.ts
+++ b/packages/server/src/services/agents/claude-code.ts
@@ -16,6 +16,10 @@ const ASKING_PATTERNS: string[] = [
   // Matches both "Enter to select · ↑/↓ to navigate" and "Enter to select, Tab to navigate"
   'Enter to select.*to navigate.*Esc to cancel',
 
+  // Bash command confirmation footer (different format from general prompts)
+  // Matches "Esc to cancel · Tab to add additional instructions"
+  'Esc to cancel.*Tab to add',
+
   // Permission prompts - Claude Code style
   'Do you want to.*\\?', // "Do you want to create/edit/run..." prompts
   '\\[y\\].*\\[n\\]', // Yes/No selection


### PR DESCRIPTION
## Summary

- ActivityDetectorがBashコマンドの確認プロンプト（「Do you want to proceed?」）を検出できず、Waiting状態にならない問題を修正
- バッファへのANSI含む生データの追加、デバウンスタイマーのリセット問題、パターン不足の3つの原因を特定し対応

## Changes

1. **バッファにクリーンデータを保存**: ANSIエスケープシーケンスを除去したデータをバッファに追加するように変更。TUI更新でバッファが溢れてプロンプトテキストが押し出される問題を防止
2. **デバウンスタイマーのリセット条件を改善**: 実際のテキストコンテンツがある場合のみデバウンスタイマーをリセット。ANSIシーケンスのみの出力でanalyzeBuffer()がブロックされる問題を防止
3. **Bashコマンド確認フッターのパターンを追加**: 「Esc to cancel · Tab to add additional instructions」形式に対応するパターンを追加

## Test plan

- [x] 既存のActivityDetectorテストがすべてパス
- [x] 新しいパターンのテストケースを追加
- [x] バッファオーバーフロー防止のテストケースを追加
- [x] 手動テストでBashコマンド確認プロンプト時に「Waiting for input」が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Bash command confirmation prompts in interactive shell operations.
  * Enhanced buffer handling to prevent overflow when processing ANSI escape sequences.
  * Optimized debounce behavior to only trigger when actual text is present, improving responsiveness.
  * Added resilience testing for scenarios with numerous ANSI sequences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->