### PR TITLE
docs: add launchd .env configuration for webhook secrets

### DIFF
--- a/scripts/com.agent-console.plist.template
+++ b/scripts/com.agent-console.plist.template
@@ -7,8 +7,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>{{COMMAND_PATH}}</string>
-        <string>{{HOME}}/.agent-console/server/index.js</string>
+        <string>{{HOME}}/.agent-console/server/start.sh</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/scripts/start.sh.template
+++ b/scripts/start.sh.template
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Load environment variables from ~/.agent-console/.env if it exists.
+# This allows configuring secrets (e.g., GITHUB_WEBHOOK_SECRET) without
+# embedding them in the launchd plist file.
+set -a
+[ -f "$HOME/.agent-console/.env" ] && source "$HOME/.agent-console/.env"
+set +a
+exec {{COMMAND_PATH}} "$HOME/.agent-console/server/index.js"

--- a/scripts/update-and-deploy-for-mac.sh
+++ b/scripts/update-and-deploy-for-mac.sh
@@ -21,6 +21,11 @@ sed -e "s|{{HOME}}|$HOME|g" \
     "$SCRIPT_DIR/com.agent-console.plist.template" \
     > ~/Library/LaunchAgents/com.agent-console.plist
 
+echo "==> Generating start script..."
+sed -e "s|{{COMMAND_PATH}}|$COMMAND_PATH|g" \
+    "$SCRIPT_DIR/start.sh.template" \
+    > /tmp/agent-console-start.sh
+
 echo "==> Cleaning up old logs..."
 rm -rf ~/Library/Logs/agent-console
 mkdir -p ~/Library/Logs/agent-console
@@ -31,6 +36,9 @@ NODE_ENV=production bun run build
 echo "==> Deploying files..."
 mkdir -p ~/.agent-console/server
 rsync -av --delete --exclude node_modules dist/ ~/.agent-console/server/
+cp /tmp/agent-console-start.sh ~/.agent-console/server/start.sh
+chmod +x ~/.agent-console/server/start.sh
+rm /tmp/agent-console-start.sh
 cd ~/.agent-console/server
 bun install --production
 


### PR DESCRIPTION
## Summary

- Introduce a wrapper start script (`start.sh`) that loads `~/.agent-console/.env` before starting the server, enabling secrets like `GITHUB_WEBHOOK_SECRET` to be configured without embedding them in the launchd plist file
- Update plist template to launch `start.sh` instead of calling `bun` directly
- Document macOS Launch Agent deployment and `.env` configuration in README

## Changes

| File | Change |
|------|--------|
| `scripts/start.sh.template` | New wrapper script that sources `.env` and exec's bun |
| `scripts/com.agent-console.plist.template` | `ProgramArguments` now points to `start.sh` |
| `scripts/update-and-deploy-for-mac.sh` | Generates `start.sh` from template and copies after rsync |
| `README.md` | Added macOS Launch Agent section with `.env` configuration docs |

## Test plan

- [ ] Run `./scripts/update-and-deploy-for-mac.sh` and verify `start.sh` is generated at `~/.agent-console/server/start.sh`
- [ ] Verify `start.sh` has execute permission and correct bun path substitution
- [ ] Create `~/.agent-console/.env` with `GITHUB_WEBHOOK_SECRET=test` and restart service
- [ ] Confirm `GET /api/system/health` shows `webhookSecretConfigured: true`
- [ ] Verify service restarts correctly via `launchctl kickstart -k`

🤖 Generated with [Claude Code](https://claude.com/claude-code)