### PR TITLE
chore: update auto-generated routeTree.gen.ts

### DIFF
--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -9,8 +9,8 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as LoginRouteImport } from './routes/login'
 import { Route as MaintenanceRouteImport } from './routes/maintenance'
+import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as JobsIndexRouteImport } from './routes/jobs/index'
@@ -24,14 +24,14 @@ import { Route as AgentsAgentIdIndexRouteImport } from './routes/agents/$agentId
 import { Route as SessionsSessionIdWorkerIdRouteImport } from './routes/sessions/$sessionId/$workerId'
 import { Route as AgentsAgentIdEditRouteImport } from './routes/agents/$agentId/edit'
 
-const LoginRoute = LoginRouteImport.update({
-  id: '/login',
-  path: '/login',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const MaintenanceRoute = MaintenanceRouteImport.update({
   id: '/maintenance',
   path: '/maintenance',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -217,18 +217,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/maintenance': {
       id: '/maintenance'
       path: '/maintenance'
       fullPath: '/maintenance'
       preLoaderRoute: typeof MaintenanceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {


### PR DESCRIPTION
## Summary
- Updated `routeTree.gen.ts` to match the latest auto-generated output from TanStack Router
- The only change is the ordering of route imports and registrations (`maintenance` and `login` swapped)

## Test plan
- [x] `bun run build` succeeds
- [x] No git diff after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)