### PR TITLE
fix: show error feedback when DiffWorker send fails on disconnected WebSocket

### DIFF
--- a/packages/client/src/hooks/__tests__/useGitDiffWorker.test.ts
+++ b/packages/client/src/hooks/__tests__/useGitDiffWorker.test.ts
@@ -218,6 +218,75 @@ describe('useGitDiffWorker', () => {
     expect(ws?.send).not.toHaveBeenCalled();
   });
 
+  it('should set error when refresh fails due to disconnected WebSocket', async () => {
+    const { result } = renderHook(() =>
+      useGitDiffWorker({ sessionId: 'session1', workerId: 'worker1' })
+    );
+
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+    });
+
+    // Simulate disconnect
+    act(() => {
+      ws?.simulateClose();
+    });
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    expect(result.current.error).toBe('Connection lost. Please try again.');
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('should set error when setBaseCommit fails due to disconnected WebSocket', async () => {
+    const { result } = renderHook(() =>
+      useGitDiffWorker({ sessionId: 'session1', workerId: 'worker1' })
+    );
+
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+    });
+
+    // Simulate disconnect
+    act(() => {
+      ws?.simulateClose();
+    });
+
+    act(() => {
+      result.current.setBaseCommit('main');
+    });
+
+    expect(result.current.error).toBe('Connection lost. Please try again.');
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('should set error when setTargetCommit fails due to disconnected WebSocket', async () => {
+    const { result } = renderHook(() =>
+      useGitDiffWorker({ sessionId: 'session1', workerId: 'worker1' })
+    );
+
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+    });
+
+    // Simulate disconnect
+    act(() => {
+      ws?.simulateClose();
+    });
+
+    act(() => {
+      result.current.setTargetCommit('HEAD');
+    });
+
+    expect(result.current.error).toBe('Connection lost. Please try again.');
+    expect(result.current.loading).toBe(false);
+  });
+
   it('should handle connection close', async () => {
     const onConnectionChange = mock(() => {});
     const { result } = renderHook(() =>

--- a/packages/client/src/lib/worker-websocket.ts
+++ b/packages/client/src/lib/worker-websocket.ts
@@ -556,6 +556,11 @@ export function sendGitDiffMessage(sessionId: string, workerId: string, msg: Git
     }
     return true;
   }
+
+  // Set error state when send fails for operations that would set loading
+  if (msg.type === 'refresh' || msg.type === 'set-base-commit' || msg.type === 'set-target-commit') {
+    updateState(key, { diffError: 'Connection lost. Please try again.', diffLoading: false });
+  }
   return false;
 }
 


### PR DESCRIPTION
## Summary

- Fix silent failure when `sendGitDiffMessage()` cannot send because the WebSocket is not open (e.g., after disconnect)
- Set `diffError` state in `sendGitDiffMessage()` for `refresh`, `set-base-commit`, and `set-target-commit` operations, so the existing error UI (with retry button) is displayed instead of no feedback
- Add 3 tests verifying error state is set when send fails due to disconnected WebSocket

Closes #190

## Test plan

- [x] New tests: verify error state is set for `refresh()`, `setBaseCommit()`, and `setTargetCommit()` when WebSocket is disconnected
- [x] Existing tests: all 2122 tests pass, 0 failures
- [x] TypeScript typecheck passes across all packages
- [ ] Manual: open DiffWorker, disconnect network, change base commit → should show "Connection lost. Please try again." with retry button

🤖 Generated with [Claude Code](https://claude.com/claude-code)