### PR TITLE
fix: add crypto.randomUUID fallback for non-secure contexts

### DIFF
--- a/packages/client/src/components/sessions/DeleteWorktreeDialog.tsx
+++ b/packages/client/src/components/sessions/DeleteWorktreeDialog.tsx
@@ -9,6 +9,7 @@ import {
   AlertDialogCancel,
 } from '../ui/alert-dialog';
 import { deleteWorktreeAsync } from '../../lib/api';
+import { generateTaskId } from '../../lib/id';
 import { useWorktreeDeletionTasksContext } from '../../routes/__root';
 
 export interface DeleteWorktreeDialogProps {
@@ -33,10 +34,7 @@ export function DeleteWorktreeDialog({
 
   const handleDeleteWorktree = async (force: boolean = false) => {
     // Generate task ID
-    const taskId =
-      typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const taskId = generateTaskId();
 
     // Add task to sidebar with retry info
     addTask({

--- a/packages/client/src/lib/__tests__/id.test.ts
+++ b/packages/client/src/lib/__tests__/id.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { generateTaskId } from '../id';
+
+describe('generateTaskId', () => {
+  it('should return a string', () => {
+    const id = generateTaskId();
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('should return a UUID when crypto.randomUUID is available', () => {
+    const id = generateTaskId();
+    // UUID v4 format: xxxxxxxx-xxxx-4xxx-[89ab]xxx-xxxxxxxxxxxx
+    const uuidPattern =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+    expect(id).toMatch(uuidPattern);
+  });
+
+  describe('non-secure context fallback', () => {
+    let originalCrypto: Crypto;
+
+    beforeEach(() => {
+      originalCrypto = globalThis.crypto;
+      // Simulate non-secure context: crypto exists but without randomUUID
+      Object.defineProperty(globalThis, 'crypto', {
+        value: { getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto) },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('should return a fallback ID when crypto.randomUUID is not available', () => {
+      const id = generateTaskId();
+      expect(typeof id).toBe('string');
+      expect(id.length).toBeGreaterThan(0);
+    });
+
+    it('should return a fallback ID matching timestamp-hex format', () => {
+      const id = generateTaskId();
+      // Format: {timestamp}-{hex}
+      const fallbackPattern = /^\d+-[0-9a-f]+$/;
+      expect(id).toMatch(fallbackPattern);
+    });
+
+    it('should generate unique fallback IDs', () => {
+      const id1 = generateTaskId();
+      const id2 = generateTaskId();
+      expect(id1).not.toBe(id2);
+    });
+  });
+});

--- a/packages/client/src/lib/id.ts
+++ b/packages/client/src/lib/id.ts
@@ -1,0 +1,12 @@
+/**
+ * Generate a unique task ID with fallback for non-secure contexts.
+ *
+ * crypto.randomUUID() requires a secure context (HTTPS or localhost).
+ * When the app is accessed via IP address over HTTP, we fall back to
+ * a timestamp + random hex string.
+ */
+export function generateTaskId(): string {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -20,6 +20,7 @@ import {
 import { useAppWsEvent, useAppWsState } from '../hooks/useAppWs';
 import { emitSessionDeleted } from '../lib/app-websocket';
 import { disconnectSession as disconnectWorkerWebSockets } from '../lib/worker-websocket.js';
+import { generateTaskId } from '../lib/id';
 import { formatPath } from '../lib/path';
 import { ConfirmDialog } from '../components/ui/confirm-dialog';
 import { ErrorDialog, useErrorDialog } from '../components/ui/error-dialog';
@@ -720,10 +721,7 @@ function RepositoryCard({ repository, sessions, pausedSessions, onUnregister, ge
 
   // Async worktree creation - returns immediately after API accepts the request
   const handleCreateWorktree = async (formRequest: CreateWorktreeFormRequest) => {
-    const taskId =
-      typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const taskId = generateTaskId();
     // Build full request with taskId for storage and API
     const request = { ...formRequest, taskId };
 
@@ -912,10 +910,7 @@ function WorktreeRow({ worktree, session, pausedSession, repositoryId }: Worktre
 
   const executeDelete = async (force: boolean) => {
     // Generate task ID
-    const taskId =
-      typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const taskId = generateTaskId();
 
     // Use session ID if available, otherwise generate a synthetic one for the task
     const effectiveSessionId = session?.id ?? `no-session-${taskId}`;

--- a/packages/client/src/routes/worktree-creation-tasks/$taskId.tsx
+++ b/packages/client/src/routes/worktree-creation-tasks/$taskId.tsx
@@ -4,6 +4,7 @@ import { AlertCircleIcon } from '../../components/Icons';
 import { Spinner } from '../../components/ui/Spinner';
 import { useWorktreeCreationTasksContext } from '../__root';
 import { createWorktreeAsync } from '../../lib/api';
+import { generateTaskId } from '../../lib/id';
 
 export const Route = createFileRoute('/worktree-creation-tasks/$taskId')({
   component: WorktreeCreationTaskPage,
@@ -36,7 +37,7 @@ function useWorktreeCreationTask(taskId: string): {
     if (!task) return;
 
     // Generate a new task ID for the retry
-    const newTaskId = crypto.randomUUID();
+    const newTaskId = generateTaskId();
 
     // Build new request with new taskId
     const newRequest = { ...task.request, taskId: newTaskId };

--- a/packages/client/src/routes/worktree-deletion-tasks/$taskId.tsx
+++ b/packages/client/src/routes/worktree-deletion-tasks/$taskId.tsx
@@ -4,6 +4,7 @@ import { AlertCircleIcon, CheckIcon } from '../../components/Icons';
 import { Spinner } from '../../components/ui/Spinner';
 import { useWorktreeDeletionTasksContext } from '../__root';
 import { deleteWorktreeAsync } from '../../lib/api';
+import { generateTaskId } from '../../lib/id';
 
 export const Route = createFileRoute('/worktree-deletion-tasks/$taskId')({
   component: WorktreeDeletionTaskPage,
@@ -36,7 +37,7 @@ function useWorktreeDeletionTask(taskId: string): {
     if (!task) return;
 
     // Generate a new task ID for the retry
-    const newTaskId = crypto.randomUUID();
+    const newTaskId = generateTaskId();
 
     // Remove the failed task
     removeTaskFromContext(taskId);


### PR DESCRIPTION
## Summary

- `crypto.randomUUID()` requires a secure context (HTTPS or localhost). When the app is accessed via IP address over HTTP, the **Force Delete** and **Retry** buttons on worktree task detail pages crash with `TypeError: crypto.randomUUID is not a function`, making them appear unresponsive.
- Extract a shared `generateTaskId()` utility with timestamp+hex fallback, and unify all 4 call sites to use it.

## Changes

- **New:** `packages/client/src/lib/id.ts` — `generateTaskId()` utility with secure context detection and fallback
- **New:** `packages/client/src/lib/__tests__/id.test.ts` — Tests including non-secure context simulation
- **Fixed:** `packages/client/src/routes/worktree-deletion-tasks/$taskId.tsx` — Force Delete button now works in non-secure contexts
- **Fixed:** `packages/client/src/routes/worktree-creation-tasks/$taskId.tsx` — Retry button now works in non-secure contexts
- **Refactored:** `packages/client/src/routes/index.tsx` — Replaced inline fallback with shared utility (2 locations)
- **Refactored:** `packages/client/src/components/sessions/DeleteWorktreeDialog.tsx` — Replaced inline fallback with shared utility

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (all packages)
- [x] New unit tests for `generateTaskId()` covering both secure and non-secure contexts
- [ ] Manual verification: access app via IP address and confirm Force Delete button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized task ID generation to ensure consistent ID creation across the application, replacing scattered implementation approaches with a unified utility.

* **Tests**
  * Added comprehensive test coverage for task ID generation, verifying functionality in both standard and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->