### PR TITLE
feat: sort agent dropdown with priority agent first

### DIFF
--- a/packages/client/src/components/AgentSelector.tsx
+++ b/packages/client/src/components/AgentSelector.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { AgentDefinition } from '@agent-console/shared';
 import { fetchAgents } from '../lib/api';
@@ -8,6 +9,7 @@ interface AgentSelectorProps {
   onChange: (agentId: string | undefined) => void;
   className?: string;
   disabled?: boolean;
+  priorityAgentId?: string;
 }
 
 export function AgentSelector({
@@ -15,6 +17,7 @@ export function AgentSelector({
   onChange,
   className = '',
   disabled = false,
+  priorityAgentId,
 }: AgentSelectorProps) {
   const { data, isLoading } = useQuery({
     queryKey: agentKeys.all(),
@@ -23,8 +26,17 @@ export function AgentSelector({
 
   const agents = data?.agents ?? [];
 
-  // Default to first agent (Claude Code) if no value provided or value doesn't match any agent
-  const selectedValue = (value && agents.some(a => a.id === value)) ? value : (agents[0]?.id ?? '');
+  const sortedAgents = useMemo(() => {
+    if (!priorityAgentId) return agents;
+    return [...agents].sort((a, b) => {
+      if (a.id === priorityAgentId) return -1;
+      if (b.id === priorityAgentId) return 1;
+      return 0;
+    });
+  }, [agents, priorityAgentId]);
+
+  const valueExists = value != null && sortedAgents.some((a) => a.id === value);
+  const selectedValue = valueExists ? value : (sortedAgents[0]?.id ?? '');
 
   if (isLoading) {
     return (
@@ -41,7 +53,7 @@ export function AgentSelector({
       className={`input ${className}`}
       disabled={disabled}
     >
-      {agents.map((agent) => (
+      {sortedAgents.map((agent) => (
         <option key={agent.id} value={agent.id}>
           {agent.name}
           {agent.isBuiltIn ? ' (built-in)' : ''}

--- a/packages/client/src/components/__tests__/AgentSelector.test.tsx
+++ b/packages/client/src/components/__tests__/AgentSelector.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, mock, beforeEach, afterEach, afterAll } from 'bun:test';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AgentSelector } from '../AgentSelector';
+
+// Save original fetch and set up mock
+const originalFetch = globalThis.fetch;
+const mockFetch = mock((_input: RequestInfo | URL) => Promise.resolve(new Response()));
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+// Restore original fetch after all tests
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// Clean up after each test
+afterEach(() => {
+  cleanup();
+});
+
+// Mock agents response with three agents to better verify ordering
+const mockAgentsResponse = {
+  agents: [
+    { id: 'claude-code', name: 'Claude Code', isBuiltIn: true },
+    { id: 'custom-agent', name: 'Custom Agent', isBuiltIn: false },
+    { id: 'another-agent', name: 'Another Agent', isBuiltIn: false },
+  ],
+};
+
+function createMockResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+// Wrapper component with QueryClientProvider
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function renderAgentSelector(props: Partial<React.ComponentProps<typeof AgentSelector>> = {}) {
+  const defaultProps = {
+    onChange: mock(() => {}),
+  };
+
+  const mergedProps = { ...defaultProps, ...props };
+
+  return {
+    ...render(
+      <TestWrapper>
+        <AgentSelector {...mergedProps} />
+      </TestWrapper>
+    ),
+    props: mergedProps,
+  };
+}
+
+describe('AgentSelector', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(createMockResponse(mockAgentsResponse));
+  });
+
+  describe('priority sorting', () => {
+    it('should render agents in original order without priorityAgentId', async () => {
+      renderAgentSelector();
+
+      // Wait for agents to load
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      const options = screen.getAllByRole('option');
+      expect(options[0].textContent).toBe('Claude Code (built-in)');
+      expect(options[1].textContent).toBe('Custom Agent');
+      expect(options[2].textContent).toBe('Another Agent');
+    });
+
+    it('should render the priority agent first when priorityAgentId is set', async () => {
+      renderAgentSelector({ priorityAgentId: 'another-agent' });
+
+      // Wait for agents to load
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      const options = screen.getAllByRole('option');
+      expect(options[0].textContent).toBe('Another Agent');
+      expect(options[1].textContent).toBe('Claude Code (built-in)');
+      expect(options[2].textContent).toBe('Custom Agent');
+    });
+
+    it('should select the priority agent when priorityAgentId is set and no value is provided', async () => {
+      renderAgentSelector({ priorityAgentId: 'another-agent' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      const select = screen.getByRole('combobox') as HTMLSelectElement;
+      expect(select.value).toBe('another-agent');
+    });
+
+    it('should keep original order when priorityAgentId does not match any agent', async () => {
+      renderAgentSelector({ priorityAgentId: 'nonexistent-agent' });
+
+      // Wait for agents to load
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      const options = screen.getAllByRole('option');
+      expect(options[0].textContent).toBe('Claude Code (built-in)');
+      expect(options[1].textContent).toBe('Custom Agent');
+      expect(options[2].textContent).toBe('Another Agent');
+    });
+  });
+});

--- a/packages/client/src/components/sessions/RestartSessionDialog.tsx
+++ b/packages/client/src/components/sessions/RestartSessionDialog.tsx
@@ -69,12 +69,10 @@ export function RestartSessionDialog({
       const newBranch = isBranchChanged ? trimmedBranch : undefined;
       await restartAgentWorker(sessionId, agentWorker.id, continueConversation, agentId, newBranch);
       onOpenChange(false);
-      if (newBranch && onBranchChange) {
-        onBranchChange(newBranch);
+      if (newBranch) {
+        onBranchChange?.(newBranch);
       }
-      if (onSessionRestart) {
-        onSessionRestart();
-      }
+      onSessionRestart?.();
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to restart session'
@@ -105,6 +103,7 @@ export function RestartSessionDialog({
               value={selectedAgentId}
               onChange={setSelectedAgentId}
               className="flex-1"
+              priorityAgentId={currentAgentId}
             />
           </div>
           {isWorktreeSession && (
@@ -122,13 +121,19 @@ export function RestartSessionDialog({
           {isBranchEmpty && (
             <p className="text-xs text-red-400">Branch name cannot be empty.</p>
           )}
-          {(isAgentChanged || isBranchChanged) && (
+          {isAgentChanged && isBranchChanged && (
             <p className="text-xs text-yellow-400">
-              {isAgentChanged && isBranchChanged
-                ? 'Agent and branch will be changed. The terminal will be restarted.'
-                : isAgentChanged
-                  ? 'Agent will be switched. The terminal will be restarted with the new agent.'
-                  : 'Branch will be renamed. The terminal will be restarted.'}
+              Agent and branch will be changed. The terminal will be restarted.
+            </p>
+          )}
+          {isAgentChanged && !isBranchChanged && (
+            <p className="text-xs text-yellow-400">
+              Agent will be switched. The terminal will be restarted with the new agent.
+            </p>
+          )}
+          {!isAgentChanged && isBranchChanged && (
+            <p className="text-xs text-yellow-400">
+              Branch will be renamed. The terminal will be restarted.
             </p>
           )}
         </div>

--- a/packages/client/src/components/sessions/__tests__/RestartSessionDialog.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/RestartSessionDialog.test.tsx
@@ -151,6 +151,29 @@ describe('RestartSessionDialog', () => {
       expect(screen.getByText('How would you like to restart this session?')).toBeTruthy();
     });
 
+    it('should render the current agent first even when it is not first in the API response', async () => {
+      // Override agents response so claude-code is NOT first
+      mockFetch.mockImplementation((...args: unknown[]) => {
+        const urlStr = resolveUrl(args[0]);
+        if (urlStr.includes('/agents')) {
+          return Promise.resolve(createMockResponse({
+            agents: [
+              { id: 'custom-agent', name: 'Custom Agent', isBuiltIn: false },
+              { id: 'claude-code', name: 'Claude Code', isBuiltIn: true },
+            ],
+          }));
+        }
+        return Promise.resolve(routeFetchByUrl(urlStr));
+      });
+
+      renderDialog({ currentAgentId: 'claude-code' });
+      await waitForAgentsToLoad();
+
+      const options = screen.getAllByRole('option');
+      expect(options[0].textContent).toBe('Claude Code (built-in)');
+      expect(options[1].textContent).toBe('Custom Agent');
+    });
+
     it('should not render when closed', async () => {
       renderDialog({ open: false });
 

--- a/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
+++ b/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
@@ -246,6 +246,7 @@ export function CreateWorktreeForm({
                     updateDefaultAgentMutation.mutate(value);
                   }
                 }}
+                priorityAgentId={defaultAgentId ?? undefined}
               />
               <label className="text-sm text-gray-400 flex items-center gap-1.5 ml-2">
                 <input

--- a/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
@@ -35,6 +35,13 @@ function createMockResponse(body: unknown) {
   } as unknown as Response;
 }
 
+function resolveUrl(input: unknown): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  if (input && typeof input === 'object' && 'url' in input) return (input as Request).url;
+  return '';
+}
+
 // Wrapper component with QueryClientProvider
 function TestWrapper({ children }: { children: React.ReactNode }) {
   const queryClient = new QueryClient({
@@ -355,11 +362,7 @@ describe('CreateWorktreeForm', () => {
       };
 
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/github-issue')) {
           return Promise.resolve(createMockResponse({ issue }));
         }
@@ -394,6 +397,38 @@ describe('CreateWorktreeForm', () => {
     });
   });
 
+  describe('default agent sorting', () => {
+    it('should render the default agent first even when it is not first in the API response', async () => {
+      // Override agents response so custom-agent is first in the API response
+      mockFetch.mockImplementation((input) => {
+        const url = resolveUrl(input);
+        if (url.includes('/agents')) {
+          return Promise.resolve(createMockResponse({
+            agents: [
+              { id: 'claude-code', name: 'Claude Code', isBuiltIn: true },
+              { id: 'custom-agent', name: 'Custom Agent', isBuiltIn: false },
+            ],
+          }));
+        }
+        if (url.includes('/remote-status')) {
+          return Promise.resolve(createMockResponse({ behind: 0, ahead: 0 }));
+        }
+        return Promise.resolve(createMockResponse({}));
+      });
+
+      renderCreateWorktreeForm({ defaultAgentId: 'custom-agent' });
+
+      // Wait for agents to load
+      await waitFor(() => {
+        expect(screen.getByText('Custom Agent')).toBeTruthy();
+      });
+
+      const options = screen.getAllByRole('option');
+      expect(options[0].textContent).toBe('Custom Agent');
+      expect(options[1].textContent).toBe('Claude Code (built-in)');
+    });
+  });
+
   describe('default agent checkbox', () => {
     it('should not pre-check "Set as default" even when defaultAgentId is provided', async () => {
       renderCreateWorktreeForm({ defaultAgentId: 'claude-code' });
@@ -413,11 +448,7 @@ describe('CreateWorktreeForm', () => {
       const updateCalls: string[] = [];
 
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/repositories/') && !url.includes('/agents') && !url.includes('/remote-status') && !url.includes('/github-issue') && !url.includes('/branches/')) {
           updateCalls.push(url);
           return Promise.resolve(createMockResponse({}));
@@ -481,11 +512,7 @@ describe('CreateWorktreeForm', () => {
       });
 
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/remote-status')) {
           return remoteStatusPromise;
         }
@@ -508,11 +535,7 @@ describe('CreateWorktreeForm', () => {
 
     it('should show warning message when base branch is behind remote', async () => {
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/remote-status')) {
           return Promise.resolve(createMockResponse({ behind: 3, ahead: 0 }));
         }
@@ -529,11 +552,7 @@ describe('CreateWorktreeForm', () => {
 
     it('should not show warning when base branch is up to date', async () => {
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/remote-status')) {
           return Promise.resolve(createMockResponse({ behind: 0, ahead: 0 }));
         }
@@ -558,11 +577,7 @@ describe('CreateWorktreeForm', () => {
 
     it('should show "Fetch & Create" button when behind', async () => {
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/remote-status')) {
           return Promise.resolve(createMockResponse({ behind: 2, ahead: 0 }));
         }
@@ -579,11 +594,7 @@ describe('CreateWorktreeForm', () => {
 
     it('should not show "Fetch & Create" button when up to date', async () => {
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/remote-status')) {
           return Promise.resolve(createMockResponse({ behind: 0, ahead: 0 }));
         }
@@ -610,11 +621,7 @@ describe('CreateWorktreeForm', () => {
       const user = userEvent.setup();
 
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/remote-status')) {
           return Promise.resolve(createMockResponse({ behind: 1, ahead: 0 }));
         }
@@ -652,11 +659,7 @@ describe('CreateWorktreeForm', () => {
 
     it('should show error message when remote status check fails', async () => {
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/remote-status')) {
           return Promise.resolve({
             ok: false,
@@ -680,11 +683,7 @@ describe('CreateWorktreeForm', () => {
       const remoteStatusCalls: string[] = [];
 
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/remote-status')) {
           // Track which branch was requested
           remoteStatusCalls.push(url);
@@ -728,11 +727,7 @@ describe('CreateWorktreeForm', () => {
       const remoteStatusCalls: string[] = [];
 
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/remote-status')) {
           remoteStatusCalls.push(url);
           return Promise.resolve(createMockResponse({ behind: 0, ahead: 0 }));
@@ -771,11 +766,7 @@ describe('CreateWorktreeForm', () => {
 
     it('should use singular form for 1 commit behind', async () => {
       mockFetch.mockImplementation((input) => {
-        const url = typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : (input as Request).url;
+        const url = resolveUrl(input);
         if (url.includes('/remote-status')) {
           return Promise.resolve(createMockResponse({ behind: 1, ahead: 0 }));
         }


### PR DESCRIPTION
## Summary
- Add `priorityAgentId` prop to `AgentSelector` component to sort the specified agent to the top of the dropdown list
- Apply in `CreateWorktreeForm` (repository default agent) and `RestartSessionDialog` (current session agent)
- Simplify nested ternary in RestartSessionDialog, extract `resolveUrl` helper in CreateWorktreeForm tests

## Changed Files
- `AgentSelector.tsx` - Added `priorityAgentId` prop with `useMemo` sorting, improved `selectedValue` readability
- `CreateWorktreeForm.tsx` - Pass `defaultAgentId` as `priorityAgentId`
- `RestartSessionDialog.tsx` - Pass `currentAgentId` as `priorityAgentId`, refactor nested ternary to separate conditionals, use optional chaining
- `AgentSelector.test.tsx` (new) - Tests for priority sorting and selected value behavior
- `RestartSessionDialog.test.tsx` - Integration test for agent sort order
- `CreateWorktreeForm.test.tsx` - Integration test for agent sort order, extract `resolveUrl` helper

## Test plan
- [x] AgentSelector: priority agent renders first in dropdown
- [x] AgentSelector: priority agent is selected when no value provided
- [x] AgentSelector: original order preserved when no priorityAgentId
- [x] AgentSelector: original order preserved for invalid priorityAgentId
- [x] RestartSessionDialog: current agent sorted first even when not first in API response
- [x] CreateWorktreeForm: default agent sorted first even when not first in API response
- [x] All 2562 tests pass, typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)