### PR TITLE
fix: default useRemote to true for worktree creation

### DIFF
--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -1201,7 +1201,7 @@ describe('MCP Server Tools', () => {
       expect(statusData.title).toBe('Dark Mode Feature');
     });
 
-    it('should handle useRemote flag by calling fetchRemote', async () => {
+    it('should call fetchRemote by default when useRemote is omitted', async () => {
       await setupDelegateEnvironment('feat/remote-branch');
 
       // fetchRemote is already mocked by mock-git-helper (resolves successfully)
@@ -1210,13 +1210,29 @@ describe('MCP Server Tools', () => {
         repositoryId: 'test-repo',
         prompt: 'Work on remote-based feature',
         branch: 'feat/remote-branch',
-        useRemote: true,
+        // useRemote is intentionally omitted — should default to true
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
 
       // Verify fetchRemote was called (the baseBranch defaults to 'main')
       expect(mockGit.fetchRemote).toHaveBeenCalledWith('main', TEST_REPO_PATH);
+    });
+
+    it('should skip fetchRemote when useRemote is explicitly false', async () => {
+      await setupDelegateEnvironment('feat/local-branch');
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Work on local-only feature',
+        branch: 'feat/local-branch',
+        useRemote: false,
+      }, nextId++);
+
+      expect(response.result?.isError).toBeUndefined();
+
+      // Verify fetchRemote was NOT called
+      expect(mockGit.fetchRemote).not.toHaveBeenCalled();
     });
 
     it('should return error when worktree creation fails', async () => {

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -441,7 +441,7 @@ export function createMcpApp(deps: McpDependencies): Hono {
       useRemote: z
         .boolean()
         .optional()
-        .describe('If true, branch from origin/<baseBranch> instead of local branch'),
+        .describe('Branch from origin/<baseBranch> instead of local branch. Defaults to true when omitted.'),
       parentSessionId: z
         .string()
         .min(1, 'parentSessionId must be non-empty')
@@ -537,7 +537,7 @@ export function createMcpApp(deps: McpDependencies): Hono {
           'main';
 
         // Handle useRemote flag
-        if (useRemote && effectiveBaseBranch) {
+        if (useRemote !== false && effectiveBaseBranch) {
           try {
             await fetchRemote(effectiveBaseBranch, repo.path);
             effectiveBaseBranch = `origin/${effectiveBaseBranch}`;

--- a/packages/server/src/routes/worktrees.ts
+++ b/packages/server/src/routes/worktrees.ts
@@ -111,7 +111,7 @@ const worktrees = new Hono<AppBindings>()
         let branchNameFallback: BranchNameFallback | undefined;
 
         // Extract useRemote flag (only available for 'prompt' and 'custom' modes)
-        const useRemote = (mode === 'prompt' || mode === 'custom') && body.useRemote === true;
+        const useRemote = (mode === 'prompt' || mode === 'custom') && body.useRemote !== false;
 
         switch (mode) {
           case 'prompt': {

--- a/packages/shared/src/schemas/repository.ts
+++ b/packages/shared/src/schemas/repository.ts
@@ -65,7 +65,7 @@ export const CreateWorktreePromptRequestSchema = v.object({
     v.minLength(1, 'Initial prompt is required for prompt mode')
   ),
   baseBranch: OptionalBranchSchema,
-  useRemote: v.optional(v.boolean()), // If true, branch from origin/<base> instead of local <base>
+  useRemote: v.optional(v.boolean()), // Branch from origin/<base> instead of local <base>. Defaults to true.
 });
 
 /**
@@ -76,7 +76,7 @@ export const CreateWorktreeCustomRequestSchema = v.object({
   mode: v.literal('custom'),
   branch: RequiredBranchSchema,
   baseBranch: OptionalBranchSchema,
-  useRemote: v.optional(v.boolean()), // If true, branch from origin/<base> instead of local <base>
+  useRemote: v.optional(v.boolean()), // Branch from origin/<base> instead of local <base>. Defaults to true.
 });
 
 /**


### PR DESCRIPTION
## Summary

- Worktree作成時、`useRemote` のデフォルトを `true` に変更。`origin/<baseBranch>` からブランチを切るようになります
- PRマージ後にローカルmainが古いまま残る問題を解消
- `useRemote: false` で従来の動作にオプトアウト可能

Closes #362

## Test plan

- [x] `useRemote` 省略時にリモートからfetchされることを確認するテスト
- [x] `useRemote: false` でfetchがスキップされることを確認するテスト
- [x] typecheck pass
- [x] all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)