### PR TITLE
refactor: extract worktree orchestration into service layer

### DIFF
--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -33,7 +33,7 @@ mock.module('../../services/session-metadata-suggester.js', () => ({
 
 // Mock worktree-deletion-service
 // NOTE: We spread the real module and overlay only the functions the MCP handler
-// uses for pre-validation. orchestrateWorktreeDeletion is NOT mocked — it runs
+// uses for pre-validation. deleteWorktreeWithSession is NOT mocked — it runs
 // the real implementation which calls mocked git operations (via mock-git-helper).
 // This avoids mock.module interference with orchestration unit tests.
 const mockValidateWorktreePath = mock(async () => null as string | null);
@@ -44,7 +44,7 @@ mock.module('../../services/worktree-deletion-service.js', () => ({
 
 // Mock worktree-creation-service
 // Like worktree-deletion-service above, we spread the real module to preserve
-// the real orchestrateWorktreeCreation for tests. This prevents mock.module
+// the real createWorktreeWithSession for tests. This prevents mock.module
 // interference with worktree-creation-orchestration.test.ts.
 mock.module('../../services/worktree-creation-service.js', () => ({
   ...require('../../services/worktree-creation-service.js'),
@@ -2159,7 +2159,7 @@ describe('MCP Server Tools', () => {
       expect(data.worktreePath).toBe('/test/worktree-path');
       expect(data.removed).toBe(true);
 
-      // Session should be deleted by orchestrateWorktreeDeletion
+      // Session should be deleted by deleteWorktreeWithSession
       expect(sessionManager.getSession(session.id)).toBeUndefined();
     });
 
@@ -2178,7 +2178,7 @@ describe('MCP Server Tools', () => {
         agentId: 'claude-code',
       });
 
-      // Make git removeWorktree fail so orchestrateWorktreeDeletion returns failure
+      // Make git removeWorktree fail so deleteWorktreeWithSession returns failure
       mockGit.removeWorktree.mockImplementation(async () => {
         throw new Error('Worktree has uncommitted changes');
       });

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -19,9 +19,9 @@ import type { TimerManager } from '../services/timer-manager.js';
 import { worktreeService } from '../services/worktree-service.js';
 import {
   validateWorktreePath,
-  orchestrateWorktreeDeletion,
+  deleteWorktreeWithSession,
 } from '../services/worktree-deletion-service.js';
-import { orchestrateWorktreeCreation } from '../services/worktree-creation-service.js';
+import { createWorktreeWithSession } from '../services/worktree-creation-service.js';
 import { findOpenPullRequest } from '../services/github-pr-service.js';
 import { CLAUDE_CODE_AGENT_ID } from '../services/agent-manager.js';
 import { suggestSessionMetadata } from '../services/session-metadata-suggester.js';
@@ -566,7 +566,7 @@ export function createMcpApp(deps: McpDependencies): Hono {
           ? sessionManager.getSession(parentSessionId)?.createdBy
           : undefined;
 
-        const result = await orchestrateWorktreeCreation({
+        const result = await createWorktreeWithSession({
           repoPath: repo.path,
           repoId: repositoryId,
           repoName: repo.name,
@@ -771,7 +771,7 @@ export function createMcpApp(deps: McpDependencies): Hono {
         }
 
         // 4. Orchestrate deletion (concurrency guard, cleanup, kill, remove, session delete)
-        const result = await orchestrateWorktreeDeletion({
+        const result = await deleteWorktreeWithSession({
           repoPath: repo.path,
           repoId: session.repositoryId,
           repoName: repo.name,

--- a/packages/server/src/routes/worktrees.ts
+++ b/packages/server/src/routes/worktrees.ts
@@ -19,9 +19,9 @@ import {
   _getDeletionsInProgress,
   isDeletionInProgress,
   validateWorktreePath,
-  orchestrateWorktreeDeletion,
+  deleteWorktreeWithSession,
 } from '../services/worktree-deletion-service.js';
-import { orchestrateWorktreeCreation } from '../services/worktree-creation-service.js';
+import { createWorktreeWithSession } from '../services/worktree-creation-service.js';
 import { findOpenPullRequest } from '../services/github-pr-service.js';
 
 export { _getDeletionsInProgress };
@@ -121,7 +121,7 @@ const worktrees = new Hono<AppBindings>()
           }
         }
 
-        const result = await orchestrateWorktreeCreation({
+        const result = await createWorktreeWithSession({
           repoPath: repo.path,
           repoId,
           repoName: repo.name,
@@ -368,7 +368,7 @@ const worktrees = new Hono<AppBindings>()
       // Execute deletion in background (fire-and-forget)
       (async () => {
         try {
-          const result = await orchestrateWorktreeDeletion({
+          const result = await deleteWorktreeWithSession({
             repoPath: repo.path,
             repoId,
             repoName: repo.name,
@@ -424,7 +424,7 @@ const worktrees = new Hono<AppBindings>()
       session => session.locationPath === worktreePath,
     );
 
-    const result = await orchestrateWorktreeDeletion({
+    const result = await deleteWorktreeWithSession({
       repoPath: repo.path,
       repoId,
       repoName: repo.name,

--- a/packages/server/src/services/__tests__/worktree-creation-orchestration.test.ts
+++ b/packages/server/src/services/__tests__/worktree-creation-orchestration.test.ts
@@ -47,7 +47,7 @@ mock.module('../../lib/logger.js', () => ({
 }));
 
 // Import after mocks
-const { orchestrateWorktreeCreation } = await import('../worktree-creation-service.js');
+const { createWorktreeWithSession } = await import('../worktree-creation-service.js');
 
 // --- Helpers ---
 
@@ -96,7 +96,7 @@ const DEFAULT_PARAMS = {
   agentId: 'claude',
 };
 
-describe('orchestrateWorktreeCreation', () => {
+describe('createWorktreeWithSession', () => {
   beforeEach(() => {
     mockListWorktrees.mockReset();
     mockCreateWorktree.mockReset();
@@ -118,7 +118,7 @@ describe('orchestrateWorktreeCreation', () => {
 
   it('happy path: fetch, create worktree, setup command, create session', async () => {
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeCreation(
+    const result = await createWorktreeWithSession(
       { ...DEFAULT_PARAMS, setupCommand: 'npm install' },
       sm,
     );
@@ -139,7 +139,7 @@ describe('orchestrateWorktreeCreation', () => {
 
   it('skips fetch when useRemote is false', async () => {
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeCreation(
+    const result = await createWorktreeWithSession(
       { ...DEFAULT_PARAMS, useRemote: false },
       sm,
     );
@@ -154,7 +154,7 @@ describe('orchestrateWorktreeCreation', () => {
 
   it('skips setup command when not configured', async () => {
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeCreation(DEFAULT_PARAMS, sm);
+    const result = await createWorktreeWithSession(DEFAULT_PARAMS, sm);
 
     expect(result.success).toBe(true);
     expect(result.setupCommandResult).toBeUndefined();
@@ -165,7 +165,7 @@ describe('orchestrateWorktreeCreation', () => {
     mockFetchRemote.mockImplementation(() => Promise.reject(new Error('network error')));
 
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeCreation(DEFAULT_PARAMS, sm);
+    const result = await createWorktreeWithSession(DEFAULT_PARAMS, sm);
 
     expect(result.success).toBe(true);
     expect(result.fetchFailed).toBe(true);
@@ -182,7 +182,7 @@ describe('orchestrateWorktreeCreation', () => {
     );
 
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeCreation(DEFAULT_PARAMS, sm);
+    const result = await createWorktreeWithSession(DEFAULT_PARAMS, sm);
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('branch already exists');
@@ -194,7 +194,7 @@ describe('orchestrateWorktreeCreation', () => {
     mockListWorktrees.mockImplementation(() => Promise.resolve([]));
 
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeCreation(DEFAULT_PARAMS, sm);
+    const result = await createWorktreeWithSession(DEFAULT_PARAMS, sm);
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Worktree was created but could not be found in the list');
@@ -207,7 +207,7 @@ describe('orchestrateWorktreeCreation', () => {
     const sm = createMockSessionManager();
     sm.createSession.mockImplementation(() => Promise.reject(new Error('DB connection lost')));
 
-    const result = await orchestrateWorktreeCreation(DEFAULT_PARAMS, sm);
+    const result = await createWorktreeWithSession(DEFAULT_PARAMS, sm);
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('DB connection lost');
@@ -218,7 +218,7 @@ describe('orchestrateWorktreeCreation', () => {
 
   it('skips session creation when autoStartSession is false', async () => {
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeCreation(
+    const result = await createWorktreeWithSession(
       { ...DEFAULT_PARAMS, autoStartSession: false },
       sm,
     );
@@ -235,7 +235,7 @@ describe('orchestrateWorktreeCreation', () => {
     mockRemoveWorktree.mockImplementation(() => Promise.reject(new Error('rollback failed')));
 
     // The original error should be returned, not the rollback error
-    const result = await orchestrateWorktreeCreation(DEFAULT_PARAMS, sm);
+    const result = await createWorktreeWithSession(DEFAULT_PARAMS, sm);
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('original error');

--- a/packages/server/src/services/__tests__/worktree-deletion-orchestration.test.ts
+++ b/packages/server/src/services/__tests__/worktree-deletion-orchestration.test.ts
@@ -39,7 +39,7 @@ mock.module('../../lib/logger.js', () => ({
 
 // Import after mocks are set up
 const {
-  orchestrateWorktreeDeletion,
+  deleteWorktreeWithSession,
   _getDeletionsInProgress,
 } = await import('../worktree-deletion-service.js');
 
@@ -66,7 +66,7 @@ const DEFAULT_PARAMS = {
   force: false,
 };
 
-describe('orchestrateWorktreeDeletion', () => {
+describe('deleteWorktreeWithSession', () => {
   beforeEach(() => {
     // Clear concurrency guard
     _getDeletionsInProgress().clear();
@@ -95,7 +95,7 @@ describe('orchestrateWorktreeDeletion', () => {
 
   it('happy path: runs cleanup, kills workers, removes worktree, deletes session', async () => {
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeDeletion(
+    const result = await deleteWorktreeWithSession(
       { ...DEFAULT_PARAMS, cleanupCommand: 'echo cleanup', sessionIds: ['sess-1'] },
       sm,
     );
@@ -110,7 +110,7 @@ describe('orchestrateWorktreeDeletion', () => {
 
   it('happy path without session: skips kill and delete', async () => {
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeDeletion(
+    const result = await deleteWorktreeWithSession(
       { ...DEFAULT_PARAMS, cleanupCommand: 'echo cleanup' },
       sm,
     );
@@ -122,7 +122,7 @@ describe('orchestrateWorktreeDeletion', () => {
 
   it('happy path without cleanup command: skips cleanup execution', async () => {
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeDeletion(
+    const result = await deleteWorktreeWithSession(
       { ...DEFAULT_PARAMS, sessionIds: ['sess-1'] },
       sm,
     );
@@ -136,7 +136,7 @@ describe('orchestrateWorktreeDeletion', () => {
     _getDeletionsInProgress().add(DEFAULT_PARAMS.worktreePath);
 
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeDeletion(
+    const result = await deleteWorktreeWithSession(
       { ...DEFAULT_PARAMS, sessionIds: ['sess-1'] },
       sm,
     );
@@ -148,7 +148,7 @@ describe('orchestrateWorktreeDeletion', () => {
 
   it('clears concurrency guard after successful deletion', async () => {
     const sm = createMockSessionManager();
-    await orchestrateWorktreeDeletion(
+    await deleteWorktreeWithSession(
       { ...DEFAULT_PARAMS, sessionIds: ['sess-1'] },
       sm,
     );
@@ -162,7 +162,7 @@ describe('orchestrateWorktreeDeletion', () => {
     );
 
     const sm = createMockSessionManager();
-    await orchestrateWorktreeDeletion(
+    await deleteWorktreeWithSession(
       { ...DEFAULT_PARAMS, sessionIds: ['sess-1'] },
       sm,
     );
@@ -176,7 +176,7 @@ describe('orchestrateWorktreeDeletion', () => {
     );
 
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeDeletion(
+    const result = await deleteWorktreeWithSession(
       { ...DEFAULT_PARAMS, sessionIds: ['sess-1'] },
       sm,
     );
@@ -196,7 +196,7 @@ describe('orchestrateWorktreeDeletion', () => {
     );
 
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeDeletion(
+    const result = await deleteWorktreeWithSession(
       { ...DEFAULT_PARAMS, sessionIds: ['sess-1'] },
       sm,
     );
@@ -209,7 +209,7 @@ describe('orchestrateWorktreeDeletion', () => {
     const sm = createMockSessionManager();
     sm.deleteSession.mockImplementation(() => Promise.reject(new Error('DB error')));
 
-    const result = await orchestrateWorktreeDeletion(
+    const result = await deleteWorktreeWithSession(
       { ...DEFAULT_PARAMS, sessionIds: ['sess-1'] },
       sm,
     );
@@ -222,7 +222,7 @@ describe('orchestrateWorktreeDeletion', () => {
 
   it('kills workers and deletes all sessions when multiple sessionIds are provided', async () => {
     const sm = createMockSessionManager();
-    const result = await orchestrateWorktreeDeletion(
+    const result = await deleteWorktreeWithSession(
       { ...DEFAULT_PARAMS, sessionIds: ['sess-1', 'sess-2'] },
       sm,
     );
@@ -241,7 +241,7 @@ describe('orchestrateWorktreeDeletion', () => {
       return Promise.resolve(true);
     });
 
-    const result = await orchestrateWorktreeDeletion(
+    const result = await deleteWorktreeWithSession(
       { ...DEFAULT_PARAMS, sessionIds: ['sess-1', 'sess-2'] },
       sm,
     );

--- a/packages/server/src/services/worktree-creation-service.ts
+++ b/packages/server/src/services/worktree-creation-service.ts
@@ -50,7 +50,7 @@ export interface CreateWorktreeResult {
  *
  * On failure after worktree creation, rolls back by force-removing the created worktree.
  */
-export async function orchestrateWorktreeCreation(
+export async function createWorktreeWithSession(
   params: CreateWorktreeParams,
   sessionManager: SessionManager,
 ): Promise<CreateWorktreeResult> {

--- a/packages/server/src/services/worktree-deletion-service.ts
+++ b/packages/server/src/services/worktree-deletion-service.ts
@@ -124,7 +124,7 @@ export interface DeleteWorktreeResult {
  * Acquires the concurrency guard internally. The caller should NOT call
  * markDeletionInProgress/clearDeletionInProgress — this function handles both.
  */
-export async function orchestrateWorktreeDeletion(
+export async function deleteWorktreeWithSession(
   params: DeleteWorktreeParams,
   sessionManager: SessionManager,
 ): Promise<DeleteWorktreeResult> {


### PR DESCRIPTION
## Summary
- Extract duplicated worktree creation/deletion orchestration from REST API routes and MCP tool handlers into service-layer functions
- Add `orchestrateWorktreeDeletion` to `worktree-deletion-service.ts` — consolidates cleanup command, PTY kill, worktree removal, session cleanup, concurrency guard, and diagnostic gitStatus capture
- Add new `worktree-creation-service.ts` with `orchestrateWorktreeCreation` — consolidates remote fetch with fallback, worktree creation, setup command, session creation, and automatic rollback on failure
- REST routes and MCP handlers become thin adapters handling only transport-specific concerns (HTTP codes, WebSocket broadcasts, MCP result formatting)
- Add 18 unit tests for the new orchestration functions

## Test plan
- [x] All 1786 server tests pass (0 failures)
- [x] TypeScript compilation clean
- [x] New orchestration unit tests cover: happy paths, error paths, concurrency guard, rollback, gitStatus capture, session preservation on failure
- [x] MCP test mocks updated to avoid mock.module interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)