### PR TITLE
refactor: migrate WebSocket handlers from singleton getters to AppContext injection

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -147,7 +147,7 @@ app.route('', mcpApp);
 
 // Setup WebSocket routes AFTER service initialization but BEFORE SPA fallback
 // WebSocket routes are not caught by the catch-all SPA handler
-await setupWebSocketRoutes(app, upgradeWebSocket);
+await setupWebSocketRoutes(app, upgradeWebSocket, appContext);
 
 // Static file serving (production only)
 // NOTE: Must be registered AFTER WebSocket routes to avoid catching /ws/* paths

--- a/packages/server/src/websocket/routes.ts
+++ b/packages/server/src/websocket/routes.ts
@@ -9,6 +9,7 @@ import type {
 import { WS_READY_STATE, WS_CLOSE_CODE } from '@agent-console/shared';
 import type { WSContext, WSMessageReceive } from 'hono/ws';
 import type { UpgradeWebSocket } from 'hono/ws';
+import type { AppContext } from '../app-context.js';
 import { getSessionManager } from '../services/session-manager.js';
 import { getAgentManager } from '../services/agent-manager.js';
 import { getRepositoryManager } from '../services/repository-manager.js';
@@ -217,28 +218,27 @@ export async function setupWebSocketRoutes(
   // Uses Hono's UpgradeWebSocket type directly from hono/ws.
   // The `any` type parameter matches Hono's own export: `UpgradeWebSocket<any>`.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  upgradeWebSocket: UpgradeWebSocket<any>
+  upgradeWebSocket: UpgradeWebSocket<any>,
+  appContext?: AppContext
 ) {
+  // Use injected AppContext when available, fall back to singletons for backward compatibility (tests)
+  const sessionManager = appContext?.sessionManager ?? getSessionManager();
+  const notificationManager = appContext?.notificationManager ?? getNotificationManager();
+  const agentManager = appContext?.agentManager ?? await getAgentManager();
+  const repositoryManager = appContext?.repositoryManager ?? getRepositoryManager();
+
   // Register output truncation callback to avoid circular dependency
   // worker-output-file.ts needs to notify clients but can't import routes.ts directly
   setOutputTruncatedCallback(notifyWorkerOutputTruncated);
-
-  // Get properly initialized SessionManager (with SQLite repository and JobQueue)
-  const sessionManager = getSessionManager();
 
   // Create worker message handler with the properly initialized sessionManager
   const handleWorkerMessage = createWorkerMessageHandler({ sessionManager });
 
   // Set up session exists callback for notification manager
   // This allows debounce callbacks to validate session existence without circular dependencies
-  try {
-    const notificationManager = getNotificationManager();
-    notificationManager.setSessionExistsCallback((sessionId) => {
-      return sessionManager.getSession(sessionId) !== undefined;
-    });
-  } catch {
-    // NotificationManager not initialized yet, skip
-  }
+  notificationManager.setSessionExistsCallback((sessionId) => {
+    return sessionManager.getSession(sessionId) !== undefined;
+  });
 
   // Set up global activity callback to broadcast to all app clients
   sessionManager.setGlobalActivityCallback((sessionId, workerId, state) => {
@@ -250,36 +250,11 @@ export async function setupWebSocketRoutes(
     });
 
     // Send notification for activity state changes
-    try {
-      const notificationManager = getNotificationManager();
-      const session = sessionManager.getSession(sessionId);
-      if (session) {
-        const worker = session.workers.find(w => w.id === workerId);
-        if (worker) {
-          notificationManager.onActivityChange(
-            {
-              id: sessionId,
-              title: session.title,
-              worktreeId: session.type === 'worktree' ? session.worktreeId : null,
-              repositoryId: session.type === 'worktree' ? session.repositoryId : null,
-            },
-            { id: workerId },
-            state
-          );
-        }
-      }
-    } catch {
-      // NotificationManager not initialized yet, skip
-    }
-  });
-
-  // Set up global worker exit callback to send notifications
-  sessionManager.setGlobalWorkerExitCallback((sessionId, workerId, exitCode) => {
-    try {
-      const notificationManager = getNotificationManager();
-      const session = sessionManager.getSession(sessionId);
-      if (session) {
-        notificationManager.onWorkerExit(
+    const session = sessionManager.getSession(sessionId);
+    if (session) {
+      const worker = session.workers.find(w => w.id === workerId);
+      if (worker) {
+        notificationManager.onActivityChange(
           {
             id: sessionId,
             title: session.title,
@@ -287,11 +262,26 @@ export async function setupWebSocketRoutes(
             repositoryId: session.type === 'worktree' ? session.repositoryId : null,
           },
           { id: workerId },
-          exitCode
+          state
         );
       }
-    } catch {
-      // NotificationManager not initialized yet, skip
+    }
+  });
+
+  // Set up global worker exit callback to send notifications
+  sessionManager.setGlobalWorkerExitCallback((sessionId, workerId, exitCode) => {
+    const session = sessionManager.getSession(sessionId);
+    if (session) {
+      notificationManager.onWorkerExit(
+        {
+          id: sessionId,
+          title: session.title,
+          worktreeId: session.type === 'worktree' ? session.worktreeId : null,
+          repositoryId: session.type === 'worktree' ? session.repositoryId : null,
+        },
+        { id: workerId },
+        exitCode
+      );
     }
   });
 
@@ -344,7 +334,6 @@ export async function setupWebSocketRoutes(
   sessionManager.setupPtyExitCallback();
 
   // Set up agent lifecycle callbacks to broadcast to all app clients
-  const agentManager = await getAgentManager();
   agentManager.setLifecycleCallbacks({
     onAgentCreated: (agent) => {
       logger.debug({ agentId: agent.id }, 'Broadcasting agent-created');
@@ -361,7 +350,6 @@ export async function setupWebSocketRoutes(
   });
 
   // Set up repository lifecycle callbacks to broadcast to all app clients
-  const repositoryManager = getRepositoryManager();
   repositoryManager.setLifecycleCallbacks({
     onRepositoryCreated: (repository) => {
       logger.debug({ repositoryId: repository.id }, 'Broadcasting repository-created');
@@ -382,14 +370,8 @@ export async function setupWebSocketRoutes(
     getAllSessions: () => sessionManager.getAllSessions(),
     getAllPausedSessions: () => sessionManager.getAllPausedSessions(),
     getWorkerActivityState: (sessionId: string, workerId: string) => sessionManager.getWorkerActivityState(sessionId, workerId),
-    getAllAgents: async () => {
-      const agentManager = await getAgentManager();
-      return agentManager.getAllAgents();
-    },
-    getAllRepositories: () => {
-      const repositoryManager = getRepositoryManager();
-      return repositoryManager.getAllRepositories();
-    },
+    getAllAgents: async () => agentManager.getAllAgents(),
+    getAllRepositories: () => repositoryManager.getAllRepositories(),
     logger,
   };
 
@@ -413,7 +395,7 @@ export async function setupWebSocketRoutes(
           // Send all sync operations
           Promise.all([
             sendSessionsSync(ws, appDeps),
-            getAgentManager().then((agentManager) => {
+            Promise.resolve().then(() => {
               const allAgents = agentManager.getAllAgents();
               const agentsSyncMsg: AppServerMessage = {
                 type: 'agents-sync',
@@ -422,10 +404,8 @@ export async function setupWebSocketRoutes(
               ws.send(JSON.stringify(agentsSyncMsg));
               logger.debug({ agentCount: allAgents.length }, 'Sent agents-sync');
             }),
-            // getRepositoryManager is sync, wrap in Promise.resolve for consistency
             Promise.resolve().then(() => {
-              const repoManager = getRepositoryManager();
-              const allRepositories = repoManager.getAllRepositories();
+              const allRepositories = repositoryManager.getAllRepositories();
               const repositoriesSyncMsg: AppServerMessage = {
                 type: 'repositories-sync',
                 repositories: allRepositories,


### PR DESCRIPTION
## Summary

- Pass `AppContext` to `setupWebSocketRoutes()` so WebSocket handlers use injected services instead of calling singleton getters (`getSessionManager()`, `getAgentManager()`, `getRepositoryManager()`, `getNotificationManager()`)
- Remove `try/catch` wrappers around `notificationManager` calls since it is guaranteed initialized from AppContext
- Simplify `appDeps` and `onOpen` sync logic by using closure-captured services directly

Part of #264 (Step 3 of 4: WebSocket handlers migration).

### Context
- Step 1 (PR #318): Route handlers migrated to `c.get('appContext')`
- Step 2 (PR #319): Service internals migrated to constructor injection
- **Step 3 (this PR): WebSocket handlers migrated to injected AppContext**
- Step 4 (next): Remove singleton getter functions and migrate tests

### Design Decision
`appContext` parameter is optional with fallback to singletons for backward compatibility with existing tests that call `setupWebSocketRoutes` with only two arguments. Singleton getter imports are retained as fallbacks until Step 4 removes them along with test migration.

### Files Changed
- `packages/server/src/websocket/routes.ts` — Accept AppContext, use injected services
- `packages/server/src/index.ts` — Pass appContext to setupWebSocketRoutes()

## Test plan
- [x] `bun run typecheck` passes (0 errors)
- [x] `bun run test` passes (2,556 pass, 0 fail)
- [x] No changes to test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)