### PR TITLE
fix: prevent worktree agent selection mismatch between UI and PTY

### DIFF
--- a/packages/client/src/components/AgentSelector.tsx
+++ b/packages/client/src/components/AgentSelector.tsx
@@ -4,6 +4,25 @@ import type { AgentDefinition } from '@agent-console/shared';
 import { fetchAgents } from '../lib/api';
 import { agentKeys } from '../lib/query-keys';
 
+function useSortedAgents(priorityAgentId?: string) {
+  const { data, isLoading } = useQuery({
+    queryKey: agentKeys.all(),
+    queryFn: fetchAgents,
+  });
+
+  const sortedAgents = useMemo(() => {
+    const agents = data?.agents ?? [];
+    if (!priorityAgentId) return agents;
+    return [...agents].sort((a, b) => {
+      if (a.id === priorityAgentId) return -1;
+      if (b.id === priorityAgentId) return 1;
+      return 0;
+    });
+  }, [data?.agents, priorityAgentId]);
+
+  return { sortedAgents, isLoading };
+}
+
 interface AgentSelectorProps {
   value?: string;
   onChange: (agentId: string | undefined) => void;
@@ -12,6 +31,11 @@ interface AgentSelectorProps {
   priorityAgentId?: string;
 }
 
+/**
+ * Pure controlled select component for choosing an agent.
+ * Does not push state back to the parent via useEffect.
+ * Callers should use `useResolvedAgentId` to derive the effective agent ID with fallback.
+ */
 export function AgentSelector({
   value,
   onChange,
@@ -19,21 +43,7 @@ export function AgentSelector({
   disabled = false,
   priorityAgentId,
 }: AgentSelectorProps) {
-  const { data, isLoading } = useQuery({
-    queryKey: agentKeys.all(),
-    queryFn: fetchAgents,
-  });
-
-  const agents = data?.agents ?? [];
-
-  const sortedAgents = useMemo(() => {
-    if (!priorityAgentId) return agents;
-    return [...agents].sort((a, b) => {
-      if (a.id === priorityAgentId) return -1;
-      if (b.id === priorityAgentId) return 1;
-      return 0;
-    });
-  }, [agents, priorityAgentId]);
+  const { sortedAgents, isLoading } = useSortedAgents(priorityAgentId);
 
   const valueExists = value != null && sortedAgents.some((a) => a.id === value);
   const selectedValue = valueExists ? value : (sortedAgents[0]?.id ?? '');
@@ -63,7 +73,24 @@ export function AgentSelector({
   );
 }
 
-// Hook to get agents list for use in other components
+/**
+ * Hook that resolves the effective agent ID with fallback logic.
+ * Returns the given value if it matches a known agent, otherwise falls back to the first
+ * sorted agent. While loading, returns the original value unchanged.
+ *
+ * Shares the same TanStack Query cache as AgentSelector, so no extra network request is made.
+ */
+export function useResolvedAgentId(
+  value: string | undefined,
+  priorityAgentId?: string
+): string | undefined {
+  const { sortedAgents, isLoading } = useSortedAgents(priorityAgentId);
+
+  if (isLoading) return value;
+  const valueExists = value != null && sortedAgents.some((a) => a.id === value);
+  return valueExists ? value : sortedAgents[0]?.id;
+}
+
 export function useAgents() {
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: agentKeys.all(),
@@ -78,7 +105,6 @@ export function useAgents() {
   };
 }
 
-// Helper to get agent by ID
 export function getAgentName(agents: AgentDefinition[], agentId?: string): string {
   if (!agentId) return 'Unknown';
   const agent = agents.find((a) => a.id === agentId);

--- a/packages/client/src/components/__tests__/AgentSelector.test.tsx
+++ b/packages/client/src/components/__tests__/AgentSelector.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, mock, beforeEach, afterEach, afterAll } from 'bun:test';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, waitFor, cleanup, renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { AgentSelector } from '../AgentSelector';
+import { AgentSelector, useResolvedAgentId } from '../AgentSelector';
 
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
@@ -36,7 +36,7 @@ function createMockResponse(body: unknown) {
 }
 
 // Wrapper component with QueryClientProvider
-function TestWrapper({ children }: { children: React.ReactNode }) {
+function createTestWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -44,7 +44,9 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
       },
     },
   });
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return function TestWrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
 }
 
 function renderAgentSelector(props: Partial<React.ComponentProps<typeof AgentSelector>> = {}) {
@@ -56,9 +58,8 @@ function renderAgentSelector(props: Partial<React.ComponentProps<typeof AgentSel
 
   return {
     ...render(
-      <TestWrapper>
-        <AgentSelector {...mergedProps} />
-      </TestWrapper>
+      <AgentSelector {...mergedProps} />,
+      { wrapper: createTestWrapper() }
     ),
     props: mergedProps,
   };
@@ -122,6 +123,102 @@ describe('AgentSelector', () => {
       expect(options[0].textContent).toBe('Claude Code (built-in)');
       expect(options[1].textContent).toBe('Custom Agent');
       expect(options[2].textContent).toBe('Another Agent');
+    });
+  });
+
+  describe('loading state', () => {
+    it('should show loading state while fetching agents', () => {
+      // Use a fetch that never resolves to keep loading state
+      mockFetch.mockReturnValue(new Promise(() => {}));
+
+      renderAgentSelector({ value: undefined });
+
+      expect(screen.getByText('Loading...')).toBeTruthy();
+    });
+  });
+});
+
+describe('useResolvedAgentId', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(createMockResponse(mockAgentsResponse));
+  });
+
+  it('should return the original value while loading', () => {
+    // Use a fetch that never resolves to keep loading state
+    mockFetch.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(
+      () => useResolvedAgentId('some-agent'),
+      { wrapper: createTestWrapper() }
+    );
+
+    expect(result.current).toBe('some-agent');
+  });
+
+  it('should return undefined while loading when value is undefined', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(
+      () => useResolvedAgentId(undefined),
+      { wrapper: createTestWrapper() }
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return first agent when value is undefined and agents are loaded', async () => {
+    const { result } = renderHook(
+      () => useResolvedAgentId(undefined),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe('claude-code');
+    });
+  });
+
+  it('should return priority agent when value is undefined and priorityAgentId is set', async () => {
+    const { result } = renderHook(
+      () => useResolvedAgentId(undefined, 'another-agent'),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe('another-agent');
+    });
+  });
+
+  it('should return existing value when it matches an agent', async () => {
+    const { result } = renderHook(
+      () => useResolvedAgentId('custom-agent'),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe('custom-agent');
+    });
+  });
+
+  it('should return first agent when value does not match any agent', async () => {
+    const { result } = renderHook(
+      () => useResolvedAgentId('nonexistent-agent'),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe('claude-code');
+    });
+  });
+
+  it('should return priority agent when value does not match and priorityAgentId is set', async () => {
+    const { result } = renderHook(
+      () => useResolvedAgentId('nonexistent-agent', 'another-agent'),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe('another-agent');
     });
   });
 });

--- a/packages/client/src/components/sessions/QuickSessionForm.tsx
+++ b/packages/client/src/components/sessions/QuickSessionForm.tsx
@@ -1,7 +1,7 @@
 import { useForm } from 'react-hook-form';
 import { valibotResolver } from '@hookform/resolvers/valibot';
 import { FormField, Input } from '../ui/FormField';
-import { AgentSelector } from '../AgentSelector';
+import { AgentSelector, useResolvedAgentId } from '../AgentSelector';
 import { FormOverlay } from '../ui/Spinner';
 import type { CreateQuickSessionRequest } from '@agent-console/shared';
 import { CreateQuickSessionRequestSchema } from '@agent-console/shared';
@@ -34,9 +34,12 @@ export function QuickSessionForm({
     mode: 'onBlur',
   });
 
+  const agentId = watch('agentId');
+  const resolvedAgentId = useResolvedAgentId(agentId);
+
   const handleFormSubmit = async (data: CreateQuickSessionRequest) => {
     try {
-      await onSubmit(data);
+      await onSubmit({ ...data, agentId: resolvedAgentId });
     } catch (err) {
       setError('root', {
         message: err instanceof Error ? err.message : 'Failed to start session',
@@ -62,7 +65,7 @@ export function QuickSessionForm({
           <div className="flex items-center gap-2">
             <span className="text-sm text-gray-400">Agent:</span>
             <AgentSelector
-              value={watch('agentId')}
+              value={resolvedAgentId}
               onChange={(value) => {
                 setValue('agentId', value);
               }}

--- a/packages/client/src/components/sessions/RestartSessionDialog.tsx
+++ b/packages/client/src/components/sessions/RestartSessionDialog.tsx
@@ -10,7 +10,7 @@ import {
   AlertDialogCancel,
 } from '../ui/alert-dialog';
 import { restartAgentWorker, getSession } from '../../lib/api';
-import { AgentSelector } from '../AgentSelector';
+import { AgentSelector, useResolvedAgentId } from '../AgentSelector';
 
 export interface RestartSessionDialogProps {
   open: boolean;
@@ -37,6 +37,7 @@ export function RestartSessionDialog({
   const [error, setError] = useState<string | null>(null);
   const [selectedAgentId, setSelectedAgentId] = useState<string | undefined>(currentAgentId);
   const [branchValue, setBranchValue] = useState(currentBranch ?? '');
+  const resolvedAgentId = useResolvedAgentId(selectedAgentId, currentAgentId);
 
   // Reset selected agent and branch when dialog opens
   useEffect(() => {
@@ -46,7 +47,7 @@ export function RestartSessionDialog({
     }
   }, [open, currentAgentId, currentBranch]);
 
-  const isAgentChanged = selectedAgentId !== currentAgentId;
+  const isAgentChanged = resolvedAgentId !== currentAgentId;
   const trimmedBranch = branchValue.trim();
   const isBranchEmpty = isWorktreeSession === true && trimmedBranch === '';
   const isBranchChanged = isWorktreeSession === true && trimmedBranch !== '' && trimmedBranch !== (currentBranch ?? '');
@@ -65,7 +66,7 @@ export function RestartSessionDialog({
       if (!agentWorker) {
         throw new Error('No agent worker found');
       }
-      const agentId = isAgentChanged ? selectedAgentId : undefined;
+      const agentId = isAgentChanged ? resolvedAgentId : undefined;
       const newBranch = isBranchChanged ? trimmedBranch : undefined;
       await restartAgentWorker(sessionId, agentWorker.id, continueConversation, agentId, newBranch);
       onOpenChange(false);
@@ -100,7 +101,7 @@ export function RestartSessionDialog({
           <div className="flex items-center gap-2">
             <span className="text-sm text-gray-400 shrink-0 w-14">Agent:</span>
             <AgentSelector
-              value={selectedAgentId}
+              value={resolvedAgentId}
               onChange={setSelectedAgentId}
               className="flex-1"
               priorityAgentId={currentAgentId}

--- a/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
+++ b/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { valibotResolver } from '@hookform/resolvers/valibot';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { FormField, Input, Textarea } from '../ui/FormField';
-import { AgentSelector } from '../AgentSelector';
+import { AgentSelector, useResolvedAgentId } from '../AgentSelector';
 import { Spinner } from '../ui/Spinner';
 import type { CreateWorktreeFormData } from '../../schemas/worktree-form';
 import { CreateWorktreeFormSchema } from '../../schemas/worktree-form';
@@ -74,6 +74,9 @@ export function CreateWorktreeForm({
     mode: 'onBlur',
     shouldUnregister: true,
   });
+
+  const agentId = watch('agentId');
+  const resolvedAgentId = useResolvedAgentId(agentId, defaultAgentId ?? undefined);
 
   const branchNameMode = watch('branchNameMode');
   const initialPrompt = watch('initialPrompt');
@@ -179,7 +182,7 @@ export function CreateWorktreeForm({
           initialPrompt: data.initialPrompt!.trim(),
           baseBranch: data.baseBranch?.trim() || undefined,
           autoStartSession: true,
-          agentId: data.agentId,
+          agentId: resolvedAgentId,
           title: data.sessionTitle?.trim() || undefined,
           useRemote,
         };
@@ -189,7 +192,7 @@ export function CreateWorktreeForm({
           branch: data.customBranch!.trim(),
           baseBranch: data.baseBranch?.trim() || undefined,
           autoStartSession: true,
-          agentId: data.agentId,
+          agentId: resolvedAgentId,
           initialPrompt: data.initialPrompt?.trim() || undefined,
           title: data.sessionTitle?.trim() || undefined,
           useRemote,
@@ -199,7 +202,7 @@ export function CreateWorktreeForm({
           mode: 'existing',
           branch: data.customBranch!.trim(),
           autoStartSession: true,
-          agentId: data.agentId,
+          agentId: resolvedAgentId,
           initialPrompt: data.initialPrompt?.trim() || undefined,
           title: data.sessionTitle?.trim() || undefined,
         };
@@ -239,7 +242,7 @@ export function CreateWorktreeForm({
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-400">Agent:</span>
               <AgentSelector
-                value={watch('agentId')}
+                value={resolvedAgentId}
                 onChange={(value) => {
                   setValue('agentId', value);
                   if (setAsDefault && value) {

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -152,6 +152,21 @@ describe('WorkerManager', () => {
       expect(ptyFactory.spawn).toHaveBeenCalledTimes(1);
     });
 
+    it('should set agentId to the actual agent id, not the requested one, when fallback occurs', () => {
+      const worker = createTestAgentWorker();
+      // Start with a different agentId to verify fallback actually updates it
+      worker.agentId = 'originally-different-agent';
+
+      workerManager.activateAgentWorkerPty(worker, {
+        ...defaultAgentActivationParams,
+        agentId: 'non-existent-agent',
+      });
+
+      // Should fall back to default agent and record its actual id
+      expect(worker.agentId).toBe(CLAUDE_CODE_AGENT_ID);
+      expect(worker.pty).not.toBeNull();
+    });
+
     it('should set initial activity state to idle and fire global callback', () => {
       const globalCallback = mock(() => {});
       workerManager.setGlobalActivityCallback(globalCallback);

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -283,7 +283,14 @@ export class WorkerManager {
     const { sessionId, locationPath, agentId, continueConversation, initialPrompt, repositoryEnvVars, repositoryId, parentSessionId, parentWorkerId } = params;
 
     const agentManager = this.agentManager;
-    const agent = agentManager.getAgent(agentId) ?? agentManager.getDefaultAgent();
+    const requestedAgent = agentManager.getAgent(agentId);
+    const agent = requestedAgent ?? agentManager.getDefaultAgent();
+    if (!requestedAgent) {
+      logger.debug(
+        { workerId: worker.id, requestedAgentId: agentId, fallbackAgentId: agent.id },
+        'Requested agent not found, falling back to default agent'
+      );
+    }
 
     const template = continueConversation && agent.continueTemplate
       ? agent.continueTemplate
@@ -339,7 +346,7 @@ export class WorkerManager {
 
     worker.pty = ptyProcess;
     worker.activityDetector = activityDetector;
-    worker.agentId = agentId;
+    worker.agentId = agent.id;
 
     // Set initial activity state to match ActivityDetector's initial state ('idle').
     // The onStateChange callback only fires on state *changes*, not on initialization,


### PR DESCRIPTION
## Summary
- CreateWorktreeでAgent選択したものが実際にPTYで動作するAgentと異なるバグを修正
- `AgentSelector`が表示上のフォールバック値をフォームに同期しておらず、`agentId: undefined`のまま送信されていた
- サーバー側の`worker.agentId`も要求されたID（存在しない可能性あり）をそのまま記録していた

### Client
- `useResolvedAgentId`フックを新設し、フォールバックロジックを1箇所に集約
- `AgentSelector`は純粋な制御コンポーネントに（`useEffect`による親状態同期を排除）
- `CreateWorktreeForm`, `QuickSessionForm`, `RestartSessionDialog`の3つのcallerで`useResolvedAgentId`を使用

### Server
- `worker.agentId = agentId` → `worker.agentId = agent.id`（実際に起動したAgentのID）
- フォールバック発生時のデバッグログを追加

## Test plan
- [x] `useResolvedAgentId`フックのユニットテスト（7件: loading中、フォールバック、priority agent、既存値一致、不一致時のフォールバック）
- [x] `worker-manager`のフォールバック時agentId記録テスト（初期値と異なるIDからの上書き検証）
- [x] クライアント全テスト: 1133 pass
- [x] サーバー全テスト: 1681 pass
- [x] TypeCheck: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)