### PR TITLE
fix: respect repository defaultAgentId in MCP and fix Set-as-default checkbox

### DIFF
--- a/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
+++ b/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
@@ -105,7 +105,7 @@ export function CreateWorktreeForm({
   });
 
   // State for "set as default agent" checkbox
-  const [setAsDefault, setSetAsDefault] = useState(!!defaultAgentId);
+  const [setAsDefault, setSetAsDefault] = useState(false);
 
   // Mutation to update repository's default agent
   const updateDefaultAgentMutation = useMutation({

--- a/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
@@ -394,6 +394,53 @@ describe('CreateWorktreeForm', () => {
     });
   });
 
+  describe('default agent checkbox', () => {
+    it('should not pre-check "Set as default" even when defaultAgentId is provided', async () => {
+      renderCreateWorktreeForm({ defaultAgentId: 'claude-code' });
+
+      // Wait for agents to load
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      // The "Set as default" checkbox should NOT be checked
+      const checkbox = screen.getByLabelText('Set as default') as HTMLInputElement;
+      expect(checkbox.checked).toBe(false);
+    });
+
+    it('should not update default agent when changing agent without checking the checkbox', async () => {
+      const user = userEvent.setup();
+      const updateCalls: string[] = [];
+
+      mockFetch.mockImplementation((input) => {
+        const url = typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+        if (url.includes('/repositories/') && !url.includes('/agents') && !url.includes('/remote-status') && !url.includes('/github-issue') && !url.includes('/branches/')) {
+          updateCalls.push(url);
+          return Promise.resolve(createMockResponse({}));
+        }
+        return Promise.resolve(createMockResponse(mockAgentsResponse));
+      });
+
+      renderCreateWorktreeForm({ defaultAgentId: 'claude-code' });
+
+      // Wait for agents to load
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      // Change the agent via the selector
+      const agentSelector = screen.getByRole('combobox');
+      await user.selectOptions(agentSelector, 'custom-agent');
+
+      // No update to repository default should have been triggered
+      expect(updateCalls.length).toBe(0);
+    });
+  });
+
   describe('UI state', () => {
     it('should call onCancel when cancel button is clicked', async () => {
       const user = userEvent.setup();

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -737,6 +737,7 @@ describe('MCP Server Tools', () => {
       id: string;
       name: string;
       path: string;
+      defaultAgentId?: string | null;
     }> = []): Promise<void> {
       const { getDatabase } = await import('../../database/connection.js');
       const db = getDatabase();
@@ -760,10 +761,12 @@ describe('MCP Server Tools', () => {
      * Sets up memfs with repo and config dirs, git mocks, and RepositoryManager.
      *
      * @param worktreeBranch - Branch name that the created worktree will report
+     * @param options.defaultAgentId - Optional default agent ID for the repository
      * @returns The worktree path that createWorktree will produce
      */
     async function setupDelegateEnvironment(
       worktreeBranch: string = 'feat/test-branch',
+      options?: { defaultAgentId?: string | null },
     ): Promise<string> {
       // The orgRepo extracted from the mock remote URL (git@github.com:owner/repo.git)
       const orgRepo = 'owner/repo';
@@ -809,9 +812,22 @@ describe('MCP Server Tools', () => {
         id: 'test-repo',
         name: 'test',
         path: TEST_REPO_PATH,
+        defaultAgentId: options?.defaultAgentId,
       }]);
 
       return repoWorktreeDir;
+    }
+
+    /**
+     * Find a PTY spawn call whose command arguments contain the given substring.
+     * Returns undefined if no matching call is found.
+     */
+    function findSpawnCallByCommand(commandSubstring: string): unknown[] | undefined {
+      const calls = ptyFactory.spawn.mock.calls as unknown as Array<[string, string[], unknown]>;
+      return calls.find((call) => {
+        const cmd = call[1]?.join(' ') ?? '';
+        return cmd.includes(commandSubstring);
+      });
     }
 
     it('should return error when repository not found', async () => {
@@ -1093,6 +1109,103 @@ describe('MCP Server Tools', () => {
 
       // Verify removeWorktree was called for rollback
       expect(mockGit.removeWorktree).toHaveBeenCalled();
+    });
+
+    // -----------------------------------------------------------------------
+    // Agent selection priority: agentId > repo.defaultAgentId > CLAUDE_CODE
+    // -----------------------------------------------------------------------
+
+    it('should use repository defaultAgentId when agentId is not provided', async () => {
+      const agentManager = await getAgentManager();
+      const registered = await agentManager.registerAgent({
+        name: 'Repo Default Agent',
+        commandTemplate: 'repo-default-agent {{prompt}}',
+      });
+
+      await setupDelegateEnvironment('feat/repo-default', {
+        defaultAgentId: registered.id,
+      });
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test repo default agent selection',
+        branch: 'feat/repo-default',
+        // agentId is intentionally omitted
+      }, nextId++);
+
+      expect(response.result?.isError).toBeUndefined();
+      expect(findSpawnCallByCommand('repo-default-agent')).toBeDefined();
+    });
+
+    it('should fall back to claude-code-builtin when agentId is not provided and repository has no defaultAgentId', async () => {
+      await setupDelegateEnvironment('feat/no-default');
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test fallback to claude-code-builtin',
+        branch: 'feat/no-default',
+        // agentId is intentionally omitted
+      }, nextId++);
+
+      // Success proves claude-code-builtin was used (the only registered agent)
+      expect(response.result?.isError).toBeUndefined();
+      const data = parseToolResult(response) as { sessionId: string };
+      expect(data.sessionId).toBeDefined();
+    });
+
+    it('should use explicit agentId even when repository has defaultAgentId', async () => {
+      const agentManager = await getAgentManager();
+      const repoDefault = await agentManager.registerAgent({
+        name: 'Repo Default Agent',
+        commandTemplate: 'repo-default-agent {{prompt}}',
+      });
+      const explicitAgent = await agentManager.registerAgent({
+        name: 'Explicit Agent',
+        commandTemplate: 'explicit-agent {{prompt}}',
+      });
+
+      await setupDelegateEnvironment('feat/explicit-override', {
+        defaultAgentId: repoDefault.id,
+      });
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test explicit agentId overrides repo default',
+        branch: 'feat/explicit-override',
+        agentId: explicitAgent.id,
+      }, nextId++);
+
+      expect(response.result?.isError).toBeUndefined();
+      expect(findSpawnCallByCommand('explicit-agent')).toBeDefined();
+      expect(findSpawnCallByCommand('repo-default-agent')).toBeUndefined();
+    });
+
+    it('should return error when repository defaultAgentId references a deleted agent', async () => {
+      // Register an agent, then set it as the repository default
+      const agentManager = await getAgentManager();
+      const tempAgent = await agentManager.registerAgent({
+        name: 'Soon Deleted Agent',
+        commandTemplate: 'soon-deleted {{prompt}}',
+      });
+
+      await setupDelegateEnvironment('feat/deleted-default', {
+        defaultAgentId: tempAgent.id,
+      });
+
+      // Delete the agent. The DB cascades ON DELETE SET NULL for default_agent_id,
+      // but RepositoryManager's in-memory cache still holds the stale defaultAgentId.
+      await agentManager.unregisterAgent(tempAgent.id);
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test deleted default agent',
+        branch: 'feat/deleted-default',
+        // agentId is intentionally omitted so the stale defaultAgentId is used
+      }, nextId++);
+      const data = parseToolResult(response) as { error: string };
+
+      expect(response.result?.isError).toBe(true);
+      expect(data.error).toContain('Agent not found');
     });
   });
 

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -308,7 +308,10 @@ mcpServer.tool(
     agentId: z
       .string()
       .optional()
-      .describe(`Agent to use (defaults to ${CLAUDE_CODE_AGENT_ID})`),
+      .describe(
+        `Agent to use. If omitted, falls back to the repository's configured default agent, ` +
+          `then to ${CLAUDE_CODE_AGENT_ID}.`,
+      ),
     title: z.string().optional().describe('Human-readable session title'),
     useRemote: z
       .boolean()
@@ -325,7 +328,7 @@ mcpServer.tool(
       }
 
       // Validate agent
-      const selectedAgentId = agentId ?? CLAUDE_CODE_AGENT_ID;
+      const selectedAgentId = agentId ?? repo.defaultAgentId ?? CLAUDE_CODE_AGENT_ID;
       const agentManager = await getAgentManager();
       const agent = agentManager.getAgent(selectedAgentId);
       if (!agent) {


### PR DESCRIPTION
## Summary

- **MCP `delegate_to_worktree` agent selection fix**: Previously ignored the repository's `defaultAgentId`, always falling back to `claude-code-builtin`. Now follows the correct priority chain: explicit `agentId` > `repo.defaultAgentId` > `CLAUDE_CODE_AGENT_ID`.
- **"Set as default" checkbox fix**: The checkbox was pre-checked when `defaultAgentId` existed, causing silent overwrites of the repository default when users changed the agent dropdown without intending to update the default. Now initializes unchecked.

## Test plan

- [x] MCP tests: 4 new tests covering agent selection priority chain (explicit, default, fallback, deleted-agent edge case)
- [x] CreateWorktreeForm tests: 2 new tests verifying checkbox starts unchecked and agent changes without checkbox don't overwrite defaults
- [x] Automated review loop (test-reviewer, code-quality-reviewer, ux-architecture-reviewer) passed with no CRITICAL/HIGH issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)