### PR TITLE
feat: add cleanupCommand to run before worktree deletion

### DIFF
--- a/packages/client/src/hooks/useWorktreeDeletionTasks.ts
+++ b/packages/client/src/hooks/useWorktreeDeletionTasks.ts
@@ -89,11 +89,10 @@ export function useWorktreeDeletionTasks(): UseWorktreeDeletionTasksReturn {
 
   const handleWorktreeDeletionCompleted = useCallback(
     (payload: WorktreeDeletionCompletedPayload) => {
-      // Update task to completed status
       setTasks((prev) =>
         prev.map((t) =>
           t.id === payload.taskId
-            ? { ...t, status: 'completed' as const }
+            ? { ...t, status: 'completed' as const, cleanupCommandResult: payload.cleanupCommandResult }
             : t
         )
       );

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -40,7 +40,7 @@ import { AddRepositoryForm, type AddRepositoryFormSubmitData } from '../componen
 import { CreateWorktreeForm, type CreateWorktreeFormRequest } from '../components/worktrees';
 import { QuickSessionForm } from '../components/sessions';
 import { useWorktreeCreationTasksContext, useWorktreeDeletionTasksContext } from './__root';
-import type { Session, Repository, Worktree, AgentActivityState, CreateQuickSessionRequest, CreateWorktreeSessionRequest, WorkerActivityInfo, BranchNameFallback, AgentDefinition, SetupCommandResult } from '@agent-console/shared';
+import type { Session, Repository, Worktree, AgentActivityState, CreateQuickSessionRequest, CreateWorktreeSessionRequest, WorkerActivityInfo, BranchNameFallback, AgentDefinition, HookCommandResult } from '@agent-console/shared';
 
 // Request notification permission on load
 function requestNotificationPermission() {
@@ -693,7 +693,7 @@ interface RepositoryCardProps {
 function RepositoryCard({ repository, sessions, pausedSessions, onUnregister, generatingDescription }: RepositoryCardProps) {
   const [showCreateWorktree, setShowCreateWorktree] = useState(false);
   const [fallbackInfo, setFallbackInfo] = useState<BranchNameFallback | null>(null);
-  const [setupCommandFailure, setSetupCommandFailure] = useState<SetupCommandResult | null>(null);
+  const [setupCommandFailure, setSetupCommandFailure] = useState<HookCommandResult | null>(null);
   const { errorDialogProps, showError: showWorktreeError } = useErrorDialog();
   const { addTask, removeTask } = useWorktreeCreationTasksContext();
   const isGitHubRemote = Boolean(
@@ -1200,7 +1200,7 @@ function BranchNameFallbackDialog({ fallbackInfo, onClose }: BranchNameFallbackD
 // =============================================================================
 
 interface SetupCommandFailureDialogProps {
-  result: SetupCommandResult | null;
+  result: HookCommandResult | null;
   onClose: () => void;
 }
 

--- a/packages/client/src/routes/worktree-deletion-tasks/$taskId.tsx
+++ b/packages/client/src/routes/worktree-deletion-tasks/$taskId.tsx
@@ -151,6 +151,17 @@ function WorktreeDeletionTaskPage() {
               </>
             )}
           </div>
+          {isCompleted && task.cleanupCommandResult && !task.cleanupCommandResult.success && (
+            <div className="mt-3 p-3 bg-yellow-900/30 border border-yellow-600 rounded text-yellow-200 text-sm">
+              <p className="font-medium">Cleanup command failed</p>
+              {task.cleanupCommandResult.error && (
+                <pre className="mt-1 text-xs text-yellow-300 whitespace-pre-wrap">{task.cleanupCommandResult.error}</pre>
+              )}
+              {task.cleanupCommandResult.output && (
+                <pre className="mt-1 text-xs text-yellow-300/70 whitespace-pre-wrap">{task.cleanupCommandResult.output}</pre>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Error details (if failed) */}
@@ -193,11 +204,7 @@ function WorktreeDeletionTaskPage() {
           <button
             onClick={removeTask}
             className={`btn text-sm ${
-              isFailed
-                ? 'bg-slate-600 hover:bg-slate-500'
-                : isDeleting
-                  ? 'bg-slate-600 hover:bg-slate-500'
-                  : 'btn-primary'
+              isCompleted ? 'btn-primary' : 'bg-slate-600 hover:bg-slate-500'
             }`}
             title={isDeleting ? 'Hide from list (deletion continues in background)' : undefined}
           >

--- a/packages/server/src/database/__tests__/mappers.test.ts
+++ b/packages/server/src/database/__tests__/mappers.test.ts
@@ -464,6 +464,22 @@ describe('mappers', () => {
       expect(row.path).toBe('/home/user/projects/my-project');
       expect(row.created_at).toBe('2024-01-15T10:30:00.000Z');
       expect(row.updated_at).toBeDefined();
+      expect(row.setup_command).toBeNull();
+      expect(row.cleanup_command).toBeNull();
+    });
+
+    it('should map cleanupCommand to cleanup_command', () => {
+      const repository: PersistedRepository = {
+        id: 'repo-cleanup',
+        name: 'cleanup-project',
+        path: '/home/user/projects/cleanup-project',
+        createdAt: '2024-01-15T10:30:00.000Z',
+        cleanupCommand: 'docker compose down',
+      };
+
+      const row = toRepositoryRow(repository);
+
+      expect(row.cleanup_command).toBe('docker compose down');
     });
   });
 
@@ -476,6 +492,7 @@ describe('mappers', () => {
         created_at: '2024-02-20T14:00:00.000Z',
         updated_at: '2024-02-20T14:00:00.000Z',
         setup_command: null,
+        cleanup_command: null,
         env_vars: null,
         description: null,
       };
@@ -487,6 +504,7 @@ describe('mappers', () => {
       expect(repository.path).toBe('/opt/repos/another-project');
       expect(repository.createdAt).toBe('2024-02-20T14:00:00.000Z');
       expect(repository.setupCommand).toBeNull();
+      expect(repository.cleanupCommand).toBeNull();
       expect(repository.envVars).toBeNull();
     });
 
@@ -498,6 +516,7 @@ describe('mappers', () => {
         created_at: '2024-12-01T00:00:00.000Z',
         updated_at: '2024-12-01T00:00:00.000Z',
         setup_command: null,
+        cleanup_command: null,
         env_vars: null,
         description: null,
       };
@@ -508,6 +527,24 @@ describe('mappers', () => {
       expect(repository.createdAt).toBe('2024-12-01T00:00:00.000Z');
     });
 
+    it('should map cleanup_command to cleanupCommand', () => {
+      const row: RepositoryRow = {
+        id: 'repo-cleanup',
+        name: 'test-repo',
+        path: '/tmp/test-repo',
+        created_at: '2024-12-01T00:00:00.000Z',
+        updated_at: '2024-12-01T00:00:00.000Z',
+        setup_command: null,
+        cleanup_command: 'docker compose down',
+        env_vars: null,
+        description: null,
+      };
+
+      const repository = toRepository(row);
+
+      expect(repository.cleanupCommand).toBe('docker compose down');
+    });
+
     it('should map setup_command to setupCommand', () => {
       const row: RepositoryRow = {
         id: 'repo-4',
@@ -516,6 +553,7 @@ describe('mappers', () => {
         created_at: '2024-12-01T00:00:00.000Z',
         updated_at: '2024-12-01T00:00:00.000Z',
         setup_command: 'npm install',
+        cleanup_command: null,
         env_vars: null,
         description: null,
       };
@@ -533,6 +571,7 @@ describe('mappers', () => {
         created_at: '2024-12-01T00:00:00.000Z',
         updated_at: '2024-12-01T00:00:00.000Z',
         setup_command: null,
+        cleanup_command: null,
         env_vars: 'FOO=bar\nBAZ=qux',
         description: null,
       };

--- a/packages/server/src/database/connection.ts
+++ b/packages/server/src/database/connection.ts
@@ -204,6 +204,10 @@ async function runMigrations(database: Kysely<Database>): Promise<void> {
   if (currentVersion < 8) {
     await migrateToV8(database);
   }
+
+  if (currentVersion < 9) {
+    await migrateToV9(database);
+  }
 }
 
 /**
@@ -513,6 +517,25 @@ async function migrateToV8(database: Kysely<Database>): Promise<void> {
   await sql`PRAGMA user_version = 8`.execute(database);
 
   logger.info('Migration to v8 completed');
+}
+
+/**
+ * Migration v9: Add cleanup_command column to repositories table.
+ * This column stores shell commands to run before deleting worktrees.
+ */
+async function migrateToV9(database: Kysely<Database>): Promise<void> {
+  logger.info('Running migration to v9: Adding cleanup_command column to repositories');
+
+  // Add cleanup_command column to repositories table
+  await database.schema
+    .alterTable('repositories')
+    .addColumn('cleanup_command', 'text')
+    .execute();
+
+  // Update schema version
+  await sql`PRAGMA user_version = 9`.execute(database);
+
+  logger.info('Migration to v9 completed');
 }
 
 /**

--- a/packages/server/src/database/mappers.ts
+++ b/packages/server/src/database/mappers.ts
@@ -262,6 +262,7 @@ export function toRepositoryRow(repository: PersistedRepository): NewRepository 
     created_at: repository.createdAt,
     updated_at: now,
     setup_command: repository.setupCommand ?? null,
+    cleanup_command: repository.cleanupCommand ?? null,
     env_vars: repository.envVars ?? null,
     description: repository.description ?? null,
   };
@@ -280,6 +281,7 @@ export function toRepository(row: RepositoryRow): Repository {
     path: row.path,
     createdAt: row.created_at,
     setupCommand: row.setup_command ?? null,
+    cleanupCommand: row.cleanup_command ?? null,
     envVars: row.env_vars ?? null,
     description: row.description ?? null,
   };

--- a/packages/server/src/database/schema.ts
+++ b/packages/server/src/database/schema.ts
@@ -99,6 +99,8 @@ export interface RepositoriesTable {
   updated_at: Generated<string>;
   /** Shell command to run after creating worktrees (added in v4) */
   setup_command: string | null;
+  /** Shell command to run before deleting worktrees (added in v9) */
+  cleanup_command: string | null;
   /** Environment variables in .env format to apply to workers (added in v5) */
   env_vars: string | null;
   /** Brief description of the repository (added in v7) */

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -408,7 +408,7 @@ mcpServer.tool(
 
         // Execute setup command if configured
         if (repo.setupCommand && wtResult.index !== undefined) {
-          await worktreeService.executeSetupCommand(
+          await worktreeService.executeHookCommand(
             repo.setupCommand,
             createdWorktreePath,
             {

--- a/packages/server/src/repositories/repository-repository.ts
+++ b/packages/server/src/repositories/repository-repository.ts
@@ -5,6 +5,7 @@ import type { Repository } from '@agent-console/shared';
  */
 export interface RepositoryUpdates {
   setupCommand?: string | null;
+  cleanupCommand?: string | null;
   envVars?: string | null;
   description?: string | null;
 }

--- a/packages/server/src/repositories/sqlite-repository-repository.ts
+++ b/packages/server/src/repositories/sqlite-repository-repository.ts
@@ -46,6 +46,7 @@ export class SqliteRepositoryRepository implements RepositoryRepository {
         created_at: repository.createdAt,
         updated_at: now,
         setup_command: repository.setupCommand ?? null,
+        cleanup_command: repository.cleanupCommand ?? null,
         env_vars: repository.envVars ?? null,
         description: repository.description ?? null,
       })
@@ -54,6 +55,7 @@ export class SqliteRepositoryRepository implements RepositoryRepository {
           name: repository.name,
           path: repository.path,
           setup_command: repository.setupCommand ?? null,
+          cleanup_command: repository.cleanupCommand ?? null,
           env_vars: repository.envVars ?? null,
           description: repository.description ?? null,
           // Note: created_at is intentionally NOT updated (should never change after insert)
@@ -76,6 +78,7 @@ export class SqliteRepositoryRepository implements RepositoryRepository {
 
     const fieldMap: Array<[keyof RepositoryUpdates, string]> = [
       ['setupCommand', 'setup_command'],
+      ['cleanupCommand', 'cleanup_command'],
       ['envVars', 'env_vars'],
       ['description', 'description'],
     ];

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -10,7 +10,7 @@ const TEST_CONFIG_DIR = '/test/config';
 
 let importCounter = 0;
 
-// Mock Bun.spawn for executeSetupCommand tests
+// Mock Bun.spawn for executeHookCommand tests
 let mockSpawnResult: {
   exited: Promise<number>;
   stdout: ReadableStream<Uint8Array>;
@@ -598,7 +598,7 @@ detached
     });
   });
 
-  describe('executeSetupCommand', () => {
+  describe('executeHookCommand', () => {
     beforeEach(() => {
       // Reset spawn tracking
       spawnCalls = [];
@@ -624,7 +624,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'echo {{WORKTREE_NUM}}',
           '/test/worktree',
           { worktreeNum: 5, branch: 'feature-1', repo: 'my-repo' }
@@ -639,7 +639,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'git checkout {{BRANCH}}',
           '/test/worktree',
           { worktreeNum: 1, branch: 'feature/my-branch', repo: 'my-repo' }
@@ -654,7 +654,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'echo Working on {{REPO}}',
           '/test/worktree',
           { worktreeNum: 1, branch: 'main', repo: 'awesome-project' }
@@ -669,7 +669,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'cd {{WORKTREE_PATH}} && ls',
           '/home/user/worktrees/wt-001',
           { worktreeNum: 1, branch: 'main', repo: 'my-repo' }
@@ -684,7 +684,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'echo "WT {{WORKTREE_NUM}} for {{REPO}} on {{BRANCH}} at {{WORKTREE_PATH}}"',
           '/worktrees/wt-003',
           { worktreeNum: 3, branch: 'fix/bug-123', repo: 'test-repo' }
@@ -701,7 +701,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'export PORT={{WORKTREE_NUM + 3000}}',
           '/test/worktree',
           { worktreeNum: 5, branch: 'main', repo: 'my-repo' }
@@ -716,7 +716,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'echo {{WORKTREE_NUM - 2}}',
           '/test/worktree',
           { worktreeNum: 10, branch: 'main', repo: 'my-repo' }
@@ -731,7 +731,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'echo {{WORKTREE_NUM * 100}}',
           '/test/worktree',
           { worktreeNum: 3, branch: 'main', repo: 'my-repo' }
@@ -746,7 +746,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'echo {{WORKTREE_NUM / 3}}',
           '/test/worktree',
           { worktreeNum: 10, branch: 'main', repo: 'my-repo' }
@@ -762,7 +762,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'export PORT={{WORKTREE_NUM   +   8080}}',
           '/test/worktree',
           { worktreeNum: 1, branch: 'main', repo: 'my-repo' }
@@ -779,7 +779,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        const result = await service.executeSetupCommand(
+        const result = await service.executeHookCommand(
           'echo "hello"',
           '/test/worktree',
           { worktreeNum: 1, branch: 'main', repo: 'my-repo' }
@@ -795,7 +795,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        const result = await service.executeSetupCommand(
+        const result = await service.executeHookCommand(
           'silent-command',
           '/test/worktree',
           { worktreeNum: 1, branch: 'main', repo: 'my-repo' }
@@ -813,7 +813,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        const result = await service.executeSetupCommand(
+        const result = await service.executeHookCommand(
           'invalid-command',
           '/test/worktree',
           { worktreeNum: 1, branch: 'main', repo: 'my-repo' }
@@ -829,7 +829,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        const result = await service.executeSetupCommand(
+        const result = await service.executeHookCommand(
           'nonexistent-command',
           '/test/worktree',
           { worktreeNum: 1, branch: 'main', repo: 'my-repo' }
@@ -844,7 +844,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        const result = await service.executeSetupCommand(
+        const result = await service.executeHookCommand(
           'protected-command',
           '/test/worktree',
           { worktreeNum: 1, branch: 'main', repo: 'my-repo' }
@@ -861,7 +861,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'echo $WORKTREE_NUM',
           '/test/worktree',
           { worktreeNum: 42, branch: 'main', repo: 'my-repo' }
@@ -877,7 +877,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'echo $BRANCH',
           '/test/worktree',
           { worktreeNum: 1, branch: 'feature/new-feature', repo: 'my-repo' }
@@ -893,7 +893,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'echo $REPO',
           '/test/worktree',
           { worktreeNum: 1, branch: 'main', repo: 'test-repository' }
@@ -909,7 +909,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'echo $WORKTREE_PATH',
           '/home/user/worktrees/wt-005',
           { worktreeNum: 5, branch: 'main', repo: 'my-repo' }
@@ -925,7 +925,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'echo $PATH',
           '/test/worktree',
           { worktreeNum: 1, branch: 'main', repo: 'my-repo' }
@@ -944,7 +944,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'pwd',
           '/home/user/worktrees/wt-001',
           { worktreeNum: 1, branch: 'main', repo: 'my-repo' }
@@ -959,7 +959,7 @@ detached
         const WorktreeService = await getWorktreeService();
         const service = new WorktreeService();
 
-        await service.executeSetupCommand(
+        await service.executeHookCommand(
           'npm install && npm run build',
           '/test/worktree',
           { worktreeNum: 1, branch: 'main', repo: 'my-repo' }

--- a/packages/server/src/services/persistence-service.ts
+++ b/packages/server/src/services/persistence-service.ts
@@ -20,6 +20,7 @@ export interface PersistedRepository {
   path: string;
   createdAt: string;
   setupCommand?: string | null;
+  cleanupCommand?: string | null;
   envVars?: string | null;
   description?: string | null;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,14 +18,15 @@ export interface Repository {
   createdAt: string;    // Creation date (ISO 8601)
   remoteUrl?: string;   // Git remote URL for origin (if available)
   setupCommand?: string | null; // Shell command to run after creating worktrees
+  cleanupCommand?: string | null; // Shell command to run before deleting worktrees
   envVars?: string | null; // Environment variables in .env format (applied to workers)
   description?: string | null; // Brief description of the repository
 }
 
 /**
- * Result of executing a setup command after worktree creation
+ * Result of executing a hook command (setup or cleanup) during worktree lifecycle
  */
-export interface SetupCommandResult {
+export interface HookCommandResult {
   success: boolean;
   output?: string;
   error?: string;

--- a/packages/shared/src/schemas/repository.ts
+++ b/packages/shared/src/schemas/repository.ts
@@ -133,6 +133,7 @@ export const DeleteWorktreeRequestSchema = v.object({
  */
 export const UpdateRepositoryRequestSchema = v.object({
   setupCommand: v.nullish(v.pipe(v.string(), v.trim())),
+  cleanupCommand: v.nullish(v.pipe(v.string(), v.trim())),
   envVars: v.nullish(v.pipe(v.string(), v.trim())),
   description: v.nullish(v.pipe(v.string(), v.trim())),
 });

--- a/packages/shared/src/types/worktree-creation.ts
+++ b/packages/shared/src/types/worktree-creation.ts
@@ -1,6 +1,6 @@
 import type { CreateWorktreeRequest } from '../schemas/repository.js';
 import type { Worker } from './worker.js';
-import type { Worktree, BranchNameFallback, SetupCommandResult } from '../index.js';
+import type { Worktree, BranchNameFallback, HookCommandResult } from '../index.js';
 
 /**
  * Session information for worktree creation completion.
@@ -67,7 +67,7 @@ export interface WorktreeCreationCompletedPayload {
   /** Present when AI branch name generation failed and fallback was used */
   branchNameFallback?: BranchNameFallback;
   /** Present when setup command was executed */
-  setupCommandResult?: SetupCommandResult;
+  setupCommandResult?: HookCommandResult;
   /** Present when fetch from remote failed */
   fetchFailed?: boolean;
   fetchError?: string;

--- a/packages/shared/src/types/worktree-deletion.ts
+++ b/packages/shared/src/types/worktree-deletion.ts
@@ -1,3 +1,5 @@
+import type { HookCommandResult } from '../index.js';
+
 /**
  * Status of a worktree deletion task (client-side only)
  */
@@ -26,6 +28,8 @@ export interface WorktreeDeletionTask {
   error?: string;
   /** Git status output when status is 'failed' */
   gitStatus?: string;
+  /** Result of cleanup command execution (when configured) */
+  cleanupCommandResult?: HookCommandResult;
   /** ISO 8601 timestamp */
   createdAt: string;
 }
@@ -37,6 +41,8 @@ export interface WorktreeDeletionCompletedPayload {
   /** Client-generated task ID for correlation */
   taskId: string;
   sessionId: string;
+  /** Present when cleanup command was executed before deletion */
+  cleanupCommandResult?: HookCommandResult;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add a repository-level `cleanupCommand` setting that executes a user-configured shell command before a worktree is deleted
- Prevents orphaned resources (e.g., Docker containers left running) when worktrees are removed
- Mirrors the existing `setupCommand` (runs after creation) as its counterpart

## Changes

- **Database**: Add `cleanup_command` column to repositories table (migration v9)
- **Shared types**: Rename `SetupCommandResult` → `HookCommandResult`, `executeSetupCommand` → `executeHookCommand` for generic lifecycle hook usage
- **Server**: Execute cleanup command before git worktree removal in both sync/async deletion paths; failure does not block deletion
- **Security**: Use `getCleanChildProcessEnv()` instead of `process.env` for hook subprocess environment
- **Frontend**: Add cleanup command form field in repository settings; surface cleanup failures as warnings in deletion task detail page

## Test plan

- [x] `bun run typecheck` passes (all 3 packages)
- [x] `bun run test` passes (2,090 tests, 0 failures)
- [x] Migration v9 test verifies `cleanup_command` column creation and null default
- [x] Mapper tests verify `cleanup_command` ↔ `cleanupCommand` round-trip
- [x] Repository update tests verify `cleanupCommand` CRUD operations
- [x] Route integration tests cover sync deletion (no command / success / failure)
- [x] Route integration tests cover async deletion path with cleanup command
- [x] Frontend tests verify cleanup command form field rendering and submission
- [x] Review loop completed (2 iterations, all CRITICAL/HIGH resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)