### PR TITLE
fix: prevent text overflow in memo panel

### DIFF
--- a/packages/client/src/components/sessions/MemoPanel.tsx
+++ b/packages/client/src/components/sessions/MemoPanel.tsx
@@ -65,7 +65,7 @@ export function MemoPanel({ sessionId }: MemoPanelProps) {
         </button>
       </div>
       {/* Content */}
-      <div className="memo-content flex-1 overflow-y-auto px-4 py-3 text-sm text-gray-300">
+      <div className="memo-content min-w-0 flex-1 overflow-y-auto px-4 py-3 text-sm text-gray-300">
         <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown>
       </div>
     </div>

--- a/packages/client/src/styles.css
+++ b/packages/client/src/styles.css
@@ -72,6 +72,10 @@
 }
 
 /* Markdown styling for memo panel */
+.memo-content {
+  overflow-wrap: break-word;
+}
+
 .memo-content h1, .memo-content h2, .memo-content h3, .memo-content h4, .memo-content h5, .memo-content h6 {
   font-weight: 600;
   margin-top: 0.75em;


### PR DESCRIPTION
## Summary
- Add `overflow-wrap: break-word` to `.memo-content` CSS so long text (especially Japanese) wraps instead of overflowing the container
- Add `min-w-0` to the memo content flex child to allow proper shrinking within the flex layout

## Test plan
- [ ] Open a session with a memo containing long Japanese text
- [ ] Verify text wraps at the right edge of the memo panel instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)