### PR TITLE
fix: sync worktreeId on restart even when git branch already matches

### DIFF
--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -1304,8 +1304,8 @@ export class SessionManager {
       const currentBranch = await gitGetCurrentBranch(session.locationPath);
       if (currentBranch !== branch) {
         await gitRenameBranch(currentBranch, branch, session.locationPath);
-        session.worktreeId = branch;
       }
+      session.worktreeId = branch;
     }
 
     const isAgentChanged = workerAgentId !== existingWorker.agentId;


### PR DESCRIPTION
## Summary

- When an AI agent externally renames a git branch during a session, `session.worktreeId` becomes stale. RestartSession with the correct branch name failed to sync `worktreeId` because the update was only inside the `if (currentBranch !== branch)` block — when git already matched, the sync was silently skipped.
- Moved `session.worktreeId = branch` outside the conditional so it always syncs regardless of whether a git rename was needed.

## Test plan

- [x] Added test: worktreeId syncs and broadcasts when AI agent externally renamed the git branch (git already matches, no rename needed)
- [x] Added test: git rename AND worktreeId sync both work when all three values differ (worktreeId, current git branch, requested branch)
- [x] All 1987 tests pass across all packages
- [x] Typecheck passes for all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for session branch synchronization and worktree ID updates.

* **Bug Fixes**
  * Improved session state synchronization to ensure worktree identifiers correctly reflect the target branch state, enhancing reliability of branch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->