### PR TITLE
docs: add keyof-first pattern guideline for enum-like definitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,26 @@ Monorepo with Bun workspaces:
 - Define shared types in `packages/shared`.
 - Always use `async/await`. Avoid fire-and-forget patterns (calling async functions without awaiting). See frontend-standards and backend-standards for detailed rules.
 
+## TypeScript Idioms
+
+### Enum-like definitions with labels
+
+When defining a set of related constants that need display labels (for UI, logs, etc.), define the labeled object first and derive the type from it:
+
+```typescript
+// ✅ Good: Object is Single Source of Truth
+const STATUS_LABELS = {
+  'pending': 'Pending',
+  'active': 'Active',
+  'completed': 'Completed',
+} as const;
+type Status = keyof typeof STATUS_LABELS;
+
+// ❌ Avoid: Type and labels defined separately (can drift)
+type Status = 'pending' | 'active' | 'completed';
+const STATUS_LABELS: Record<Status, string> = { ... };
+```
+
 ## Schema Validation (Valibot)
 
 **Always add `minLength(1)` before regex validation.** When an empty string reaches a regex, it fails with a confusing error message (e.g., "Invalid branch name" instead of "Branch name is required"). Users cannot understand what to fix.


### PR DESCRIPTION
## Summary

- Add "TypeScript Idioms" section to CLAUDE.md
- Include the keyof-first pattern guideline with examples for defining enum-like constants with labels

## Background

When Claude defines a set of related constants that need display labels, the initial instinct is often to define the type first, then add labels separately. This can lead to:
- Drift between type and labels
- Forgetting to add labels when adding new values
- Less DRY code

The keyof-first pattern makes the labeled object the single source of truth, ensuring type safety and consistency.

## Test plan

- [x] Documentation change only - no code affected

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "TypeScript Idioms" section to developer guidance covering best practices for type definition patterns and deriving types from labeled objects.
  * Expanded TypeScript validation documentation with examples demonstrating improved error handling and validation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->