### PR TITLE
refactor: migrate service internals from singleton getters to constructor injection

### DIFF
--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -107,7 +107,8 @@ function restoreBunSpawn() {
 import { resetRepositoryManager, initializeRepositoryManager, getRepositoryManager } from '../services/repository-manager.js';
 import { resetSessionManager, initializeSessionManager, getSessionManager } from '../services/session-manager.js';
 import { createSessionRepository } from '../repositories/index.js';
-import { resetAgentManager, getAgentManager } from '../services/agent-manager.js';
+import { AgentManager, resetAgentManager, getAgentManager } from '../services/agent-manager.js';
+import { SqliteAgentRepository } from '../repositories/sqlite-agent-repository.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../database/connection.js';
 import { JobQueue, resetJobQueue } from '../jobs/index.js';
 import {
@@ -265,21 +266,25 @@ describe('API Routes Integration', () => {
 
     // Initialize managers with test JobQueue
     // This ensures cleanup operations have a valid jobQueue
+    let agentManager: Awaited<ReturnType<typeof AgentManager.create>> | undefined;
     if (testJobQueue) {
       const sessionRepository = await createSessionRepository();
-      await initializeSessionManager({ sessionRepository, jobQueue: testJobQueue });
+      resetAgentManager();
+      agentManager = await AgentManager.create(new SqliteAgentRepository(getDatabase()));
+      await initializeSessionManager({ sessionRepository, jobQueue: testJobQueue, agentManager });
       await initializeRepositoryManager({ jobQueue: testJobQueue });
     }
 
     const app = new Hono<AppBindings>();
     // Inject AppContext constructed from test singletons
+    // Use the same agentManager instance that was injected into SessionManager
     app.use('*', async (c, next) => {
       c.set('appContext', {
         jobQueue: testJobQueue!,
         sessionManager: getSessionManager(),
         repositoryManager: getRepositoryManager(),
         systemCapabilities: getSystemCapabilities(),
-        agentManager: await getAgentManager(),
+        agentManager: agentManager ?? await getAgentManager(),
       } as unknown as AppContext);
       await next();
     });

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -91,9 +91,12 @@ export interface CreateAppContextOptions {
  * 1. Database connection
  * 2. Job queue (depends on db)
  * 3. Repositories (depend on db)
- * 4. Managers (depend on repositories and job queue)
- * 5. Wire cross-dependencies between managers
- * 6. Notification services
+ * 4. Agent manager (depends on repository)
+ * 5. Notification services
+ * 6. Managers (depend on repositories, job queue, and services above)
+ * 7. Wire cross-dependencies between managers
+ * 8. Inbound integration
+ * 9. System capabilities
  *
  * @param options - Configuration options
  * @returns Initialized application context
@@ -118,10 +121,20 @@ export async function createAppContext(
   const sessionRepository = new SqliteSessionRepository(db);
   const repositoryRepository = new SqliteRepositoryRepository(db);
 
-  // 4. Create managers
+  // 4. Create agent manager (needed by SessionManager)
+  const agentRepository = new SqliteAgentRepository(db);
+  const agentManager = await AgentManagerClass.create(agentRepository);
+
+  // 5. Create notification services (needed by SessionManager)
+  const slackHandler = new SlackHandler();
+  const notificationManager = new NotificationManagerClass(slackHandler);
+
+  // 6. Create managers (with injected dependencies)
   const sessionManager = await SessionManagerClass.create({
     sessionRepository,
     jobQueue,
+    agentManager,
+    notificationManager,
   });
 
   const repositoryManager = await RepositoryManagerClass.create({
@@ -129,7 +142,7 @@ export async function createAppContext(
     jobQueue,
   });
 
-  // 5. Wire cross-dependencies between managers
+  // 7. Wire cross-dependencies between managers
   repositoryManager.setDependencyCallbacks({
     getSessionsUsingRepository: (repoId) =>
       sessionManager.getSessionsUsingRepository(repoId),
@@ -140,16 +153,12 @@ export async function createAppContext(
     isInitialized: () => true, // Always true once context is created
   });
 
-  // 6. Create notification services
-  const slackHandler = new SlackHandler();
-  const notificationManager = new NotificationManagerClass(slackHandler);
-
   // Wire notification callbacks
   notificationManager.setSessionExistsCallback((sessionId) =>
     sessionManager.getSession(sessionId) !== undefined
   );
 
-  // 7. Initialize inbound integration
+  // 8. Initialize inbound integration
   const inboundIntegration = initializeInboundIntegration({
     jobQueue,
     sessionManager,
@@ -157,13 +166,9 @@ export async function createAppContext(
     broadcastToApp: options?.broadcastToApp ?? (() => {}),
   });
 
-  // 8. Detect system capabilities
+  // 9. Detect system capabilities
   const systemCapabilities = new SystemCapabilitiesServiceClass();
   await systemCapabilities.detect();
-
-  // 9. Create agent manager
-  const agentRepository = new SqliteAgentRepository(db);
-  const agentManager = await AgentManagerClass.create(agentRepository);
 
   logger.info('All services initialized');
 
@@ -222,10 +227,21 @@ export async function createTestContext(
     overrides?.sessionRepository ?? new SqliteSessionRepository(db);
   const repositoryRepository = new SqliteRepositoryRepository(db);
 
-  // Create managers
+  // Create agent manager (needed by SessionManager)
+  const agentRepository = new SqliteAgentRepository(db);
+  const agentManager = await AgentManagerClass.create(agentRepository);
+
+  // Use provided or create new notification manager (needed by SessionManager)
+  const notificationManager =
+    overrides?.notificationManager ??
+    new NotificationManagerClass(new SlackHandler());
+
+  // Create managers (with injected dependencies)
   const sessionManager = await SessionManagerClass.create({
     sessionRepository,
     jobQueue,
+    agentManager,
+    notificationManager,
   });
 
   const repositoryManager = await RepositoryManagerClass.create({
@@ -243,11 +259,6 @@ export async function createTestContext(
     getRepository: (repoId) => repositoryManager.getRepository(repoId),
     isInitialized: () => true,
   });
-
-  // Use provided or create new notification manager
-  const notificationManager =
-    overrides?.notificationManager ??
-    new NotificationManagerClass(new SlackHandler());
 
   notificationManager.setSessionExistsCallback((sessionId) =>
     sessionManager.getSession(sessionId) !== undefined
@@ -269,10 +280,6 @@ export async function createTestContext(
     systemCapabilities = new SystemCapabilitiesServiceClass();
     await systemCapabilities.detect();
   }
-
-  // Create agent manager
-  const agentRepository = new SqliteAgentRepository(db);
-  const agentManager = await AgentManagerClass.create(agentRepository);
 
   return {
     db,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,6 +14,7 @@ import { createAppContext, shutdownAppContext, type AppContext, type AppBindings
 import { setSessionManager } from './services/session-manager.js';
 import { setRepositoryManager } from './services/repository-manager.js';
 import { setNotificationManager } from './services/notifications/index.js';
+import { setAgentManager } from './services/agent-manager.js';
 import { setSystemCapabilities } from './services/system-capabilities-service.js';
 import * as path from 'path';
 
@@ -96,6 +97,7 @@ try {
 setSessionManager(appContext.sessionManager);
 setRepositoryManager(appContext.repositoryManager);
 setNotificationManager(appContext.notificationManager);
+setAgentManager(appContext.agentManager);
 setSystemCapabilities(appContext.systemCapabilities);
 logger.info('Singletons populated from AppContext');
 

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -5,7 +5,7 @@ import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.j
 import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
-import { initializeDatabase, closeDatabase } from '../../database/connection.js';
+import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { initializeJobQueue, resetJobQueue } from '../../jobs/index.js';
 import {
   resetSessionManager,
@@ -17,7 +17,8 @@ import {
   setRepositoryManager,
   RepositoryManager,
 } from '../../services/repository-manager.js';
-import { getAgentManager, resetAgentManager } from '../../services/agent-manager.js';
+import { AgentManager, getAgentManager, resetAgentManager, setAgentManager } from '../../services/agent-manager.js';
+import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 import { JsonSessionRepository } from '../../repositories/index.js';
 import { SqliteRepositoryRepository } from '../../repositories/sqlite-repository-repository.js';
 import type { PtySpawnOptions } from '../../lib/pty-provider.js';
@@ -176,12 +177,18 @@ describe('MCP Server Tools', () => {
     // Create session repository
     const sessionRepository = new JsonSessionRepository(`${TEST_CONFIG_DIR}/sessions.json`);
 
+    // Create AgentManager for dependency injection and singleton
+    const db = getDatabase();
+    const agentMgr = await AgentManager.create(new SqliteAgentRepository(db));
+    setAgentManager(agentMgr);
+
     // Create SessionManager directly
     sessionManager = await SessionManager.create({
       ptyProvider: ptyFactory.provider,
       pathExists: async () => true,
       sessionRepository,
       jobQueue: testJobQueue,
+      agentManager: agentMgr,
     });
     setSessionManager(sessionManager);
 

--- a/packages/server/src/routes/__tests__/sessions.test.ts
+++ b/packages/server/src/routes/__tests__/sessions.test.ts
@@ -6,7 +6,9 @@ import type { AppBindings, AppContext } from '../../app-context.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
-import { initializeDatabase, closeDatabase } from '../../database/connection.js';
+import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
+import { AgentManager, resetAgentManager } from '../../services/agent-manager.js';
+import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 import { initializeJobQueue, resetJobQueue } from '../../jobs/index.js';
 import { resetSessionManager, SessionManager, setSessionManager } from '../../services/session-manager.js';
 import { JsonSessionRepository } from '../../repositories/index.js';
@@ -46,6 +48,11 @@ describe('Sessions API - Pause/Resume', () => {
     // Reset PTY factory
     ptyFactory.reset();
 
+    // Reset and create AgentManager for dependency injection
+    resetAgentManager();
+    const db = getDatabase();
+    const agentMgr = await AgentManager.create(new SqliteAgentRepository(db));
+
     // Create session repository
     const sessionRepository = new JsonSessionRepository(`${TEST_CONFIG_DIR}/sessions.json`);
 
@@ -55,6 +62,7 @@ describe('Sessions API - Pause/Resume', () => {
       pathExists: async () => true,
       sessionRepository,
       jobQueue: testJobQueue,
+      agentManager: agentMgr,
     });
 
     // Set the singleton
@@ -72,6 +80,7 @@ describe('Sessions API - Pause/Resume', () => {
 
   afterEach(async () => {
     resetSessionManager();
+    resetAgentManager();
     await resetJobQueue();
     await closeDatabase();
     cleanupMemfs();

--- a/packages/server/src/services/__tests__/repository-manager.test.ts
+++ b/packages/server/src/services/__tests__/repository-manager.test.ts
@@ -7,7 +7,9 @@ import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-proces
 import { JobQueue } from '../../jobs/index.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { resetSessionManager, initializeSessionManager } from '../session-manager.js';
+import { AgentManager, resetAgentManager } from '../agent-manager.js';
 import { createSessionRepository, SqliteRepositoryRepository } from '../../repositories/index.js';
+import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 
 // Test JobQueue instance (created fresh for each test)
 let testJobQueue: JobQueue | null = null;
@@ -35,13 +37,15 @@ describe('RepositoryManager', () => {
 
     // Reset session manager singleton (needed for unregisterRepository check)
     resetSessionManager();
+    resetAgentManager();
 
     // Create a test JobQueue with the shared database connection
     testJobQueue = new JobQueue(getDatabase());
 
     // Initialize session manager singleton (needed for unregisterRepository check)
     const sessionRepository = await createSessionRepository();
-    await initializeSessionManager({ sessionRepository, jobQueue: testJobQueue });
+    const agentManager = await AgentManager.create(new SqliteAgentRepository(getDatabase()));
+    await initializeSessionManager({ sessionRepository, jobQueue: testJobQueue, agentManager });
 
     // Reset process mock
     resetProcessMock();
@@ -57,6 +61,7 @@ describe('RepositoryManager', () => {
   });
 
   afterEach(async () => {
+    resetAgentManager();
     // Clean up test JobQueue
     if (testJobQueue) {
       await testJobQueue.stop();

--- a/packages/server/src/services/__tests__/session-manager-cleanup.test.ts
+++ b/packages/server/src/services/__tests__/session-manager-cleanup.test.ts
@@ -4,7 +4,9 @@ import type { PersistedSession } from '../persistence-service.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
-import { initializeDatabase, closeDatabase } from '../../database/connection.js';
+import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
+import { AgentManager, resetAgentManager } from '../agent-manager.js';
+import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 
 // Test config directory
 const TEST_CONFIG_DIR = '/test/config';
@@ -32,11 +34,15 @@ describe('SessionManager cleanup on initialization', () => {
     // Reset process mock tracking
     resetProcessMock();
 
+    // Reset AgentManager singleton
+    resetAgentManager();
+
     // Create fresh PTY factory
     ptyFactory = createMockPtyFactory();
   });
 
   afterEach(async () => {
+    resetAgentManager();
     await closeDatabase();
     cleanupMemfs();
     delete process.env.AGENT_CONSOLE_HOME;
@@ -63,7 +69,9 @@ describe('SessionManager cleanup on initialization', () => {
   // Helper to create a SessionManager instance using the factory pattern (async initialization)
   async function createSessionManager() {
     const SessionManager = await getSessionManager();
-    return SessionManager.create({ ptyProvider: ptyFactory.provider });
+    const db = getDatabase();
+    const agentMgr = await AgentManager.create(new SqliteAgentRepository(db));
+    return SessionManager.create({ ptyProvider: ptyFactory.provider, agentManager: agentMgr });
   }
 
   it('should mark legacy sessions as paused and kill worker processes', async () => {

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -6,7 +6,8 @@ import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.j
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
-import { resetAgentManager } from '../agent-manager.js';
+import { AgentManager, resetAgentManager, setAgentManager } from '../agent-manager.js';
+import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 import type { PersistedWorker } from '../persistence-service.js';
 import { JobQueue } from '../../jobs/index.js';
 import type { PtyProvider, PtySpawnOptions } from '../../lib/pty-provider.js';
@@ -21,6 +22,7 @@ let testJobQueue: JobQueue | null = null;
 const ptyFactory = createMockPtyFactory(10000);
 
 let importCounter = 0;
+let agentManager: AgentManager;
 
 describe('SessionManager', () => {
   beforeEach(async () => {
@@ -52,6 +54,11 @@ describe('SessionManager', () => {
 
     // Reset AgentManager singleton so it re-initializes with the new database
     resetAgentManager();
+
+    // Create AgentManager for dependency injection and singleton
+    const db = getDatabase();
+    agentManager = await AgentManager.create(new SqliteAgentRepository(db));
+    setAgentManager(agentManager);
   });
 
   afterEach(async () => {
@@ -75,6 +82,7 @@ describe('SessionManager', () => {
       ptyProvider: ptyFactory.provider,
       pathExists: mockPathExists,
       jobQueue: testJobQueue,
+      agentManager,
     });
   }
 
@@ -1378,7 +1386,7 @@ describe('SessionManager', () => {
     // Helper to get SessionManager with custom pathExists mock using factory pattern
     async function getSessionManagerWithPathExists(pathExistsFn: (path: string) => Promise<boolean>) {
       const module = await import(`../session-manager.js?v=${++importCounter}`);
-      return module.SessionManager.create({ ptyProvider: ptyFactory.provider, pathExists: pathExistsFn });
+      return module.SessionManager.create({ ptyProvider: ptyFactory.provider, pathExists: pathExistsFn, agentManager });
     }
 
     it('should return null from resumeSession when session path no longer exists', async () => {
@@ -1602,9 +1610,7 @@ describe('SessionManager', () => {
     it('should restart with a different agent when agentId is provided', async () => {
       const manager = await getSessionManager();
 
-      // Register a custom agent
-      const { getAgentManager } = await import('../agent-manager.js');
-      const agentManager = await getAgentManager();
+      // Register a custom agent using the injected agentManager
       const customAgent = await agentManager.registerAgent({
         name: 'Custom Agent',
         commandTemplate: 'custom-agent',
@@ -1629,9 +1635,7 @@ describe('SessionManager', () => {
     it('should update worker name when agent changes', async () => {
       const manager = await getSessionManager();
 
-      // Register a custom agent
-      const { getAgentManager } = await import('../agent-manager.js');
-      const agentManager = await getAgentManager();
+      // Register a custom agent using the injected agentManager
       const customAgent = await agentManager.registerAgent({
         name: 'Custom Agent',
         commandTemplate: 'custom-agent',
@@ -1686,9 +1690,7 @@ describe('SessionManager', () => {
     it('should broadcast session-updated after agent switch', async () => {
       const manager = await getSessionManager();
 
-      // Register a custom agent
-      const { getAgentManager } = await import('../agent-manager.js');
-      const agentManager = await getAgentManager();
+      // Register a custom agent using the injected agentManager
       const customAgent = await agentManager.registerAgent({
         name: 'Custom Agent',
         commandTemplate: 'custom-agent',
@@ -2476,6 +2478,7 @@ describe('SessionManager', () => {
         ptyProvider: ptyFactory.provider,
         pathExists: pathExistsOnlyDuringInit,
         jobQueue: testJobQueue,
+        agentManager,
       });
 
       // Mark initialization as complete so subsequent pathExists calls return false
@@ -2518,6 +2521,7 @@ describe('SessionManager', () => {
         ptyProvider: failingPtyProvider,
         pathExists: mockPathExists,
         jobQueue: testJobQueue,
+        agentManager,
       });
 
       // Resume should fail because PTY activation throws

--- a/packages/server/src/services/__tests__/worker-history-initialization.test.ts
+++ b/packages/server/src/services/__tests__/worker-history-initialization.test.ts
@@ -19,6 +19,8 @@ import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
+import { AgentManager, resetAgentManager } from '../agent-manager.js';
+import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 import { JobQueue } from '../../jobs/index.js';
 
 // Test config directory
@@ -31,6 +33,7 @@ let testJobQueue: JobQueue | null = null;
 const ptyFactory = createMockPtyFactory(10000);
 
 let importCounter = 0;
+let agentManager: AgentManager;
 
 describe('Worker History File Initialization', () => {
   beforeEach(async () => {
@@ -56,6 +59,11 @@ describe('Worker History File Initialization', () => {
 
     // Reset PTY factory
     ptyFactory.reset();
+
+    // Reset and create AgentManager for dependency injection
+    resetAgentManager();
+    const db = getDatabase();
+    agentManager = await AgentManager.create(new SqliteAgentRepository(db));
   });
 
   afterEach(async () => {
@@ -64,6 +72,7 @@ describe('Worker History File Initialization', () => {
       await testJobQueue.stop();
       testJobQueue = null;
     }
+    resetAgentManager();
     await closeDatabase();
     cleanupMemfs();
   });
@@ -79,6 +88,7 @@ describe('Worker History File Initialization', () => {
       ptyProvider: ptyFactory.provider,
       pathExists: mockPathExists,
       jobQueue: testJobQueue,
+      agentManager,
     });
   }
 

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -12,7 +12,8 @@ import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.j
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { resetGitMocks, mockGit } from '../../__tests__/utils/mock-git-helper.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
-import { resetAgentManager, CLAUDE_CODE_AGENT_ID } from '../agent-manager.js';
+import { AgentManager, resetAgentManager, CLAUDE_CODE_AGENT_ID } from '../agent-manager.js';
+import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 import { WorkerManager } from '../worker-manager.js';
 import { WorkerLifecycleManager, type WorkerLifecycleDeps } from '../worker-lifecycle-manager.js';
 import type { InternalAgentWorker, InternalTerminalWorker, InternalGitDiffWorker } from '../worker-types.js';
@@ -31,6 +32,7 @@ let testJobQueue: JobQueue | null = null;
 describe('WorkerLifecycleManager', () => {
   let workerManager: WorkerManager;
   let lifecycleManager: WorkerLifecycleManager;
+  let agentManager: AgentManager;
   let sessions: Map<string, InternalSession>;
   let mockPersistSession: ReturnType<typeof mock>;
   let mockPathExists: ReturnType<typeof mock>;
@@ -70,6 +72,8 @@ describe('WorkerLifecycleManager', () => {
   function createDeps(overrides: Partial<WorkerLifecycleDeps> = {}): WorkerLifecycleDeps {
     return {
       workerManager,
+      agentManager,
+      notificationManager: null,
       pathExists: mockPathExists as unknown as (path: string) => Promise<boolean>,
       getSession: (id: string) => sessions.get(id),
       persistSession: mockPersistSession as unknown as (session: InternalSession) => Promise<void>,
@@ -116,6 +120,9 @@ describe('WorkerLifecycleManager', () => {
     resetGitMocks();
     resetAgentManager();
 
+    const db = getDatabase();
+    agentManager = await AgentManager.create(new SqliteAgentRepository(db));
+
     sessions = new Map();
     mockPersistSession = mock(() => Promise.resolve());
     mockPathExists = mock(() => Promise.resolve(true));
@@ -130,7 +137,7 @@ describe('WorkerLifecycleManager', () => {
       onDiffBaseCommitChanged: mockOnDiffBaseCommitChanged as any,
     };
 
-    workerManager = new WorkerManager(ptyFactory.provider);
+    workerManager = new WorkerManager(ptyFactory.provider, agentManager);
     lifecycleManager = new WorkerLifecycleManager(createDeps());
   });
 
@@ -1001,7 +1008,7 @@ describe('WorkerLifecycleManager', () => {
       const failingProvider = {
         spawn: () => { throw new Error('PTY spawn failed'); },
       };
-      const failingWorkerManager = new WorkerManager(failingProvider as any);
+      const failingWorkerManager = new WorkerManager(failingProvider as any, agentManager);
       const manager = new WorkerLifecycleManager(createDeps({
         workerManager: failingWorkerManager,
       }));

--- a/packages/server/src/services/__tests__/worker-manager-env.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager-env.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
-import { initializeDatabase, closeDatabase } from '../../database/connection.js';
-import { resetAgentManager } from '../agent-manager.js';
+import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
+import { AgentManager, resetAgentManager } from '../agent-manager.js';
+import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 import { WorkerManager } from '../worker-manager.js';
 import type { InternalAgentWorker, InternalTerminalWorker } from '../worker-types.js';
 import type { PtySpawnOptions } from '../../lib/pty-provider.js';
@@ -23,11 +24,14 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     setupMemfs({ '/test/config/.keep': '' });
     process.env.AGENT_CONSOLE_HOME = '/test/config';
 
-    // Use in-memory database so getAgentManager() doesn't hit real filesystem
+    // Use in-memory database for test isolation
     await initializeDatabase(':memory:');
 
+    const db = getDatabase();
+    const agentManager = await AgentManager.create(new SqliteAgentRepository(db));
+
     ptyFactory.reset();
-    workerManager = new WorkerManager(ptyFactory.provider);
+    workerManager = new WorkerManager(ptyFactory.provider, agentManager);
   });
 
   afterEach(async () => {

--- a/packages/server/src/services/agent-manager.ts
+++ b/packages/server/src/services/agent-manager.ts
@@ -250,6 +250,19 @@ export async function getAgentManager(): Promise<AgentManager> {
   return initializationPromise;
 }
 
+/**
+ * Set the AgentManager singleton from an existing instance.
+ * Used by AppContext to set the singleton without re-creating.
+ * @internal For AppContext initialization only.
+ */
+export function setAgentManager(instance: AgentManager): void {
+  if (agentManagerInstance) {
+    throw new Error('AgentManager already initialized');
+  }
+  agentManagerInstance = instance;
+  initializationPromise = null;
+}
+
 // For testing: reset the singleton
 export function resetAgentManager(): void {
   agentManagerInstance = null;

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -27,6 +27,8 @@ import type { InternalSession } from './internal-types.js';
 import { WorkerManager } from './worker-manager.js';
 import { WorkerLifecycleManager, type RestoreWorkerResult } from './worker-lifecycle-manager.js';
 import { CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
+import type { AgentManager } from './agent-manager.js';
+import type { NotificationManager } from './notifications/notification-manager.js';
 import { filterRepositoryEnvVars } from './env-filter.js';
 import { parseEnvVars } from '../lib/env-parser.js';
 import { getConfigDir, getServerPid } from '../lib/config.js';
@@ -37,7 +39,6 @@ import {
   renameBranch as gitRenameBranch,
 } from '../lib/git.js';
 import { stopWatching, calculateBaseCommit } from './git-diff-service.js';
-import { getNotificationManager } from './notifications/index.js';
 import type { SessionLifecycleCallbacks } from './session-lifecycle-types.js';
 import { MessageService } from './message-service.js';
 import { interSessionMessageService } from './inter-session-message-service.js';
@@ -99,6 +100,7 @@ export class SessionManager {
   private pathExists: (path: string) => Promise<boolean>;
   private sessionRepository: SessionRepository;
   private jobQueue: JobQueue | null = null;
+  private notificationManager: NotificationManager | null = null;
 
   /**
    * Options for creating a SessionManager instance.
@@ -114,11 +116,13 @@ export class SessionManager {
    * @param options.jobQueue - JobQueue instance for background cleanup tasks.
    *                           Must be provided for proper cleanup operations.
    */
-  static async create(options?: {
+  static async create(options: {
     ptyProvider?: PtyProvider;
     pathExists?: (path: string) => Promise<boolean>;
     sessionRepository?: SessionRepository;
     jobQueue?: JobQueue | null;
+    agentManager: AgentManager;
+    notificationManager?: NotificationManager | null;
   }): Promise<SessionManager> {
     const manager = new SessionManager(options);
     await manager.initialize();
@@ -129,14 +133,18 @@ export class SessionManager {
    * Private constructor - use SessionManager.create() for async initialization.
    * The constructor is only public for backward compatibility during migration.
    */
-  constructor(options?: {
+  constructor(options: {
     ptyProvider?: PtyProvider;
     pathExists?: (path: string) => Promise<boolean>;
     sessionRepository?: SessionRepository;
     jobQueue?: JobQueue | null;
+    agentManager: AgentManager;
+    notificationManager?: NotificationManager | null;
   }) {
     const ptyProvider = options?.ptyProvider ?? bunPtyProvider;
-    this.workerManager = new WorkerManager(ptyProvider);
+    const agentManager = options.agentManager;
+    this.notificationManager = options?.notificationManager ?? null;
+    this.workerManager = new WorkerManager(ptyProvider, agentManager);
     this.pathExists = options?.pathExists ?? defaultPathExists;
     this.sessionRepository = options?.sessionRepository ??
       new JsonSessionRepository(path.join(getConfigDir(), 'sessions.json'));
@@ -144,6 +152,8 @@ export class SessionManager {
 
     this.workerLifecycleManager = new WorkerLifecycleManager({
       workerManager: this.workerManager,
+      agentManager,
+      notificationManager: this.notificationManager,
       pathExists: this.pathExists,
       getSession: (id) => this.sessions.get(id),
       persistSession: (session) => this.persistSession(session),
@@ -588,12 +598,7 @@ export class SessionManager {
       await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: id });
 
       // 2. Clean up notification state (throttle timers, debounce timers)
-      try {
-        const notificationManager = getNotificationManager();
-        notificationManager.cleanupSession(id);
-      } catch {
-        // NotificationManager not initialized yet, skip
-      }
+      this.notificationManager?.cleanupSession(id);
 
       // 2b. Clean up inter-worker message history
       this.messageService.clearSession(id);
@@ -747,12 +752,7 @@ export class SessionManager {
     }
 
     // Clean up notification state (throttle timers, debounce timers)
-    try {
-      const notificationManager = getNotificationManager();
-      notificationManager.cleanupSession(id);
-    } catch {
-      // NotificationManager not initialized yet, skip
-    }
+    this.notificationManager?.cleanupSession(id);
 
     // Clean up inter-worker message history
     this.messageService.clearSession(id);
@@ -1371,6 +1371,8 @@ let sessionManagerInstance: SessionManager | null = null;
 export async function initializeSessionManager(options: {
   sessionRepository: SessionRepository;
   jobQueue: JobQueue;
+  agentManager: AgentManager;
+  notificationManager?: NotificationManager | null;
 }): Promise<void> {
   if (sessionManagerInstance) {
     throw new Error('SessionManager already initialized');

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -34,10 +34,11 @@ import type { InternalSession } from './internal-types.js';
 import type { WorkerManager } from './worker-manager.js';
 import type { JobQueue } from '../jobs/index.js';
 import { JOB_TYPES } from '../jobs/index.js';
-import { getAgentManager, CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
+import { CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
+import type { AgentManager } from './agent-manager.js';
+import type { NotificationManager } from './notifications/notification-manager.js';
 import { interSessionMessageService } from './inter-session-message-service.js';
 import { stopWatching, calculateBaseCommit } from './git-diff-service.js';
-import { getNotificationManager } from './notifications/index.js';
 import {
   getCurrentBranch as gitGetCurrentBranch,
   renameBranch as gitRenameBranch,
@@ -56,6 +57,8 @@ const logger = createLogger('worker-lifecycle-manager');
  */
 export interface WorkerLifecycleDeps {
   workerManager: WorkerManager;
+  agentManager: AgentManager;
+  notificationManager: NotificationManager | null;
   pathExists: (path: string) => Promise<boolean>;
   getSession: (sessionId: string) => InternalSession | undefined;
   persistSession: (session: InternalSession) => Promise<void>;
@@ -95,20 +98,20 @@ export class WorkerLifecycleManager {
     const workerId = crypto.randomUUID();
     const createdAt = new Date().toISOString();
     const agentIdForName = request.type === 'agent' ? request.agentId : undefined;
-    const workerName = request.name ?? await this.generateWorkerName(session, request.type, agentIdForName);
+    const workerName = request.name ?? this.generateWorkerName(session, request.type, agentIdForName);
 
     let worker: InternalWorker;
     const repositoryEnvVars = this.deps.getRepositoryEnvVars(sessionId);
     const repositoryId = session.type === 'worktree' ? session.repositoryId : undefined;
 
     if (request.type === 'agent') {
-      const agentWorker = await this.deps.workerManager.initializeAgentWorker({
+      const agentWorker = this.deps.workerManager.initializeAgentWorker({
         id: workerId,
         name: workerName,
         createdAt,
         agentId: request.agentId,
       });
-      await this.deps.workerManager.activateAgentWorkerPty(agentWorker, {
+      this.deps.workerManager.activateAgentWorkerPty(agentWorker, {
         sessionId,
         locationPath: session.locationPath,
         repositoryEnvVars,
@@ -195,8 +198,8 @@ export class WorkerLifecycleManager {
 
     // Activate PTY based on worker type
     if (worker.type === 'agent') {
-      const effectiveAgentId = await this.resolveEffectiveAgentId(worker.agentId, { sessionId, workerId });
-      await this.deps.workerManager.activateAgentWorkerPty(worker, {
+      const effectiveAgentId = this.resolveEffectiveAgentId(worker.agentId, { sessionId, workerId });
+      this.deps.workerManager.activateAgentWorkerPty(worker, {
         sessionId,
         locationPath: session.locationPath,
         repositoryEnvVars,
@@ -238,12 +241,7 @@ export class WorkerLifecycleManager {
     }
 
     // Clean up notification state (debounce timers, previous state)
-    try {
-      const notificationManager = getNotificationManager();
-      notificationManager.cleanupWorker(sessionId, workerId);
-    } catch {
-      // NotificationManager not initialized yet, skip
-    }
+    this.deps.notificationManager?.cleanupWorker(sessionId, workerId);
 
     // Clean up inter-session message files for this worker
     try {
@@ -280,7 +278,7 @@ export class WorkerLifecycleManager {
 
     // Validate that the agent exists if a new agentId was provided
     if (agentId) {
-      const agentManager = await getAgentManager();
+      const agentManager = this.deps.agentManager;
       const agent = agentManager.getAgent(agentId);
       if (!agent) {
         logger.warn({ workerId, sessionId, agentId }, 'Cannot restart worker: agent not found');
@@ -320,7 +318,7 @@ export class WorkerLifecycleManager {
 
     // Capture worker metadata before killing (needed for new worker creation)
     const workerName = isAgentChanged
-      ? await this.generateWorkerName(session, 'agent', workerAgentId)
+      ? this.generateWorkerName(session, 'agent', workerAgentId)
       : existingWorker.name;
     const workerCreatedAt = existingWorker.createdAt;
     const locationPath = session.locationPath;
@@ -334,13 +332,13 @@ export class WorkerLifecycleManager {
     // Create new worker with same ID, preserving original createdAt for tab order
     const repositoryEnvVars = this.deps.getRepositoryEnvVars(sessionId);
     const repositoryId = session.type === 'worktree' ? session.repositoryId : undefined;
-    const newWorker = await this.deps.workerManager.initializeAgentWorker({
+    const newWorker = this.deps.workerManager.initializeAgentWorker({
       id: workerId,
       name: workerName,
       createdAt: workerCreatedAt,
       agentId: workerAgentId,
     });
-    await this.deps.workerManager.activateAgentWorkerPty(newWorker, {
+    this.deps.workerManager.activateAgentWorkerPty(newWorker, {
       sessionId,
       locationPath,
       repositoryEnvVars,
@@ -469,8 +467,8 @@ export class WorkerLifecycleManager {
       const repositoryId = session.type === 'worktree' ? session.repositoryId : undefined;
 
       if (existingWorker.type === 'agent') {
-        const effectiveAgentId = await this.resolveEffectiveAgentId(existingWorker.agentId, { sessionId, workerId });
-        await this.deps.workerManager.activateAgentWorkerPty(existingWorker, {
+        const effectiveAgentId = this.resolveEffectiveAgentId(existingWorker.agentId, { sessionId, workerId });
+        this.deps.workerManager.activateAgentWorkerPty(existingWorker, {
           sessionId,
           locationPath: session.locationPath,
           repositoryEnvVars,
@@ -602,8 +600,8 @@ export class WorkerLifecycleManager {
   /**
    * Resolve effective agent ID, falling back to default if the original agent is no longer registered.
    */
-  private async resolveEffectiveAgentId(agentId: string, context: { sessionId: string; workerId: string }): Promise<string> {
-    const agentManager = await getAgentManager();
+  private resolveEffectiveAgentId(agentId: string, context: { sessionId: string; workerId: string }): string {
+    const agentManager = this.deps.agentManager;
     const agent = agentManager.getAgent(agentId);
     if (agent) return agentId;
 
@@ -611,9 +609,9 @@ export class WorkerLifecycleManager {
     return CLAUDE_CODE_AGENT_ID;
   }
 
-  private async generateWorkerName(session: InternalSession, type: 'agent' | 'terminal' | 'git-diff', agentId?: string): Promise<string> {
+  private generateWorkerName(session: InternalSession, type: 'agent' | 'terminal' | 'git-diff', agentId?: string): string {
     if (type === 'agent') {
-      const agentManager = await getAgentManager();
+      const agentManager = this.deps.agentManager;
       const agent = agentId ? agentManager.getAgent(agentId) : undefined;
       return agent?.name ?? 'AI';
     }

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -36,7 +36,8 @@ import type {
   Disposable,
 } from './worker-types.js';
 import { ActivityDetector } from './activity-detector.js';
-import { getAgentManager, CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
+import { CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
+import type { AgentManager } from './agent-manager.js';
 import { getCleanChildProcessEnv, getUnsetEnvPrefix } from './env-filter.js';
 import { expandTemplate } from '../lib/template.js';
 import { calculateBaseCommit, resolveRef } from './git-diff-service.js';
@@ -145,12 +146,14 @@ export interface SessionInfoForNotification {
 
 export class WorkerManager {
   private ptyProvider: PtyProvider;
+  private agentManager: AgentManager;
   private globalActivityCallback?: GlobalActivityCallback;
   private globalPtyExitCallback?: PtyExitCallback;
   private globalWorkerExitCallback?: GlobalWorkerExitCallback;
 
-  constructor(ptyProvider: PtyProvider) {
+  constructor(ptyProvider: PtyProvider, agentManager: AgentManager) {
     this.ptyProvider = ptyProvider;
+    this.agentManager = agentManager;
   }
 
   /**
@@ -181,11 +184,11 @@ export class WorkerManager {
    * Initialize an agent worker WITHOUT starting the PTY.
    * The PTY will be activated later via activateAgentWorkerPty.
    */
-  async initializeAgentWorker(params: AgentWorkerInitParams): Promise<InternalAgentWorker> {
+  initializeAgentWorker(params: AgentWorkerInitParams): InternalAgentWorker {
     const { id, name, createdAt, agentId } = params;
 
     const resolvedAgentId = agentId ?? CLAUDE_CODE_AGENT_ID;
-    const agentManager = await getAgentManager();
+    const agentManager = this.agentManager;
     const agent = agentManager.getAgent(resolvedAgentId) ?? agentManager.getDefaultAgent();
 
     const worker: InternalAgentWorker = {
@@ -259,10 +262,10 @@ export class WorkerManager {
    * Activate PTY for an agent worker.
    * Mutates the worker object to add pty and activityDetector.
    */
-  async activateAgentWorkerPty(
+  activateAgentWorkerPty(
     worker: InternalAgentWorker,
     params: AgentActivationParams
-  ): Promise<void> {
+  ): void {
     // Idempotent: If PTY already active, skip
     if (worker.pty !== null) {
       logger.debug(
@@ -274,7 +277,7 @@ export class WorkerManager {
 
     const { sessionId, locationPath, agentId, continueConversation, initialPrompt, repositoryEnvVars, repositoryId } = params;
 
-    const agentManager = await getAgentManager();
+    const agentManager = this.agentManager;
     const agent = agentManager.getAgent(agentId) ?? agentManager.getDefaultAgent();
 
     const template = continueConversation && agent.continueTemplate

--- a/packages/server/src/websocket/__tests__/routes-notifications.test.ts
+++ b/packages/server/src/websocket/__tests__/routes-notifications.test.ts
@@ -27,7 +27,8 @@ import { JobQueue, resetJobQueue } from '../../jobs/index.js';
 import { createSessionRepository } from '../../repositories/index.js';
 import { initializeSessionManager, resetSessionManager, getSessionManager } from '../../services/session-manager.js';
 import { initializeRepositoryManager, resetRepositoryManager } from '../../services/repository-manager.js';
-import { resetAgentManager } from '../../services/agent-manager.js';
+import { AgentManager, resetAgentManager } from '../../services/agent-manager.js';
+import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 import {
   initializeNotificationServices,
   shutdownNotificationServices,
@@ -71,7 +72,8 @@ describe('WebSocket routes notifications', () => {
 
     testJobQueue = new JobQueue(getDatabase());
     const sessionRepository = await createSessionRepository();
-    await initializeSessionManager({ sessionRepository, jobQueue: testJobQueue });
+    const agentManager = await AgentManager.create(new SqliteAgentRepository(getDatabase()));
+    await initializeSessionManager({ sessionRepository, jobQueue: testJobQueue, agentManager });
     await initializeRepositoryManager({ jobQueue: testJobQueue });
     initializeNotificationServices();
   });

--- a/packages/server/src/websocket/__tests__/routes-worker-error-codes.test.ts
+++ b/packages/server/src/websocket/__tests__/routes-worker-error-codes.test.ts
@@ -27,7 +27,8 @@ import { JobQueue, resetJobQueue } from '../../jobs/index.js';
 import { createSessionRepository } from '../../repositories/index.js';
 import { initializeSessionManager, resetSessionManager, getSessionManager } from '../../services/session-manager.js';
 import { initializeRepositoryManager, resetRepositoryManager } from '../../services/repository-manager.js';
-import { resetAgentManager } from '../../services/agent-manager.js';
+import { AgentManager, resetAgentManager } from '../../services/agent-manager.js';
+import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 import {
   initializeNotificationServices,
   shutdownNotificationServices,
@@ -98,7 +99,8 @@ describe('Worker WebSocket connection error codes', () => {
 
     testJobQueue = new JobQueue(getDatabase());
     const sessionRepository = await createSessionRepository();
-    await initializeSessionManager({ sessionRepository, jobQueue: testJobQueue });
+    const agentManager = await AgentManager.create(new SqliteAgentRepository(getDatabase()));
+    await initializeSessionManager({ sessionRepository, jobQueue: testJobQueue, agentManager });
     await initializeRepositoryManager({ jobQueue: testJobQueue });
     initializeNotificationServices();
 


### PR DESCRIPTION
## Summary

Step 2 of 4 in the singleton removal migration (Issue #264). Replaces `getAgentManager()` and `getNotificationManager()` singleton getter calls **inside service classes** with constructor-injected dependencies.

- **WorkerManager**: Accepts `AgentManager` as a required constructor parameter. `initializeAgentWorker()` and `activateAgentWorkerPty()` are now synchronous.
- **WorkerLifecycleManager**: `AgentManager` and `NotificationManager | null` added to `WorkerLifecycleDeps`. `resolveEffectiveAgentId()` and `generateWorkerName()` are now synchronous.
- **SessionManager**: Accepts and forwards `agentManager` (required) and `notificationManager` (optional) to inner services. Replaces try/catch `getNotificationManager()` with `this.notificationManager?.cleanupSession()`.
- **app-context.ts**: Reorders initialization — `AgentManager` and `NotificationManager` are now created before `SessionManager`.
- **agent-manager.ts**: Adds `setAgentManager()` function (consistent with `setNotificationManager()`, `setSessionManager()`, etc.).
- **index.ts**: Calls `setAgentManager()` to keep the singleton consistent with AppContext for legacy callers.

Singleton functions are **NOT removed** — they are still used in WebSocket handlers and MCP tools (to be migrated in Steps 3-4).

### Files changed (17)
- 4 production service files (`worker-manager.ts`, `worker-lifecycle-manager.ts`, `session-manager.ts`, `agent-manager.ts`)
- 2 infrastructure files (`app-context.ts`, `index.ts`)
- 11 test files updated to pass `AgentManager` as explicit dependency

## Test plan
- [x] `bun run typecheck` passes (all 3 packages)
- [x] `bun run test` passes (1452 server tests, 891 client tests, 204 shared tests, 9 integration tests — 0 failures)
- [ ] Verify no regressions in dev mode (`bun run dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)