### PR TITLE
fix: use double --force for worktree removal to handle locked worktrees

### DIFF
--- a/packages/server/src/lib/__tests__/git.test.ts
+++ b/packages/server/src/lib/__tests__/git.test.ts
@@ -428,4 +428,46 @@ index abc1234..def5678 100644
       expect(spawnCalls[0].args).toEqual(['git', 'diff', '--numstat', 'abc123', 'def456']);
     });
   });
+
+  describe('removeWorktree', () => {
+    it('should call git worktree remove without --force by default', async () => {
+      setMockSpawnResult('');
+      const { removeWorktree } = await getGitModule();
+
+      await removeWorktree('/path/to/worktree', '/repo');
+
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args).toEqual(['git', 'worktree', 'remove', '/path/to/worktree']);
+      expect(spawnCalls[0].options.cwd).toBe('/repo');
+    });
+
+    it('should call git worktree remove without --force when force is false', async () => {
+      setMockSpawnResult('');
+      const { removeWorktree } = await getGitModule();
+
+      await removeWorktree('/path/to/worktree', '/repo', { force: false });
+
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args).toEqual(['git', 'worktree', 'remove', '/path/to/worktree']);
+    });
+
+    it('should call git worktree remove with --force twice when force is true', async () => {
+      setMockSpawnResult('');
+      const { removeWorktree } = await getGitModule();
+
+      await removeWorktree('/path/to/worktree', '/repo', { force: true });
+
+      expect(spawnCalls.length).toBe(1);
+      // --force twice removes both unclean worktrees AND locked worktrees
+      expect(spawnCalls[0].args).toEqual(['git', 'worktree', 'remove', '/path/to/worktree', '--force', '--force']);
+      expect(spawnCalls[0].options.cwd).toBe('/repo');
+    });
+
+    it('should throw GitError when removal fails', async () => {
+      setMockSpawnResult('', 128, "fatal: '/path/to/worktree' is not a working tree");
+      const { removeWorktree, GitError } = await getGitModule();
+
+      await expect(removeWorktree('/path/to/worktree', '/repo')).rejects.toBeInstanceOf(GitError);
+    });
+  });
 });

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -303,7 +303,8 @@ export async function removeWorktree(
   const args = ['worktree', 'remove', worktreePath];
 
   if (options?.force) {
-    args.push('--force');
+    // --force twice: removes unclean worktrees AND locked worktrees
+    args.push('--force', '--force');
   }
 
   await git(args, cwd);


### PR DESCRIPTION
## Summary

- Enhanced the `--force` option for worktree deletion to also handle locked worktrees
- Changed to pass `--force` twice to `git worktree remove` when `force=true`

## Background

Git worktree removal behavior:
- `--force` once: Can remove unclean worktrees (with uncommitted changes)
- `--force` twice: Can also remove locked worktrees

When users select "Force Delete" in the UI, they explicitly intend to delete regardless of any state. This change ensures deletion succeeds whether the worktree is locked or not.

## Test plan

- [x] Unit tests added for `removeWorktree` function (4 test cases)
- [ ] Verify Force Delete works on worktrees with uncommitted changes
- [ ] Verify Force Delete works on locked worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)