### PR TITLE
docs: add guardrail principles from webhook routing investigation

### DIFF
--- a/.claude/skills/development-workflow-standards/development-workflow-standards.md
+++ b/.claude/skills/development-workflow-standards/development-workflow-standards.md
@@ -151,6 +151,10 @@ gh pr list -R ms2sato/agent-console
 gh pr view 123 -R ms2sato/agent-console
 ```
 
+## Design Documents as Specification
+
+Design documents (`docs/design/`) are specifications. Code is their implementation. When adding new features or changing behavior, update the design document FIRST as the spec, then implement code to match. When code changes affect the spec, update the design document as well. The spec and implementation must never silently diverge.
+
 ## Commit Standards
 
 Use conventional commit format: `type: description`

--- a/.claude/skills/test-standards/test-standards.md
+++ b/.claude/skills/test-standards/test-standards.md
@@ -245,6 +245,13 @@ describe('Client-Server Boundary', () => {
 });
 ```
 
+## Test Strategy: Unit vs Integration Responsibilities
+
+**Unit test exhaustiveness vs integration test connectivity — these are separate responsibilities.**
+- **Unit tests**: Each component must exhaustively cover all patterns defined in the spec. A parser must test all event types. A handler must test all supported event types.
+- **Integration tests**: Verify pipeline connectivity (e.g., parser → job handler → handler) with 1-2 representative events. Exhaustive coverage is the unit test's job — do not duplicate it in integration tests.
+- These responsibilities must not be confused.
+
 ## Pre-Implementation Checklist
 
 Before writing tests, verify:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Do not blindly follow existing patterns.** Existing code is not automatically correct. Evaluate whether patterns in the codebase are appropriate before adopting them.
 
+**Enforce constraints through structure, not convention.** If a constraint can be expressed in the type system, do not enforce it through runtime checks, wrapper functions, documentation, or code review. `string` where a union type would work, `Record<string, string>` where a typed interface would work, a runtime guard that re-checks what the compiler could guarantee — all are type safety gaps. Convention can be bypassed; the compiler cannot. Always choose the path that makes invalid states unrepresentable.
+
+**Define types by what they represent, not where they're used.** When creating a type, ask: is this a system-wide concept or a package-internal implementation detail? A type's home is determined by the scope of the concept it models, not by which module first needs it.
+
 **Think before you act.** When facing a problem, first consider the correct approach rather than immediately implementing the easiest solution.
 
 **Speak up about issues.** When you notice something inappropriate or problematic outside the current task scope, mention it as a supplementary note. Do not silently ignore issues just because they are not directly related to the task at hand.


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Add two new Working Principles — "Enforce constraints through structure, not convention" (prefer type system over runtime checks) and "Define types by what they represent, not where they're used" (type placement by concept scope)
- **development-workflow-standards**: Add "Design Documents as Specification" section — design docs are specs, code is implementation, they must never silently diverge
- **test-standards**: Add "Test Strategy: Unit vs Integration Responsibilities" section — unit tests for exhaustive coverage, integration tests for connectivity only

## Test plan
- [x] `bun run typecheck` passes (no code changes, documentation only)
- [ ] Review that principles are clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)