### PR TITLE
feat: add Stop Session option to preserve worktrees while freeing memory

### DIFF
--- a/packages/client/src/components/QuickSessionSettings.tsx
+++ b/packages/client/src/components/QuickSessionSettings.tsx
@@ -49,7 +49,7 @@ export function QuickSessionSettings({
       />
 
       <EndSessionDialog
-        open={activeDialog === 'end-session'}
+        open={activeDialog === 'stop-session'}
         onOpenChange={(open) => !open && closeDialog()}
         sessionId={sessionId}
         sessionTitle={sessionTitle}

--- a/packages/client/src/components/SessionSettings.tsx
+++ b/packages/client/src/components/SessionSettings.tsx
@@ -84,7 +84,7 @@ export function SessionSettings({
       />
 
       <EndSessionDialog
-        open={activeDialog === 'end-session'}
+        open={activeDialog === 'stop-session'}
         onOpenChange={(open) => !open && closeDialog()}
         sessionId={sessionId}
         sessionTitle={currentTitle}

--- a/packages/client/src/components/sessions/EndSessionDialog.tsx
+++ b/packages/client/src/components/sessions/EndSessionDialog.tsx
@@ -55,7 +55,7 @@ export function EndSessionDialog({
       // (no optimistic update to avoid race condition/flicker)
     },
     onError: (err) => {
-      setError(err instanceof Error ? err.message : 'Failed to end session');
+      setError(err instanceof Error ? err.message : 'Failed to stop session');
     },
   });
 
@@ -75,11 +75,11 @@ export function EndSessionDialog({
     <AlertDialog open={open} onOpenChange={handleClose}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle className="text-red-400">End Session</AlertDialogTitle>
+          <AlertDialogTitle className="text-red-400">Stop Session</AlertDialogTitle>
           <AlertDialogDescription asChild>
             <div className="space-y-2">
               <p>
-                Are you sure you want to end{' '}
+                Are you sure you want to stop{' '}
                 <span className="font-medium text-gray-300">
                   {sessionTitle || 'this session'}
                 </span>
@@ -110,8 +110,8 @@ export function EndSessionDialog({
             className="btn btn-danger"
             disabled={deleteMutation.isPending}
           >
-            <ButtonSpinner isPending={deleteMutation.isPending} pendingText="Ending...">
-              End Session
+            <ButtonSpinner isPending={deleteMutation.isPending} pendingText="Stopping...">
+              Stop Session
             </ButtonSpinner>
           </button>
         </AlertDialogFooter>

--- a/packages/client/src/components/sessions/QuickSessionSettingsMenu.tsx
+++ b/packages/client/src/components/sessions/QuickSessionSettingsMenu.tsx
@@ -5,7 +5,7 @@ import {
   StopIcon,
 } from '../Icons';
 
-export type QuickMenuAction = 'view-initial-prompt' | 'end-session';
+export type QuickMenuAction = 'view-initial-prompt' | 'stop-session';
 
 export interface QuickSessionSettingsMenuProps {
   initialPrompt?: string;
@@ -80,11 +80,11 @@ export function QuickSessionSettingsMenu({
               <div className="border-t border-slate-700 my-1" />
             )}
             <button
-              onClick={() => handleMenuAction('end-session')}
+              onClick={() => handleMenuAction('stop-session')}
               className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2"
             >
               <StopIcon />
-              End Session
+              Stop Session
             </button>
           </div>
         </div>

--- a/packages/client/src/components/sessions/SessionSettingsMenu.tsx
+++ b/packages/client/src/components/sessions/SessionSettingsMenu.tsx
@@ -16,7 +16,7 @@ import { Spinner } from '../ui/Spinner';
 import { openPath, openInVSCode, fetchSessionPrLink } from '../../lib/api';
 import { hasVSCode } from '../../lib/capabilities';
 
-export type MenuAction = 'edit' | 'restart' | 'delete-worktree' | 'end-session' | 'view-initial-prompt';
+export type MenuAction = 'edit' | 'restart' | 'delete-worktree' | 'stop-session' | 'view-initial-prompt';
 
 export interface SessionSettingsMenuProps {
   sessionId: string;
@@ -185,15 +185,14 @@ export function SessionSettingsMenu({
               {copySuccess ? 'Copied!' : 'Copy Path'}
             </button>
             <div className="border-t border-slate-700 my-1" />
-            {isMainWorktree ? (
-              <button
-                onClick={() => handleMenuAction('end-session')}
-                className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2"
-              >
-                <StopIcon />
-                End Session
-              </button>
-            ) : (
+            <button
+              onClick={() => handleMenuAction('stop-session')}
+              className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2"
+            >
+              <StopIcon />
+              Stop Session
+            </button>
+            {!isMainWorktree && (
               <button
                 onClick={() => handleMenuAction('delete-worktree')}
                 className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2"


### PR DESCRIPTION
## Summary

- Add ability to stop sessions while preserving worktrees
- Rename "End Session" to "Stop Session" for consistency with Start/Stop terminology
- Show both "Stop Session" and "Delete Worktree" options for added worktree sessions

## Motivation

Previously, added worktrees only had the "Delete Worktree" option, with no way to stop just the session. Stopping a session terminates agent processes (like Claude Code) to free memory, while keeping the worktree on the filesystem. Users can later create a new session for the same worktree.

## Changes

| Session Type | Before | After |
|--------------|--------|-------|
| Main Worktree | "End Session" | "Stop Session" |
| Added Worktree | "Delete Worktree" only | "Stop Session" + "Delete Worktree" |
| Quick Session | "End Session" | "Stop Session" |

## Test plan

- [x] `bun run typecheck` passed
- [x] `bun run test` passed (1900 tests)
- [ ] Manual testing: Main worktree shows "Stop Session" only
- [ ] Manual testing: Added worktree shows both options
- [ ] Manual testing: Quick session shows "Stop Session"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated session termination terminology from "End Session" to "Stop Session" in dialogs, buttons, confirmation prompts, and error messages for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->