### PR TITLE
feat: display port configuration on dev server startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,18 @@ bun run typecheck  # Type check all packages
 bun run lint       # Lint all packages
 ```
 
+**Before starting `bun run dev`:** Check `.env` for port configuration. Each worktree may use different ports to avoid conflicts:
+
+```bash
+cat .env  # Check PORT and CLIENT_PORT values
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | 3457 | Backend server port |
+| `CLIENT_PORT` | 5173 | Frontend dev server port |
+| `AGENT_CONSOLE_HOME` | ~/.agent-console-dev | Data directory |
+
 ## Claude Code on the Web (Remote Environment)
 
 When running in Claude Code on the Web, `gh` CLI is automatically installed via a SessionStart hook (`.claude/hooks/gh-setup.sh`). The following setup is required in the Claude Code Web custom environment:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,8 +1,27 @@
 #!/bin/bash
-export AGENT_CONSOLE_HOME=$HOME/.agent-console-dev
+
+# Load .env file if exists (for direct script execution)
+if [ -f .env ]; then
+  set -a
+  source .env
+  set +a
+fi
+
+export AGENT_CONSOLE_HOME=${AGENT_CONSOLE_HOME:-$HOME/.agent-console-dev}
 export CLIENT_PORT=${CLIENT_PORT:-5173}
 export PORT=${PORT:-3457}
 export APP_URL=${APP_URL:-http://localhost:$CLIENT_PORT}
+
+echo ""
+echo "========================================"
+echo "  Development Server Starting"
+echo "----------------------------------------"
+echo "  Frontend: http://localhost:$CLIENT_PORT"
+echo "  Backend:  http://localhost:$PORT"
+echo "  Data:     $AGENT_CONSOLE_HOME"
+echo "========================================"
+echo ""
+
 exec concurrently -n client,server -c cyan,yellow \
   "cd packages/client && bun run dev --port $CLIENT_PORT" \
   "cd packages/server && bun run dev"


### PR DESCRIPTION
## Summary

- Add `.env` loading to `dev.sh` for direct script execution
- Display startup banner with Frontend/Backend URLs and data directory
- Add CLAUDE.md guidance to check `.env` before starting dev server

This helps AI agents know which ports to use when starting development servers in different worktrees.

## Example output

```
========================================
  Development Server Starting
----------------------------------------
  Frontend: http://localhost:6104
  Backend:  http://localhost:3504
  Data:     /Users/ms2sato/.agent-console-dev-4
========================================
```

## Test plan

- [ ] Run `bun run dev` and verify banner displays correct port values from `.env`
- [ ] Run `./scripts/dev.sh` directly and verify `.env` is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive documentation on port configuration and environment variables.

* **New Features**
  * Added startup banner displaying frontend/backend URLs and data directory information.
  * Added support for loading environment configuration from .env files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->