### PR TITLE
fix: add AbortController to cancel stale cache loads during rapid tab switching

### DIFF
--- a/packages/client/src/components/Terminal.tsx
+++ b/packages/client/src/components/Terminal.tsx
@@ -342,6 +342,8 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
     stateRef.current.currentWorkerId = workerId;
     // Increment mount generation counter to detect stale async operations
     const currentGeneration = ++stateRef.current.mountGeneration;
+    // Create AbortController for this mount cycle to cancel in-flight cache loads on tab switch
+    const abortController = new AbortController();
 
     // Register state getter with save manager for idle-based saves
     const stateGetter = () => {
@@ -369,8 +371,12 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
 
     // Try to restore terminal state from cache before processing server history
     // This eliminates flickering when switching between workers
-    loadTerminalState(sessionId, workerId)
+    loadTerminalState(sessionId, workerId, abortController.signal)
       .then(async (cached) => {
+        // AbortController cancelled this operation (tab switched during cache load)
+        if (abortController.signal.aborted) return;
+
+        // Existing stale checks remain as defense-in-depth
         // Race condition check: abort if component unmounted, worker changed, or mount generation changed
         if (!stateRef.current.isMounted) {
           console.debug('[Terminal] Abandoned cache read: component unmounted for workerId:', workerId);
@@ -402,6 +408,9 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
         setCacheProcessed(true);
       })
       .catch((e) => {
+        // Silently ignore aborted operations (not an error)
+        if (abortController.signal.aborted) return;
+
         console.warn('[Terminal] Failed to load cached state:', e);
         setCacheError('Failed to load cached terminal state');
 
@@ -541,6 +550,9 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
     });
 
     return () => {
+      // Abort any in-flight cache load to prevent stale data from being written to terminal
+      abortController.abort();
+
       // Unregister from save manager - this triggers final save (async, best-effort)
       unregisterSaveManager(sessionId, workerId)
         .catch((e) => console.warn('[Terminal] Failed to save on unmount:', e));

--- a/packages/client/src/lib/__tests__/terminal-state-cache.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-state-cache.test.ts
@@ -218,6 +218,57 @@ describe('terminal-state-cache', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should return null immediately when signal is already aborted', async () => {
+      const state = createValidState();
+      mockStore.set('terminal:session-1:worker-1', state);
+
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await loadTerminalState('session-1', 'worker-1', controller.signal);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when signal is aborted and IndexedDB throws', async () => {
+      getMockThrows = true;
+
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await loadTerminalState('session-1', 'worker-1', controller.signal);
+
+      expect(result).toBeNull();
+    });
+
+    it('should load normally when signal is not aborted', async () => {
+      const state = createValidState();
+      mockStore.set('terminal:session-1:worker-1', state);
+
+      const controller = new AbortController();
+
+      const result = await loadTerminalState('session-1', 'worker-1', controller.signal);
+
+      expect(result).toEqual(state);
+    });
+
+    it('should return null when signal is aborted during IndexedDB read', async () => {
+      const state = createValidState();
+      mockStore.set('terminal:session-1:worker-1', state);
+
+      const controller = new AbortController();
+
+      // Start the load - the mock get() returns synchronously but await yields
+      const loadPromise = loadTerminalState('session-1', 'worker-1', controller.signal);
+
+      // Abort after loadTerminalState starts but before it processes the result
+      // The signal.aborted check after `await get(key)` will catch this
+      controller.abort();
+
+      const result = await loadPromise;
+      expect(result).toBeNull();
+    });
   });
 
   describe('clearTerminalState', () => {

--- a/packages/client/src/lib/terminal-state-cache.ts
+++ b/packages/client/src/lib/terminal-state-cache.ts
@@ -143,11 +143,17 @@ export async function saveTerminalState(
  */
 export async function loadTerminalState(
   sessionId: string,
-  workerId: string
+  workerId: string,
+  signal?: AbortSignal
 ): Promise<CachedState | null> {
   try {
     const key = buildKey(sessionId, workerId);
+
+    if (signal?.aborted) return null;
+
     const value = await get(key);
+
+    if (signal?.aborted) return null;
 
     if (value === undefined) {
       return null;
@@ -174,6 +180,7 @@ export async function loadTerminalState(
 
     return value;
   } catch (error) {
+    if (signal?.aborted) return null;
     console.warn('Failed to load terminal state from IndexedDB:', error);
     return null;
   }


### PR DESCRIPTION
## Summary

- Add AbortController to Terminal.tsx initialization effect to cancel in-flight `loadTerminalState()` calls when the worker changes (tab switch triggers unmount/remount)
- Add optional `AbortSignal` parameter to `loadTerminalState()` in terminal-state-cache.ts with abort checks at each async boundary
- Existing stale checks (currentWorkerId, isMounted, mountGeneration) are kept as defense-in-depth alongside the AbortController

Closes #209 (Task 2)

## Test plan

- [x] Added tests for AbortSignal behavior in `terminal-state-cache.test.ts`:
  - Signal already aborted before call returns null
  - Signal aborted during IndexedDB read returns null
  - Signal aborted when IndexedDB throws returns null
  - Non-aborted signal loads normally
- [x] All 2,429 tests pass (0 failures)
- [x] TypeScript type checking passes for all packages
- [ ] Manual: Rapidly switch between tabs and verify no terminal flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)