### PR TITLE
chore: apply sprint retrospective improvements to skills and scripts

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -25,6 +25,7 @@ You are acting as the Orchestrator of this project. Your job is strategic decisi
 - **Prioritize accuracy over speed.** You have plenty of time. Rushing leads to sloppy judgments that increase the owner's review burden — the opposite of the Orchestrator's purpose. When checklists or criteria exist, apply every item explicitly. Never shortcut with intuition.
 - **Before reporting conclusions, pause and verify.** Ask yourself: "Is this based on evidence I personally verified, or an assumption?" If assumption, verify first or clearly state it as unverified.
 - Use `write_memo` for all owner-facing communication (status updates, questions, blockers). Terminal output gets buried when the owner monitors multiple sessions. Update the memo on every state change: PR merged, acceptance check completed, new task delegated, task blocked.
+- **Write memos in the user's preferred language.** Follow the Language Policy in CLAUDE.md — adapt to the language the user uses. Technical terms, PR/Issue numbers, and links can remain in English.
 - **Always include links when referencing Issues or PRs in memos.** Use full Markdown links: `[#123](https://github.com/owner/repo/issues/123)` for Issues, `[#123](https://github.com/owner/repo/pull/123)` for PRs. The owner clicks through from the memo — bare numbers are not actionable.
 - Use `create_timer` after delegating tasks to monitor progress. Delete the timer when the agent reports back.
 
@@ -134,6 +135,7 @@ You are acting as the Orchestrator of this project. Your job is strategic decisi
   2. If issues found -> send specific feedback to the agent with concrete fix instructions
   3. If uncertain -> escalate to the owner
   4. If all checks pass -> report to the owner as ready for review (use `write_memo` so the owner sees it)
+- **CodeRabbit Rate Limit handling**: If CodeRabbit cannot review due to rate limiting, note the retry-after time from the error message. Create a timer via `create_timer` for that duration. When the timer fires, post `@coderabbitai review` as a PR comment. Delete the timer after the review is requested.
 - **Important**: Run acceptance checks in parallel when multiple PRs are ready
 
 ### 7-9. Sprint Lifecycle, Post-Merge Flow, Retrospectives

--- a/.claude/skills/orchestrator/acceptance-check.js
+++ b/.claude/skills/orchestrator/acceptance-check.js
@@ -91,17 +91,15 @@ function findTestFiles(changedFiles) {
     }
   }
 
-  // For each production file, check if a corresponding test exists in the PR
+  // For each production file, check if the conventionally-named test exists in the PR
   const testCoverage = [];
   for (const prodFile of productionFiles) {
     const baseName = prodFile.replace(/\.(ts|tsx|js|jsx)$/, '');
-    const hasTest = testFiles.some(
-      (tf) =>
-        tf.includes(baseName + '.test.') ||
-        tf.includes(baseName + '.spec.') ||
-        tf.includes(baseName.split('/').pop() + '.test.')
-    );
-    testCoverage.push({ file: prodFile, hasTest });
+    const dir = baseName.substring(0, baseName.lastIndexOf('/'));
+    const fileName = baseName.substring(baseName.lastIndexOf('/') + 1);
+    const expectedTestPath = dir + '/__tests__/' + fileName + '.test.';
+    const hasTest = testFiles.some(tf => tf.startsWith(expectedTestPath));
+    testCoverage.push({ file: prodFile, hasTest, expectedTestPath: dir + '/__tests__/' + fileName + '.test.ts' });
   }
 
   return { testFiles, productionFiles, testCoverage };
@@ -248,9 +246,12 @@ function printAutoDetection(autoDetection) {
   if (testCoverage.length === 0) {
     console.log('  (no production code files)');
   } else {
-    for (const { file, hasTest } of testCoverage) {
-      const status = hasTest ? 'covered' : 'NO TEST';
-      console.log(`  ${status === 'covered' ? '  ' : '! '}${file} -> ${status}`);
+    for (const { file, hasTest, expectedTestPath } of testCoverage) {
+      if (hasTest) {
+        console.log(`    ${file} -> covered`);
+      } else {
+        console.log(`  ! ${file} -> NO TEST (expected: ${expectedTestPath})`);
+      }
     }
   }
   console.log();

--- a/.claude/skills/orchestrator/delegation-prompt.js
+++ b/.claude/skills/orchestrator/delegation-prompt.js
@@ -108,4 +108,16 @@ After PR merge, report your retrospective in the following format:
 > ### Suggestions for improvement
 `;
 
+const mcpCallExample = `## MCP Call Example
+\`\`\`
+delegate_to_worktree({
+  repositoryId: <your AGENT_CONSOLE_REPOSITORY_ID>,
+  prompt: <the full text above>,
+  parentSessionId: <your AGENT_CONSOLE_SESSION_ID>,
+  parentWorkerId: <your AGENT_CONSOLE_WORKER_ID>,
+})
+\`\`\`
+`;
+
 console.log(output);
+console.log(mcpCallExample);

--- a/.claude/skills/test-standards/test-standards.md
+++ b/.claude/skills/test-standards/test-standards.md
@@ -252,6 +252,13 @@ describe('Client-Server Boundary', () => {
 - **Integration tests**: Verify pipeline connectivity (e.g., parser → job handler → handler) with 1-2 representative events. Exhaustive coverage is the unit test's job — do not duplicate it in integration tests.
 - These responsibilities must not be confused.
 
+## Test File Naming Convention
+
+### Test File Naming Convention
+- Test files MUST be named after the production file they test: `foo-bar.ts` → `__tests__/foo-bar.test.ts`
+- Place test files in the `__tests__/` directory at the same level as the production file
+- The acceptance-check script verifies this convention — misnamed test files will be flagged
+
 ## Pre-Implementation Checklist
 
 Before writing tests, verify:


### PR DESCRIPTION
## Summary
- Add memo language rule to orchestrator SKILL.md (adapt to user's preferred language per Language Policy)
- Add MCP call example section to delegation-prompt.js output template showing `delegate_to_worktree` usage with `parentSessionId`/`parentWorkerId`
- Add CodeRabbit rate limit handling procedure to acceptance check flow (use `create_timer` for retry)
- Add test file naming convention to test-standards (`foo-bar.ts` → `__tests__/foo-bar.test.ts`)
- Update acceptance-check.js `findTestFiles` to use strict convention-based matching and show expected test path on missing tests

## Test plan
- [ ] Verify `node .claude/skills/orchestrator/delegation-prompt.js <issue>` outputs MCP Call Example section
- [ ] Verify `node .claude/skills/orchestrator/acceptance-check.js <pr>` shows expected test paths for uncovered files
- [ ] Review SKILL.md changes for correctness
- [ ] Review test-standards.md naming convention section

🤖 Generated with [Claude Code](https://claude.com/claude-code)