### PR TITLE
fix: guard against NaN in pullFastForward commit count

### DIFF
--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -546,7 +546,11 @@ export async function pullFastForward(cwd: string): Promise<number> {
 
   // Count commits between old and new HEAD
   const countStr = await git(['rev-list', '--count', `${headBefore}..${headAfter}`], cwd);
-  return parseInt(countStr, 10);
+  const commitsPulled = Number.parseInt(countStr, 10);
+  if (Number.isNaN(commitsPulled)) {
+    throw new GitError(`Invalid commit count from git rev-list: "${countStr}"`, -1, countStr);
+  }
+  return commitsPulled;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add NaN validation for `parseInt` result in `pullFastForward()` to prevent invalid data in WebSocket payloads

## Context

Follow-up from CodeRabbit review on #316. If `git rev-list --count` returns unexpected output, `parseInt` would silently return `NaN`, which would propagate into `WorktreePullCompletedPayload.commitsPulled`. Now throws a `GitError` instead.

## Test plan

- [x] Existing `pullFastForward` tests pass (happy path already returns valid integers)
- [ ] Manual: verify pull still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)