### PR TITLE
test: add unit tests for client utility modules

### DIFF
--- a/packages/client/src/lib/__tests__/favicon-manager.test.ts
+++ b/packages/client/src/lib/__tests__/favicon-manager.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import type { AgentActivityState } from '@agent-console/shared';
+import { updateFavicon, hasAnyAskingWorker } from '../favicon-manager';
+
+describe('updateFavicon', () => {
+  beforeEach(() => {
+    let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    if (!link) {
+      link = document.createElement('link');
+      link.rel = 'icon';
+      document.head.appendChild(link);
+    }
+    link.href = '';
+    // Reset module-level cached state to a known baseline
+    updateFavicon(false);
+  });
+
+  it('sets favicon to waiting when hasAskingWorker is true', () => {
+    updateFavicon(true);
+
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    expect(link?.href).toContain('/favicon-waiting.svg');
+  });
+
+  it('sets favicon to normal when hasAskingWorker is false', () => {
+    // First set to waiting so the transition actually happens
+    updateFavicon(true);
+
+    updateFavicon(false);
+
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    expect(link?.href).toContain('/favicon.svg');
+    expect(link?.href).not.toContain('waiting');
+  });
+
+  it('does not update DOM when favicon already matches', () => {
+    updateFavicon(true);
+
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    const hrefAfterFirstCall = link?.href;
+
+    // Mutate href to a sentinel value so we can detect if it gets overwritten
+    link!.href = '/sentinel.svg';
+
+    // Call again with same state - should skip due to cached path
+    updateFavicon(true);
+
+    expect(link?.href).toContain('/sentinel.svg');
+    expect(link?.href).not.toBe(hrefAfterFirstCall);
+  });
+
+  it('does nothing if no link[rel="icon"] element exists', () => {
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    link?.remove();
+
+    // Should not throw
+    expect(() => updateFavicon(true)).not.toThrow();
+  });
+});
+
+describe('hasAnyAskingWorker', () => {
+  it('returns false for empty object', () => {
+    expect(hasAnyAskingWorker({})).toBe(false);
+  });
+
+  it('returns false when no workers are asking', () => {
+    const states: Record<string, Record<string, AgentActivityState>> = {
+      session1: {
+        worker1: 'idle',
+        worker2: 'active',
+      },
+    };
+    expect(hasAnyAskingWorker(states)).toBe(false);
+  });
+
+  it('returns true when one worker is asking', () => {
+    const states: Record<string, Record<string, AgentActivityState>> = {
+      session1: {
+        worker1: 'asking',
+      },
+    };
+    expect(hasAnyAskingWorker(states)).toBe(true);
+  });
+
+  it('returns true when asking worker is in a different session', () => {
+    const states: Record<string, Record<string, AgentActivityState>> = {
+      session1: {
+        worker1: 'idle',
+      },
+      session2: {
+        worker1: 'asking',
+      },
+    };
+    expect(hasAnyAskingWorker(states)).toBe(true);
+  });
+
+  it('returns false for other activity states', () => {
+    const nonAskingStates: AgentActivityState[] = ['idle', 'active', 'unknown'];
+    for (const state of nonAskingStates) {
+      const states: Record<string, Record<string, AgentActivityState>> = {
+        session1: { worker1: state },
+      };
+      expect(hasAnyAskingWorker(states)).toBe(false);
+    }
+  });
+
+  it('detects asking among multiple sessions and workers', () => {
+    const states: Record<string, Record<string, AgentActivityState>> = {
+      session1: {
+        worker1: 'idle',
+        worker2: 'active',
+      },
+      session2: {
+        worker1: 'unknown',
+        worker2: 'idle',
+      },
+      session3: {
+        worker1: 'asking',
+      },
+    };
+    expect(hasAnyAskingWorker(states)).toBe(true);
+  });
+});

--- a/packages/client/src/lib/__tests__/format.test.ts
+++ b/packages/client/src/lib/__tests__/format.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'bun:test';
+import { formatTimestamp, formatAbsoluteTimestamp } from '../format';
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe('formatTimestamp', () => {
+  it('returns "just now" for less than 60 seconds ago', () => {
+    const now = Date.now();
+    expect(formatTimestamp(now - 30 * SECOND)).toBe('just now');
+  });
+
+  it('returns minutes ago for timestamps between 1 and 59 minutes', () => {
+    const now = Date.now();
+    expect(formatTimestamp(now - 5 * MINUTE)).toBe('5m ago');
+  });
+
+  it('returns hours ago for timestamps between 1 and 23 hours', () => {
+    const now = Date.now();
+    expect(formatTimestamp(now - 3 * HOUR)).toBe('3h ago');
+  });
+
+  it('returns days ago for timestamps between 1 and 6 days', () => {
+    const now = Date.now();
+    expect(formatTimestamp(now - 2 * DAY)).toBe('2d ago');
+  });
+
+  describe('boundary conditions', () => {
+    it('returns "just now" at exactly 59 seconds', () => {
+      const now = Date.now();
+      expect(formatTimestamp(now - 59 * SECOND)).toBe('just now');
+    });
+
+    it('returns "1m ago" at exactly 60 seconds', () => {
+      const now = Date.now();
+      expect(formatTimestamp(now - 60 * SECOND)).toBe('1m ago');
+    });
+
+    it('returns "59m ago" at exactly 59 minutes', () => {
+      const now = Date.now();
+      expect(formatTimestamp(now - 59 * MINUTE)).toBe('59m ago');
+    });
+
+    it('returns "1h ago" at exactly 60 minutes', () => {
+      const now = Date.now();
+      expect(formatTimestamp(now - 60 * MINUTE)).toBe('1h ago');
+    });
+
+    it('returns "23h ago" at exactly 23 hours', () => {
+      const now = Date.now();
+      expect(formatTimestamp(now - 23 * HOUR)).toBe('23h ago');
+    });
+
+    it('returns "1d ago" at exactly 24 hours', () => {
+      const now = Date.now();
+      expect(formatTimestamp(now - 24 * HOUR)).toBe('1d ago');
+    });
+
+    it('returns "6d ago" at exactly 6 days', () => {
+      const now = Date.now();
+      expect(formatTimestamp(now - 6 * DAY)).toBe('6d ago');
+    });
+
+    it('returns a locale-formatted date for 7+ days ago', () => {
+      const now = Date.now();
+      const result = formatTimestamp(now - 7 * DAY);
+      expect(typeof result).toBe('string');
+      expect(result).not.toMatch(/d ago$/);
+      expect(result).not.toBe('just now');
+    });
+  });
+});
+
+describe('formatAbsoluteTimestamp', () => {
+  it('returns a string for a valid timestamp', () => {
+    const result = formatAbsoluteTimestamp(1700000000000);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('produces consistent output for the same input', () => {
+    const timestamp = 1700000000000;
+    const result1 = formatAbsoluteTimestamp(timestamp);
+    const result2 = formatAbsoluteTimestamp(timestamp);
+    expect(result1).toBe(result2);
+  });
+});

--- a/packages/client/src/lib/__tests__/utils.test.ts
+++ b/packages/client/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'bun:test';
+import { cn } from '../utils';
+
+describe('cn', () => {
+  it('should return a single class string as-is', () => {
+    expect(cn('p-4')).toBe('p-4');
+  });
+
+  it('should merge multiple class strings', () => {
+    expect(cn('font-bold', 'text-lg')).toBe('font-bold text-lg');
+  });
+
+  it('should ignore falsy values', () => {
+    expect(cn('p-4', false, null, undefined, 0, '', 'mt-2')).toBe('p-4 mt-2');
+  });
+
+  it('should deduplicate Tailwind classes with last-wins precedence', () => {
+    expect(cn('p-4', 'p-2')).toBe('p-2');
+  });
+
+  it('should resolve conflicting Tailwind utility classes', () => {
+    expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500');
+  });
+
+  it('should return empty string when called with no arguments', () => {
+    expect(cn()).toBe('');
+  });
+
+  it('should accept an array of classes', () => {
+    expect(cn(['p-4', 'mt-2'])).toBe('p-4 mt-2');
+  });
+
+  it('should handle mixed input types', () => {
+    const result = cn(
+      'base',
+      ['array-class'],
+      { 'object-true': true, 'object-false': false },
+      undefined,
+      null,
+      false,
+      'last'
+    );
+    expect(result).toBe('base array-class object-true last');
+  });
+});

--- a/packages/client/src/lib/__tests__/websocket-url.test.ts
+++ b/packages/client/src/lib/__tests__/websocket-url.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { getWsProtocol, getAppWsUrl, getWorkerWsUrl } from '../websocket-url';
+
+function setLocation(protocol: string, host: string) {
+  Object.defineProperty(window, 'location', {
+    value: { protocol, host },
+    writable: true,
+  });
+}
+
+describe('getWsProtocol', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('returns ws: for http: protocol', () => {
+    setLocation('http:', 'localhost:3000');
+    expect(getWsProtocol()).toBe('ws:');
+  });
+
+  it('returns wss: for https: protocol', () => {
+    setLocation('https:', 'example.com');
+    expect(getWsProtocol()).toBe('wss:');
+  });
+});
+
+describe('getAppWsUrl', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('returns correct URL with ws: for http page', () => {
+    setLocation('http:', 'localhost:3000');
+    expect(getAppWsUrl()).toBe('ws://localhost:3000/ws/app');
+  });
+
+  it('returns correct URL with wss: for https page', () => {
+    setLocation('https:', 'example.com');
+    expect(getAppWsUrl()).toBe('wss://example.com/ws/app');
+  });
+
+  it('includes the host from window.location', () => {
+    setLocation('http:', 'myhost:8080');
+    expect(getAppWsUrl()).toBe('ws://myhost:8080/ws/app');
+  });
+});
+
+describe('getWorkerWsUrl', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    setLocation('http:', 'localhost:3000');
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('returns correct URL without fromOffset', () => {
+    expect(getWorkerWsUrl('session-1', 'worker-1')).toBe(
+      'ws://localhost:3000/ws/session/session-1/worker/worker-1'
+    );
+  });
+
+  it('returns correct URL with fromOffset query parameter', () => {
+    expect(getWorkerWsUrl('session-1', 'worker-1', 42)).toBe(
+      'ws://localhost:3000/ws/session/session-1/worker/worker-1?fromOffset=42'
+    );
+  });
+
+  it('includes fromOffset of 0 (not treated as falsy)', () => {
+    expect(getWorkerWsUrl('session-1', 'worker-1', 0)).toBe(
+      'ws://localhost:3000/ws/session/session-1/worker/worker-1?fromOffset=0'
+    );
+  });
+
+  it('correctly places sessionId and workerId in path', () => {
+    const url = getWorkerWsUrl('abc-123', 'def-456');
+    expect(url).toContain('/ws/session/abc-123/worker/def-456');
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `packages/client/src/lib/utils.ts` (cn function - 8 tests)
- Add unit tests for `packages/client/src/lib/format.ts` (formatTimestamp, formatAbsoluteTimestamp - 14 tests)
- Add unit tests for `packages/client/src/lib/favicon-manager.ts` (updateFavicon, hasAnyAskingWorker - 10 tests)
- Add unit tests for `packages/client/src/lib/websocket-url.ts` (getWsProtocol, getAppWsUrl, getWorkerWsUrl - 9 tests)

Closes #210 (Task 2)

## Test plan
- [x] All 41 new tests pass (`bun run test`)
- [x] Typecheck passes (`bun run typecheck`)
- [x] Happy path, edge cases, and boundary conditions covered
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)