### PR TITLE
feat: add Ubuntu systemd support with UID-based port assignment

### DIFF
--- a/scripts/agent-console.service.template
+++ b/scripts/agent-console.service.template
@@ -1,0 +1,21 @@
+[Unit]
+Description=Agent Console Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={{COMMAND_PATH}} {{HOME}}/.agent-console/server/index.js
+WorkingDirectory={{HOME}}/.agent-console/server
+Restart=always
+RestartSec=5
+
+Environment=NODE_ENV=production
+Environment=PORT={{PORT}}
+Environment=APP_URL={{APP_URL}}
+Environment=PATH={{PATH}}
+
+StandardOutput=append:{{HOME}}/.local/share/agent-console/logs/agent-console.log
+StandardError=append:{{HOME}}/.local/share/agent-console/logs/agent-console.error.log
+
+[Install]
+WantedBy=default.target

--- a/scripts/update-and-deploy-for-mac.sh
+++ b/scripts/update-and-deploy-for-mac.sh
@@ -11,8 +11,14 @@ bun install
 
 echo "==> Installing plist..."
 COMMAND_PATH=$(which bun)
-PORT=${PORT:-6340}
+DEFAULT_PORT=$((6000 + $(id -u) % 1000))
+PORT=${PORT:-$DEFAULT_PORT}
 APP_URL=${APP_URL:-"http://localhost:$PORT"}
+
+echo ""
+echo "  Port: $PORT"
+echo "  URL:  $APP_URL"
+echo ""
 sed -e "s|{{HOME}}|$HOME|g" \
     -e "s|{{COMMAND_PATH}}|$COMMAND_PATH|g" \
     -e "s|{{PORT}}|$PORT|g" \

--- a/scripts/update-and-deploy-for-ubuntu.sh
+++ b/scripts/update-and-deploy-for-ubuntu.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+echo "==> Installing dependencies..."
+bun install
+
+echo "==> Installing systemd user service..."
+COMMAND_PATH=$(which bun)
+DEFAULT_PORT=$((6000 + $(id -u) % 1000))
+PORT=${PORT:-$DEFAULT_PORT}
+APP_URL=${APP_URL:-"http://localhost:$PORT"}
+
+echo ""
+echo "  Port: $PORT"
+echo "  URL:  $APP_URL"
+echo ""
+
+# Create systemd user directory if not exists
+mkdir -p ~/.config/systemd/user
+
+sed -e "s|{{HOME}}|$HOME|g" \
+    -e "s|{{COMMAND_PATH}}|$COMMAND_PATH|g" \
+    -e "s|{{PORT}}|$PORT|g" \
+    -e "s|{{APP_URL}}|$APP_URL|g" \
+    -e "s|{{PATH}}|$PATH|g" \
+    "$SCRIPT_DIR/agent-console.service.template" \
+    > ~/.config/systemd/user/agent-console.service
+
+echo "==> Cleaning up old logs..."
+rm -rf ~/.local/share/agent-console/logs
+mkdir -p ~/.local/share/agent-console/logs
+
+echo "==> Building..."
+NODE_ENV=production bun run build
+
+echo "==> Deploying files..."
+mkdir -p ~/.agent-console/server
+rsync -av --delete --exclude node_modules dist/ ~/.agent-console/server/
+cd ~/.agent-console/server
+bun install --production
+
+echo "==> Reloading systemd and restarting service..."
+systemctl --user daemon-reload
+systemctl --user restart agent-console.service
+systemctl --user enable agent-console.service
+
+echo "==> Waiting for service to start..."
+sleep 2
+
+echo "==> Service status:"
+systemctl --user status agent-console.service --no-pager || true
+
+echo ""
+echo "==> Done!"
+echo ""
+echo "Useful commands:"
+echo "  systemctl --user status agent-console   # Check status"
+echo "  systemctl --user stop agent-console     # Stop service"
+echo "  systemctl --user start agent-console    # Start service"
+echo "  journalctl --user -u agent-console -f   # View logs (journald)"
+echo "  tail -f ~/.local/share/agent-console/logs/agent-console.log  # View logs (file)"

--- a/scripts/update-and-deploy-for-ubuntu.sh
+++ b/scripts/update-and-deploy-for-ubuntu.sh
@@ -7,6 +7,9 @@
 #   - The service port defaults to 6000 + (uid % 1000). Known caveat: users whose
 #     UIDs differ by a multiple of 1000 (e.g. 1000 and 2000) collide on the same
 #     port. Set PORT explicitly to override.
+#   - Base 6000 overlaps the X11 TCP range (6000-6063), but impact is low: this
+#     targets headless servers (no X server), and modern X11 defaults to
+#     `-nolisten tcp` (desktops default to Wayland). Override with PORT if needed.
 #   - Enables systemd "lingering" for the current user so the service keeps running
 #     after logout and starts on boot (no login session required).
 #

--- a/scripts/update-and-deploy-for-ubuntu.sh
+++ b/scripts/update-and-deploy-for-ubuntu.sh
@@ -1,10 +1,28 @@
 #!/bin/bash
+#
+# Deploy Agent Console as a per-user systemd service on Ubuntu/Linux.
+#
+# Notes:
+#   - Requires `rsync` (checked below). Install with: sudo apt-get install -y rsync
+#   - The service port defaults to 6000 + (uid % 1000). Known caveat: users whose
+#     UIDs differ by a multiple of 1000 (e.g. 1000 and 2000) collide on the same
+#     port. Set PORT explicitly to override.
+#   - Enables systemd "lingering" for the current user so the service keeps running
+#     after logout and starts on boot (no login session required).
+#
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
 cd "$PROJECT_DIR"
+
+# Fail early with a clear message if rsync is missing (used during deploy below).
+if ! command -v rsync >/dev/null 2>&1; then
+    echo "Error: rsync is required but was not found." >&2
+    echo "Install it with: sudo apt-get install -y rsync" >&2
+    exit 1
+fi
 
 echo "==> Installing dependencies..."
 bun install
@@ -43,6 +61,19 @@ mkdir -p ~/.agent-console/server
 rsync -av --delete --exclude node_modules dist/ ~/.agent-console/server/
 cd ~/.agent-console/server
 bun install --production
+
+echo "==> Enabling lingering (keeps the service running after logout / across reboots)..."
+# Without lingering, a --user service stops at logout and does not start on boot.
+# enable-linger for one's own user may or may not require privileges depending on
+# the system's polkit policy, so do not abort the whole deploy if it fails.
+LINGER_USER="${USER:-$(id -un)}"
+if loginctl enable-linger "$LINGER_USER" 2>/dev/null; then
+    echo "  Lingering enabled for $LINGER_USER"
+else
+    echo "  Warning: could not enable lingering for $LINGER_USER."
+    echo "  The service will stop at logout and not start on boot until you run:"
+    echo "    sudo loginctl enable-linger $LINGER_USER"
+fi
 
 echo "==> Reloading systemd and restarting service..."
 systemctl --user daemon-reload


### PR DESCRIPTION
## Summary
- Add systemd user service template and deployment script for Ubuntu
- Implement UID-based automatic port calculation (6000 + UID % 1000) for multi-user environments
- Display port and URL during deployment on both macOS and Ubuntu

## Test plan
- [ ] Run `./scripts/update-and-deploy-for-ubuntu.sh` on Ubuntu
- [ ] Verify service starts with `systemctl --user status agent-console`
- [ ] Confirm port is correctly calculated based on UID
- [ ] Test `PORT=xxxx` override still works

## Hardening & verification (follow-up commit)
Added in `5b9ab20`:
- **systemd lingering**: `loginctl enable-linger` is now run so the `--user`
  service survives logout and starts on boot. It warns (does not abort) if it
  lacks privileges, pointing the user to `sudo loginctl enable-linger <user>`.
- **rsync precondition**: the script fails early with a clear message if `rsync`
  is missing, instead of an opaque `command not found` partway through deploy.
- **Inline docs**: header comments document the rsync requirement, the
  UID-based port collision caveat (UIDs differing by a multiple of 1000 collide),
  and the linger behavior.

Verified in Docker (oven/bun:1.3.8 + ubuntu:24.04 with systemd 255):
- `shellcheck` clean on both deploy scripts.
- `systemd-analyze verify` reports valid unit syntax for the rendered service.
- Full build → `rsync` deploy → start `bun ~/.agent-console/server/index.js`
  → `curl /api/config` returns a valid response.
- UID-based port calculation varies correctly per UID.
- rsync-missing path fails fast with the expected error.
- linger warn path degrades gracefully when `loginctl`/systemd is unavailable.

**Not verifiable in Docker**: the linger *success* path (creation of the
`/var/lib/systemd/linger/<user>` marker) and the `systemctl --user` start
require a booted systemd (PID 1), which a container without systemd cannot
provide. The command syntax and failure handling are confirmed; marker
creation on real Ubuntu remains to be confirmed on a host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
