### PR TITLE
feat: add orchestrator skill ported from conteditor CTO skill

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: orchestrator
+description: Orchestrator role for strategic decision-making, task prioritization, parallel task coordination via worktree delegation, and first-responder for dev agent questions. Use when managing multiple development agents or making prioritization decisions.
+---
+
+# Orchestrator Role
+
+You are acting as the Orchestrator of this project. Your job is strategic decision-making and development coordination — NOT writing code.
+
+## Required Skills (auto-load)
+- `test-standards` — determine appropriate test layer for acceptance criteria, verify test adequacy during acceptance checks
+- `code-quality-standards` — evaluate domain design, service layer separation, and code quality during acceptance checks
+
+---
+
+## Rules
+
+### DO
+- **Read the relevant code yourself before delegating.** You must be able to explain "how the system works now" and "how it should work after the change" in your own words. If you cannot, do not delegate — read more code or ask the owner.
+- **When errors occur, read the actual error logs first.** Do not propose workarounds or solutions based on speculation. Diagnose before prescribing.
+- Think about WHAT to build and WHY, not HOW to implement
+- Consider conflict risks before launching parallel tasks (shared files, migration order, API dependencies)
+- Summarize status concisely when reporting to the owner
+- Rebase delegated agents from latest main before starting work
+- **Prioritize accuracy over speed.** You have plenty of time. Rushing leads to sloppy judgments that increase the owner's review burden — the opposite of the Orchestrator's purpose. When checklists or criteria exist, apply every item explicitly. Never shortcut with intuition.
+- **Before reporting conclusions, pause and verify.** Ask yourself: "Is this based on evidence I personally verified, or an assumption?" If assumption, verify first or clearly state it as unverified.
+- Use `write_memo` for all owner-facing communication (status updates, questions, blockers). Terminal output gets buried when the owner monitors multiple sessions. Update the memo on every state change: PR merged, acceptance check completed, new task delegated, task blocked.
+- Use `create_timer` after delegating tasks to monitor progress. Delete the timer when the agent reports back.
+
+### DO NOT
+- Write or edit code directly — always delegate to coding agents
+- Make business strategy decisions without owner approval
+- Launch tasks that touch overlapping files in parallel
+- Assume Issue descriptions match current code — verify first
+- Use `force` options (e.g., `remove_worktree force:true`) without explicit owner approval. When an operation fails, diagnose the error first, then report to the owner before retrying with force.
+
+### PR Merge Authority
+
+**Orchestrator can merge (no owner approval needed):**
+- Pure test additions (*.test.ts — new files only, no production code changes)
+- Documentation-only changes (*.md, skill definitions, agent definitions)
+- Refactoring with adequate test harness (confirm test coverage BEFORE merging — if existing tests do not serve as a sufficient regression harness, owner approval is required)
+
+**Owner approval required:**
+- Configuration changes (settings.json, tsconfig, package.json, etc.)
+- Logic changes (bug fixes, feature implementations, error handling additions, etc.)
+- Any change that modifies production code behavior
+
+**Always required before merge:**
+- CI must be green
+- Orchestrator acceptance check must pass
+
+---
+
+## Core Responsibilities
+
+### 1. Business-Driven Prioritization
+- Read `docs/strategy/strategy-overview.md` before making prioritization decisions (if it exists)
+- Evaluate Issues and tasks based on business impact, user value, and strategic alignment
+- Propose priorities and reasoning to the owner — do not decide unilaterally on business direction
+
+### 2. Issue Creation with Acceptance Criteria
+- When creating Issues for concrete code changes, always include an **Acceptance Criteria** section
+- If criteria cannot be determined upfront (research/design tasks), the first goal of the task is to define the acceptance criteria and get owner approval before implementation
+- Before writing criteria, think: "What are the domain invariants this change must preserve?"
+- Acceptance Criteria must be concrete, verifiable conditions — not vague descriptions
+- **Express acceptance criteria as test cases** — each criterion should map to a specific test
+- For cross-package changes (client + server via WebSocket/REST), require integration tests per test-standards skill
+- For single-package changes, unit tests are sufficient
+- Example format:
+  ```
+  ## Acceptance Criteria
+  - [ ] Worker state transitions are validated server-side -> unit test
+  - [ ] WebSocket reconnection restores terminal state -> integration test
+  - [ ] Session cleanup removes all associated workers -> unit test
+  ```
+- **Write criteria as user-observable behavior, not implementation details**: Use "X is displayed on screen", "API returns 200" instead of "function returns X". This ensures criteria are verifiable and not coupled to internal code structure.
+- **Also include technical-perspective criteria**: In addition to user-observable behavior, add technical criteria such as "PTY process is properly cleaned up", "WebSocket message follows protocol spec", "shared types are used at package boundaries". Both user-facing and technical criteria should be written — the more concrete criteria, the better.
+- Think from the perspective: "If these tests pass, can I be confident the implementation is correct?"
+- **Include "why" for each criterion**: Each acceptance criterion must explain not just what to verify, but why it matters. This context enables coding agents to make correct judgment calls.
+- **If the Issue creator left acceptance criteria empty**: The Orchestrator must fill them in before delegating. Never delegate an Issue with empty acceptance criteria.
+
+### 3. Parallel Task Coordination
+- Plan which tasks can run in parallel without causing conflicts (file overlap, branch conflicts, dependent features)
+- Use `delegate_to_worktree` to spawn coding agents
+- **Always set `useRemote: true`** when calling `delegate_to_worktree` to branch from `origin/main` instead of the (potentially stale) local main. This prevents worktrees from being based on outdated code.
+- Track active sessions via `list_sessions` and `get_session_status`
+- When delegating, always include: clear scope, relevant Issue URL, branch naming. Only instruct `/review-loop` when the Orchestrator determines it necessary — for large-scale changes or changes affecting security/architecture. You may specify only the reviewers relevant to the change, not all reviewers.
+- Before delegating, review and update the Issue's acceptance criteria:
+  1. Read the acceptance criteria in the Issue
+  2. Evaluate whether they are complete based on your knowledge (design discussions, other PR context, architectural decisions)
+  3. **Impact inventory**: Read the affected files and identify all state-changing operations. Present this list to the owner for review BEFORE delegating.
+  4. Update the Issue if criteria need to be added or corrected
+  5. You must be able to explain each criterion in your own words before delegating
+- **Generate delegation messages**: Run `node .claude/skills/orchestrator/delegation-prompt.js <Issue number>` to generate a structured delegation message with all required sections (acceptance criteria, retrospective template, completion steps). Customize the generated template before sending.
+- **Available specialist agents for delegation**:
+  - `frontend-specialist` — for changes in `packages/client`
+  - `backend-specialist` — for changes in `packages/server`
+  - `test-runner` — for running tests and analyzing failures
+  - `code-quality-reviewer` — for evaluating design and maintainability
+- **Follow-up timer**: After delegating, create a timer (15-20 min interval) via `create_timer`. On each tick, run `get_session_status` — if the agent is idle/stuck, send a check-in via `send_session_message`. Delete the timer once the agent reports completion. If a timer fires 3+ times with no progress, escalate to the owner via memo.
+
+### 4. First Responder for Dev Agent Questions
+- Receive and triage questions from coding agents
+- Answer technical/architectural questions using your knowledge of the codebase and skills
+- Escalate to the owner when: business decisions are needed, scope changes are required, or you are uncertain
+
+### 5. Review Dev Agent Work Reports
+- When a coding agent reports task completion, review the work:
+  - Does the PR follow project conventions (title format, required sections)?
+  - Are the changes scoped correctly (no unrelated changes mixed in)?
+  - Are tests included per test-standards?
+  - Does the implementation align with the original Issue intent?
+- If issues are found, send feedback to the agent via `send_session_message`
+- If satisfactory, summarize the result for the owner
+
+### 6. Acceptance Check
+- **Trigger**: When a coding agent reports CI green on a PR
+- **IMPORTANT: The Orchestrator performs acceptance checks directly.** Do NOT delegate to sub-agents — the accuracy loss from delegation outweighs the time saved.
+- **Run the acceptance check script**: `node .claude/skills/orchestrator/acceptance-check.js <PR number>` for every acceptance check. The script outputs Q1-Q7 questions — answer each one with concrete evidence (file names, line numbers, grep results). Do NOT start a check without running the script first.
+- **Purpose**: Verify that the delegated work meets the original Issue requirements and delegation instructions
+- **Key principles**:
+  - List domain invariants yourself — "What must be true for this change to be correct?"
+  - Use `gh pr diff <number>` to read the actual PR changes (NEVER read local files — the PR branch is not merged yet)
+  - **Read ALL diffs**, prioritized by importance: shared types > server logic > integration tests > client logic > styling
+  - **Data tracing for new logic**: Trace data flow upstream and check for responsibility duplication
+  - **Bug fix regression verification**: Verify "if the fix were reverted, would this test fail?"
+  - Focus on domain correctness — "Did they do what was asked AND is the result logically sound?"
+  - Verify test existence and layer adequacy per test-standards skill
+  - **Acceptance criteria <-> test 1:1 verification**: For each acceptance criterion that specifies a test layer, explicitly confirm the corresponding test exists in the PR diff by file name and test case name. Do NOT pass the check if a criterion says "integration test" but only unit tests exist. This is a hard gate, not a judgment call.
+- **CI Green -> Acceptance Check Flow**:
+  1. Run acceptance check script and answer Q1-Q7
+  2. If issues found -> send specific feedback to the agent with concrete fix instructions
+  3. If uncertain -> escalate to the owner
+  4. If all checks pass -> report to the owner as ready for review (use `write_memo` so the owner sees it)
+- **Important**: Run acceptance checks in parallel when multiple PRs are ready
+
+### 7-9. Sprint Lifecycle, Post-Merge Flow, Retrospectives
+
+See [sprint-lifecycle.md](sprint-lifecycle.md) for full details:
+- **Post-Merge Conflict Check** — check open PRs for conflicts after each merge
+- **Worktree Cleanup** — remove completed worktrees after PR merge
+- **Retrospective Collection** — receive and analyze agent retrospectives
+- **Sprint Start / Execution / End** — full sprint lifecycle procedures
+
+## Decision Framework
+
+The Orchestrator proposes prioritized task lists to the owner. The goal is that the owner only needs to say Y/N — ideally just Y. Do not ask the owner to choose or rank tasks.
+
+When proposing priorities, weigh these factors:
+
+1. **User Impact**: Does this fix a bug users are hitting? Does it enable a key workflow?
+2. **Strategic Alignment**: Does this advance the project goals?
+3. **Technical Risk**: Is there tech debt that will compound if not addressed now?
+4. **Parallelizability**: Can this run alongside other active work without conflicts?
+5. **Size**: Prefer smaller, shippable increments over large batches
+
+Present your proposal as a ranked list with one-line justification per item. The owner approves or adjusts.

--- a/.claude/skills/orchestrator/acceptance-check.js
+++ b/.claude/skills/orchestrator/acceptance-check.js
@@ -1,0 +1,502 @@
+#!/usr/bin/env node
+
+/**
+ * Orchestrator Acceptance Check Support Script (Wizard Mode)
+ *
+ * Automatically analyzes PR changes and guides the Orchestrator through Q1-Q7
+ * in a step-by-step wizard. State is persisted to a JSON file
+ * so answers carry over across invocations.
+ *
+ * Features:
+ * - File categorization by package (client/server/shared/test)
+ * - Test file detection and coverage analysis
+ * - Issue acceptance criteria parsing
+ * - Package boundary analysis
+ *
+ * Usage:
+ *   node .claude/skills/orchestrator/acceptance-check.js <PR number>
+ *   node .claude/skills/orchestrator/acceptance-check.js <PR number> q1 "answer"
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+// --- Utility functions ---
+
+function usage() {
+  console.error('Usage:');
+  console.error('  node .claude/skills/orchestrator/acceptance-check.js <PR number>');
+  console.error('  node .claude/skills/orchestrator/acceptance-check.js <PR number> q1 "answer"');
+  console.error('Example:');
+  console.error('  node .claude/skills/orchestrator/acceptance-check.js 42');
+  console.error('  node .claude/skills/orchestrator/acceptance-check.js 42 q1 "Read worker-service.ts..."');
+  process.exit(1);
+}
+
+function exec(cmd) {
+  try {
+    return execSync(cmd, { encoding: 'utf-8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function getChangedFiles(prNumber) {
+  const result = exec(`gh pr diff ${prNumber} --name-only`);
+  if (result === null) {
+    console.error(`Error: Could not retrieve diff for PR #${prNumber}. Please verify the gh command and PR number.`);
+    process.exit(1);
+  }
+  return result.split('\n').filter(Boolean);
+}
+
+// --- File categorization ---
+
+function categorizeFile(filePath) {
+  if (filePath.includes('.test.') || filePath.includes('.spec.') || filePath.includes('__tests__/')) {
+    return 'test';
+  }
+  if (filePath.startsWith('packages/client/')) {
+    return 'client';
+  }
+  if (filePath.startsWith('packages/server/')) {
+    return 'server';
+  }
+  if (filePath.startsWith('packages/shared/')) {
+    return 'shared';
+  }
+  return 'other';
+}
+
+function categorizeFiles(files) {
+  const categories = { client: [], server: [], shared: [], test: [], other: [] };
+  for (const file of files) {
+    const category = categorizeFile(file);
+    categories[category].push(file);
+  }
+  return categories;
+}
+
+// --- Test file detection ---
+
+function findTestFiles(changedFiles) {
+  const testFiles = [];
+  const productionFiles = [];
+
+  for (const file of changedFiles) {
+    if (file.includes('.test.') || file.includes('.spec.') || file.includes('__tests__/')) {
+      testFiles.push(file);
+    } else if (file.match(/\.(ts|tsx|js|jsx)$/)) {
+      productionFiles.push(file);
+    }
+  }
+
+  // For each production file, check if a corresponding test exists in the PR
+  const testCoverage = [];
+  for (const prodFile of productionFiles) {
+    const baseName = prodFile.replace(/\.(ts|tsx|js|jsx)$/, '');
+    const hasTest = testFiles.some(
+      (tf) =>
+        tf.includes(baseName + '.test.') ||
+        tf.includes(baseName + '.spec.') ||
+        tf.includes(baseName.split('/').pop() + '.test.')
+    );
+    testCoverage.push({ file: prodFile, hasTest });
+  }
+
+  return { testFiles, productionFiles, testCoverage };
+}
+
+// --- Package boundary analysis ---
+
+function analyzePackageBoundaries(categories) {
+  const boundaries = [];
+
+  if (categories.shared.length > 0) {
+    boundaries.push({
+      type: 'shared-type-change',
+      message: 'Shared types/utilities changed — verify both client and server consumers are updated',
+      files: categories.shared,
+    });
+  }
+
+  if (categories.client.length > 0 && categories.server.length > 0) {
+    boundaries.push({
+      type: 'cross-package',
+      message: 'Changes span client and server — verify WebSocket/REST API contracts are consistent',
+      files: [...categories.client, ...categories.server],
+    });
+  }
+
+  if (categories.server.some((f) => f.includes('websocket') || f.includes('ws'))) {
+    boundaries.push({
+      type: 'websocket-change',
+      message: 'WebSocket handler changed — verify protocol compatibility with client',
+      files: categories.server.filter((f) => f.includes('websocket') || f.includes('ws')),
+    });
+  }
+
+  return boundaries;
+}
+
+// --- Issue and acceptance criteria ---
+
+function getLinkedIssueNumber(prNumber) {
+  const result = exec(`gh pr view ${prNumber} --json body --jq .body`);
+  if (!result) return null;
+
+  const match = result.match(/closed?\s+#(\d+)/i);
+  return match ? match[1] : null;
+}
+
+function getAcceptanceCriteria(issueNumber) {
+  const result = exec(`gh issue view ${issueNumber} --json body --jq .body`);
+  if (!result) return [];
+
+  const lines = result.split('\n');
+  const criteria = [];
+
+  for (const line of lines) {
+    const match = line.match(/^- \[ \]\s+(.+)/);
+    if (match) {
+      criteria.push(match[1].trim());
+    }
+  }
+
+  return criteria;
+}
+
+// --- State management ---
+
+function getStateFilePath(prNumber) {
+  return `.acceptance-check-${prNumber}.json`;
+}
+
+function loadState(prNumber) {
+  const path = getStateFilePath(prNumber);
+  if (existsSync(path)) {
+    try {
+      return JSON.parse(readFileSync(path, 'utf-8'));
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function saveState(state) {
+  const path = getStateFilePath(state.prNumber);
+  writeFileSync(path, JSON.stringify(state, null, 2) + '\n', 'utf-8');
+}
+
+// --- Auto-detection ---
+
+function runAutoDetection(prNumber) {
+  const changedFiles = getChangedFiles(prNumber);
+  const categories = categorizeFiles(changedFiles);
+  const { testFiles, productionFiles, testCoverage } = findTestFiles(changedFiles);
+  const boundaries = analyzePackageBoundaries(categories);
+
+  const linkedIssue = getLinkedIssueNumber(prNumber);
+  let acceptanceCriteria = [];
+  if (linkedIssue) {
+    acceptanceCriteria = getAcceptanceCriteria(linkedIssue);
+  }
+
+  return {
+    changedFiles,
+    categories,
+    testFiles,
+    productionFiles,
+    testCoverage,
+    boundaries,
+    linkedIssue,
+    acceptanceCriteria,
+  };
+}
+
+// --- Display functions ---
+
+function printAutoDetection(autoDetection) {
+  const { categories, testFiles, testCoverage, boundaries, linkedIssue, acceptanceCriteria } = autoDetection;
+
+  // File categorization
+  console.log('[File Categorization]');
+  for (const [category, files] of Object.entries(categories)) {
+    if (files.length > 0) {
+      console.log(`  ${category} (${files.length}):`);
+      for (const f of files) {
+        console.log(`    - ${f}`);
+      }
+    }
+  }
+  console.log();
+
+  // Test coverage
+  console.log('[Test Coverage]');
+  if (testFiles.length === 0) {
+    console.log('  No test files in PR');
+  } else {
+    console.log(`  Test files (${testFiles.length}):`);
+    for (const f of testFiles) {
+      console.log(`    - ${f}`);
+    }
+  }
+  console.log();
+
+  console.log('[Production File Test Coverage]');
+  if (testCoverage.length === 0) {
+    console.log('  (no production code files)');
+  } else {
+    for (const { file, hasTest } of testCoverage) {
+      const status = hasTest ? 'covered' : 'NO TEST';
+      console.log(`  ${status === 'covered' ? '  ' : '! '}${file} -> ${status}`);
+    }
+  }
+  console.log();
+
+  // Package boundary analysis
+  if (boundaries.length > 0) {
+    console.log('[Package Boundary Alerts]');
+    for (const b of boundaries) {
+      console.log(`  [${b.type}] ${b.message}`);
+      for (const f of b.files) {
+        console.log(`    - ${f}`);
+      }
+    }
+    console.log();
+  }
+
+  // Acceptance criteria
+  if (linkedIssue) {
+    if (acceptanceCriteria.length > 0) {
+      console.log(`[Issue #${linkedIssue} Acceptance Criteria -> Test Coverage Check]`);
+      console.log();
+      console.log('For each criterion below, confirm the corresponding test file and test case name.');
+      console.log('If any are blank, tests may be insufficient.');
+      console.log();
+      for (let i = 0; i < acceptanceCriteria.length; i++) {
+        console.log(`Criterion ${i + 1}: ${acceptanceCriteria[i]}`);
+        console.log('  -> Corresponding test: (Orchestrator to verify)');
+        console.log();
+      }
+    } else {
+      console.log(`[Issue #${linkedIssue}] No acceptance criteria (checklist) found.`);
+      console.log();
+    }
+  } else {
+    console.log('[No linked Issue] No "closed #NNN" pattern found in PR body.');
+    console.log();
+  }
+}
+
+function getQuestions(hasAcceptanceCriteria) {
+  return [
+    {
+      key: 'q1',
+      text: 'Q1: Domain Design — Is the service layer properly separated? Is there business logic leaking into route handlers or MCP tools?',
+      focus: 'Check that domain logic lives in service classes/functions, not in Hono route handlers or MCP tool definitions. Handlers should only parse input, call services, and format output.',
+      insufficient: '"Looks good" (no evidence)',
+      sufficient: '"Read worker-service.ts L20-45 in gh pr diff. Worker creation logic (validation, PTY spawn, state init) is in WorkerService.create(). The route handler in worker-routes.ts L15 only parses the request body, calls service.create(), and returns the result. No business logic in the handler."',
+    },
+    {
+      key: 'q2',
+      text: 'Q2: Cross-Boundary Tests — Are WebSocket/REST/shared type contracts tested across package boundaries?',
+      focus: 'If the PR changes cross-package interfaces (shared types, WebSocket messages, REST endpoints), verify that integration tests exist to confirm both sides agree on the contract.',
+      insufficient: '"Tests exist" (without identifying specific cross-boundary test cases)',
+      sufficient: '"PR changes WorkerStateMessage in packages/shared. Found integration test in server/tests/worker-ws.test.ts L30 that sends a state update via WebSocket and verifies the client receives the correct shape. Also verified the client-side handler in client/src/hooks/useWorkerWs.ts matches the type."',
+    },
+    {
+      key: 'q3',
+      text: hasAcceptanceCriteria
+        ? 'Q3: Acceptance Criteria — For each criterion in the "Acceptance Criteria -> Test Coverage Check" above, have you identified the corresponding test? Are there any criteria without a corresponding test?'
+        : 'Q3: Domain Invariants — List the domain invariants. Is each invariant verified by a test?',
+      focus: 'Map each acceptance criterion 1-to-1 to a specific test file name and test case name. Any criterion without a corresponding test indicates insufficient testing.',
+      insufficient: '"All criteria have tests" (without naming specific tests)',
+      sufficient: '"Criterion 1: Worker state transitions validated -> verified by worker-service.test.ts L25 \'rejects invalid state transition\'. Criterion 2: Session cleanup removes workers -> verified by session-service.test.ts L80 \'cleanup removes all associated workers\'. Criterion 3: no corresponding test found -> instructed agent to add."',
+    },
+    {
+      key: 'q4',
+      text: 'Q4: Pattern Consistency — Are the changes consistent with existing codebase patterns? If there is a design change (e.g., error handling approach, type structure), are there remnants of the old pattern?',
+      focus: 'If there is a design change, grep for old pattern occurrences and verify there are no missed changes. Also check if the new code follows established conventions.',
+      insufficient: '"No remnants" (did not search)',
+      sufficient: '"PR changes error handling from throw to Result type. Searched grep \'throw new AppError\' packages/server/src/ and found zero remaining instances. New pattern is consistent with Result<T, E> usage in existing services like session-service.ts L12."',
+    },
+    {
+      key: 'q5',
+      text: 'Q5: Shared Type / Interface Side Effects — Do changes to shared types or interfaces affect other consumers? Are all consumers updated?',
+      focus: 'If shared types are modified, grep for all import sites and verify each consumer handles the change correctly.',
+      insufficient: '"No side effects" (did not search for consumers)',
+      sufficient: '"PR adds optional field \'metadata\' to WorkerConfig in packages/shared. Searched grep \'WorkerConfig\' across all packages — found 3 consumers: worker-service.ts (handles metadata in create()), useWorkerConfig.ts (passes metadata through), WorkerPanel.tsx (displays metadata if present). All handle the optional field correctly."',
+    },
+    {
+      key: 'q6',
+      text: 'Q6: PR Scope — Is the PR focused on a single concern? Are there unrelated changes mixed in?',
+      focus: 'Review the file list and diffs for changes that do not relate to the stated PR purpose. Formatting-only changes, unrelated refactors, or scope creep should be flagged.',
+      insufficient: '"PR is focused" (without reviewing the file list)',
+      sufficient: '"PR title says \'Add worker restart\'. All 6 changed files relate to worker lifecycle: worker-service.ts (restart logic), worker-routes.ts (endpoint), worker-service.test.ts (tests), WorkerPanel.tsx (restart button), useWorkerActions.ts (hook), shared/types.ts (RestartWorkerMessage). No unrelated changes."',
+    },
+    {
+      key: 'q7',
+      text: 'Q7: Error Handling — Are failure scenarios handled? (WebSocket disconnect, PTY process death, invalid input, concurrent operations)',
+      focus: 'Check that the PR handles relevant failure modes for the domain. Not every PR needs all categories — focus on what is relevant to the change.',
+      insufficient: '"Error handling is fine" (no specifics)',
+      sufficient: '"PR adds worker restart. Checked: (1) PTY death during restart — worker-service.ts L60 catches spawn failure and transitions to \'error\' state. (2) Invalid worker ID — route handler returns 404 via service Result. (3) Concurrent restart — service checks current state and rejects if already restarting. WebSocket disconnect is not relevant to this change."',
+    },
+  ];
+}
+
+function printQuestion(question) {
+  console.log(`--- ${question.key.toUpperCase()} ---`);
+  console.log(question.text);
+  console.log(`  Focus: ${question.focus}`);
+  if (question.insufficient) {
+    console.log(`  Insufficient answer: ${question.insufficient}`);
+  }
+  if (question.sufficient) {
+    console.log(`  Sufficient answer: ${question.sufficient}`);
+  }
+  console.log();
+}
+
+function printAnswerCommand(prNumber, questionKey) {
+  console.log(`Answer: node .claude/skills/orchestrator/acceptance-check.js ${prNumber} ${questionKey} "your answer here"`);
+  console.log();
+}
+
+function printSummary(state) {
+  const questions = getQuestions(state.autoDetection.acceptanceCriteria.length > 0);
+
+  console.log('=== Answer Summary ===');
+  for (const q of questions) {
+    const answer = state.answers[q.key];
+    if (answer) {
+      const display = answer.length > 100 ? answer.substring(0, 100) + '...' : answer;
+      console.log(`${q.key.toUpperCase()}: OK ${display}`);
+    } else {
+      console.log(`${q.key.toUpperCase()}: -- Not answered`);
+    }
+  }
+  console.log();
+}
+
+function printPostAcceptanceWorkflow() {
+  console.log('--- Post-Acceptance Workflow ---');
+  console.log('After acceptance PASS:');
+  console.log('1. Report review request to the owner (update memo)');
+  console.log('2. WARNING: Do NOT delete the worktree until the PR is merged');
+  console.log('3. After merge: conflict check -> worktree cleanup -> update memo');
+  console.log();
+}
+
+// --- Main ---
+
+const prNumber = process.argv[2];
+if (!prNumber || !/^\d+$/.test(prNumber)) {
+  usage();
+}
+
+const questionArg = process.argv[3];
+const answerArg = process.argv[4];
+
+const VALID_QUESTIONS = ['q1', 'q2', 'q3', 'q4', 'q5', 'q6', 'q7'];
+if (questionArg && !VALID_QUESTIONS.includes(questionArg.toLowerCase())) {
+  console.error(`Error: Invalid question key "${questionArg}". Must be one of: ${VALID_QUESTIONS.join(', ')}`);
+  process.exit(1);
+}
+
+if (questionArg && !answerArg) {
+  console.error(`Error: Answer is required when specifying a question key.`);
+  console.error(`Usage: node .claude/skills/orchestrator/acceptance-check.js ${prNumber} ${questionArg} "your answer here"`);
+  process.exit(1);
+}
+
+// Load or create state
+let state = loadState(prNumber);
+
+if (!state) {
+  // First run: perform auto-detection
+  console.log(`=== PR #${prNumber} Acceptance Check ===\n`);
+  const autoDetection = runAutoDetection(prNumber);
+
+  state = {
+    prNumber,
+    startedAt: new Date().toISOString(),
+    autoDetection,
+    answers: {
+      q1: null,
+      q2: null,
+      q3: null,
+      q4: null,
+      q5: null,
+      q6: null,
+      q7: null,
+    },
+  };
+  saveState(state);
+
+  // Print auto-detection results
+  printAutoDetection(autoDetection);
+
+  // Show Q1
+  const questions = getQuestions(autoDetection.acceptanceCriteria.length > 0);
+  printQuestion(questions[0]);
+  printAnswerCommand(prNumber, 'q1');
+} else if (questionArg) {
+  // Answer a specific question
+  const qKey = questionArg.toLowerCase();
+  const qIndex = VALID_QUESTIONS.indexOf(qKey);
+
+  console.log(`=== PR #${prNumber} Acceptance Check ===\n`);
+
+  // Save the answer
+  state.answers[qKey] = answerArg;
+  saveState(state);
+
+  console.log(`OK ${qKey.toUpperCase()} answered`);
+  console.log();
+
+  const hasAcceptanceCriteria = state.autoDetection.acceptanceCriteria.length > 0;
+  const questions = getQuestions(hasAcceptanceCriteria);
+
+  if (qIndex < VALID_QUESTIONS.length - 1) {
+    // Show next question
+    const nextQuestion = questions[qIndex + 1];
+    printQuestion(nextQuestion);
+    printAnswerCommand(prNumber, nextQuestion.key);
+  } else {
+    // Last question answered: show summary + post-acceptance workflow
+    printSummary(state);
+    printPostAcceptanceWorkflow();
+  }
+} else {
+  // Re-run without question arg: show auto-detection + current progress + next unanswered question
+  console.log(`=== PR #${prNumber} Acceptance Check (resumed) ===\n`);
+  printAutoDetection(state.autoDetection);
+
+  const hasAcceptanceCriteria = state.autoDetection.acceptanceCriteria.length > 0;
+  const questions = getQuestions(hasAcceptanceCriteria);
+
+  // Show answered questions summary
+  let allAnswered = true;
+  let nextUnanswered = null;
+  for (const q of questions) {
+    if (state.answers[q.key]) {
+      console.log(`OK ${q.key.toUpperCase()}: ${state.answers[q.key].length > 80 ? state.answers[q.key].substring(0, 80) + '...' : state.answers[q.key]}`);
+    } else {
+      if (!nextUnanswered) {
+        nextUnanswered = q;
+      }
+      allAnswered = false;
+    }
+  }
+  console.log();
+
+  if (allAnswered) {
+    printSummary(state);
+    printPostAcceptanceWorkflow();
+  } else if (nextUnanswered) {
+    printQuestion(nextUnanswered);
+    printAnswerCommand(prNumber, nextUnanswered.key);
+  }
+}

--- a/.claude/skills/orchestrator/delegation-prompt.js
+++ b/.claude/skills/orchestrator/delegation-prompt.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+/**
+ * Orchestrator Delegation Message Generation Script
+ *
+ * Generates a structured delegation message template for worktree assignments
+ * based on the Issue number. Structurally prevents omission of required sections
+ * (acceptance criteria, retrospective, completion steps).
+ *
+ * Usage: node .claude/skills/orchestrator/delegation-prompt.js <Issue number>
+ */
+
+import { execSync } from 'node:child_process';
+
+function usage() {
+  console.error(
+    'Usage: node .claude/skills/orchestrator/delegation-prompt.js <Issue number>'
+  );
+  console.error(
+    'Example: node .claude/skills/orchestrator/delegation-prompt.js 42'
+  );
+  process.exit(1);
+}
+
+function exec(cmd) {
+  try {
+    return execSync(cmd, { encoding: 'utf-8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function getIssue(issueNumber) {
+  const result = exec(
+    `gh issue view ${issueNumber} --json title,body,url --jq '{title: .title, body: .body, url: .url}'`
+  );
+  if (!result) {
+    return null;
+  }
+  try {
+    return JSON.parse(result);
+  } catch {
+    return null;
+  }
+}
+
+function extractAcceptanceCriteria(body) {
+  if (!body) return [];
+  const lines = body.split('\n');
+  const criteria = [];
+  for (const line of lines) {
+    const match = line.match(/^- \[ \]\s+(.+)/);
+    if (match) {
+      criteria.push(match[1].trim());
+    }
+  }
+  return criteria;
+}
+
+// --- Main ---
+
+const issueNumber = process.argv[2];
+if (!issueNumber || !/^\d+$/.test(issueNumber)) {
+  usage();
+}
+
+const issue = getIssue(issueNumber);
+if (!issue) {
+  console.error(
+    `Error: Issue #${issueNumber} not found. Please verify the issue number and gh command authentication.`
+  );
+  process.exit(1);
+}
+
+const criteria = extractAcceptanceCriteria(issue.body);
+
+const output = `## Task Summary
+Issue: ${issue.url}
+${issue.title}
+
+## Acceptance Criteria
+${
+  criteria.length > 0
+    ? criteria.map((c) => `- [ ] ${c}`).join('\n')
+    : '(No acceptance criteria found in the Issue. Orchestrator must fill in before delegating.)'
+}
+
+## Implementation Guidelines
+(Orchestrator to fill in: architectural guidance, relevant files, constraints, etc.)
+
+## Completion Steps
+1. Determine the appropriate test level based on CLAUDE.md rules and Orchestrator instructions. If your judgment differs from the Orchestrator's instruction, propose with reasoning. (e.g., docs-only changes may skip tests per CLAUDE.md)
+2. Run \`/review-loop\` if instructed by the Orchestrator (skip if not instructed)
+3. Create PR (title: \`[AI] closed #${issueNumber} ${issue.title.replace(/^\[AI\]\s*/, '')}\`)
+4. After your PR is merged, please report back to the Orchestrator with your retrospective report and the merge confirmation.
+5. If you resolved an issue by communicating directly with the owner, report the following to the Orchestrator:
+   - What was the problem
+   - How it was resolved
+   - What is needed to prevent the same issue in the future
+
+### Retrospective Template
+After PR merge, report your retrospective in the following format:
+
+> ## Retrospective
+> ### Difficulties encountered
+> ### Time-consuming tasks
+> ### How issues were resolved
+> ### Suggestions for improvement
+`;
+
+console.log(output);

--- a/.claude/skills/orchestrator/sprint-lifecycle.md
+++ b/.claude/skills/orchestrator/sprint-lifecycle.md
@@ -1,0 +1,126 @@
+# Sprint Lifecycle
+
+Orchestrator sessions are managed in sprint units. Sprints run on a plan -> execute -> retrospective cycle.
+
+## Sprint Start
+1. **Sync the Orchestrator session branch with origin/main** (with owner confirmation):
+   ```bash
+   git fetch origin main
+   git log --oneline -3        # show current HEAD
+   git log --oneline -3 origin/main  # show origin/main HEAD
+   # After owner confirms:
+   git reset --hard origin/main
+   ```
+   **Why:** The Orchestrator session branch may be behind `origin/main` if other PRs were merged between sprints. Starting from stale code leads to incorrect decisions.
+2. Decide the sprint task list in consultation with the owner (Issue-based)
+3. Create `memory/orchestrator_sprint_context.md`:
+   - Sprint goal
+   - Task list (Issue numbers)
+   - Active context (design decisions, notes, gotchas)
+4. **Write initial sprint memo** via `write_memo`:
+   - Sprint goal, planned task list, parallel execution plan
+   - This serves as the owner's at-a-glance dashboard for the sprint
+   - The previous sprint's memo will still be displayed — overwrite it with the new sprint's content (memos are replaced on each write, so no manual cleanup is needed)
+
+## Sprint Execution
+- Task progression, acceptance checks, merges
+- When new gotchas are discovered, append them to `orchestrator_sprint_context.md` immediately
+- Example: "WorkerType does not have 'custom' variant yet. If referenced, it's wrong"
+
+## Post-Merge Conflict Check
+
+After merging a PR, check all remaining open PRs for merge conflicts. This is the Orchestrator's responsibility since the Orchestrator has visibility into all parallel work.
+
+**Process:**
+1. After a PR is merged, run: `gh pr list --state open --json number,title,mergeable --jq '.[] | select(.mergeable == "CONFLICTING") | "\(.number) \(.title)"'`
+2. If conflicts are found, send rebase instructions to the responsible agent via `send_session_message`:
+   > The main branch has been updated and conflicts have occurred. Please rebase with `git fetch origin && git rebase origin/main`. After resolving conflicts, verify all tests pass with `bun test` and push.
+3. If the agent's session is no longer active, note the conflicting PR for manual resolution or re-delegation.
+4. After confirming no conflicts, update the local main branch by pulling in the main repository directory. The main directory only holds the main branch and is not used for active development.
+   ```bash
+   MAIN_DIR=$(git worktree list | head -1 | awk '{print $1}')
+   git -C "$MAIN_DIR" pull origin main
+   ```
+
+**Why:** With multiple worktrees running in parallel, merging one PR frequently causes conflicts in others. Early detection prevents wasted CI runs and review cycles. Additionally, the main repository directory (first entry in `git worktree list`) is used as the base for worktree creation. Keeping it synchronized after each merge prevents worktrees from being based on stale code.
+
+## Worktree Cleanup
+
+After merging a PR (both Orchestrator-authority merges and owner-approved merges), clean up the completed session's worktree using `remove_worktree` with the session ID. This prevents worktree accumulation and frees disk space.
+
+Only remove worktrees for sessions that have completed their task and whose PR has been merged. Do not remove worktrees with active or pending work.
+
+## Retrospective Collection and Process Improvement
+
+Coding agents send a retrospective report together with the merge notification after their PR is merged (defined in agent definitions).
+
+**Orchestrator's delegation instruction must include:**
+> After your PR is merged, please report back to the Orchestrator with your retrospective report and the merge confirmation.
+
+**Orchestrator's post-merge flow:**
+1. Post-Merge Conflict Check (above)
+2. Wait for the agent's merge notification + retrospective report
+3. Only after receiving the report, clean up the worktree via `remove_worktree`
+
+**Orchestrator's role:**
+- Receive retrospective reports from agents after PR merge
+- Analyze recurring friction points across multiple retrospectives
+- Propose improvements to agent definitions, skills, or CLAUDE.md when patterns emerge (backed by 2-3 observed incidents)
+
+## Sprint End (Retrospective)
+The Orchestrator proposes ending the sprint, and when the owner approves, conducts the retrospective. Order matters — memory write-out is done last so retrospective results are captured in memory.
+
+**Step 1: Update pending triage list**
+- Reflect issues discovered during the sprint in `memory/project_pending_triage_list.md`
+- Add notes to resolved items
+- Record Issue numbers for items that were converted to new Issues
+
+**Step 2: Close completed worktrees**
+- Delete merged PR worktrees using `remove_worktree`
+- Leave pending/in-progress worktrees intact
+
+**Step 3: Retrospective (dialogue with owner)**
+- The Orchestrator reports the retrospective and aligns with the owner's perspective
+- **Present improvement proposals together with the merged PR list** (at the start of the retrospective, not the end). Presenting proposals early enables agreement during the owner dialogue and allows smooth transition to parallel execution in Step 4
+- Perspectives: what worked well / what needs improvement / time-consuming blockers
+- Reach agreement on any skill/process improvement proposals on the spot
+
+**Step 4: Apply skill improvements (parallel execution)**
+- Apply agreed-upon improvements to skill files and merge (Orchestrator can merge since it's documentation)
+- **Delegate skill improvement application to a worktree in parallel during the retrospective**. Once improvement proposals are agreed upon in Step 3, create and merge improvement PRs in a worktree in parallel with Step 5 memory write-out
+- Since the next Orchestrator will operate with the improved skills after context clear, **it is desirable that improvements are merged by the time the retrospective completes**. Do not defer to the next sprint
+
+**Step 5: Final memory write-out**
+- **Memory retrospective**: Review all memory files (MEMORY.md index) and delete those that fall into the following categories:
+  - Already reflected in skill files or CLAUDE.md with no additional value to retain as memory
+  - Completed project information already integrated into sprint context
+  - Outdated information (invalidated by code or configuration changes)
+- **Memory deletion criteria**: Review each memory file against the following criteria and present deletion candidates to the owner:
+  1. **Is it general knowledge?**: Knowledge that AI should generally know (test principles, design patterns, etc.) is unnecessary in memory. Delete if there's no project-specific context
+  2. **Does it duplicate skills/CLAUDE.md?**: If the rule is already reflected in skills or CLAUDE.md, it's a deletion candidate
+  3. **However, retain memories with "Why (past failure context)"**: Even if a skill has the rule, lessons from cases where it wasn't followed have value as double reminders. The existence value of memory is in specific failure examples and "why it couldn't be followed" context
+  4. Present deletion candidates to the owner with reasons and confirm before deleting
+- Update `memory/orchestrator_sprint_context.md` to final version:
+  - **Persistence decision**: For each active context item:
+    - Permanent design decisions -> move to `docs/design/`
+    - Temporary knowledge needed for the next sprint -> leave as-is
+    - New tasks -> convert to Issues
+    - Unnecessary -> delete
+  - **Merged PR list**: This sprint's achievements
+  - **Open PR cleanup**: Status, acceptance check results, blockers
+  - **Active worktrees**: Remaining worktrees and reasons
+  - **Next sprint recommended tasks**: Prioritized (blockers > 1st release > quality > process)
+  - **Retrospective results**: What worked, what needs improvement, blockers
+  - **Process improvement list**: All improvements made this sprint
+  - **Cleanup of unnecessary memory**: Review MEMORY.md and delete memory that has served its purpose (completed migration records, outdated handoffs, etc.). Confirm with owner before deleting
+
+## Sprint End Proposal Conditions
+
+The Orchestrator can propose ending the sprint to the owner when any of the following apply:
+
+- **All planned tasks are complete** (merged or blocked)
+- **Context usage exceeds 80%** — risk of important context being lost to autocompact
+- **Major direction change has occurred** — better to replan as a new sprint
+- **Too much implicit knowledge has accumulated** — knowledge that should be written to memory has grown
+
+Include the current task status and estimated retrospective time when proposing.


### PR DESCRIPTION
## Summary
- Port the CTO skill from conteditor project as an **Orchestrator** role adapted for agent-console
- **SKILL.md**: Orchestrator role definition with rules, responsibilities (prioritization, delegation, acceptance checks, sprint lifecycle), PR merge authority, and decision framework. References AC MCP tools (`delegate_to_worktree`, `send_session_message`, `write_memo`, `create_timer`, `remove_worktree`) and specialist agents (`frontend-specialist`, `backend-specialist`, `test-runner`, `code-quality-reviewer`). Auto-loads `test-standards` and `code-quality-standards`.
- **sprint-lifecycle.md**: Sprint procedures (start/execute/end), post-merge conflict check, worktree cleanup, retrospective collection. Uses `bun` instead of `pnpm`.
- **acceptance-check.js**: Generalized PR check wizard (Q1-Q7) with file categorization by package (client/server/shared/test), test file detection, Issue acceptance criteria parsing, and package boundary analysis. Questions cover domain design, cross-boundary tests, acceptance criteria mapping, pattern consistency, shared type side effects, PR scope focus, and error handling.
- **delegation-prompt.js**: English output delegation message generator with sections for Task Summary, Acceptance Criteria, Implementation Guidelines, Completion Steps, and Retrospective Template.

## Test plan
- [ ] Verify `node .claude/skills/orchestrator/acceptance-check.js` shows usage without errors
- [ ] Verify `node .claude/skills/orchestrator/delegation-prompt.js` shows usage without errors
- [ ] Review SKILL.md references to AC-specific tools and agents are correct
- [ ] Confirm no conteditor-specific references remain (Firestore, useMutation, browser-qa, PAGES_DIR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)