### PR TITLE
fix: navigate within same tab when creating QuickStart session

### DIFF
--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -130,6 +130,7 @@ function getSessionActivityState(session: Session, workerActivityStates: Record<
 
 function DashboardPage() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const [showAddRepo, setShowAddRepo] = useState(false);
   const [showAddSession, setShowAddSession] = useState(false);
   // Repository to unregister (for confirmation dialog)
@@ -521,7 +522,7 @@ function DashboardPage() {
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['sessions'] });
       setShowAddSession(false);
-      window.open(`/sessions/${data.session.id}`, '_blank', 'noopener,noreferrer');
+      navigate({ to: `/sessions/${data.session.id}` });
     },
   });
 


### PR DESCRIPTION
## Summary
- QuickStart でセッション作成後、新しいタブを開く代わりに同じタブ内でナビゲーションするように変更

## Changes
- `window.open()` を TanStack Router の `navigate()` に変更

## Test plan
- [ ] QuickStart でセッションを作成し、同じタブ内で遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated navigation behavior when creating a new session to remain within the app instead of opening in a new window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->