### PR TITLE
docs: add .env configuration for multiple development instances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Development Server Configuration
+# Copy this file to .env and customize for your environment.
+#
+# These settings are useful when running multiple development instances
+# (e.g., in different git worktrees) to avoid port and data conflicts.
+#
+# Bun automatically loads .env files - no additional setup required.
+
+# Server ports
+# Default: PORT=3457, CLIENT_PORT=5173
+# PORT=3458
+# CLIENT_PORT=5174
+
+# Data directory (database, worker outputs, etc.)
+# Default: ~/.agent-console (production) or ~/.agent-console-dev (via scripts/dev.sh)
+# Example for worktree wt-001: ~/.agent-console-dev-001
+# AGENT_CONSOLE_HOME=~/.agent-console-dev-001

--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ The development server runs at:
 - Frontend: http://localhost:5173
 - Backend: http://localhost:3457
 
+### Environment Configuration
+
+When running multiple development instances (e.g., in different git worktrees), you can use a `.env` file to avoid port and data conflicts.
+
+```bash
+# Copy the example file
+cp .env.example .env
+
+# Edit .env with your settings
+```
+
+Available variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3457` | Backend server port |
+| `CLIENT_PORT` | `5173` | Frontend dev server port |
+| `AGENT_CONSOLE_HOME` | `~/.agent-console-dev` | Data directory (DB, outputs) |
+
+Bun automatically loads `.env` files - no additional packages required.
+
 ### Build
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `.env.example` file with configuration template for development servers
- Document environment configuration in README to help developers run multiple instances in parallel

This allows developers to run multiple development servers (e.g., in different git worktrees) without port or database conflicts by customizing `PORT`, `CLIENT_PORT`, and `AGENT_CONSOLE_HOME` via `.env` file.

## Test plan
- [ ] Verify `.env.example` is created with correct content
- [ ] Verify README includes Environment Configuration section
- [ ] Verify Bun loads `.env` file automatically when running `bun dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced environment configuration template file with guidance for development server setup, including configurable port settings and optional data directory variables for customization.
  * Enhanced README with dedicated environment configuration section containing setup instructions, variable definitions, and reference information needed for development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->