### PR TITLE
docs: add language reminder to PR section in development-workflow-standards

### DIFF
--- a/.claude/skills/development-workflow-standards/development-workflow-standards.md
+++ b/.claude/skills/development-workflow-standards/development-workflow-standards.md
@@ -74,6 +74,7 @@ git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD
 
 1. Open pull requests for review
 2. **Merging is the user's responsibility** - Never merge PRs automatically. Always leave the merge decision to the user.
+3. **Write in English** - PR titles, descriptions, and comments must be written in English (per Language Policy).
 
 ## Testing Requirements
 


### PR DESCRIPTION
## Summary
- Add a reminder to write PRs in English in the Pull Request section of development-workflow-standards
- This reinforces the existing Language Policy by making it explicit in the PR workflow checklist

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] Verified only one line was added

🤖 Generated with [Claude Code](https://claude.com/claude-code)