### PR TITLE
fix: use connection state for base commit in git-diff handler

### DIFF
--- a/packages/server/src/websocket/routes.ts
+++ b/packages/server/src/websocket/routes.ts
@@ -446,8 +446,6 @@ export async function setupWebSocketRoutes(
       const sessionId = c.req.param('sessionId');
       const workerId = c.req.param('workerId');
 
-      // Track current baseCommit for git-diff workers (can be updated via set-base-commit message)
-      let currentGitDiffBaseCommit: string | null = null;
       // Track connection ID for this WebSocket (used to detach callbacks on close)
       let connectionId: string | null = null;
 
@@ -614,13 +612,12 @@ export async function setupWebSocketRoutes(
 
           // Handle git-diff workers differently
           if (worker.type === 'git-diff') {
-            currentGitDiffBaseCommit = (worker as GitDiffWorker).baseCommit;
             handleGitDiffConnection(
               ws,
               sessionId,
               workerId,
               session.locationPath,
-              currentGitDiffBaseCommit
+              (worker as GitDiffWorker).baseCommit
             ).catch((err) => {
               logger.error({ sessionId, workerId, err }, 'Error handling git-diff connection');
               // Send error to client and close WebSocket on critical connection errors
@@ -669,7 +666,6 @@ export async function setupWebSocketRoutes(
               sessionId,
               workerId,
               session.locationPath,
-              currentGitDiffBaseCommit || (worker as GitDiffWorker).baseCommit,
               data
             ).catch((err) => {
               logger.error({ sessionId, workerId, err }, 'Error handling git-diff message');


### PR DESCRIPTION
## Summary
- Fix bug where `refresh` or file changes after `set-base-commit` would revert to the stale base commit
- Remove `currentBaseCommit` parameter from `handleMessage`, using internal connection state (`activeConnections`) as single source of truth
- Remove redundant `currentGitDiffBaseCommit` variable from `routes.ts`

## Test plan
- [x] Test that `refresh` after `set-base-commit` uses updated base commit
- [x] Test that `set-target-commit` after `set-base-commit` uses updated base commit
- [x] Test error handling when message is sent without active connection
- [x] All 13 tests pass
- [x] typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added defensive validation to properly detect and report errors when messages are received without an active WebSocket connection, preventing silent failures.

* **Chores**
  * Optimized internal state management by streamlining parameter passing and eliminating redundant checks.
  * Expanded test coverage to validate edge cases and verify correct state handling across multiple operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->