### PR TITLE
fix: reset connection and activity state on session/tab switch

### DIFF
--- a/packages/client/src/components/sessions/SessionPage.tsx
+++ b/packages/client/src/components/sessions/SessionPage.tsx
@@ -185,6 +185,10 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
     setTabs([]);
     setActiveTabId(null);
     pendingWorkerIdRef.current = null;
+    setConnectionStatus('connecting');
+    setActivityState('unknown');
+    setExitInfo(undefined);
+    setWorkerActivityStates({});
   }, [sessionId]);
 
   // Initialize tabs when state becomes active
@@ -460,7 +464,11 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
   const handleTabClick = (tabId: string) => {
     // Use startTransition to mark this update as non-urgent
     // This keeps the UI responsive during the state update
+    // Status resets are inside startTransition to render atomically with tab switch
     startTransition(() => {
+      const knownState = workerActivityStates[tabId];
+      setActivityState(knownState ?? 'unknown');
+      setExitInfo(undefined);
       setActiveTabId(tabId);
       navigateToWorker(tabId);
     });


### PR DESCRIPTION
## Summary

- SessionPage did not reset `connectionStatus`, `activityState`, `exitInfo`, or `workerActivityStates` when navigating to a different session, causing stale status (e.g. "Starting Claude...") to persist from the previous session
- On tab switch within a session, activity state is now initialized from known `workerActivityStates` and status resets are inside `startTransition` to render atomically with the tab change

## Related Issues

- Closes #244 (architectural duplication of `workerActivityStates` — filed as a separate improvement)

## Test plan

- [ ] Switch between two active sessions — status bar should reset to "Connecting..." then update correctly
- [ ] Switch tabs within a session — status bar should immediately reflect the target tab's known activity state
- [ ] Verify no flash of stale status from previous session/tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)