### PR TITLE
fix: convert CRLF/LF to CR when injecting multi-line messages into PTY

### DIFF
--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -429,6 +429,44 @@ describe('SessionManager', () => {
       expect(ptyFactory.instances[0].writtenData).toContain('hello world');
     });
 
+    it('should convert newlines to carriage returns in multi-line content', async () => {
+      const manager = await getSessionManager();
+      const session = await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      const agentWorker = session.workers.find((w: Worker) => w.type === 'agent')!;
+
+      const message = manager.sendMessage(session.id, null, agentWorker.id, 'line1\nline2\nline3');
+      expect(message).not.toBeNull();
+      // Content stored in message should retain original newlines
+      expect(message!.content).toBe('line1\nline2\nline3');
+      // PTY input should use carriage returns instead of newlines
+      const pty = ptyFactory.instances[0];
+      expect(pty.writtenData).toContain('line1\rline2\rline3');
+      expect(pty.writtenData).not.toContain('line1\nline2\nline3');
+    });
+
+    it('should handle CRLF line endings from form submissions', async () => {
+      const manager = await getSessionManager();
+      const session = await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      const agentWorker = session.workers.find((w: Worker) => w.type === 'agent')!;
+
+      // Browser form submissions normalize line endings to \r\n
+      const message = manager.sendMessage(session.id, null, agentWorker.id, 'line1\r\nline2\r\nline3');
+      expect(message).not.toBeNull();
+      expect(message!.content).toBe('line1\r\nline2\r\nline3');
+      const pty = ptyFactory.instances[0];
+      // \r\n should become single \r, not \r\r
+      expect(pty.writtenData).toContain('line1\rline2\rline3');
+      expect(pty.writtenData).not.toContain('\r\r');
+    });
+
     it('should inject content with file paths when files provided', async () => {
       const manager = await getSessionManager();
       const session = await manager.createSession({

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -355,7 +355,7 @@ export class SessionManager {
     // Inject message into target worker's PTY
     // Send each part with delays so TUI agents can process input sequentially
     const parts: string[] = [];
-    if (content) parts.push(content);
+    if (content) parts.push(content.replace(/\r?\n/g, '\r'));
     if (filePaths && filePaths.length > 0) {
       parts.push(...filePaths);
     }


### PR DESCRIPTION
## Summary
- メッセージパネルから複数行メッセージを送信すると、各行の間に余計な空行が入るバグを修正
- ブラウザのフォーム送信が改行を `\r\n` に正規化するため、PTYに書き込む際に `\r\r` となり二重改行になっていた
- `\r?\n` → `\r` の変換で、CRLF/LF両方を単一のCRに統一

## Test plan
- [x] 既存テスト全131件パス
- [x] `\n` → `\r` 変換のテスト追加
- [x] `\r\n` → `\r` 変換（`\r\r` にならない）のテスト追加
- [x] 開発サーバーで複数行メッセージ送信の動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)