### PR TITLE
fix: correct mismatched schema version comments in migration tests

### DIFF
--- a/packages/server/src/database/__tests__/migration.test.ts
+++ b/packages/server/src/database/__tests__/migration.test.ts
@@ -640,7 +640,7 @@ describe('migration', () => {
       // Initialize database (runs all migrations up to current version)
       const db = await initializeDatabase(':memory:');
 
-      // Verify the schema version is the latest (9)
+      // Verify the schema version is the latest (10)
       const { sql } = await import('kysely');
       const result = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
       expect(result.rows[0]?.user_version).toBe(10);
@@ -735,7 +735,7 @@ describe('migration', () => {
     it('should create worktrees table with correct columns', async () => {
       const db = await initializeDatabase(':memory:');
 
-      // Verify the schema version is 9
+      // Verify the schema version is 10
       const { sql } = await import('kysely');
       const result = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
       expect(result.rows[0]?.user_version).toBe(10);


### PR DESCRIPTION
## Summary
- Fix comments in migration tests that referenced outdated schema version numbers (9 instead of 10)

## Test plan
- [ ] Verify CodeRabbit bot automatically reviews this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)