### PR TITLE
docs: add PR review/comment event types to inbound integration spec

### DIFF
--- a/docs/design/integration-inbound.md
+++ b/docs/design/integration-inbound.md
@@ -22,6 +22,11 @@ type InboundEventType =
 
 > **Note**: `SystemEventType` in [System Events](./system-events.md) is the union of `InboundEventType` and `OutboundTriggerEventType`.
 
+```typescript
+/** Inbound system event — a SystemEvent constrained to inbound event types */
+type InboundSystemEvent = SystemEvent & { type: InboundEventType };
+```
+
 ## Overview
 
 Inbound integration provides a **generalized event routing system** that receives external events (webhooks, etc.) and dispatches them to appropriate handlers based on event type and target.
@@ -175,7 +180,8 @@ class AgentWorkerHandler implements InboundEventHandler {
 
   /**
    * Resolve the intent for a given event type.
-   * Exhaustive — every supported event type must be mapped.
+   * Exhaustive over InboundEventType (not just supportedEvents) so the
+   * compiler forces a decision when new event types are added to the union.
    */
   private resolveIntent(type: InboundEventType): 'inform' | 'triage' {
     switch (type) {
@@ -506,7 +512,7 @@ interface ServiceParser {
   authenticate(payload: string, headers: Headers): Promise<boolean>;
 
   /**
-   * Parse raw payload into SystemEvent.
+   * Parse raw payload into InboundSystemEvent.
    * Returns null if the event type is not supported.
    */
   parse(payload: string, headers: Headers): Promise<InboundSystemEvent | null>;


### PR DESCRIPTION
## Summary
- Add three new inbound event types (`pr:review_comment`, `pr:changes_requested`, `pr:comment`) to `docs/design/system-events.md` and `docs/design/integration-inbound.md`
- Define handler routing (AgentWorker notify + UI alert), exhaustive `resolveIntent` mapping, and GitHub parser pseudocode for `pull_request_review_comment`, `pull_request_review`, and `issue_comment` webhook events
- Change `ServiceParser.parse()` return type from `SystemEvent` to `InboundSystemEvent` in the spec

## Test plan
- [x] `bun run typecheck` passes (no code files modified, spec-only changes)
- [ ] Verify new event types are consistent with existing table formatting
- [ ] Verify pseudocode covers edge cases (non-PR issue comments filtered, only `changes_requested` review state handled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)