### PR TITLE
feat: enable cross-repository worktree delegation via MCP

### DIFF
--- a/packages/server/src/database/__tests__/mappers.test.ts
+++ b/packages/server/src/database/__tests__/mappers.test.ts
@@ -477,6 +477,7 @@ describe('mappers', () => {
         updated_at: '2024-02-20T14:00:00.000Z',
         setup_command: null,
         env_vars: null,
+        description: null,
       };
 
       const repository = toRepository(row);
@@ -498,6 +499,7 @@ describe('mappers', () => {
         updated_at: '2024-12-01T00:00:00.000Z',
         setup_command: null,
         env_vars: null,
+        description: null,
       };
 
       const repository = toRepository(row);
@@ -515,6 +517,7 @@ describe('mappers', () => {
         updated_at: '2024-12-01T00:00:00.000Z',
         setup_command: 'npm install',
         env_vars: null,
+        description: null,
       };
 
       const repository = toRepository(row);
@@ -531,6 +534,7 @@ describe('mappers', () => {
         updated_at: '2024-12-01T00:00:00.000Z',
         setup_command: null,
         env_vars: 'FOO=bar\nBAZ=qux',
+        description: null,
       };
 
       const repository = toRepository(row);

--- a/packages/server/src/database/connection.ts
+++ b/packages/server/src/database/connection.ts
@@ -195,6 +195,10 @@ async function runMigrations(database: Kysely<Database>): Promise<void> {
   if (currentVersion < 6) {
     await migrateToV6(database);
   }
+
+  if (currentVersion < 7) {
+    await migrateToV7(database);
+  }
 }
 
 /**
@@ -449,6 +453,25 @@ async function migrateToV6(database: Kysely<Database>): Promise<void> {
   await sql`PRAGMA user_version = 6`.execute(database);
 
   logger.info('Migration to v6 completed');
+}
+
+/**
+ * Migration v7: Add description column to repositories table.
+ * This column stores a brief description of the repository.
+ */
+async function migrateToV7(database: Kysely<Database>): Promise<void> {
+  logger.info('Running migration to v7: Adding description column to repositories');
+
+  // Add description column to repositories table
+  await database.schema
+    .alterTable('repositories')
+    .addColumn('description', 'text')
+    .execute();
+
+  // Update schema version
+  await sql`PRAGMA user_version = 7`.execute(database);
+
+  logger.info('Migration to v7 completed');
 }
 
 /**

--- a/packages/server/src/database/mappers.ts
+++ b/packages/server/src/database/mappers.ts
@@ -263,6 +263,7 @@ export function toRepositoryRow(repository: PersistedRepository): NewRepository 
     updated_at: now,
     setup_command: repository.setupCommand ?? null,
     env_vars: repository.envVars ?? null,
+    description: repository.description ?? null,
   };
 }
 
@@ -280,6 +281,7 @@ export function toRepository(row: RepositoryRow): Repository {
     createdAt: row.created_at,
     setupCommand: row.setup_command ?? null,
     envVars: row.env_vars ?? null,
+    description: row.description ?? null,
   };
 }
 

--- a/packages/server/src/database/schema.ts
+++ b/packages/server/src/database/schema.ts
@@ -100,6 +100,8 @@ export interface RepositoriesTable {
   setup_command: string | null;
   /** Environment variables in .env format to apply to workers (added in v5) */
   env_vars: string | null;
+  /** Brief description of the repository (added in v7) */
+  description: string | null;
 }
 
 /** Repository row as returned from SELECT queries */

--- a/packages/server/src/repositories/repository-repository.ts
+++ b/packages/server/src/repositories/repository-repository.ts
@@ -6,6 +6,7 @@ import type { Repository } from '@agent-console/shared';
 export interface RepositoryUpdates {
   setupCommand?: string | null;
   envVars?: string | null;
+  description?: string | null;
 }
 
 /**

--- a/packages/server/src/services/persistence-service.ts
+++ b/packages/server/src/services/persistence-service.ts
@@ -21,6 +21,7 @@ export interface PersistedRepository {
   createdAt: string;
   setupCommand?: string | null;
   envVars?: string | null;
+  description?: string | null;
 }
 
 // Base for all persisted workers

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,6 +19,7 @@ export interface Repository {
   remoteUrl?: string;   // Git remote URL for origin (if available)
   setupCommand?: string | null; // Shell command to run after creating worktrees
   envVars?: string | null; // Environment variables in .env format (applied to workers)
+  description?: string | null; // Brief description of the repository
 }
 
 /**

--- a/packages/shared/src/schemas/repository.ts
+++ b/packages/shared/src/schemas/repository.ts
@@ -133,6 +133,7 @@ export const DeleteWorktreeRequestSchema = v.object({
 export const UpdateRepositoryRequestSchema = v.object({
   setupCommand: v.nullish(v.pipe(v.string(), v.trim())),
   envVars: v.nullish(v.pipe(v.string(), v.trim())),
+  description: v.nullish(v.pipe(v.string(), v.trim())),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Add `list_repositories` MCP tool for agents to discover all registered repositories (exposes id, name, remoteUrl, description — NOT path, setupCommand, envVars)
- Add `description` field to Repository model across all layers (shared types, DB schema, migration v7, mappers, persistence, REST API update schema)
- Enrich `list_sessions` and `get_session_status` MCP responses with `repositoryId` / `repositoryName` for worktree sessions
- Update `delegate_to_worktree` tool description to document cross-repository usage
- Add migration tests for v4-v7 (previously v4-v6 had no dedicated tests)

## Test plan

- [x] Migration v4-v7 tests pass (`bun test packages/server/src/database/__tests__/migration.test.ts` — 26 tests)
- [x] Repository CRUD with description field (`bun test packages/server/src/repositories/` — includes 6 new tests)
- [x] MCP tool tests (`bun test packages/server/src/mcp/` — list_repositories, session enrichment)
- [x] Mapper tests with description fixtures (`bun test packages/server/src/database/__tests__/mappers.test.ts`)
- [x] Full test suite passes: Server 1123, Client 672, Shared 195, Integration 9
- [x] Type check passes for all packages
- [ ] Manual: Start server, call `list_repositories` via MCP, verify response includes description
- [ ] Manual: PATCH repository to set description, verify it appears in `list_repositories`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Repositories now support optional descriptions for better organization
  * New tool to list all repositories with details including remote URL and description
  * Sessions now display their associated repository information

* **Tests**
  * Comprehensive test coverage added for repository and session features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->