### PR TITLE
fix: show proper state for phantom sessions after server restart

### DIFF
--- a/packages/client/src/components/sidebar/ActiveSessionsSidebar.tsx
+++ b/packages/client/src/components/sidebar/ActiveSessionsSidebar.tsx
@@ -84,7 +84,9 @@ interface SessionItemProps {
 
 function SessionItem({ sessionWithActivity, collapsed, isActive, onClick }: SessionItemProps) {
   const { session, activityState } = sessionWithActivity;
+  const isHibernated = session.activationState === 'hibernated';
   const { primary, secondary, tooltip } = getSessionDisplayInfo(session);
+  const label = isHibernated ? 'Hibernated' : getActivityLabel(activityState);
 
   if (collapsed) {
     return (
@@ -93,7 +95,7 @@ function SessionItem({ sessionWithActivity, collapsed, isActive, onClick }: Sess
         className={`w-full p-3 flex justify-center hover:bg-slate-800 transition-colors ${
           isActive ? 'bg-slate-800' : ''
         }`}
-        title={`${tooltip} (${getActivityLabel(activityState)})`}
+        title={`${tooltip} (${label})`}
       >
         <ActivityIndicator state={activityState} />
       </button>

--- a/packages/client/src/hooks/__tests__/useActiveSessionsWithActivity.test.ts
+++ b/packages/client/src/hooks/__tests__/useActiveSessionsWithActivity.test.ts
@@ -340,6 +340,114 @@ describe('useActiveSessionsWithActivity', () => {
     });
   });
 
+  describe('phantom sessions (hibernated, not paused)', () => {
+    it('should include phantom sessions with unknown activity state', () => {
+      const session = createMockSession({
+        id: 'phantom-1',
+        activationState: 'hibernated',
+      });
+
+      const { result } = renderHook(() =>
+        useActiveSessionsWithActivity([session], {})
+      );
+
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0].session.id).toBe('phantom-1');
+      expect(result.current[0].activityState).toBe('unknown');
+    });
+
+    it('should sort phantom sessions after running sessions', () => {
+      const sessions = [
+        createMockSession({ id: 'phantom-1', activationState: 'hibernated' }),
+        createMockSession({ id: 'running-1', activationState: 'running' }),
+      ];
+      const activityStates = createWorkerActivityStates([
+        { sessionId: 'running-1', workerId: 'worker-1', state: 'active' },
+      ]);
+
+      const { result } = renderHook(() =>
+        useActiveSessionsWithActivity(sessions, activityStates)
+      );
+
+      expect(result.current).toHaveLength(2);
+      expect(result.current[0].session.id).toBe('running-1');
+      expect(result.current[1].session.id).toBe('phantom-1');
+    });
+
+    it('should sort multiple running sessions by priority before phantom sessions', () => {
+      const sessions = [
+        createMockSession({ id: 'phantom-1', activationState: 'hibernated' }),
+        createMockSession({ id: 'active-1', activationState: 'running' }),
+        createMockSession({ id: 'asking-1', activationState: 'running' }),
+      ];
+      const activityStates = createWorkerActivityStates([
+        { sessionId: 'active-1', workerId: 'worker-1', state: 'active' },
+        { sessionId: 'asking-1', workerId: 'worker-1', state: 'asking' },
+      ]);
+
+      const { result } = renderHook(() =>
+        useActiveSessionsWithActivity(sessions, activityStates)
+      );
+
+      expect(result.current).toHaveLength(3);
+      expect(result.current[0].session.id).toBe('asking-1');
+      expect(result.current[1].session.id).toBe('active-1');
+      expect(result.current[2].session.id).toBe('phantom-1');
+    });
+  });
+
+  describe('paused sessions exclusion', () => {
+    it('should exclude paused sessions', () => {
+      const session = createMockSession({
+        id: 'paused-1',
+        activationState: 'hibernated',
+        paused: true,
+      });
+
+      const { result } = renderHook(() =>
+        useActiveSessionsWithActivity([session], {})
+      );
+
+      expect(result.current).toEqual([]);
+    });
+
+    it('should exclude paused sessions even if they have activity states', () => {
+      const session = createMockSession({
+        id: 'paused-1',
+        activationState: 'hibernated',
+        paused: true,
+      });
+      const activityStates = createWorkerActivityStates([
+        { sessionId: 'paused-1', workerId: 'worker-1', state: 'active' },
+      ]);
+
+      const { result } = renderHook(() =>
+        useActiveSessionsWithActivity([session], activityStates)
+      );
+
+      expect(result.current).toEqual([]);
+    });
+
+    it('should include phantom but exclude paused when mixed', () => {
+      const sessions = [
+        createMockSession({ id: 'phantom-1', activationState: 'hibernated' }),
+        createMockSession({ id: 'paused-1', activationState: 'hibernated', paused: true }),
+        createMockSession({ id: 'running-1', activationState: 'running' }),
+      ];
+      const activityStates = createWorkerActivityStates([
+        { sessionId: 'running-1', workerId: 'worker-1', state: 'idle' },
+      ]);
+
+      const { result } = renderHook(() =>
+        useActiveSessionsWithActivity(sessions, activityStates)
+      );
+
+      expect(result.current).toHaveLength(2);
+      expect(result.current[0].session.id).toBe('running-1');
+      expect(result.current[1].session.id).toBe('phantom-1');
+    });
+  });
+
   describe('memoization behavior', () => {
     it('should return same reference for same inputs', () => {
       const sessions = [createMockSession({ id: 'session-1' })];

--- a/packages/client/src/hooks/__tests__/useSessionState.test.ts
+++ b/packages/client/src/hooks/__tests__/useSessionState.test.ts
@@ -173,23 +173,23 @@ describe('useSessionState', () => {
       expect(result.current.sessions[1].title).toBe('Session 2');
     });
 
-    it('should handle non-existent session gracefully', () => {
+    it('should add session if not yet in the list', () => {
       const { result } = renderHook(() => useSessionState());
 
       const session = createMockSession({ id: 'session-1' });
-      const nonExistentSession = createMockSession({ id: 'non-existent' });
+      const newSession = createMockSession({ id: 'session-2', title: 'New' });
 
       act(() => {
         result.current.handleSessionsSync([session], []);
       });
 
       act(() => {
-        result.current.handleSessionUpdated(nonExistentSession);
+        result.current.handleSessionUpdated(newSession);
       });
 
-      // Original session should remain unchanged
-      expect(result.current.sessions).toHaveLength(1);
-      expect(result.current.sessions[0].id).toBe('session-1');
+      expect(result.current.sessions).toHaveLength(2);
+      expect(result.current.sessions[1].id).toBe('session-2');
+      expect(result.current.sessionsRef.current).toHaveLength(2);
     });
   });
 
@@ -248,6 +248,86 @@ describe('useSessionState', () => {
       });
 
       expect(result.current.sessions).toHaveLength(1);
+    });
+  });
+
+  describe('handleSessionPaused', () => {
+    it('should mark session as paused and hibernated', () => {
+      const { result } = renderHook(() => useSessionState());
+
+      const session = createMockSession({ id: 'session-1', activationState: 'running' });
+
+      act(() => {
+        result.current.handleSessionsSync([session], []);
+      });
+
+      act(() => {
+        result.current.handleSessionPaused('session-1');
+      });
+
+      expect(result.current.sessions[0].paused).toBe(true);
+      expect(result.current.sessions[0].activationState).toBe('hibernated');
+      expect(result.current.sessionsRef.current[0].paused).toBe(true);
+      expect(result.current.sessionsRef.current[0].activationState).toBe('hibernated');
+    });
+
+    it('should not affect other sessions', () => {
+      const { result } = renderHook(() => useSessionState());
+
+      const session1 = createMockSession({ id: 'session-1', activationState: 'running' });
+      const session2 = createMockSession({ id: 'session-2', activationState: 'running' });
+
+      act(() => {
+        result.current.handleSessionsSync([session1, session2], []);
+      });
+
+      act(() => {
+        result.current.handleSessionPaused('session-1');
+      });
+
+      expect(result.current.sessions[0].paused).toBe(true);
+      expect(result.current.sessions[1].paused).toBeUndefined();
+      expect(result.current.sessions[1].activationState).toBe('running');
+    });
+  });
+
+  describe('handleSessionResumed', () => {
+    it('should add resumed session if not in list', () => {
+      const { result } = renderHook(() => useSessionState());
+
+      act(() => {
+        result.current.handleSessionsSync([], []);
+      });
+
+      const resumedSession = createMockSession({ id: 'session-1', activationState: 'running' });
+
+      act(() => {
+        result.current.handleSessionResumed(resumedSession);
+      });
+
+      expect(result.current.sessions).toHaveLength(1);
+      expect(result.current.sessions[0].id).toBe('session-1');
+      expect(result.current.sessionsRef.current).toHaveLength(1);
+    });
+
+    it('should update existing session when resumed', () => {
+      const { result } = renderHook(() => useSessionState());
+
+      const session = createMockSession({ id: 'session-1', activationState: 'hibernated', paused: true });
+
+      act(() => {
+        result.current.handleSessionsSync([session], []);
+      });
+
+      const resumedSession = createMockSession({ id: 'session-1', activationState: 'running' });
+
+      act(() => {
+        result.current.handleSessionResumed(resumedSession);
+      });
+
+      expect(result.current.sessions).toHaveLength(1);
+      expect(result.current.sessions[0].activationState).toBe('running');
+      expect(result.current.sessions[0].paused).toBeUndefined();
     });
   });
 

--- a/packages/client/src/hooks/useActiveSessionsWithActivity.ts
+++ b/packages/client/src/hooks/useActiveSessionsWithActivity.ts
@@ -41,9 +41,10 @@ function getSessionActivityState(
 
 /**
  * Hook that returns sessions filtered and sorted by activity state.
- * - Only includes running sessions (excludes hibernated sessions)
- * - Only includes sessions with activity state != 'unknown'
- * - Sorted by priority: asking > idle > active
+ * - Excludes paused sessions (they are handled separately in the dashboard)
+ * - Includes running sessions with known activity state
+ * - Includes phantom sessions (hibernated, not paused) with 'unknown' activity state
+ * - Sorted by priority: asking > idle > active, then hibernated at the end
  */
 export function useActiveSessionsWithActivity(
   sessions: Session[],
@@ -52,21 +53,28 @@ export function useActiveSessionsWithActivity(
   return useMemo(() => {
     const sessionsWithActivity: SessionWithActivity[] = [];
 
-    // Filter to only running sessions (exclude hibernated)
-    const runningSessions = sessions.filter(s => s.activationState === 'running');
+    for (const session of sessions) {
+      // Exclude paused sessions (they're handled separately in the dashboard)
+      if (session.paused) continue;
 
-    for (const session of runningSessions) {
       const activityState = getSessionActivityState(session, workerActivityStates);
-      // Only include sessions with known activity state
-      if (activityState !== 'unknown') {
-        sessionsWithActivity.push({ session, activityState });
+
+      // Include sessions with known activity state OR phantom (hibernated) sessions
+      if (activityState !== 'unknown' || session.activationState === 'hibernated') {
+        sessionsWithActivity.push({
+          session,
+          activityState: session.activationState === 'hibernated' ? 'unknown' : activityState,
+        });
       }
     }
 
-    // Sort by activity priority (asking first, then idle, then active)
-    sessionsWithActivity.sort(
-      (a, b) => activityPriority[a.activityState] - activityPriority[b.activityState]
-    );
+    // Sort: running sessions first (by priority), then hibernated at the end
+    sessionsWithActivity.sort((a, b) => {
+      const aHibernated = a.session.activationState === 'hibernated' ? 1 : 0;
+      const bHibernated = b.session.activationState === 'hibernated' ? 1 : 0;
+      if (aHibernated !== bHibernated) return aHibernated - bHibernated;
+      return activityPriority[a.activityState] - activityPriority[b.activityState];
+    });
 
     return sessionsWithActivity;
   }, [sessions, workerActivityStates]);

--- a/packages/client/src/hooks/useSessionState.ts
+++ b/packages/client/src/hooks/useSessionState.ts
@@ -18,6 +18,10 @@ interface UseSessionStateReturn {
   handleSessionUpdated: (session: Session) => void;
   /** Handle session deleted */
   handleSessionDeleted: (sessionId: string) => void;
+  /** Handle session paused (removed from memory but preserved in DB) */
+  handleSessionPaused: (sessionId: string) => void;
+  /** Handle paused session resumed */
+  handleSessionResumed: (session: Session) => void;
   /** Handle worker activity state change */
   handleWorkerActivity: (sessionId: string, workerId: string, state: AgentActivityState) => void;
   /** Set sessions from REST API fallback */
@@ -52,8 +56,16 @@ export function useSessionState(): UseSessionStateReturn {
   }, []);
 
   const handleSessionUpdated = useCallback((session: Session) => {
-    setSessions(prev => prev.map(s => s.id === session.id ? session : s));
-    sessionsRef.current = sessionsRef.current.map(s => s.id === session.id ? session : s);
+    setSessions(prev => {
+      const exists = prev.some(s => s.id === session.id);
+      if (exists) {
+        return prev.map(s => s.id === session.id ? session : s);
+      }
+      return [...prev, session];
+    });
+    sessionsRef.current = sessionsRef.current.some(s => s.id === session.id)
+      ? sessionsRef.current.map(s => s.id === session.id ? session : s)
+      : [...sessionsRef.current, session];
   }, []);
 
   const handleSessionDeleted = useCallback((sessionId: string) => {
@@ -65,6 +77,28 @@ export function useSessionState(): UseSessionStateReturn {
       delete next[sessionId];
       return next;
     });
+  }, []);
+
+  const handleSessionPaused = useCallback((sessionId: string) => {
+    setSessions(prev => prev.map(s =>
+      s.id === sessionId ? { ...s, paused: true, activationState: 'hibernated' as const } : s
+    ));
+    sessionsRef.current = sessionsRef.current.map(s =>
+      s.id === sessionId ? { ...s, paused: true, activationState: 'hibernated' as const } : s
+    );
+  }, []);
+
+  const handleSessionResumed = useCallback((session: Session) => {
+    setSessions(prev => {
+      const exists = prev.some(s => s.id === session.id);
+      if (exists) {
+        return prev.map(s => s.id === session.id ? session : s);
+      }
+      return [...prev, session];
+    });
+    sessionsRef.current = sessionsRef.current.some(s => s.id === session.id)
+      ? sessionsRef.current.map(s => s.id === session.id ? session : s)
+      : [...sessionsRef.current, session];
   }, []);
 
   const handleWorkerActivity = useCallback((sessionId: string, workerId: string, state: AgentActivityState) => {
@@ -89,6 +123,8 @@ export function useSessionState(): UseSessionStateReturn {
     handleSessionCreated,
     handleSessionUpdated,
     handleSessionDeleted,
+    handleSessionPaused,
+    handleSessionResumed,
     handleWorkerActivity,
     setSessionsFromApi,
   };

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -77,6 +77,8 @@ function RootLayout() {
     handleSessionCreated,
     handleSessionUpdated,
     handleSessionDeleted,
+    handleSessionPaused,
+    handleSessionResumed,
     handleWorkerActivity,
   } = useSessionState();
 
@@ -99,6 +101,8 @@ function RootLayout() {
     onSessionCreated: handleSessionCreated,
     onSessionUpdated: handleSessionUpdated,
     onSessionDeleted: handleSessionDeleted,
+    onSessionPaused: handleSessionPaused,
+    onSessionResumed: handleSessionResumed,
     onWorkerActivity: handleWorkerActivity,
     onWorktreeCreationCompleted: worktreeCreationTasks.handleWorktreeCreationCompleted,
     onWorktreeCreationFailed: worktreeCreationTasks.handleWorktreeCreationFailed,

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -169,20 +169,19 @@ function DashboardPage() {
   const handleSessionsSync = useCallback((sessions: Session[], activityStates: WorkerActivityInfo[]) => {
     console.log(`[Sync] Initializing ${sessions.length} sessions from WebSocket`);
 
-    // Separate active sessions from paused sessions by activationState
-    const activeSessions = sessions.filter(s => s.activationState === 'running');
-    const hibernatedSessions = sessions.filter(s => s.activationState === 'hibernated');
+    // Separate paused sessions (DB-only, explicitly paused) from active/phantom sessions
+    const activeSessions = sessions.filter(s => !s.paused);
+    const pausedSessionsList = sessions.filter(s => s.paused === true);
 
-    console.log(`[Sync] Active: ${activeSessions.length}, Paused: ${hibernatedSessions.length}`);
+    console.log(`[Sync] Active/Phantom: ${activeSessions.length}, Paused: ${pausedSessionsList.length}`);
 
-    // Update active sessions list (only running sessions)
+    // Update active sessions list (running + phantom/hibernated)
     setWsSessions(activeSessions);
     sessionsRef.current = activeSessions;
 
-    // Build pausedSessions map from hibernated worktree sessions
-    // Store full session objects to preserve title and other metadata
+    // Build pausedSessions map from truly paused worktree sessions
     const newPausedSessions: Record<string, Session> = {};
-    for (const session of hibernatedSessions) {
+    for (const session of pausedSessionsList) {
       if (session.type === 'worktree') {
         newPausedSessions[session.locationPath] = session;
       }
@@ -219,8 +218,20 @@ function DashboardPage() {
   // Handle session updated
   const handleSessionUpdated = useCallback((session: Session) => {
     console.log(`[Session] Updated: ${session.id}`);
-    setWsSessions(prev => prev.map(s => s.id === session.id ? session : s));
-    sessionsRef.current = sessionsRef.current.map(s => s.id === session.id ? session : s);
+    setWsSessions(prev => {
+      const exists = prev.some(s => s.id === session.id);
+      if (exists) {
+        return prev.map(s => s.id === session.id ? session : s);
+      }
+      // Session not in list yet - add it if it's not paused
+      if (!session.paused) {
+        return [...prev, session];
+      }
+      return prev;
+    });
+    sessionsRef.current = sessionsRef.current.some(s => s.id === session.id)
+      ? sessionsRef.current.map(s => s.id === session.id ? session : s)
+      : (!session.paused ? [...sessionsRef.current, session] : sessionsRef.current);
   }, []);
 
   // Handle session deleted
@@ -266,7 +277,7 @@ function DashboardPage() {
     if (session && session.type === 'worktree') {
       // Track as paused session for "Resume" button, storing full session to preserve title
       // Update activationState to 'hibernated' since it's now paused
-      const pausedSession: Session = { ...session, activationState: 'hibernated' };
+      const pausedSession: Session = { ...session, activationState: 'hibernated', paused: true };
       setPausedSessions(prev => ({
         ...prev,
         [session.locationPath]: pausedSession,
@@ -946,12 +957,14 @@ function WorktreeRow({ worktree, session, pausedSession, repositoryId }: Worktre
   };
 
   const statusColor = session
-    ? session.status === 'active'
-      ? 'bg-green-500'
-      : 'bg-gray-500'
+    ? session.activationState === 'hibernated'
+      ? 'bg-yellow-500'   // Phantom session (hibernated but in-memory)
+      : session.status === 'active'
+        ? 'bg-green-500'
+        : 'bg-gray-500'
     : pausedSession
-      ? 'bg-yellow-500'  // Paused session
-      : 'bg-gray-600';   // No session
+      ? 'bg-yellow-500'    // Paused session
+      : 'bg-gray-600';     // No session
 
   return (
     <div className="flex items-center gap-3 p-2 bg-slate-800 rounded">
@@ -989,7 +1002,12 @@ function WorktreeRow({ worktree, session, pausedSession, repositoryId }: Worktre
               <VSCodeIcon className="w-4 h-4" />
             </button>
           )}
-          {session && <ActivityBadge state={session.activityState} />}
+          {session && session.activationState === 'hibernated' && (
+            <span className="text-xs px-1.5 py-0.5 rounded font-medium bg-yellow-500/20 text-yellow-400">
+              Hibernated
+            </span>
+          )}
+          {session && session.activationState !== 'hibernated' && <ActivityBadge state={session.activityState} />}
         </div>
         <PathLink path={worktree.path} className="text-xs text-gray-500 truncate" />
       </div>
@@ -1101,9 +1119,11 @@ function SessionCard({ session }: SessionCardProps) {
   });
 
   const statusColor =
-    session.status === 'active'
-      ? 'bg-green-500'
-      : 'bg-gray-500';
+    session.activationState === 'hibernated'
+      ? 'bg-yellow-500'
+      : session.status === 'active'
+        ? 'bg-green-500'
+        : 'bg-gray-500';
 
   return (
     <>
@@ -1117,7 +1137,13 @@ function SessionCard({ session }: SessionCardProps) {
           )}
           <div className="text-sm text-gray-200 overflow-hidden text-ellipsis whitespace-nowrap flex items-center gap-2">
             <PathLink path={session.locationPath} className="truncate" />
-            <ActivityBadge state={session.activityState} />
+            {session.activationState === 'hibernated' ? (
+              <span className="text-xs px-1.5 py-0.5 rounded font-medium bg-yellow-500/20 text-yellow-400">
+                Hibernated
+              </span>
+            ) : (
+              <ActivityBadge state={session.activityState} />
+            )}
           </div>
           <div className="text-xs text-gray-500 mt-1">
             Workers: {session.workers.length} | Started: {new Date(session.createdAt).toLocaleString()}

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import * as fs from 'fs';
-import type { CreateSessionRequest, CreateWorkerParams, Worker } from '@agent-console/shared';
+import type { CreateSessionRequest, CreateWorkerParams, Session, Worker } from '@agent-console/shared';
 import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
@@ -2287,6 +2287,49 @@ describe('SessionManager', () => {
 
       const result = await managerWithMissingPath.resumeSession(session.id);
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getAllPausedSessions', () => {
+    it('should return paused sessions with paused: true', async () => {
+      const manager = await getSessionManager();
+
+      // Create and pause a worktree session
+      const session = await manager.createSession({
+        type: 'worktree',
+        locationPath: '/test/path',
+        repositoryId: 'repo-1',
+        worktreeId: 'feature-branch',
+        agentId: 'claude-code',
+      });
+
+      await manager.pauseSession(session.id);
+
+      // Get paused sessions
+      const pausedSessions = await manager.getAllPausedSessions();
+
+      expect(pausedSessions.length).toBe(1);
+      expect(pausedSessions[0].id).toBe(session.id);
+      expect(pausedSessions[0].paused).toBe(true);
+      expect(pausedSessions[0].activationState).toBe('hibernated');
+    });
+
+    it('should not set paused on active in-memory sessions', async () => {
+      const manager = await getSessionManager();
+
+      const session = await manager.createSession({
+        type: 'worktree',
+        locationPath: '/test/path',
+        repositoryId: 'repo-1',
+        worktreeId: 'feature-branch',
+        agentId: 'claude-code',
+      });
+
+      // Active sessions via getAllSessions should not have paused: true
+      const allSessions: Session[] = manager.getAllSessions();
+      const activeSession = allSessions.find((s) => s.id === session.id);
+      expect(activeSession).toBeDefined();
+      expect(activeSession?.paused).toBeUndefined();
     });
   });
 

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -73,12 +73,21 @@ describe('WorkerLifecycleManager', () => {
       getSession: (id: string) => sessions.get(id),
       persistSession: mockPersistSession as unknown as (session: InternalSession) => Promise<void>,
       getRepositoryEnvVars: () => ({}),
-      toPublicSession: (session: InternalSession) => ({
-        ...session,
-        workers: Array.from(session.workers.values()).map((w) =>
-          workerManager.toPublicWorker(w)
-        ),
-      }) as Session,
+      toPublicSession: (session: InternalSession) => {
+        const ptyWorkers = Array.from(session.workers.values()).filter(
+          (w) => w.type === 'agent' || w.type === 'terminal'
+        ) as Array<InternalAgentWorker | InternalTerminalWorker>;
+        const activationState = ptyWorkers.length === 0
+          ? 'running' as const
+          : ptyWorkers.some((w) => w.pty !== null) ? 'running' as const : 'hibernated' as const;
+        return {
+          ...session,
+          activationState,
+          workers: Array.from(session.workers.values()).map((w) =>
+            workerManager.toPublicWorker(w)
+          ),
+        } as Session;
+      },
       getJobQueue: () => testJobQueue,
       getSessionLifecycleCallbacks: () => mockCallbacks,
       ...overrides,
@@ -829,6 +838,33 @@ describe('WorkerLifecycleManager', () => {
       expect(mockPersistSession).toHaveBeenCalled();
     });
 
+    it('should call onSessionUpdated callback after restoration', async () => {
+      const session = createTestSession();
+      sessions.set(session.id, session);
+
+      const agentWorker: InternalAgentWorker = {
+        id: 'restored-session-update',
+        type: 'agent',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+        pty: null,
+        outputBuffer: '',
+        outputOffset: 0,
+        activityState: 'unknown',
+        activityDetector: null,
+        connectionCallbacks: new Map(),
+      };
+      session.workers.set(agentWorker.id, agentWorker);
+
+      await lifecycleManager.restoreWorker(session.id, agentWorker.id);
+
+      expect(mockOnSessionUpdated).toHaveBeenCalledTimes(1);
+      const updatedSession = mockOnSessionUpdated.mock.calls[0][0] as Session;
+      expect(updatedSession.id).toBe(session.id);
+      expect(updatedSession.activationState).toBe('running');
+    });
+
     it('should call onWorkerActivated callback after restoration', async () => {
       const session = createTestSession();
       sessions.set(session.id, session);
@@ -954,6 +990,30 @@ describe('WorkerLifecycleManager', () => {
       const result = await manager.getAvailableWorker(session.id, terminalWorker.id);
 
       expect(result).toBeNull();
+    });
+
+    it('should call onSessionUpdated callback after activating PTY', async () => {
+      const session = createTestSession();
+      sessions.set(session.id, session);
+
+      const terminalWorker: InternalTerminalWorker = {
+        id: 'session-update-on-activate',
+        type: 'terminal',
+        name: 'Terminal',
+        createdAt: new Date().toISOString(),
+        pty: null,
+        outputBuffer: '',
+        outputOffset: 0,
+        connectionCallbacks: new Map(),
+      };
+      session.workers.set(terminalWorker.id, terminalWorker);
+
+      await lifecycleManager.getAvailableWorker(session.id, terminalWorker.id);
+
+      expect(mockOnSessionUpdated).toHaveBeenCalledTimes(1);
+      const updatedSession = mockOnSessionUpdated.mock.calls[0][0] as Session;
+      expect(updatedSession.id).toBe(session.id);
+      expect(updatedSession.activationState).toBe('running');
     });
 
     it('should persist session after activating PTY', async () => {

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -706,6 +706,7 @@ export class SessionManager {
       workers,
       initialPrompt: p.initialPrompt,
       title: p.title,
+      paused: true,
     };
 
     if (p.type === 'worktree') {

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -214,6 +214,9 @@ export class WorkerLifecycleManager {
     await this.deps.persistSession(session);
     logger.info({ workerId, sessionId, workerType: worker.type }, 'Worker PTY activated');
 
+    // Broadcast session-updated since activationState may have changed
+    this.deps.getSessionLifecycleCallbacks()?.onSessionUpdated?.(this.deps.toPublicSession(session));
+
     return worker;
   }
 
@@ -450,6 +453,9 @@ export class WorkerLifecycleManager {
 
     // Notify listeners that the worker was activated (broadcasts to app clients)
     this.deps.getSessionLifecycleCallbacks()?.onWorkerActivated?.(sessionId, workerId);
+
+    // Broadcast session-updated so clients learn the activationState changed (e.g., hibernated -> running)
+    this.deps.getSessionLifecycleCallbacks()?.onSessionUpdated?.(this.deps.toPublicSession(session));
 
     return { success: true, worker: existingWorker, wasRestored: true };
   }

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -56,6 +56,8 @@ export interface SessionBase {
   workers: Worker[];
   initialPrompt?: string;    // The prompt used to start the session
   title?: string;            // Human-readable title for the session
+  /** Whether this session is explicitly paused (not in server memory, requires resume API) */
+  paused?: boolean;
 }
 
 export interface WorktreeSession extends SessionBase {


### PR DESCRIPTION
## Summary

Fixes #303

After a server crash/restart, phantom sessions (in-memory but with dead PTY processes) were indistinguishable from explicitly paused sessions, causing misleading "Paused" state on the dashboard.

- **Server**: Add `paused?: boolean` to `SessionBase` type; set `paused: true` only for DB-only paused sessions
- **Server**: Broadcast `session-updated` after PTY activation in `restoreWorker()` and `getAvailableWorker()` so clients learn about `activationState` changes (hibernated → running)
- **Client**: Dashboard separates sessions by `paused` flag instead of `activationState`, showing phantom sessions with yellow "Hibernated" badge and "Open" button
- **Client**: Sidebar includes phantom sessions with gray dot indicator
- **Client**: Root layout subscribes to `session-paused`/`session-resumed` events for sidebar state sync

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes (2,315 tests, 0 failures)
- [ ] Start server, create a worktree session, kill server, restart → phantom session shows "Hibernated" badge with "Open" button (not "Resume")
- [ ] Sidebar shows phantom session with gray dot
- [ ] Click "Open" → session page loads → terminal connects → PTY restored → dashboard/sidebar update to running state
- [ ] Explicitly paused sessions still show "Resume" button correctly
- [ ] Quick sessions that are phantom show "Hibernated" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)