### PR TITLE
docs: sync README with current implementation

### DIFF
--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -83,11 +83,11 @@ function generateRandomSuffix(length: number): string {
 
 /**
  * Find templates directory for a repository
- * Priority: 1. .git-wt/ in repo root  2. $AGENT_CONSOLE_HOME/repositories/<owner>/<repo>/templates/
+ * Priority: 1. .agent-console/ in repo root  2. $AGENT_CONSOLE_HOME/repositories/<owner>/<repo>/templates/
  */
 function findTemplatesDir(repoPath: string, orgRepo: string): string | null {
   // Check repo-local templates
-  const localTemplates = path.join(repoPath, '.git-wt');
+  const localTemplates = path.join(repoPath, '.agent-console');
   if (fs.existsSync(localTemplates) && fs.statSync(localTemplates).isDirectory()) {
     return localTemplates;
   }


### PR DESCRIPTION
## Summary
- Update architecture diagram to reflect Session/Worker model
- Add Key Concepts section (Session, Worker) and new features (Multiple Workers, Inter-worker Messaging)
- Fix Bun version requirement (`>= 1.3.0` → `>= 1.3.5`)
- Rename repo-local templates directory from `.git-wt/` to `.agent-console/` (implementation + docs)
- Add tests for template file copying during worktree creation

## Test plan
- [x] All 1,898 tests pass (`bun run test`)
- [x] Type check passes (`bun run typecheck`)
- [ ] Verify `.agent-console/` templates directory works in manual worktree creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple workers per session
  * Introduced inter-worker messaging capability

* **Documentation**
  * Updated architecture diagram and documentation with improved clarity on SessionManager and worker interactions
  * Added Key Concepts section explaining core architectural components

* **Chores**
  * Updated Bun requirement to >= 1.3.5
  * Updated template configuration directory structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->