### PR TITLE
fix: show End Session instead of Delete Worktree for primary worktree sessions

### DIFF
--- a/packages/client/src/components/SessionSettings.tsx
+++ b/packages/client/src/components/SessionSettings.tsx
@@ -4,6 +4,7 @@ import {
   EditSessionDialog,
   RestartSessionDialog,
   DeleteWorktreeDialog,
+  EndSessionDialog,
   InitialPromptDialog,
   type MenuAction,
 } from './sessions';
@@ -15,6 +16,7 @@ interface SessionSettingsProps {
   currentTitle?: string;
   initialPrompt?: string;
   worktreePath: string;
+  isMainWorktree: boolean;
   onBranchChange: (newBranch: string) => void;
   onTitleChange?: (newTitle: string) => void;
   onSessionRestart?: () => void;
@@ -29,6 +31,7 @@ export function SessionSettings({
   currentTitle,
   initialPrompt,
   worktreePath,
+  isMainWorktree,
   onBranchChange,
   onTitleChange,
   onSessionRestart,
@@ -49,6 +52,7 @@ export function SessionSettings({
         sessionId={sessionId}
         worktreePath={worktreePath}
         initialPrompt={initialPrompt}
+        isMainWorktree={isMainWorktree}
         onMenuAction={handleMenuAction}
       />
 
@@ -75,6 +79,13 @@ export function SessionSettings({
         onOpenChange={(open) => !open && closeDialog()}
         repositoryId={repositoryId}
         worktreePath={worktreePath}
+        sessionId={sessionId}
+        sessionTitle={currentTitle}
+      />
+
+      <EndSessionDialog
+        open={activeDialog === 'end-session'}
+        onOpenChange={(open) => !open && closeDialog()}
         sessionId={sessionId}
         sessionTitle={currentTitle}
       />

--- a/packages/client/src/components/__tests__/SessionSettings.test.tsx
+++ b/packages/client/src/components/__tests__/SessionSettings.test.tsx
@@ -109,6 +109,7 @@ describe('SessionSettings', () => {
     repositoryId: 'test-repo-id',
     currentBranch: 'test-branch',
     worktreePath: '/path/to/worktree',
+    isMainWorktree: false,
     onBranchChange: mock(() => {}),
     onSessionRestart: mock(() => {}),
   };

--- a/packages/client/src/components/sessions/SessionPage.tsx
+++ b/packages/client/src/components/sessions/SessionPage.tsx
@@ -595,6 +595,7 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
               currentTitle={sessionTitle}
               initialPrompt={session.initialPrompt}
               worktreePath={session.locationPath}
+              isMainWorktree={session.isMainWorktree}
               onBranchChange={setBranchName}
               onTitleChange={setSessionTitle}
               onSessionRestart={() => {

--- a/packages/client/src/components/sessions/SessionSettingsMenu.tsx
+++ b/packages/client/src/components/sessions/SessionSettingsMenu.tsx
@@ -7,6 +7,7 @@ import {
   FolderIcon,
   CopyIcon,
   TrashIcon,
+  StopIcon,
   DocumentIcon,
   ExternalLinkIcon,
   VSCodeIcon,
@@ -15,12 +16,13 @@ import { Spinner } from '../ui/Spinner';
 import { openPath, openInVSCode, fetchSessionPrLink } from '../../lib/api';
 import { hasVSCode } from '../../lib/capabilities';
 
-export type MenuAction = 'edit' | 'restart' | 'delete-worktree' | 'view-initial-prompt';
+export type MenuAction = 'edit' | 'restart' | 'delete-worktree' | 'end-session' | 'view-initial-prompt';
 
 export interface SessionSettingsMenuProps {
   sessionId: string;
   worktreePath: string;
   initialPrompt?: string;
+  isMainWorktree: boolean;
   onMenuAction: (action: MenuAction) => void;
 }
 
@@ -28,6 +30,7 @@ export function SessionSettingsMenu({
   sessionId,
   worktreePath,
   initialPrompt,
+  isMainWorktree,
   onMenuAction,
 }: SessionSettingsMenuProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -182,13 +185,23 @@ export function SessionSettingsMenu({
               {copySuccess ? 'Copied!' : 'Copy Path'}
             </button>
             <div className="border-t border-slate-700 my-1" />
-            <button
-              onClick={() => handleMenuAction('delete-worktree')}
-              className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2"
-            >
-              <TrashIcon />
-              Delete Worktree
-            </button>
+            {isMainWorktree ? (
+              <button
+                onClick={() => handleMenuAction('end-session')}
+                className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2"
+              >
+                <StopIcon />
+                End Session
+              </button>
+            ) : (
+              <button
+                onClick={() => handleMenuAction('delete-worktree')}
+                className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2"
+              >
+                <TrashIcon />
+                Delete Worktree
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
+++ b/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
@@ -19,6 +19,7 @@ function createMockWorktreeSession(
     repositoryId: 'repo-1',
     repositoryName: 'my-repo',
     worktreeId: 'wt-1',
+    isMainWorktree: false,
     locationPath: '/path/to/worktree',
     title: 'test-branch',
     status: 'active' as const,

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -33,7 +33,7 @@ import { parseEnvVars } from '../lib/env-parser.js';
  * Injected by index.ts after both SessionManager and RepositoryManager are initialized.
  */
 export interface SessionRepositoryCallbacks {
-  getRepository: (repositoryId: string) => { name: string; envVars?: string | null } | undefined;
+  getRepository: (repositoryId: string) => { name: string; path: string; envVars?: string | null } | undefined;
   isInitialized: () => boolean;
 }
 import { getConfigDir, getServerPid } from '../lib/config.js';
@@ -1380,6 +1380,7 @@ export class SessionManager {
         repositoryId: session.repositoryId,
         repositoryName: repository?.name ?? 'Unknown',
         worktreeId: session.worktreeId,
+        isMainWorktree: repository?.path === session.locationPath,
       } as WorktreeSession;
     }
 

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -62,6 +62,7 @@ export interface WorktreeSession extends SessionBase {
   repositoryId: string;
   repositoryName: string;    // Human-readable repository name
   worktreeId: string;        // Worktree identifier (branch name)
+  isMainWorktree: boolean;   // Whether this session is on the main (non-added) worktree
 }
 
 export interface QuickSession extends SessionBase {


### PR DESCRIPTION
## Summary
- Primary (main) worktree sessions now show "End Session" instead of "Delete Worktree" in the settings menu
- `isMainWorktree` field added to `WorktreeSession` type, dynamically computed by comparing session path with repository path
- End Session stops all workers and removes the session without touching the directory

## Background
When a session was opened on the main repository directory (not an added worktree), the only close option was "Delete Worktree" which attempted `git worktree remove` — git rejects this for the main worktree, resulting in an error with no way to close the session.

## Test plan
- [ ] Verify typecheck and tests pass (`bun run test`)
- [ ] Open a session on a primary (main) worktree and confirm "End Session" appears instead of "Delete Worktree"
- [ ] Open a session on an added worktree and confirm "Delete Worktree" still appears
- [ ] Confirm "End Session" on primary worktree successfully closes the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now distinguish between main and secondary worktrees with context-specific actions in session settings menus.
  * Main worktree sessions now display an "End Session" action instead of "Delete Worktree".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->