### PR TITLE
feat: add timestamp to all PTY notifications

### DIFF
--- a/packages/server/src/lib/__tests__/pty-notification.test.ts
+++ b/packages/server/src/lib/__tests__/pty-notification.test.ts
@@ -91,7 +91,15 @@ describe('writePtyNotification', () => {
       writeInput,
     });
 
-    expect(result).toBe('\n[inbound:ci:failed] type=ci:failed source=github repo=owner/repo branch=main url=https://example.com summary="Build failed" intent=triage');
+    // Timestamp is dynamic, so verify structure rather than exact match
+    expect(result).toMatch(/^\n\[inbound:ci:failed\] timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z /);
+    expect(result).toContain('type=ci:failed');
+    expect(result).toContain('source=github');
+    expect(result).toContain('repo=owner/repo');
+    expect(result).toContain('branch=main');
+    expect(result).toContain('url=https://example.com');
+    expect(result).toContain('summary="Build failed"');
+    expect(result).toContain('intent=triage');
     expect(written[0]).toBe(result);
   });
 
@@ -166,5 +174,62 @@ describe('writePtyNotification', () => {
     });
 
     expect(written[0]).toContain('intent=inform');
+  });
+
+  it('includes timestamp in ISO 8601 format for inbound-event notifications', () => {
+    const written: string[] = [];
+
+    writePtyNotification({
+      kind: 'inbound-event',
+      tag: 'inbound:ci:failed',
+      fields: { type: 'ci:failed', source: 'github', repo: 'owner/repo', branch: 'main', url: 'https://example.com', summary: 'Build failed' },
+      intent: 'triage',
+      writeInput: (data) => { written.push(data); },
+    });
+
+    expect(written[0]).toMatch(/timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+  });
+
+  it('includes timestamp in ISO 8601 format for internal-message notifications', () => {
+    const written: string[] = [];
+
+    writePtyNotification({
+      kind: 'internal-message',
+      tag: 'internal:message',
+      fields: { source: 'session', from: 'sender-1', summary: 'Test message', path: '/tmp/msg' },
+      intent: 'inform',
+      writeInput: (data) => { written.push(data); },
+    });
+
+    expect(written[0]).toMatch(/timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+  });
+
+  it('includes timestamp in ISO 8601 format for internal-timer notifications', () => {
+    const written: string[] = [];
+
+    writePtyNotification({
+      kind: 'internal-timer',
+      tag: 'internal:timer',
+      fields: { timerId: 'timer-1', action: 'check', fireCount: '1' },
+      intent: 'inform',
+      writeInput: (data) => { written.push(data); },
+    });
+
+    expect(written[0]).toMatch(/timestamp=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+  });
+
+  it('places timestamp as the first field in the notification', () => {
+    const written: string[] = [];
+
+    writePtyNotification({
+      kind: 'internal-timer',
+      tag: 'internal:timer',
+      fields: { timerId: 'timer-1', action: 'check', fireCount: '1' },
+      intent: 'inform',
+      writeInput: (data) => { written.push(data); },
+    });
+
+    // After the tag, timestamp should be the first key=value pair
+    expect(written[0]).toMatch(/^\n\[internal:timer\] timestamp=/);
   });
 });

--- a/packages/server/src/lib/pty-notification.ts
+++ b/packages/server/src/lib/pty-notification.ts
@@ -89,7 +89,7 @@ export type WritePtyNotificationParams =
  */
 export function writePtyNotification(params: WritePtyNotificationParams): string {
   const { tag, fields, writeInput, intent } = params;
-  const allFields: Record<string, string> = { ...fields, intent };
+  const allFields: Record<string, string> = { timestamp: new Date().toISOString(), ...fields, intent };
 
   const fieldString = Object.entries(allFields)
     .map(([key, value]) => `${key}=${formatFieldValue(value)}`)


### PR DESCRIPTION
## Summary
- Add ISO 8601 `timestamp` field as the first field in all PTY notification types (inbound-event, internal-message, internal-timer)
- Timestamp is generated at notification write time via `new Date().toISOString()`
- Existing field order and behavior unchanged; timestamp is prepended

## Test plan
- [x] All 26 existing + new tests pass (`bun test`)
- [x] Timestamp present in ISO 8601 format for all 3 notification kinds
- [x] Timestamp appears as the first field after the tag
- [x] Existing field formatting and sanitization unaffected

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)