### PR TITLE
[AI] closed #403 fix: clipboard image paste and drag-and-drop not working in Terminal

### DIFF
--- a/packages/client/src/components/Terminal.tsx
+++ b/packages/client/src/components/Terminal.tsx
@@ -721,11 +721,14 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
     };
     container.addEventListener('wheel', handleWheel, { passive: true });
 
-    container.addEventListener('paste', handlePaste);
-    container.addEventListener('dragenter', handleDragEnter);
-    container.addEventListener('dragover', handleDragOver);
-    container.addEventListener('dragleave', handleDragLeave);
-    container.addEventListener('drop', handleDrop);
+    // Use capture phase so our handlers fire before xterm.js calls stopPropagation()
+    // on paste events (xterm's handlePasteEvent stops propagation in the bubble phase).
+    // DnD handlers also use capture for consistency and reliability.
+    container.addEventListener('paste', handlePaste, { capture: true });
+    container.addEventListener('dragenter', handleDragEnter, { capture: true });
+    container.addEventListener('dragover', handleDragOver, { capture: true });
+    container.addEventListener('dragleave', handleDragLeave, { capture: true });
+    container.addEventListener('drop', handleDrop, { capture: true });
     window.addEventListener('resize', handleResize);
 
     // Listen for scroll events to update scroll-to-bottom button visibility
@@ -802,11 +805,11 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
       viewportObserver.disconnect();
 
       container.removeEventListener('wheel', handleWheel);
-      container.removeEventListener('paste', handlePaste);
-      container.removeEventListener('dragenter', handleDragEnter);
-      container.removeEventListener('dragover', handleDragOver);
-      container.removeEventListener('dragleave', handleDragLeave);
-      container.removeEventListener('drop', handleDrop);
+      container.removeEventListener('paste', handlePaste, { capture: true });
+      container.removeEventListener('dragenter', handleDragEnter, { capture: true });
+      container.removeEventListener('dragover', handleDragOver, { capture: true });
+      container.removeEventListener('dragleave', handleDragLeave, { capture: true });
+      container.removeEventListener('drop', handleDrop, { capture: true });
       dragCounterRef.current = 0;
       window.removeEventListener('resize', handleResize);
       container.removeEventListener('scroll', handleDOMScroll, { capture: true });


### PR DESCRIPTION
## Summary
- Use capture phase (`{ capture: true }`) for paste and drag-and-drop event listeners in Terminal component
- xterm.js calls `stopPropagation()` in its `handlePasteEvent` handler, which prevented paste events from bubbling to our container-level handler for image detection
- Updated `removeEventListener` calls to include `{ capture: true }` to ensure proper cleanup

## Root Cause
xterm.js v5.5.0's `handlePasteEvent` function calls `e.stopPropagation()` on paste events registered on both its internal textarea and element. Since our paste handler was registered on the container in the default bubble phase, it never received the event.

By switching to capture phase, our handler fires during the capture (outer→inner) traversal, before xterm.js's bubble-phase handler can stop propagation.

## Test plan
- [ ] Cmd+V / Ctrl+V with image in clipboard attaches the image to MessagePanel
- [ ] Drag-and-drop files into terminal area attaches them to MessagePanel
- [ ] Text paste in terminal continues to work normally
- [ ] File attach button (📎) continues to work as before

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)