### PR TITLE
fix: move VS Code icon next to branch name

### DIFF
--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -798,26 +798,27 @@ function WorktreeRow({ worktree, session, repositoryId }: WorktreeRowProps) {
           {worktree.isMain && (
             <span className="text-xs text-gray-500">(primary)</span>
           )}
+          {hasVSCode() && (
+            <button
+              onClick={async (e) => {
+                e.stopPropagation();
+                try {
+                  await openInVSCode(worktree.path);
+                } catch (err) {
+                  console.error('Failed to open in VS Code:', err);
+                }
+              }}
+              className="p-1 text-gray-400 hover:text-white hover:bg-slate-700 rounded"
+              title="Open in VS Code"
+            >
+              <VSCodeIcon className="w-4 h-4" />
+            </button>
+          )}
           {session && <ActivityBadge state={session.activityState} />}
         </div>
         <PathLink path={worktree.path} className="text-xs text-gray-500 truncate" />
       </div>
       <div className="flex gap-2 shrink-0">
-        {hasVSCode() && (
-          <button
-            onClick={async () => {
-              try {
-                await openInVSCode(worktree.path);
-              } catch (err) {
-                console.error('Failed to open in VS Code:', err);
-              }
-            }}
-            className="p-1.5 text-gray-400 hover:text-white hover:bg-slate-700 rounded"
-            title="Open in VS Code"
-          >
-            <VSCodeIcon className="w-4 h-4" />
-          </button>
-        )}
         {session ? (
           <Link
             to="/sessions/$sessionId"


### PR DESCRIPTION
## Summary
- Repositioned VS Code icon from right-side button group to immediately after the branch name in worktree rows
- Better visual association between the branch and the action to open it in VS Code

## Test plan
- [x] Verified typecheck passes
- [ ] Visual inspection: VS Code icon now appears right after branch name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned the Open in VS Code button to appear alongside branch/session labels in each row for improved UI layout and accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->