### PR TITLE
[AI] closed #397 ux: show non-blocking loading indicator during terminal history reload on session switch

### DIFF
--- a/packages/client/src/components/Icons.tsx
+++ b/packages/client/src/components/Icons.tsx
@@ -309,6 +309,15 @@ export function LayoutListIcon({ className = 'w-4 h-4' }: IconProps) {
   );
 }
 
+export function SpinnerIcon({ className = 'w-4 h-4' }: IconProps) {
+  return (
+    <svg className={`${className} animate-spin`} viewBox="0 0 24 24" fill="none">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+    </svg>
+  );
+}
+
 export function GitForkIcon({ className = 'w-4 h-4' }: IconProps) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/packages/client/src/components/Terminal.tsx
+++ b/packages/client/src/components/Terminal.tsx
@@ -22,7 +22,7 @@ import { emitSessionDeleted } from '../lib/app-websocket.js';
 import type { AgentActivityState } from '@agent-console/shared';
 import { logger } from '../lib/logger';
 import { createRenderWatchdog, type RenderWatchdog } from '../lib/render-diagnostics.js';
-import { ChevronDownIcon } from './Icons';
+import { ChevronDownIcon, SpinnerIcon } from './Icons';
 import { WorkerErrorRecovery } from './WorkerErrorRecovery';
 
 /**
@@ -112,6 +112,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
     mountGeneration: 0,
   });
   const [cacheProcessed, setCacheProcessed] = useState(false);
+  const [loadingHistory, setLoadingHistory] = useState(false);
   const offsetRef = useRef<number>(0);
   const connectedRef = useRef(false);
   const [status, setStatus] = useState<ConnectionStatus>('connecting');
@@ -224,6 +225,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
   }, [sessionId, workerId, updateScrollButtonVisibility, processOutput]);
 
   const handleHistory = useCallback((data: string, offset: number) => {
+    setLoadingHistory(false);
     watchdogRef.current?.onHistoryReceived(data.length, offset);
     offsetRef.current = offset;
 
@@ -286,6 +288,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
     if (!connected) {
       // Reset historyRequested so reconnect will re-request
       stateRef.current.historyRequested = false;
+      setLoadingHistory(false);
     }
   }, []);
 
@@ -848,6 +851,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
       const fromOffset = offsetRef.current;
       stateRef.current.historyRequested = true;
       stateRef.current.requestedWithOffset = fromOffset;
+      setLoadingHistory(true);
       requestHistory(sessionId, workerId, fromOffset);
     }
   }, [connected, cacheProcessed, sessionId, workerId]);
@@ -893,6 +897,12 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
           <span className="text-gray-500 text-sm">
             {getStatusText()}
           </span>
+          {loadingHistory && (
+            <span className="text-blue-400 text-xs flex items-center gap-1.5 ml-auto">
+              <SpinnerIcon className="w-3 h-3" />
+              Loading history...
+            </span>
+          )}
         </div>
       )}
       {cacheError && (


### PR DESCRIPTION
## Summary
- Add `loadingHistory` state to `Terminal.tsx` that tracks the window between history request and response
- Display a subtle "Loading history..." spinner badge in the terminal status bar (right-aligned, blue text)
- Add reusable `SpinnerIcon` component to `Icons.tsx`

## Changes
- `packages/client/src/components/Terminal.tsx` — add `loadingHistory` state, set on request/response, render indicator in status bar
- `packages/client/src/components/Icons.tsx` — add `SpinnerIcon` with CSS `animate-spin`

## Test plan
- [ ] Switch between sessions and verify "Loading history..." appears briefly in the status bar
- [ ] Verify the indicator does NOT overlay or block terminal text
- [ ] Verify the indicator disappears after history is fully loaded
- [ ] Verify no indicator appears when terminal is already connected (no false positives)
- [ ] Verify it works for both agent workers and terminal workers

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)