### PR TITLE
refactor: enforce typed fields in PTY notification interfaces

### DIFF
--- a/docs/design/integration-inbound.md
+++ b/docs/design/integration-inbound.md
@@ -122,7 +122,7 @@ Inbound integration handles external source events defined in [System Events](./
 
 ### Handler Interface
 
-Handlers receive `SystemEvent` (defined in [System Events](./system-events.md)) and process them for specific targets.
+Handlers receive `InboundSystemEvent` (defined in [System Events](./system-events.md)) and process them for specific targets.
 
 ```typescript
 interface InboundEventHandler {
@@ -136,7 +136,7 @@ interface InboundEventHandler {
    * Handle the event for a specific target.
    * Returns true if handled successfully.
    */
-  handle(event: SystemEvent, target: EventTarget): Promise<boolean>;
+  handle(event: InboundSystemEvent, target: EventTarget): Promise<boolean>;
 }
 
 interface EventTarget {
@@ -159,7 +159,7 @@ class AgentWorkerHandler implements InboundEventHandler {
     'pr:review_comment', 'pr:changes_requested', 'pr:comment',
   ];
 
-  async handle(event: SystemEvent, target: EventTarget): Promise<boolean> {
+  async handle(event: InboundSystemEvent, target: EventTarget): Promise<boolean> {
     const worker = this.sessionManager.getWorker(target.sessionId, target.workerId);
     if (!worker || worker.type !== 'agent') return false;
 
@@ -168,7 +168,7 @@ class AgentWorkerHandler implements InboundEventHandler {
     return true;
   }
 
-  private formatMessage(event: SystemEvent): string {
+  private formatMessage(event: InboundSystemEvent): string {
     // Format: structured tag + key/value fields for reliable parsing.
     // Example: [inbound:ci-failed] source=github repo=owner/repo branch=main url=... summary="..." intent=triage
     const intent = this.resolveIntent(event.type);
@@ -208,7 +208,7 @@ class DiffWorkerHandler implements InboundEventHandler {
   readonly handlerId = 'diff-worker';
   readonly supportedEvents: InboundEventType[] = ['ci:completed', 'pr:merged'];
 
-  async handle(event: SystemEvent, target: EventTarget): Promise<boolean> {
+  async handle(event: InboundSystemEvent, target: EventTarget): Promise<boolean> {
     const workers = this.sessionManager.getWorkersByType(target.sessionId, 'git-diff');
     if (workers.length === 0) return false;
 
@@ -232,7 +232,7 @@ class UINotificationHandler implements InboundEventHandler {
     'pr:review_comment', 'pr:changes_requested', 'pr:comment',
   ];
 
-  async handle(event: SystemEvent, target: EventTarget): Promise<boolean> {
+  async handle(event: InboundSystemEvent, target: EventTarget): Promise<boolean> {
     // Broadcast to all clients viewing this session
     this.appWebSocket.broadcast({
       type: 'inbound-event',
@@ -461,7 +461,7 @@ Sessions are matched to webhooks by comparing repository identifiers.
 
 1. **Runtime resolution** (current approach):
    ```typescript
-   async function resolveTargets(event: SystemEvent): Promise<EventTarget[]> {
+   async function resolveTargets(event: InboundSystemEvent): Promise<EventTarget[]> {
      const sessions = await sessionRepository.findAll();
      const targets: EventTarget[] = [];
 
@@ -501,7 +501,7 @@ Sessions are matched to webhooks by comparing repository identifiers.
 
 ### Service Parser Interface
 
-Service parsers authenticate webhooks and convert raw payloads to `SystemEvent`.
+Service parsers authenticate webhooks and convert raw payloads to `InboundSystemEvent`.
 
 ```typescript
 interface ServiceParser {
@@ -585,7 +585,7 @@ async parse(payload: string, headers: Headers): Promise<InboundSystemEvent | nul
   }
 }
 
-private parseWorkflowRun(body: unknown): SystemEvent {
+private parseWorkflowRun(body: unknown): InboundSystemEvent {
   const conclusion = body.workflow_run.conclusion;
   return {
     type: conclusion === 'success' ? 'ci:completed' : 'ci:failed',
@@ -601,7 +601,7 @@ private parseWorkflowRun(body: unknown): SystemEvent {
   };
 }
 
-private parseIssueClosed(body: unknown): SystemEvent {
+private parseIssueClosed(body: unknown): InboundSystemEvent {
   return {
     type: 'issue:closed',
     source: 'github',
@@ -615,7 +615,7 @@ private parseIssueClosed(body: unknown): SystemEvent {
   };
 }
 
-private parsePullRequest(body: unknown): SystemEvent | null {
+private parsePullRequest(body: unknown): InboundSystemEvent | null {
   const action = body.action;
 
   if (action === 'closed' && body.pull_request.merged) {
@@ -776,7 +776,7 @@ class SessionActionHandler implements InboundEventHandler {
   readonly handlerId = 'session-action';
   readonly supportedEvents: InboundEventType[] = ['issue:closed', 'pr:merged'];
 
-  async handle(event: SystemEvent, target: EventTarget): Promise<boolean> {
+  async handle(event: InboundSystemEvent, target: EventTarget): Promise<boolean> {
     // Example: Show dialog suggesting to close session
     if (event.type === 'issue:closed' || event.type === 'pr:merged') {
       this.appWebSocket.broadcast({

--- a/packages/server/src/lib/__tests__/pty-notification.test.ts
+++ b/packages/server/src/lib/__tests__/pty-notification.test.ts
@@ -86,20 +86,20 @@ describe('writePtyNotification', () => {
     const result = writePtyNotification({
       kind: 'inbound-event',
       tag: 'inbound:ci:failed',
-      fields: { type: 'ci:failed', source: 'github', summary: 'Build failed' },
+      fields: { type: 'ci:failed', source: 'github', repo: 'owner/repo', branch: 'main', url: 'https://example.com', summary: 'Build failed' },
       intent: 'triage',
       writeInput,
     });
 
-    expect(result).toBe('\n[inbound:ci:failed] type=ci:failed source=github summary="Build failed" intent=triage');
+    expect(result).toBe('\n[inbound:ci:failed] type=ci:failed source=github repo=owner/repo branch=main url=https://example.com summary="Build failed" intent=triage');
     expect(written[0]).toBe(result);
   });
 
   it('returns the notification string without trailing carriage return', () => {
     const result = writePtyNotification({
       kind: 'inbound-event',
-      tag: 'test',
-      fields: { key: 'value' },
+      tag: 'inbound:ci:completed',
+      fields: { type: 'ci:completed', source: 'github', repo: 'owner/repo', branch: 'main', url: 'https://example.com', summary: 'CI passed' },
       intent: 'inform',
       writeInput: () => {},
     });
@@ -117,7 +117,7 @@ describe('writePtyNotification', () => {
       writePtyNotification({
         kind: 'internal-message',
         tag: 'internal:message',
-        fields: { source: 'session', from: 'sender-1' },
+        fields: { source: 'session', from: 'sender-1', summary: 'Test message', path: '/tmp/msg' },
         intent: 'triage',
         writeInput,
       });
@@ -141,17 +141,17 @@ describe('writePtyNotification', () => {
     const written: string[] = [];
 
     writePtyNotification({
-      kind: 'inbound-event',
-      tag: 'test',
-      fields: { msg: 'hello world', safe: 'simple' },
+      kind: 'internal-message',
+      tag: 'internal:message',
+      fields: { source: 'session', from: 'sender-1', summary: 'hello world', path: '/tmp/simple' },
       intent: 'inform',
       writeInput: (data) => { written.push(data); },
     });
 
     // 'hello world' has a space, so it should be quoted
-    expect(written[0]).toContain('msg="hello world"');
-    // 'simple' has no special chars, so it should be unquoted
-    expect(written[0]).toContain('safe=simple');
+    expect(written[0]).toContain('summary="hello world"');
+    // '/tmp/simple' has no special chars requiring quoting (slash and alphanumeric)
+    expect(written[0]).toContain('path=/tmp/simple');
   });
 
   it('includes intent field in notification output', () => {
@@ -160,7 +160,7 @@ describe('writePtyNotification', () => {
     writePtyNotification({
       kind: 'inbound-event',
       tag: 'inbound:ci:completed',
-      fields: { type: 'ci:completed', source: 'github' },
+      fields: { type: 'ci:completed', source: 'github', repo: 'owner/repo', branch: 'main', url: 'https://example.com', summary: 'CI passed' },
       intent: 'inform',
       writeInput: (data) => { written.push(data); },
     });

--- a/packages/server/src/lib/pty-notification.ts
+++ b/packages/server/src/lib/pty-notification.ts
@@ -5,7 +5,7 @@
  * key=value formatted messages into agent worker terminals.
  */
 
-import type { PtyNotificationIntent } from '@agent-console/shared';
+import type { InboundEventType, PtyNotificationIntent } from '@agent-console/shared';
 
 /**
  * Sanitize and quote a string value for use in a key=value PTY notification field.
@@ -38,21 +38,27 @@ interface BasePtyNotificationParams {
 
 export interface InboundEventPtyNotification extends BasePtyNotificationParams {
   kind: 'inbound-event';
-  /** Tag for the notification, e.g. "inbound:ci:failed" */
-  tag: string;
-  /** Key-value fields to include in the notification */
-  fields: Record<string, string>;
-  /** Notification intent */
+  tag: `inbound:${InboundEventType}`;
+  fields: {
+    type: InboundEventType;
+    source: string;
+    repo: string;
+    branch: string;
+    url: string;
+    summary: string;
+  };
   intent: PtyNotificationIntent;
 }
 
 export interface InternalMessagePtyNotification extends BasePtyNotificationParams {
   kind: 'internal-message';
-  /** Tag for the notification: "internal:message" */
   tag: 'internal:message';
-  /** Key-value fields to include in the notification */
-  fields: Record<string, string>;
-  /** Notification intent */
+  fields: {
+    source: string;
+    from: string;
+    summary: string;
+    path: string;
+  };
   intent: PtyNotificationIntent;
 }
 
@@ -71,7 +77,7 @@ export type WritePtyNotificationParams =
  */
 export function writePtyNotification(params: WritePtyNotificationParams): string {
   const { tag, fields, writeInput, intent } = params;
-  const allFields = { ...fields, intent };
+  const allFields: Record<string, string> = { ...fields, intent };
 
   const fieldString = Object.entries(allFields)
     .map(([key, value]) => `${key}=${formatFieldValue(value)}`)


### PR DESCRIPTION
## Summary

- Replace `Record<string, string>` with typed field objects in `WritePtyNotificationParams` discriminated union
- Replace `tag: string` with template literal type `` `inbound:${InboundEventType}` `` for compile-time tag validation
- Fix 12 remaining `SystemEvent` → `InboundSystemEvent` references in `integration-inbound.md` design spec

This is a follow-up to #329, enforcing the "constraints through structure, not convention" principle: field omissions and invalid tags are now caught at compile time rather than relying on convention.

## Test plan

- [x] `bun run typecheck` passes across all 3 packages
- [x] All 65 inbound-related tests pass (pty-notification, inbound-handlers, inbound-integration)
- [x] Existing callers (handlers.ts, mcp-server.ts) already pass correctly typed fields — no caller changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)