### PR TITLE
fix: detect asking state for numbered selection menu permission prompts

### DIFF
--- a/packages/server/src/services/__tests__/activity-detector.test.ts
+++ b/packages/server/src/services/__tests__/activity-detector.test.ts
@@ -14,6 +14,7 @@ const CLAUDE_CODE_PATTERNS: AgentActivityPatterns = {
     'Allow.*\\?',
     '\\[A\\].*\\[B\\]',
     '\\[1\\].*\\[2\\]',
+    '❯\\s+\\d+\\.\\s',
     '╰─+╯\\s*>\\s*$',
   ],
 };
@@ -161,6 +162,16 @@ describe('ActivityDetector', () => {
     it('should detect asking state from numbered selection pattern', () => {
       travel(new Date('2025-01-01T00:00:00Z'), (c) => {
         detector.processOutput('[1] First choice  [2] Second choice');
+
+        c.tick(TEST_TIMEOUTS.debounceMs + 50);
+
+        expect(detector.getState()).toBe('asking');
+      });
+    });
+
+    it('should detect asking state from numbered selection menu with cursor', () => {
+      travel(new Date('2025-01-01T00:00:00Z'), (c) => {
+        detector.processOutput('❯ 1. Yes\n  2. Yes, and don\'t ask again for www.npmjs.com\n  3. No, and tell Claude what to do differently (esc)');
 
         c.tick(TEST_TIMEOUTS.debounceMs + 50);
 

--- a/packages/server/src/services/agents/claude-code.ts
+++ b/packages/server/src/services/agents/claude-code.ts
@@ -30,6 +30,9 @@ const ASKING_PATTERNS: string[] = [
   '\\[A\\].*\\[B\\]', // A/B selection
   '\\[1\\].*\\[2\\]', // Numbered selection
 
+  // Numbered selection menu with cursor indicator (permission prompts)
+  '❯\\s+\\d+\\.\\s', // "❯ 1. Yes" style selection menu
+
   // Selection box with prompt
   '╰─+╯\\s*>\\s*$', // Box bottom + prompt
 ];


### PR DESCRIPTION
## Summary
- Claude Codeのパーミッションプロンプト（Fetch確認等）で `❯ 1. Yes` 形式の番号付き選択メニューが表示された際、対応するASKINGパターンがなく `idle` 状態になっていた問題を修正
- `❯\s+\d+\.\s` パターンを追加し、選択メニュー表示時に `asking` 状態へ正しく遷移するように

## Test plan
- [x] 新規テストケースで選択メニュー出力時の `asking` 状態遷移を検証
- [x] 既存テスト全件パス確認
- [x] 型チェックパス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of numbered selection menus to better recognize interactive input states during code sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->