### PR TITLE
fix: mock calculateBackoff in exponential backoff test to avoid CI timeout

### DIFF
--- a/packages/server/src/jobs/__tests__/job-queue.test.ts
+++ b/packages/server/src/jobs/__tests__/job-queue.test.ts
@@ -263,11 +263,17 @@ describe('JobQueue', () => {
     });
 
     it('should use exponential backoff', async () => {
-      const timestamps: number[] = [];
-      let attempts = 0;
+      const calculatedDelays: number[] = [];
+      const originalCalculateBackoff = (jobQueue as any).calculateBackoff.bind(jobQueue);
+      (jobQueue as any).calculateBackoff = function (attempts: number): number {
+        const realDelay = originalCalculateBackoff(attempts);
+        calculatedDelays.push(realDelay);
+        // Return 0 so both next_retry_at and setTimeout use zero delay
+        return 0;
+      };
 
+      let attempts = 0;
       jobQueue.registerHandler('test:job', async () => {
-        timestamps.push(Date.now());
         attempts++;
         if (attempts < 3) {
           throw new Error('Failure');
@@ -277,20 +283,16 @@ describe('JobQueue', () => {
       await jobQueue.enqueue('test:job', {}, { maxAttempts: 3 });
       await jobQueue.start();
 
-      // Wait for all 3 attempts to complete
-      await waitFor(() => attempts >= 3, 10000);
+      // All 3 attempts complete quickly since backoff returns 0
+      await waitFor(() => attempts >= 3);
 
-      expect(timestamps.length).toBe(3);
+      expect(attempts).toBe(3);
 
-      // First retry after ~1 second
-      const delay1 = timestamps[1] - timestamps[0];
-      expect(delay1).toBeGreaterThanOrEqual(900);
-      expect(delay1).toBeLessThan(1500);
-
-      // Second retry after ~2 seconds
-      const delay2 = timestamps[2] - timestamps[1];
-      expect(delay2).toBeGreaterThanOrEqual(1800);
-      expect(delay2).toBeLessThan(2500);
+      // Verify exponential backoff delays were calculated correctly
+      expect(calculatedDelays).toEqual([
+        1000, // First retry: backoffBase * 2^0 = 1000ms
+        2000, // Second retry: backoffBase * 2^1 = 2000ms
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary

- Fix flaky `should use exponential backoff` test that timed out in CI after 5000ms
- Instead of waiting for real backoff delays (~1s + ~2s = ~3s), intercept `calculateBackoff` to capture delay values while returning 0
- This allows retries to fire immediately since the return value flows to both `next_retry_at` in the database and `setTimeout` delay
- Test now verifies the exact calculated backoff values `[1000, 2000]` match the expected exponential pattern

## Test plan

- [x] All 54 job-queue tests pass (0 failures)
- [x] TypeScript type check passes
- [x] The previously flaky test completes in milliseconds instead of ~3 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)