### PR TITLE
fix: detect permission check prompts as waiting state

### DIFF
--- a/packages/server/src/services/__tests__/activity-detector.test.ts
+++ b/packages/server/src/services/__tests__/activity-detector.test.ts
@@ -119,6 +119,55 @@ describe('ActivityDetector', () => {
       });
     });
 
+    it('should detect asking state from permission prompt with space-padded TUI output', () => {
+      travel(new Date('2025-01-01T00:00:00Z'), (c) => {
+        // Simulate Claude Code TUI output where each line is padded to terminal width (120 cols)
+        const pad = (text: string) => text.padEnd(120);
+        const lines = [
+          pad(' Bash command'),
+          pad(''),
+          pad('   pnpm build 2>&1'),
+          pad('   Build all packages'),
+          pad(''),
+          pad(' This command requires approval'),
+          pad(''),
+          pad(' Do you want to proceed?'),
+          pad(' ❯ 1. Yes'),
+          pad('   2. Yes, and don\'t ask again for: pnpm build:*'),
+          pad('   3. No'),
+          pad(''),
+          pad(' Esc to cancel · Tab to amend · ctrl+e to explain'),
+        ];
+        detector.processOutput(lines.join('\n'));
+
+        c.tick(TEST_TIMEOUTS.debounceMs + 50);
+
+        expect(detector.getState()).toBe('asking');
+      });
+    });
+
+    it('should detect asking state from TUI cursor-positioned text (no spaces)', () => {
+      travel(new Date('2025-01-01T00:00:00Z'), (c) => {
+        // TUI renders text via ANSI cursor positioning, so after ANSI stripping
+        // spaces between words are lost. This simulates the actual buffer content
+        // observed from real Claude Code permission prompts.
+        detector.processOutput(
+          'Createfiletest123.txt\n' +
+          '1test\n' +
+          'Doyouwanttocreatetest123.txt?\n' +
+          '❯1.Yes\n' +
+          '2.Yes,allowalleditsduringthissession(shift+tab)\n' +
+          '3.No\n' +
+          '\n' +
+          'Esctocancel·Tabtoamend\n'
+        );
+
+        c.tick(TEST_TIMEOUTS.debounceMs + 50);
+
+        expect(detector.getState()).toBe('asking');
+      });
+    });
+
     it('should detect asking state from Yes/No selection pattern', () => {
       travel(new Date('2025-01-01T00:00:00Z'), (c) => {
         detector.processOutput('[y] Yes  [n] No');

--- a/packages/server/src/services/activity-detector.ts
+++ b/packages/server/src/services/activity-detector.ts
@@ -60,6 +60,8 @@ export class ActivityDetector {
 
   // Pattern-based detection: compiled regex patterns from agent definition
   private askingPatterns: RegExp[] = [];
+  // Spaceless variants for TUI cursor-positioned text (ANSI stripping loses spaces)
+  private spacelessAskingPatterns: RegExp[] = [];
 
   constructor(options: ActivityDetectorOptions = {}) {
     this.bufferSize = options.bufferSize ?? 1000;
@@ -75,6 +77,12 @@ export class ActivityDetector {
       this.askingPatterns = options.activityPatterns.askingPatterns.map(
         pattern => new RegExp(pattern, 'i')
       );
+      // Also compile spaceless variants: TUI renders text via ANSI cursor positioning,
+      // so after ANSI stripping, spaces between words are lost (e.g., "Do you want" → "Doyouwant").
+      // Remove literal spaces from patterns to match this concatenated text.
+      this.spacelessAskingPatterns = options.activityPatterns.askingPatterns.map(
+        pattern => new RegExp(pattern.replace(/ /g, ''), 'i')
+      );
     }
   }
 
@@ -88,13 +96,18 @@ export class ActivityDetector {
     // Strip ANSI escape sequences for clean character count
     const cleanData = data.replace(ANSI_REGEX, '');
 
+    // Compress consecutive spaces/tabs to single space for buffer efficiency
+    // TUI output often pads lines with spaces to fill terminal width,
+    // which wastes buffer space and can push asking patterns out of the analysis window
+    const compressedData = cleanData.replace(/[^\S\n]{2,}/g, ' ');
+
     // Debug: Log all incoming output
     if (cleanData.length > 0) {
       logger.trace({ charCount: cleanData.length, data: cleanData }, 'Received output');
     }
 
-    // Add to buffer for pattern analysis (use clean data to prevent ANSI overflow)
-    this.buffer += cleanData;
+    // Add to buffer for pattern analysis (use compressed data to prevent overflow)
+    this.buffer += compressedData;
     if (this.buffer.length > this.bufferSize) {
       this.buffer = this.buffer.slice(-this.bufferSize);
     }
@@ -164,6 +177,11 @@ export class ActivityDetector {
   /**
    * Check if any asking pattern matches the buffer
    * Returns false if no patterns are configured (rate-based detection only)
+   *
+   * Tests both original patterns and spaceless variants because TUI applications
+   * render text via ANSI cursor positioning. After ANSI stripping, spaces between
+   * words are lost (e.g., "Do you want to" → "Doyouwantto"), so patterns must
+   * also be tested without spaces.
    */
   private hasAskingPattern(text: string): boolean {
     // Skip pattern-based detection if no patterns configured
@@ -171,11 +189,22 @@ export class ActivityDetector {
       return false;
     }
 
+    // Test original patterns against original text
     for (const pattern of this.askingPatterns) {
       if (pattern.test(text)) {
         return true;
       }
     }
+
+    // Test spaceless patterns against spaceless text
+    // TUI cursor positioning causes spaces to be lost after ANSI stripping
+    const spacelessText = text.replace(/ /g, '');
+    for (const pattern of this.spacelessAskingPatterns) {
+      if (pattern.test(spacelessText)) {
+        return true;
+      }
+    }
+
     return false;
   }
 


### PR DESCRIPTION
## Summary
- Fix activity detector failing to detect Claude Code permission prompts as "waiting" (asking) state
- Root cause: TUI renders text via ANSI cursor positioning, so after ANSI stripping, spaces between words are lost (e.g., "Do you want to" → "Doyouwantto"), causing regex patterns to fail
- Add spaceless pattern matching as secondary check alongside original patterns
- Add whitespace compression in buffer to prevent space-padded TUI output from overflowing the 500-char analysis window

## Test plan
- [x] Unit test: TUI cursor-positioned text (no spaces) detection
- [x] Unit test: Space-padded TUI output (wide terminal) detection
- [x] All 1770 server tests pass
- [x] Typecheck passes
- [x] Manual verification: confirmed "Waiting for input" displayed in UI when Claude Code shows permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)