### PR TITLE
fix: eliminate terminal clear() on output truncation to prevent scroll-to-top

### DIFF
--- a/packages/client/src/components/Terminal.tsx
+++ b/packages/client/src/components/Terminal.tsx
@@ -223,7 +223,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
     stateRef.current.requestedWithOffset = 0;
   }, []);
 
-  const handleOutputTruncated = useCallback((message: string) => {
+  const handleOutputTruncated = useCallback((message: string, newOffset: number) => {
     if (truncationTimeoutRef.current) {
       clearTimeout(truncationTimeoutRef.current);
     }
@@ -233,15 +233,11 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
       truncationTimeoutRef.current = null;
     }, 10000);
 
-    resetTerminalForFreshHistory();
-
-    // Request immediately if connected (no need to wait for cacheProcessed since truncation means we're already past that)
-    if (connectedRef.current) {
-      stateRef.current.historyRequested = true;
-      stateRef.current.requestedWithOffset = 0;
-      requestHistory(sessionId, workerId, 0);
-    }
-  }, [sessionId, workerId, resetTerminalForFreshHistory]);
+    // Just update offset — no need to re-render terminal content.
+    // The xterm.js terminal still has valid content; the server only removed
+    // old data from the beginning of the file.
+    offsetRef.current = newOffset;
+  }, []);
 
   // Handle worker-restarted event from app WebSocket
   const handleWorkerRestarted = useCallback((restartedSessionId: string, restartedWorkerId: string) => {

--- a/packages/client/src/components/__tests__/Terminal.test.tsx
+++ b/packages/client/src/components/__tests__/Terminal.test.tsx
@@ -503,28 +503,19 @@ describe('Terminal state machine sync', () => {
   }
 
   /**
-   * Simulates handleOutputTruncated (lines 216-228):
-   *   offsetRef.current = 0; historyRequested = false; requestedWithOffset = 0;
-   *   if (connectedRef.current) { historyRequested = true; requestedWithOffset = 0; requestHistory(..., 0); }
+   * Simulates handleOutputTruncated:
+   *   offsetRef.current = newOffset;
+   *   (no state reset, no history re-request — the xterm.js terminal still has valid content)
    */
-  function handleTruncation(state: SimulatedState, connected: boolean): {
+  function handleTruncation(state: SimulatedState, _connected: boolean, newOffset: number): {
     state: SimulatedState;
-    immediateRequest: boolean;
   } {
-    const resetState: SimulatedState = {
-      ...state,
-      currentOffset: 0,
-      historyRequested: false,
-      requestedWithOffset: 0,
+    return {
+      state: {
+        ...state,
+        currentOffset: newOffset,
+      },
     };
-
-    if (connected) {
-      return {
-        state: { ...resetState, historyRequested: true, requestedWithOffset: 0 },
-        immediateRequest: true,
-      };
-    }
-    return { state: resetState, immediateRequest: false };
   }
 
   /**
@@ -621,8 +612,8 @@ describe('Terminal state machine sync', () => {
     });
   });
 
-  describe('truncation -> reset -> full history', () => {
-    it('should reset offset and request full history when connected', () => {
+  describe('truncation -> offset update only', () => {
+    it('should update offset to newOffset without re-requesting history when connected', () => {
       // 1. Initial sync completed, offset at 3000
       let state = createInitialState({
         cacheProcessed: true,
@@ -631,22 +622,20 @@ describe('Terminal state machine sync', () => {
         currentOffset: 3000,
       });
 
-      // 2. Truncation event while connected
-      const truncResult = handleTruncation(state, true);
+      // 2. Truncation event while connected — server provides newOffset
+      const newOffset = 1500;
+      const truncResult = handleTruncation(state, true, newOffset);
       state = truncResult.state;
 
-      // Truncation immediately requests history when connected
-      expect(truncResult.immediateRequest).toBe(true);
-      expect(state.currentOffset).toBe(0);
+      // Truncation just updates offset — no history re-request
+      expect(state.currentOffset).toBe(newOffset);
+      // historyRequested remains unchanged (already true)
       expect(state.historyRequested).toBe(true);
-      expect(state.requestedWithOffset).toBe(0);
-
-      // 3. handleHistory arrives -> full write since requestedWithOffset is 0
-      const action = determineHistoryAction(state.requestedWithOffset, true);
-      expect(action).toBe('full-write');
+      // requestedWithOffset remains unchanged
+      expect(state.requestedWithOffset).toBe(500);
     });
 
-    it('should defer history request when disconnected at truncation time', () => {
+    it('should update offset to newOffset without re-requesting history when disconnected', () => {
       let state = createInitialState({
         cacheProcessed: true,
         historyRequested: true,
@@ -654,18 +643,16 @@ describe('Terminal state machine sync', () => {
         currentOffset: 3000,
       });
 
-      // Truncation while disconnected
-      const truncResult = handleTruncation(state, false);
+      // Truncation while disconnected — same behavior, just update offset
+      const newOffset = 1500;
+      const truncResult = handleTruncation(state, false, newOffset);
       state = truncResult.state;
 
-      expect(truncResult.immediateRequest).toBe(false);
-      expect(state.historyRequested).toBe(false);
-      expect(state.currentOffset).toBe(0);
-
-      // Later, reconnect -> useEffect fires and requests from offset 0
-      const request = evaluateHistoryRequest(state, true);
-      expect(request.shouldRequest).toBe(true);
-      expect(request.requestOffset).toBe(0);
+      expect(state.currentOffset).toBe(newOffset);
+      // historyRequested remains unchanged
+      expect(state.historyRequested).toBe(true);
+      // requestedWithOffset remains unchanged
+      expect(state.requestedWithOffset).toBe(500);
     });
   });
 
@@ -716,19 +703,20 @@ describe('Terminal state machine sync', () => {
   describe('scroll position preservation: truncation vs worker restart', () => {
     /**
      * Simulates handleOutputTruncated behavior including terminal.reset() decision.
-     * Maps to Terminal.tsx handleOutputTruncated (lines ~226-244):
-     *   - Calls resetTerminalForFreshHistory() which does NOT call terminal.reset()
-     *   - Requests history immediately if connected
+     * Maps to Terminal.tsx handleOutputTruncated:
+     *   - Just updates offsetRef.current = newOffset
+     *   - Does NOT call terminal.reset() or re-request history
      */
     function handleTruncationWithTerminalBehavior(
       state: SimulatedState,
-      connected: boolean
-    ): { state: SimulatedState; immediateRequest: boolean; terminalResetCalled: boolean } {
-      const truncResult = handleTruncation(state, connected);
+      _connected: boolean,
+      newOffset: number
+    ): { state: SimulatedState; terminalResetCalled: boolean } {
+      const truncResult = handleTruncation(state, _connected, newOffset);
       return {
         ...truncResult,
-        // resetTerminalForFreshHistory() does NOT call terminal.reset()
-        // Content stays visible until writeFullHistory() replaces it atomically
+        // handleOutputTruncated does NOT call terminal.reset()
+        // Content stays visible — server only removed old data from beginning of file
         terminalResetCalled: false,
       };
     }
@@ -764,12 +752,14 @@ describe('Terminal state machine sync', () => {
         currentOffset: 8000,
       });
 
-      const result = handleTruncationWithTerminalBehavior(state, true);
+      const newOffset = 4000;
+      const result = handleTruncationWithTerminalBehavior(state, true, newOffset);
 
-      // terminal.reset() must NOT be called — old content stays visible until
-      // writeFullHistory() atomically replaces it, preventing scroll position loss
+      // terminal.reset() must NOT be called — xterm.js still has valid content;
+      // the server only removed old data from the beginning of the file
       expect(result.terminalResetCalled).toBe(false);
-      expect(result.immediateRequest).toBe(true);
+      // offset is updated to the server-provided newOffset
+      expect(result.state.currentOffset).toBe(newOffset);
     });
 
     it('should call terminal.reset() on worker restart (immediate visual feedback)', () => {
@@ -787,7 +777,7 @@ describe('Terminal state machine sync', () => {
       expect(result.terminalResetCalled).toBe(true);
     });
 
-    it('should reset the same state variables in both scenarios', () => {
+    it('should have different behaviors: truncation updates offset, restart resets everything', () => {
       const initialState = createInitialState({
         cacheProcessed: true,
         historyRequested: true,
@@ -795,18 +785,21 @@ describe('Terminal state machine sync', () => {
         currentOffset: 8000,
       });
 
-      const truncResult = handleTruncationWithTerminalBehavior(initialState, true);
+      const newOffset = 4000;
+      const truncResult = handleTruncationWithTerminalBehavior(initialState, true, newOffset);
       const restartResult = handleWorkerRestartWithTerminalBehavior(initialState);
 
-      // Both scenarios reset offset to 0
-      expect(truncResult.state.currentOffset).toBe(0);
+      // Truncation: offset updated to newOffset, other state unchanged
+      expect(truncResult.state.currentOffset).toBe(newOffset);
+      expect(truncResult.state.historyRequested).toBe(true);
+      expect(truncResult.state.requestedWithOffset).toBe(500);
+
+      // Restart: everything reset to 0
       expect(restartResult.state.currentOffset).toBe(0);
-
-      // Both scenarios reset requestedWithOffset to 0
-      expect(truncResult.state.requestedWithOffset).toBe(0);
       expect(restartResult.state.requestedWithOffset).toBe(0);
+      expect(restartResult.state.historyRequested).toBe(false);
 
-      // The only difference is terminal.reset() behavior
+      // terminal.reset() behavior differs
       expect(truncResult.terminalResetCalled).toBe(false);
       expect(restartResult.terminalResetCalled).toBe(true);
     });
@@ -819,12 +812,14 @@ describe('Terminal state machine sync', () => {
         currentOffset: 8000,
       });
 
-      const result = handleTruncationWithTerminalBehavior(state, false);
+      const newOffset = 4000;
+      const result = handleTruncationWithTerminalBehavior(state, false, newOffset);
 
       expect(result.terminalResetCalled).toBe(false);
-      expect(result.immediateRequest).toBe(false);
-      // historyRequested stays false when disconnected — will be requested on reconnect
-      expect(result.state.historyRequested).toBe(false);
+      // offset is updated to newOffset
+      expect(result.state.currentOffset).toBe(newOffset);
+      // historyRequested stays unchanged — truncation does not touch it
+      expect(result.state.historyRequested).toBe(true);
     });
   });
 

--- a/packages/client/src/hooks/useTerminalWebSocket.ts
+++ b/packages/client/src/hooks/useTerminalWebSocket.ts
@@ -9,7 +9,7 @@ interface UseTerminalWebSocketOptions {
   onExit: (exitCode: number, signal: string | null) => void;
   onConnectionChange: (connected: boolean) => void;
   onActivity?: (state: AgentActivityState) => void;
-  onOutputTruncated?: (message: string) => void;
+  onOutputTruncated?: (message: string, newOffset: number) => void;
 }
 
 export interface WorkerError {

--- a/packages/client/src/lib/__tests__/terminal-chunk-writer.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-chunk-writer.test.ts
@@ -25,7 +25,6 @@ function createMockTerminal(): ChunkableTerminal & {
         setTimeout(callback, 0);
       }
     }),
-    clear: mock(() => {}),
     scrollToBottom: mock(() => {}),
   };
 }
@@ -291,15 +290,6 @@ describe('terminal-chunk-writer', () => {
   });
 
   describe('writeFullHistory', () => {
-    it('should call terminal.clear() first', async () => {
-      const terminal = createMockTerminal();
-      const data = 'History content';
-
-      await writeFullHistory(terminal, data);
-
-      expect(terminal.clear).toHaveBeenCalledTimes(1);
-    });
-
     it('should write the data', async () => {
       const terminal = createMockTerminal();
       const data = 'History content';
@@ -323,7 +313,6 @@ describe('terminal-chunk-writer', () => {
 
       await writeFullHistory(terminal, '');
 
-      expect(terminal.clear).toHaveBeenCalledTimes(1);
       expect(terminal.writtenData).toHaveLength(1);
       expect(terminal.writtenData[0]).toBe('');
       expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
@@ -335,7 +324,6 @@ describe('terminal-chunk-writer', () => {
 
       await writeFullHistory(terminal, data);
 
-      expect(terminal.clear).toHaveBeenCalledTimes(1);
       expect(terminal.writtenData.join('')).toBe(data);
       expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
     });

--- a/packages/client/src/lib/terminal-chunk-writer.ts
+++ b/packages/client/src/lib/terminal-chunk-writer.ts
@@ -4,7 +4,6 @@
  */
 export interface ChunkableTerminal {
   write: (data: string, callback?: () => void) => void;
-  clear: () => void;
   scrollToBottom: () => void;
 }
 
@@ -176,8 +175,6 @@ export async function writeDataInChunks(
  * staying well within these limits.
  */
 export async function writeFullHistory(terminal: ChunkableTerminal, data: string): Promise<void> {
-  terminal.clear();
-
   await writeDataInChunks(terminal, data);
 
   terminal.scrollToBottom();

--- a/packages/client/src/lib/terminal-utils.ts
+++ b/packages/client/src/lib/terminal-utils.ts
@@ -1,5 +1,3 @@
-import type { Terminal } from '@xterm/xterm';
-
 /**
  * Interface representing the minimal buffer properties needed for scroll position checks.
  * This allows for easy mocking in tests without depending on the full xterm.js Terminal type.
@@ -34,17 +32,3 @@ export function isScrolledToBottom(terminal: TerminalScrollInfo): boolean {
   const buffer = terminal.buffer.active;
   return buffer.viewportY + terminal.rows >= buffer.length;
 }
-
-/**
- * Clear terminal and write data, preserving scroll position.
- * The writeFn should return a Promise that resolves when the last write completes.
- */
-export const clearAndWrite = async (
-  terminal: Terminal,
-  writeFn: () => Promise<void>
-): Promise<void> => {
-  const scrollPosition = terminal.buffer.active.viewportY;
-  terminal.clear();
-  await writeFn();
-  terminal.scrollToLine(scrollPosition);
-};

--- a/packages/client/src/lib/worker-websocket.ts
+++ b/packages/client/src/lib/worker-websocket.ts
@@ -85,7 +85,7 @@ export interface TerminalWorkerCallbacks {
   onExit: (exitCode: number, signal: string | null) => void;
   onActivity?: (state: AgentActivityState) => void;
   onError?: (message: string, code?: WorkerErrorCode) => void;
-  onOutputTruncated?: (message: string) => void;
+  onOutputTruncated?: (message: string, newOffset: number) => void;
 }
 
 // Callbacks for git-diff workers
@@ -276,7 +276,7 @@ function handleTerminalMessage(
         });
 
       // Notify the terminal component about the truncation
-      callbacks.onOutputTruncated?.(msg.message);
+      callbacks.onOutputTruncated?.(msg.message, msg.newOffset);
       break;
     }
     case 'server-restarted':

--- a/packages/server/src/lib/worker-output-file.ts
+++ b/packages/server/src/lib/worker-output-file.ts
@@ -15,7 +15,7 @@ const logger = createLogger('worker-output-file');
  * Callback type for output truncation notification.
  * Used to notify WebSocket clients when output file is truncated.
  */
-export type OutputTruncatedCallback = (sessionId: string, workerId: string) => void;
+export type OutputTruncatedCallback = (sessionId: string, workerId: string, newOffset: number) => void;
 
 /** Registered callback for output truncation notifications */
 let onOutputTruncatedCallback: OutputTruncatedCallback | null = null;
@@ -292,7 +292,7 @@ export class WorkerOutputFileManager {
 
       // Notify connected clients about the truncation via registered callback
       if (onOutputTruncatedCallback) {
-        onOutputTruncatedCallback(sessionId, workerId);
+        onOutputTruncatedCallback(sessionId, workerId, trimmedBuffer.length);
       }
     } catch (error) {
       logger.error({ filePath, err: error }, 'Failed to truncate output file');

--- a/packages/server/src/websocket/routes.ts
+++ b/packages/server/src/websocket/routes.ts
@@ -197,7 +197,7 @@ export function notifySessionPaused(sessionId: string): void {
  * Registered as callback in setupWebSocketRoutes() to avoid circular dependency.
  * Called by WorkerOutputFileManager when output file exceeds size limits.
  */
-function notifyWorkerOutputTruncated(sessionId: string, workerId: string): void {
+function notifyWorkerOutputTruncated(sessionId: string, workerId: string, newOffset: number): void {
   const connections = registry.getWorkerConnections(sessionId, workerId);
   if (!connections || connections.size === 0) {
     logger.debug({ sessionId, workerId }, 'No worker connections to notify for output truncation');
@@ -207,6 +207,7 @@ function notifyWorkerOutputTruncated(sessionId: string, workerId: string): void 
   const msg: WorkerServerMessage = {
     type: 'output-truncated',
     message: 'Output history truncated due to size limits',
+    newOffset,
   };
   const msgStr = JSON.stringify(msg);
 

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -121,7 +121,7 @@ export type WorkerServerMessage =
   | { type: 'history'; data: string; offset: number; timedOut?: boolean }
   | { type: 'activity'; state: AgentActivityState }  // Agent workers only
   | { type: 'error'; message: string; code?: WorkerErrorCode }
-  | { type: 'output-truncated'; message: string }
+  | { type: 'output-truncated'; message: string; newOffset: number }
   | { type: 'server-restarted'; serverPid: number };  // Server was restarted, client should invalidate cache
 
 export interface WorkerActivityInfo {


### PR DESCRIPTION
## Summary
- When output file truncation occurred (>10MB), the client re-requested full history and called `terminal.clear()`, causing scroll position to jump to the top
- Server now includes `newOffset` in the `output-truncated` WebSocket message
- Client just updates its offset on truncation — no re-render, no `clear()`, no full history re-request
- Removed unused `clearAndWrite` from terminal-utils.ts

## Test plan
- [ ] Verify large output (>10MB) no longer causes scroll-to-top when truncation occurs
- [ ] Verify new output continues flowing after truncation
- [ ] Verify reconnection after truncation works correctly
- [ ] Verify worker restart still clears terminal (different code path)
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)