### PR TITLE
fix: strip CSI 3J scrollback clear from terminal output

### DIFF
--- a/packages/client/src/components/Terminal.tsx
+++ b/packages/client/src/components/Terminal.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { useTerminalWebSocket, type WorkerError } from '../hooks/useTerminalWebSocket';
 import { useAppWsEvent } from '../hooks/useAppWs';
 import { disconnect, requestHistory } from '../lib/worker-websocket.js';
-import { isScrolledToBottom } from '../lib/terminal-utils.js';
+import { isScrolledToBottom, stripScrollbackClear } from '../lib/terminal-utils.js';
 import { writeFullHistory } from '../lib/terminal-chunk-writer.js';
 import { saveTerminalState, loadTerminalState, clearTerminalState, getCurrentServerPid } from '../lib/terminal-state-cache.js';
 import {
@@ -159,7 +159,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
 
   const handleOutput = useCallback((data: string, offset: number) => {
     offsetRef.current = offset;
-    terminalRef.current?.write(data, () => {
+    terminalRef.current?.write(stripScrollbackClear(data), () => {
       updateScrollButtonVisibility();
     });
     // Mark as dirty for idle-based save (replaces fire-and-forget saves)
@@ -175,7 +175,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
     if (stateRef.current.requestedWithOffset > 0) {
       // Had cache — append diff
       if (data) {
-        terminal.write(data, () => {
+        terminal.write(stripScrollbackClear(data), () => {
           updateScrollButtonVisibility();
           saveCurrentTerminalState();
         });
@@ -185,7 +185,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
     } else {
       // No cache — full history
       if (!data) return;
-      writeFullHistory(terminal, data)
+      writeFullHistory(terminal, stripScrollbackClear(data))
         .then(() => {
           updateScrollButtonVisibility();
           saveCurrentTerminalState();
@@ -406,7 +406,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
         const currentTerminal = terminalRef.current;
         if (cached && cached.data && currentTerminal) {
           // Restore cached terminal state
-          currentTerminal.write(cached.data, () => {
+          currentTerminal.write(stripScrollbackClear(cached.data), () => {
             updateScrollButtonVisibility();
           });
           offsetRef.current = cached.offset;

--- a/packages/client/src/lib/__tests__/terminal-utils.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { isScrolledToBottom, type TerminalScrollInfo } from '../terminal-utils';
+import { isScrolledToBottom, stripScrollbackClear, type TerminalScrollInfo } from '../terminal-utils';
 
 /**
  * Helper to create a mock terminal with scroll info.
@@ -104,6 +104,32 @@ describe('terminal-utils', () => {
         const terminal = createMockTerminal(99, 1, 100);
         expect(isScrolledToBottom(terminal)).toBe(true);
       });
+    });
+  });
+
+  describe('stripScrollbackClear', () => {
+    it('should strip CSI 3J from a string', () => {
+      const input = 'hello\x1b[3Jworld';
+      expect(stripScrollbackClear(input)).toBe('helloworld');
+    });
+
+    it('should preserve CSI 2J (screen clear) and other sequences', () => {
+      const input = '\x1b[2J\x1b[H\x1b[0m';
+      expect(stripScrollbackClear(input)).toBe('\x1b[2J\x1b[H\x1b[0m');
+    });
+
+    it('should handle multiple occurrences', () => {
+      const input = '\x1b[3Jfoo\x1b[3Jbar\x1b[3J';
+      expect(stripScrollbackClear(input)).toBe('foobar');
+    });
+
+    it('should return empty string unchanged', () => {
+      expect(stripScrollbackClear('')).toBe('');
+    });
+
+    it('should return string without the sequence unchanged', () => {
+      const input = 'no escape sequences here';
+      expect(stripScrollbackClear(input)).toBe(input);
     });
   });
 });

--- a/packages/client/src/lib/terminal-utils.ts
+++ b/packages/client/src/lib/terminal-utils.ts
@@ -32,3 +32,15 @@ export function isScrolledToBottom(terminal: TerminalScrollInfo): boolean {
   const buffer = terminal.buffer.active;
   return buffer.viewportY + terminal.rows >= buffer.length;
 }
+
+/**
+ * Strip CSI 3J (Erase Scrollback) escape sequence from terminal output.
+ *
+ * TUI programs like Claude Code send \x1b[3J as part of screen redraws,
+ * which clears the xterm.js scrollback buffer and resets scroll position to top.
+ * In a browser-based terminal manager, preserving scrollback is more valuable
+ * than honoring scrollback-clear requests.
+ */
+export function stripScrollbackClear(data: string): string {
+  return data.replaceAll('\x1b[3J', '');
+}


### PR DESCRIPTION
## Summary
- Filter out `\x1b[3J` (CSI 3J - Erase Scrollback) escape sequence from terminal output before writing to xterm.js
- TUI programs like Claude Code send this sequence during screen redraws, which clears the scrollback buffer and resets scroll position to top in xterm.js
- Applied at all 4 terminal write points: real-time output, history diff, full history, and cache restore

## Test plan
- [x] Unit tests for `stripScrollbackClear` utility function (5 cases)
- [x] `bun run typecheck` passes
- [x] `bun test` passes
- [ ] Manual: Open a Claude Code agent session, verify terminal no longer jumps to top during TUI redraws
- [ ] Manual: Verify screen clear (`\x1b[2J`) still works normally
- [ ] Manual: Verify scrollback buffer is preserved across redraws

🤖 Generated with [Claude Code](https://claude.com/claude-code)