### PR TITLE
[AI] closed #376 refactor: relocate session data directories under repositories/

### DIFF
--- a/packages/server/src/jobs/handlers.ts
+++ b/packages/server/src/jobs/handlers.ts
@@ -25,9 +25,9 @@ export function registerJobHandlers(jobQueue: JobQueue): void {
   // Handler for deleting all output files for a session
   jobQueue.registerHandler<CleanupSessionOutputsPayload>(
     JOB_TYPES.CLEANUP_SESSION_OUTPUTS,
-    async ({ sessionId }) => {
-      logger.debug({ sessionId }, 'Executing cleanup:session-outputs job');
-      await workerOutputFileManager.deleteSessionOutputs(sessionId);
+    async ({ sessionId, repositoryName }) => {
+      logger.debug({ sessionId, repositoryName }, 'Executing cleanup:session-outputs job');
+      await workerOutputFileManager.deleteSessionOutputs(sessionId, repositoryName);
       logger.info({ sessionId }, 'Session outputs cleanup completed');
     }
   );
@@ -35,9 +35,9 @@ export function registerJobHandlers(jobQueue: JobQueue): void {
   // Handler for deleting output file for a single worker
   jobQueue.registerHandler<CleanupWorkerOutputPayload>(
     JOB_TYPES.CLEANUP_WORKER_OUTPUT,
-    async ({ sessionId, workerId }) => {
-      logger.debug({ sessionId, workerId }, 'Executing cleanup:worker-output job');
-      await workerOutputFileManager.deleteWorkerOutput(sessionId, workerId);
+    async ({ sessionId, workerId, repositoryName }) => {
+      logger.debug({ sessionId, workerId, repositoryName }, 'Executing cleanup:worker-output job');
+      await workerOutputFileManager.deleteWorkerOutput(sessionId, workerId, repositoryName);
       logger.info({ sessionId, workerId }, 'Worker output cleanup completed');
     }
   );

--- a/packages/server/src/lib/__tests__/config.test.ts
+++ b/packages/server/src/lib/__tests__/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as os from 'os';
 import * as path from 'path';
-import { getConfigDir, getRepositoriesDir, getRepositoryDir, getMessagesDir, getServerPid } from '../config.js';
+import { getConfigDir, getRepositoriesDir, getRepositoryDir, getMessagesDir, getOutputsDir, getMemosDir, getServerPid } from '../config.js';
 
 describe('config', () => {
   const originalEnv = process.env.AGENT_CONSOLE_HOME;
@@ -66,17 +66,44 @@ describe('config', () => {
   });
 
   describe('getMessagesDir', () => {
-    it('should return messages subdirectory of config dir', () => {
-      delete process.env.AGENT_CONSOLE_HOME;
-
-      const expected = path.join(os.homedir(), '.agent-console', 'messages');
-      expect(getMessagesDir()).toBe(expected);
-    });
-
-    it('should respect AGENT_CONSOLE_HOME', () => {
+    it('should return _quick/messages when repositoryName is not provided', () => {
       process.env.AGENT_CONSOLE_HOME = '/custom/path';
 
-      expect(getMessagesDir()).toBe('/custom/path/messages');
+      expect(getMessagesDir()).toBe('/custom/path/_quick/messages');
+    });
+
+    it('should return repository-scoped messages dir when repositoryName is provided', () => {
+      process.env.AGENT_CONSOLE_HOME = '/custom/path';
+
+      expect(getMessagesDir('org/repo')).toBe('/custom/path/repositories/org/repo/messages');
+    });
+  });
+
+  describe('getOutputsDir', () => {
+    it('should return _quick/outputs when repositoryName is not provided', () => {
+      process.env.AGENT_CONSOLE_HOME = '/custom/path';
+
+      expect(getOutputsDir()).toBe('/custom/path/_quick/outputs');
+    });
+
+    it('should return repository-scoped outputs dir when repositoryName is provided', () => {
+      process.env.AGENT_CONSOLE_HOME = '/custom/path';
+
+      expect(getOutputsDir('org/repo')).toBe('/custom/path/repositories/org/repo/outputs');
+    });
+  });
+
+  describe('getMemosDir', () => {
+    it('should return _quick/memos when repositoryName is not provided', () => {
+      process.env.AGENT_CONSOLE_HOME = '/custom/path';
+
+      expect(getMemosDir()).toBe('/custom/path/_quick/memos');
+    });
+
+    it('should return repository-scoped memos dir when repositoryName is provided', () => {
+      process.env.AGENT_CONSOLE_HOME = '/custom/path';
+
+      expect(getMemosDir('org/repo')).toBe('/custom/path/repositories/org/repo/memos');
     });
   });
 

--- a/packages/server/src/lib/__tests__/worker-output-file.test.ts
+++ b/packages/server/src/lib/__tests__/worker-output-file.test.ts
@@ -30,12 +30,12 @@ describe('WorkerOutputFileManager', () => {
   describe('getOutputFilePath', () => {
     it('should return correct path structure', () => {
       const path = manager.getOutputFilePath('session-1', 'worker-1');
-      expect(path).toBe(`${TEST_CONFIG_DIR}/outputs/session-1/worker-1.log`);
+      expect(path).toBe(`${TEST_CONFIG_DIR}/_quick/outputs/session-1/worker-1.log`);
     });
 
     it('should handle special characters in IDs', () => {
       const path = manager.getOutputFilePath('session_123', 'worker-abc');
-      expect(path).toBe(`${TEST_CONFIG_DIR}/outputs/session_123/worker-abc.log`);
+      expect(path).toBe(`${TEST_CONFIG_DIR}/_quick/outputs/session_123/worker-abc.log`);
     });
   });
 
@@ -135,7 +135,7 @@ describe('WorkerOutputFileManager', () => {
     it('should read full history when no offset specified', async () => {
       // Create file with content
       const filePath = manager.getOutputFilePath('session-1', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-1`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world');
 
       const result = await manager.readHistoryWithOffset('session-1', 'worker-1');
@@ -147,7 +147,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should read history from specific offset', async () => {
       const filePath = manager.getOutputFilePath('session-1', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-1`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world');
 
       // Read from offset 6 (skip 'hello ')
@@ -160,7 +160,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should return empty data when offset equals file size', async () => {
       const filePath = manager.getOutputFilePath('session-1', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-1`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world');
 
       const result = await manager.readHistoryWithOffset('session-1', 'worker-1', 11);
@@ -172,7 +172,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should return full history when offset exceeds file size (truncation resync)', async () => {
       const filePath = manager.getOutputFilePath('session-1', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-1`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world');
 
       // Client has offset 100 but file is only 11 bytes — file was truncated
@@ -221,7 +221,7 @@ describe('WorkerOutputFileManager', () => {
   describe('getCurrentOffset', () => {
     it('should return file size when file exists', async () => {
       const filePath = manager.getOutputFilePath('session-1', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-1`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world');
 
       const offset = await manager.getCurrentOffset('session-1', 'worker-1');
@@ -235,7 +235,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should flush pending buffer before returning offset', async () => {
       const filePath = manager.getOutputFilePath('session-1', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-1`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello'); // 5 bytes
 
       manager.bufferOutput('session-1', 'worker-1', ' world'); // 6 bytes pending
@@ -298,7 +298,7 @@ describe('WorkerOutputFileManager', () => {
   describe('deleteWorkerOutput', () => {
     it('should delete worker output file', async () => {
       const filePath = manager.getOutputFilePath('session-1', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-1`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'content');
 
       await manager.deleteWorkerOutput('session-1', 'worker-1');
@@ -339,7 +339,7 @@ describe('WorkerOutputFileManager', () => {
 
   describe('deleteSessionOutputs', () => {
     it('should delete all output files for a session', async () => {
-      const sessionDir = `${TEST_CONFIG_DIR}/outputs/session-1`;
+      const sessionDir = `${TEST_CONFIG_DIR}/_quick/outputs/session-1`;
       vol.mkdirSync(sessionDir, { recursive: true });
       vol.writeFileSync(`${sessionDir}/worker-1.log`, 'content1');
       vol.writeFileSync(`${sessionDir}/worker-2.log`, 'content2');
@@ -351,8 +351,8 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should not affect other sessions', async () => {
-      const session1Dir = `${TEST_CONFIG_DIR}/outputs/session-1`;
-      const session2Dir = `${TEST_CONFIG_DIR}/outputs/session-2`;
+      const session1Dir = `${TEST_CONFIG_DIR}/_quick/outputs/session-1`;
+      const session2Dir = `${TEST_CONFIG_DIR}/_quick/outputs/session-2`;
       vol.mkdirSync(session1Dir, { recursive: true });
       vol.mkdirSync(session2Dir, { recursive: true });
       vol.writeFileSync(`${session1Dir}/worker-1.log`, 'content1');
@@ -470,7 +470,7 @@ describe('WorkerOutputFileManager', () => {
     it('should include pending buffer when reading with file existing', async () => {
       // Write some data to file first
       const filePath = manager.getOutputFilePath('session-1', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-1`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'existing');
 
       // Buffer more data (not flushed yet)
@@ -488,7 +488,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should return only pending buffer when offset equals file size', async () => {
       const filePath = manager.getOutputFilePath('session-offset-eq', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-offset-eq`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-offset-eq`, { recursive: true });
       vol.writeFileSync(filePath, 'existing'); // 8 bytes
 
       // Buffer more data (not flushed yet)
@@ -504,7 +504,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should return partial pending buffer when offset is within pending buffer range', async () => {
       const filePath = manager.getOutputFilePath('session-partial', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-partial`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-partial`, { recursive: true });
       vol.writeFileSync(filePath, 'file'); // 4 bytes
 
       // Buffer more data (not flushed yet)
@@ -520,7 +520,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should return empty when offset equals total size (file + pending)', async () => {
       const filePath = manager.getOutputFilePath('session-total', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-total`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-total`, { recursive: true });
       vol.writeFileSync(filePath, 'file'); // 4 bytes
 
       // Buffer more data (not flushed yet)
@@ -536,7 +536,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should return full history when offset exceeds total size (file + pending) after truncation', async () => {
       const filePath = manager.getOutputFilePath('session-total-exceed', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-total-exceed`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-total-exceed`, { recursive: true });
       vol.writeFileSync(filePath, 'file'); // 4 bytes
 
       manager.bufferOutput('session-total-exceed', 'worker-1', 'buffer'); // 6 bytes
@@ -551,7 +551,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should return file data from offset + full pending buffer', async () => {
       const filePath = manager.getOutputFilePath('session-mid', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-mid`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-mid`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world'); // 11 bytes
 
       // Buffer more data (not flushed yet)
@@ -567,7 +567,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should handle multi-byte UTF-8 in pending buffer with offset', async () => {
       const filePath = manager.getOutputFilePath('session-utf8-pending', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-utf8-pending`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-utf8-pending`, { recursive: true });
       vol.writeFileSync(filePath, 'ABC'); // 3 bytes
 
       // Buffer Japanese characters (3 bytes each)
@@ -593,7 +593,7 @@ describe('WorkerOutputFileManager', () => {
     it('should handle concurrent reads and writes', async () => {
       // Write initial data
       const filePath = manager.getOutputFilePath('session-1', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-1`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'initial');
 
       // Perform concurrent operations
@@ -833,7 +833,7 @@ describe('WorkerOutputFileManager', () => {
   describe('readLastNLines', () => {
     it('should return last N lines from file', async () => {
       const filePath = manager.getOutputFilePath('session-lines', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-lines`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-lines`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\nline2\nline3\nline4\nline5');
 
       const result = await manager.readLastNLines('session-lines', 'worker-1', 3);
@@ -846,7 +846,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should return all lines if file has fewer than maxLines', async () => {
       const filePath = manager.getOutputFilePath('session-lines-2', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-lines-2`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-lines-2`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\nline2');
 
       const result = await manager.readLastNLines('session-lines-2', 'worker-1', 10);
@@ -857,7 +857,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should handle CRLF line endings', async () => {
       const filePath = manager.getOutputFilePath('session-crlf', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-crlf`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-crlf`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\r\nline2\r\nline3\r\nline4');
 
       const result = await manager.readLastNLines('session-crlf', 'worker-1', 2);
@@ -868,7 +868,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should handle empty lines in count', async () => {
       const filePath = manager.getOutputFilePath('session-empty', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-empty`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-empty`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\n\nline3\nline4');
 
       const result = await manager.readLastNLines('session-empty', 'worker-1', 3);
@@ -897,7 +897,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should return 0 lines when maxLines is 0', async () => {
       const filePath = manager.getOutputFilePath('session-zero', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-zero`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-zero`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\nline2');
 
       const result = await manager.readLastNLines('session-zero', 'worker-1', 0);
@@ -908,7 +908,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should preserve newline at end of content', async () => {
       const filePath = manager.getOutputFilePath('session-trailing', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-trailing`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-trailing`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\nline2\nline3\n');
 
       const result = await manager.readLastNLines('session-trailing', 'worker-1', 2);
@@ -920,7 +920,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should include pending buffer when file exists', async () => {
       const filePath = manager.getOutputFilePath('session-pending-file', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-pending-file`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-pending-file`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\nline2\nline3'); // 17 bytes
 
       // Buffer more data (not flushed yet)
@@ -937,7 +937,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should include pending buffer even when fewer lines requested', async () => {
       const filePath = manager.getOutputFilePath('session-pending-fewer', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-pending-fewer`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-pending-fewer`, { recursive: true });
       vol.writeFileSync(filePath, 'old1\nold2\nold3'); // 14 bytes
 
       // Buffer more data that contains the most recent output (not flushed yet)
@@ -954,7 +954,7 @@ describe('WorkerOutputFileManager', () => {
 
     it('should handle pending buffer with multi-byte UTF-8 characters', async () => {
       const filePath = manager.getOutputFilePath('session-pending-utf8', 'worker-1');
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/outputs/session-pending-utf8`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-pending-utf8`, { recursive: true });
       vol.writeFileSync(filePath, 'hello\n'); // 6 bytes
 
       // Buffer Japanese characters (3 bytes each)
@@ -967,6 +967,47 @@ describe('WorkerOutputFileManager', () => {
       expect(result!.data).toBe('hello\nテスト');
       // Offset should be file size (6) + pending buffer byte length (9)
       expect(result!.offset).toBe(15);
+    });
+  });
+
+  describe('repository-scoped paths', () => {
+    it('should return repository-scoped path when repositoryName is provided', () => {
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', 'org/repo');
+      expect(filePath).toBe(`${TEST_CONFIG_DIR}/repositories/org/repo/outputs/session-1/worker-1.log`);
+    });
+
+    it('should initialize worker output under repository path when repositoryName is provided', async () => {
+      await manager.initializeWorkerOutput('session-1', 'worker-1', 'org/repo');
+
+      const filePath = `${TEST_CONFIG_DIR}/repositories/org/repo/outputs/session-1/worker-1.log`;
+      expect(vol.existsSync(filePath)).toBe(true);
+    });
+
+    it('should flush buffered output to repository-scoped path when repositoryName is provided', async () => {
+      manager.bufferOutput('session-1', 'worker-1', 'repo data', 'org/repo');
+
+      // Wait for flush interval
+      await new Promise(resolve => setTimeout(resolve, 150));
+
+      const filePath = `${TEST_CONFIG_DIR}/repositories/org/repo/outputs/session-1/worker-1.log`;
+      expect(vol.existsSync(filePath)).toBe(true);
+
+      const content = vol.readFileSync(filePath, 'utf-8');
+      expect(content).toBe('repo data');
+    });
+
+    it('should delete session outputs from repository-scoped path when repositoryName is provided', async () => {
+      await manager.initializeWorkerOutput('session-1', 'worker-1', 'org/repo');
+      const sessionDir = `${TEST_CONFIG_DIR}/repositories/org/repo/outputs/session-1`;
+      expect(vol.existsSync(sessionDir)).toBe(true);
+
+      await manager.deleteSessionOutputs('session-1', 'org/repo');
+      expect(vol.existsSync(sessionDir)).toBe(false);
+    });
+
+    it('should use _quick fallback when repositoryName is not provided', () => {
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      expect(filePath).toBe(`${TEST_CONFIG_DIR}/_quick/outputs/session-1/worker-1.log`);
     });
   });
 });

--- a/packages/server/src/lib/config.ts
+++ b/packages/server/src/lib/config.ts
@@ -37,18 +37,35 @@ export function getDbPath(): string {
 
 /**
  * Get the directory for inter-session message files.
- * Structure: ~/.agent-console/messages/
+ * @param repositoryName - org/repo string for worktree sessions, undefined for quick sessions
  */
-export function getMessagesDir(): string {
-  return path.join(getConfigDir(), 'messages');
+export function getMessagesDir(repositoryName?: string): string {
+  if (repositoryName) {
+    return path.join(getRepositoriesDir(), repositoryName, 'messages');
+  }
+  return path.join(getConfigDir(), '_quick', 'messages');
 }
 
 /**
  * Get the directory for memo files.
- * Structure: ~/.agent-console/memos/
+ * @param repositoryName - org/repo string for worktree sessions, undefined for quick sessions
  */
-export function getMemosDir(): string {
-  return path.join(getConfigDir(), 'memos');
+export function getMemosDir(repositoryName?: string): string {
+  if (repositoryName) {
+    return path.join(getRepositoriesDir(), repositoryName, 'memos');
+  }
+  return path.join(getConfigDir(), '_quick', 'memos');
+}
+
+/**
+ * Get the directory for worker output files.
+ * @param repositoryName - org/repo string for worktree sessions, undefined for quick sessions
+ */
+export function getOutputsDir(repositoryName?: string): string {
+  if (repositoryName) {
+    return path.join(getRepositoriesDir(), repositoryName, 'outputs');
+  }
+  return path.join(getConfigDir(), '_quick', 'outputs');
 }
 
 /**

--- a/packages/server/src/lib/worker-output-file.ts
+++ b/packages/server/src/lib/worker-output-file.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { gunzipSync } from 'bun';
-import { getConfigDir } from './config.js';
+import { getOutputsDir } from './config.js';
 import { serverConfig } from './server-config.js';
 import { createLogger } from './logger.js';
 
@@ -45,6 +45,7 @@ export interface HistoryReadResult {
 interface PendingFlush {
   buffer: string;
   timer: ReturnType<typeof setTimeout> | null;
+  repositoryName?: string;
 }
 
 /**
@@ -77,10 +78,9 @@ export class WorkerOutputFileManager {
 
   /**
    * Get the output file path for a worker.
-   * Structure: ${AGENT_CONSOLE_HOME}/outputs/${sessionId}/${workerId}.log
    */
-  getOutputFilePath(sessionId: string, workerId: string): string {
-    return path.join(getConfigDir(), 'outputs', sessionId, `${workerId}.log`);
+  getOutputFilePath(sessionId: string, workerId: string, repositoryName?: string): string {
+    return path.join(getOutputsDir(repositoryName), sessionId, `${workerId}.log`);
   }
 
   /**
@@ -102,9 +102,10 @@ export class WorkerOutputFileManager {
    *
    * Note: Legacy .log.gz files are still supported for reading (migration compatibility).
    */
-  private async getActualFilePath(sessionId: string, workerId: string): Promise<{ path: string; isCompressed: boolean } | null> {
-    const uncompressedPath = path.join(getConfigDir(), 'outputs', sessionId, `${workerId}.log`);
-    const compressedPath = path.join(getConfigDir(), 'outputs', sessionId, `${workerId}.log.gz`);
+  private async getActualFilePath(sessionId: string, workerId: string, repositoryName?: string): Promise<{ path: string; isCompressed: boolean } | null> {
+    const outputsDir = getOutputsDir(repositoryName);
+    const uncompressedPath = path.join(outputsDir, sessionId, `${workerId}.log`);
+    const compressedPath = path.join(outputsDir, sessionId, `${workerId}.log.gz`);
 
     // Check uncompressed file first (current format)
     if (await this.fileExists(uncompressedPath)) {
@@ -131,15 +132,15 @@ export class WorkerOutputFileManager {
    * Call this immediately when creating a new worker to ensure history file exists.
    * This prevents race conditions where WebSocket connects before any output is buffered.
    */
-  async initializeWorkerOutput(sessionId: string, workerId: string): Promise<void> {
-    const filePath = this.getOutputFilePath(sessionId, workerId);
+  async initializeWorkerOutput(sessionId: string, workerId: string, repositoryName?: string): Promise<void> {
+    const filePath = this.getOutputFilePath(sessionId, workerId, repositoryName);
 
     try {
       // Ensure directory exists
       await fs.mkdir(path.dirname(filePath), { recursive: true });
 
       // Check if file already exists (e.g., from previous run)
-      const actualFile = await this.getActualFilePath(sessionId, workerId);
+      const actualFile = await this.getActualFilePath(sessionId, workerId, repositoryName);
       if (actualFile) {
         // File already exists, no need to initialize
         return;
@@ -158,12 +159,12 @@ export class WorkerOutputFileManager {
    * Buffer output data for periodic flushing to file.
    * Flushes immediately if buffer exceeds threshold.
    */
-  bufferOutput(sessionId: string, workerId: string, data: string): void {
+  bufferOutput(sessionId: string, workerId: string, data: string, repositoryName?: string): void {
     const key = this.getKey(sessionId, workerId);
     let pending = this.pendingFlushes.get(key);
 
     if (!pending) {
-      pending = { buffer: '', timer: null };
+      pending = { buffer: '', timer: null, repositoryName };
       this.pendingFlushes.set(key, pending);
     }
 
@@ -209,14 +210,15 @@ export class WorkerOutputFileManager {
     const dataToWrite = pending.buffer;
     pending.buffer = '';
 
-    const filePath = this.getOutputFilePath(sessionId, workerId);
+    const repositoryName = pending.repositoryName;
+    const filePath = this.getOutputFilePath(sessionId, workerId, repositoryName);
 
     try {
       // Ensure directory exists
       await fs.mkdir(path.dirname(filePath), { recursive: true });
 
       // Check if we need to migrate from legacy compressed file
-      const actualFile = await this.getActualFilePath(sessionId, workerId);
+      const actualFile = await this.getActualFilePath(sessionId, workerId, repositoryName);
       if (actualFile?.isCompressed) {
         // Migrate from compressed to uncompressed
         const rawBuffer = await fs.readFile(actualFile.path);
@@ -316,7 +318,8 @@ export class WorkerOutputFileManager {
   async readHistoryWithOffset(
     sessionId: string,
     workerId: string,
-    fromOffset?: number
+    fromOffset?: number,
+    repositoryName?: string
   ): Promise<HistoryReadResult> {
     try {
       // Get pending buffer for this worker
@@ -326,7 +329,7 @@ export class WorkerOutputFileManager {
       const pendingByteLength = Buffer.byteLength(pendingBuffer, 'utf-8');
 
       // Find the actual file (uncompressed or legacy compressed)
-      const actualFile = await this.getActualFilePath(sessionId, workerId);
+      const actualFile = await this.getActualFilePath(sessionId, workerId, repositoryName);
 
       if (!actualFile) {
         // No file exists, return only pending buffer
@@ -415,7 +418,8 @@ export class WorkerOutputFileManager {
   async readLastNLines(
     sessionId: string,
     workerId: string,
-    maxLines: number
+    maxLines: number,
+    repositoryName?: string
   ): Promise<HistoryReadResult> {
     try {
       // Get pending buffer for this worker
@@ -425,7 +429,7 @@ export class WorkerOutputFileManager {
       const pendingByteLength = Buffer.byteLength(pendingBuffer, 'utf-8');
 
       // Find the actual file (uncompressed or legacy compressed)
-      const actualFile = await this.getActualFilePath(sessionId, workerId);
+      const actualFile = await this.getActualFilePath(sessionId, workerId, repositoryName);
 
       if (!actualFile) {
         // No file exists, return only pending buffer
@@ -528,13 +532,13 @@ export class WorkerOutputFileManager {
    * Returns 0 if file doesn't exist.
    * Supports legacy .log.gz files for backward compatibility.
    */
-  async getCurrentOffset(sessionId: string, workerId: string): Promise<number> {
+  async getCurrentOffset(sessionId: string, workerId: string, repositoryName?: string): Promise<number> {
     // Flush any pending buffer first to ensure accurate offset
     // This prevents race conditions where offset is read before buffer is flushed
     await this.flushBuffer(sessionId, workerId);
 
     try {
-      const actualFile = await this.getActualFilePath(sessionId, workerId);
+      const actualFile = await this.getActualFilePath(sessionId, workerId, repositoryName);
       if (!actualFile) {
         return 0;
       }
@@ -563,7 +567,7 @@ export class WorkerOutputFileManager {
    * Used when restarting a worker to prevent offset mismatch with client cache.
    * Clears pending buffers and creates an empty file.
    */
-  async resetWorkerOutput(sessionId: string, workerId: string): Promise<void> {
+  async resetWorkerOutput(sessionId: string, workerId: string, repositoryName?: string): Promise<void> {
     // Clear any pending flush
     const key = this.getKey(sessionId, workerId);
     const pending = this.pendingFlushes.get(key);
@@ -574,7 +578,7 @@ export class WorkerOutputFileManager {
       this.pendingFlushes.delete(key);
     }
 
-    const filePath = this.getOutputFilePath(sessionId, workerId);
+    const filePath = this.getOutputFilePath(sessionId, workerId, repositoryName);
 
     try {
       // Ensure directory exists
@@ -606,7 +610,7 @@ export class WorkerOutputFileManager {
    * Delete output file for a worker.
    * Also deletes legacy .log.gz files if present.
    */
-  async deleteWorkerOutput(sessionId: string, workerId: string): Promise<void> {
+  async deleteWorkerOutput(sessionId: string, workerId: string, repositoryName?: string): Promise<void> {
     // Clear any pending flush
     const key = this.getKey(sessionId, workerId);
     const pending = this.pendingFlushes.get(key);
@@ -618,8 +622,9 @@ export class WorkerOutputFileManager {
     }
 
     // Delete both possible file formats
-    const compressedPath = path.join(getConfigDir(), 'outputs', sessionId, `${workerId}.log.gz`);
-    const uncompressedPath = path.join(getConfigDir(), 'outputs', sessionId, `${workerId}.log`);
+    const outputsDir = getOutputsDir(repositoryName);
+    const compressedPath = path.join(outputsDir, sessionId, `${workerId}.log.gz`);
+    const uncompressedPath = path.join(outputsDir, sessionId, `${workerId}.log`);
 
     const deleteFile = async (filePath: string): Promise<boolean> => {
       try {
@@ -646,7 +651,7 @@ export class WorkerOutputFileManager {
   /**
    * Delete all output files for a session.
    */
-  async deleteSessionOutputs(sessionId: string): Promise<void> {
+  async deleteSessionOutputs(sessionId: string, repositoryName?: string): Promise<void> {
     // Clear any pending flushes for this session
     const keysToDelete: string[] = [];
     for (const [key, pending] of this.pendingFlushes) {
@@ -661,7 +666,7 @@ export class WorkerOutputFileManager {
       this.pendingFlushes.delete(key);
     }
 
-    const sessionDir = path.join(getConfigDir(), 'outputs', sessionId);
+    const sessionDir = path.join(getOutputsDir(repositoryName), sessionId);
 
     try {
       await fs.rm(sessionDir, { recursive: true, force: true });

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -379,11 +379,13 @@ export function createMcpApp(deps: McpDependencies): Hono {
         }
 
         // 3. Write message file
+        const repositoryName = targetSession.type === 'worktree' ? targetSession.repositoryName : undefined;
         const result = await interSessionMessageService.sendMessage({
           toSessionId,
           toWorkerId: resolvedWorkerId,
           fromSessionId,
           content,
+          repositoryName,
         });
 
         // 4. PTY notification (best-effort -- message file is already written)

--- a/packages/server/src/services/__tests__/inter-session-message-service.test.ts
+++ b/packages/server/src/services/__tests__/inter-session-message-service.test.ts
@@ -31,7 +31,7 @@ describe('InterSessionMessageService', () => {
         content: 'hello',
       });
 
-      const dirPath = `${TEST_CONFIG_DIR}/messages/session-target/worker-1`;
+      const dirPath = `${TEST_CONFIG_DIR}/_quick/messages/session-target/worker-1`;
       const dirExists = vol.existsSync(dirPath);
       expect(dirExists).toBe(true);
     });
@@ -71,7 +71,7 @@ describe('InterSessionMessageService', () => {
 
       expect(result.messageId).toBeDefined();
       expect(result.path).toContain(TEST_CONFIG_DIR);
-      expect(result.path).toContain('messages/session-target/worker-1');
+      expect(result.path).toContain('_quick/messages/session-target/worker-1');
       expect(result.path).toEndWith(result.messageId);
     });
 
@@ -83,7 +83,7 @@ describe('InterSessionMessageService', () => {
         content: 'test',
       });
 
-      const dirPath = `${TEST_CONFIG_DIR}/messages/session-target/worker-1`;
+      const dirPath = `${TEST_CONFIG_DIR}/_quick/messages/session-target/worker-1`;
       const files = vol.readdirSync(dirPath) as string[];
       const tmpFiles = files.filter((f) => f.startsWith('.tmp-'));
       expect(tmpFiles).toHaveLength(0);
@@ -160,11 +160,11 @@ describe('InterSessionMessageService', () => {
       });
 
       // Verify directory exists
-      expect(vol.existsSync(`${TEST_CONFIG_DIR}/messages/session-1`)).toBe(true);
+      expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/messages/session-1`)).toBe(true);
 
       await service.deleteSessionMessages('session-1');
 
-      expect(vol.existsSync(`${TEST_CONFIG_DIR}/messages/session-1`)).toBe(false);
+      expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/messages/session-1`)).toBe(false);
     });
 
     it('should not throw when directory does not exist', async () => {
@@ -194,9 +194,9 @@ describe('InterSessionMessageService', () => {
       await service.deleteWorkerMessages('session-1', 'worker-2');
 
       // worker-1 messages should remain
-      expect(vol.existsSync(`${TEST_CONFIG_DIR}/messages/session-1/worker-1`)).toBe(true);
+      expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/messages/session-1/worker-1`)).toBe(true);
       // worker-2 messages should be gone
-      expect(vol.existsSync(`${TEST_CONFIG_DIR}/messages/session-1/worker-2`)).toBe(false);
+      expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/messages/session-1/worker-2`)).toBe(false);
     });
 
     it('should not throw when directory does not exist', async () => {
@@ -253,6 +253,48 @@ describe('InterSessionMessageService', () => {
       await expect(
         service.deleteWorkerMessages('valid-session', '../../../etc'),
       ).rejects.toThrow('Invalid workerId');
+    });
+  });
+
+  describe('repository-scoped paths', () => {
+    it('should write to repository-scoped path when repositoryName is provided', async () => {
+      const result = await service.sendMessage({
+        toSessionId: 'session-target',
+        toWorkerId: 'worker-1',
+        fromSessionId: 'session-sender',
+        content: 'hello',
+        repositoryName: 'org/repo',
+      });
+
+      expect(result.path).toContain(`${TEST_CONFIG_DIR}/repositories/org/repo/messages/session-target/worker-1`);
+      expect(vol.existsSync(`${TEST_CONFIG_DIR}/repositories/org/repo/messages/session-target/worker-1`)).toBe(true);
+    });
+
+    it('should delete from repository-scoped path when repositoryName is provided', async () => {
+      await service.sendMessage({
+        toSessionId: 'session-1',
+        toWorkerId: 'worker-1',
+        fromSessionId: 'sender',
+        content: 'msg',
+        repositoryName: 'org/repo',
+      });
+
+      expect(vol.existsSync(`${TEST_CONFIG_DIR}/repositories/org/repo/messages/session-1`)).toBe(true);
+
+      await service.deleteSessionMessages('session-1', 'org/repo');
+
+      expect(vol.existsSync(`${TEST_CONFIG_DIR}/repositories/org/repo/messages/session-1`)).toBe(false);
+    });
+
+    it('should write to _quick fallback path when repositoryName is not provided', async () => {
+      const result = await service.sendMessage({
+        toSessionId: 'session-target',
+        toWorkerId: 'worker-1',
+        fromSessionId: 'session-sender',
+        content: 'hello',
+      });
+
+      expect(result.path).toContain(`${TEST_CONFIG_DIR}/_quick/messages/session-target/worker-1`);
     });
   });
 

--- a/packages/server/src/services/__tests__/memo-service.test.ts
+++ b/packages/server/src/services/__tests__/memo-service.test.ts
@@ -28,8 +28,8 @@ describe('MemoService', () => {
     it('should create the memos directory and write the file', async () => {
       const filePath = await service.writeMemo('session-1', '# My Memo');
 
-      expect(filePath).toBe(`${TEST_CONFIG_DIR}/memos/session-1.md`);
-      expect(vol.existsSync(`${TEST_CONFIG_DIR}/memos`)).toBe(true);
+      expect(filePath).toBe(`${TEST_CONFIG_DIR}/_quick/memos/session-1.md`);
+      expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/memos`)).toBe(true);
 
       const content = vol.readFileSync(filePath, 'utf-8');
       expect(content).toBe('# My Memo');
@@ -39,7 +39,7 @@ describe('MemoService', () => {
       await service.writeMemo('session-1', 'first version');
       await service.writeMemo('session-1', 'second version');
 
-      const content = vol.readFileSync(`${TEST_CONFIG_DIR}/memos/session-1.md`, 'utf-8');
+      const content = vol.readFileSync(`${TEST_CONFIG_DIR}/_quick/memos/session-1.md`, 'utf-8');
       expect(content).toBe('second version');
     });
 
@@ -54,8 +54,8 @@ describe('MemoService', () => {
       await service.writeMemo('session-a', 'memo A');
       await service.writeMemo('session-b', 'memo B');
 
-      const contentA = vol.readFileSync(`${TEST_CONFIG_DIR}/memos/session-a.md`, 'utf-8');
-      const contentB = vol.readFileSync(`${TEST_CONFIG_DIR}/memos/session-b.md`, 'utf-8');
+      const contentA = vol.readFileSync(`${TEST_CONFIG_DIR}/_quick/memos/session-a.md`, 'utf-8');
+      const contentB = vol.readFileSync(`${TEST_CONFIG_DIR}/_quick/memos/session-b.md`, 'utf-8');
       expect(contentA).toBe('memo A');
       expect(contentB).toBe('memo B');
     });
@@ -78,17 +78,51 @@ describe('MemoService', () => {
   describe('deleteMemo', () => {
     it('should remove an existing memo file', async () => {
       await service.writeMemo('session-1', 'content');
-      expect(vol.existsSync(`${TEST_CONFIG_DIR}/memos/session-1.md`)).toBe(true);
+      expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/memos/session-1.md`)).toBe(true);
 
       await service.deleteMemo('session-1');
-      expect(vol.existsSync(`${TEST_CONFIG_DIR}/memos/session-1.md`)).toBe(false);
+      expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/memos/session-1.md`)).toBe(false);
     });
 
     it('should not throw when memo does not exist', async () => {
       // Ensure memos dir exists so rm doesn't fail on missing parent
-      vol.mkdirSync(`${TEST_CONFIG_DIR}/memos`, { recursive: true });
+      vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/memos`, { recursive: true });
 
       await expect(service.deleteMemo('nonexistent')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('repository-scoped paths', () => {
+    it('should write memo to repository-scoped path when repositoryName is provided', async () => {
+      const filePath = await service.writeMemo('session-1', '# Repo Memo', 'org/repo');
+
+      expect(filePath).toBe(`${TEST_CONFIG_DIR}/repositories/org/repo/memos/session-1.md`);
+      expect(vol.existsSync(filePath)).toBe(true);
+
+      const content = vol.readFileSync(filePath, 'utf-8');
+      expect(content).toBe('# Repo Memo');
+    });
+
+    it('should read memo from repository-scoped path when repositoryName is provided', async () => {
+      await service.writeMemo('session-1', '# Repo Memo', 'org/repo');
+
+      const content = await service.readMemo('session-1', 'org/repo');
+      expect(content).toBe('# Repo Memo');
+    });
+
+    it('should delete memo from repository-scoped path when repositoryName is provided', async () => {
+      await service.writeMemo('session-1', 'content', 'org/repo');
+      const filePath = `${TEST_CONFIG_DIR}/repositories/org/repo/memos/session-1.md`;
+      expect(vol.existsSync(filePath)).toBe(true);
+
+      await service.deleteMemo('session-1', 'org/repo');
+      expect(vol.existsSync(filePath)).toBe(false);
+    });
+
+    it('should use _quick fallback when repositoryName is not provided', async () => {
+      const filePath = await service.writeMemo('session-1', '# Quick Memo');
+
+      expect(filePath).toBe(`${TEST_CONFIG_DIR}/_quick/memos/session-1.md`);
     });
   });
 

--- a/packages/server/src/services/__tests__/worker-history-initialization.test.ts
+++ b/packages/server/src/services/__tests__/worker-history-initialization.test.ts
@@ -174,7 +174,7 @@ describe('Worker History File Initialization', () => {
 
       // The history file should exist on disk immediately
       // Check both compressed and uncompressed paths
-      const outputsDir = `${TEST_CONFIG_DIR}/outputs/${session.id}`;
+      const outputsDir = `${TEST_CONFIG_DIR}/_quick/outputs/${session.id}`;
       const uncompressedPath = `${outputsDir}/${agentWorker!.id}.log`;
       const compressedPath = `${outputsDir}/${agentWorker!.id}.log.gz`;
 

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -97,6 +97,7 @@ describe('WorkerLifecycleManager', () => {
       resolveSpawnUsername: async () => 'testuser',
       getJobQueue: () => testJobQueue,
       getSessionLifecycleCallbacks: () => mockCallbacks,
+      getRepositoryName: () => undefined,
       ...overrides,
     };
   }

--- a/packages/server/src/services/inter-session-message-service.ts
+++ b/packages/server/src/services/inter-session-message-service.ts
@@ -47,6 +47,7 @@ export interface SendMessageParams {
   toWorkerId: string;
   fromSessionId: string;
   content: string;
+  repositoryName?: string;
 }
 
 export interface SendMessageResult {
@@ -66,7 +67,7 @@ export class InterSessionMessageService {
    * 4. Return { messageId, path }
    */
   async sendMessage(params: SendMessageParams): Promise<SendMessageResult> {
-    const { toSessionId, toWorkerId, fromSessionId, content } = params;
+    const { toSessionId, toWorkerId, fromSessionId, content, repositoryName } = params;
 
     validateId(toSessionId, 'toSessionId');
     validateId(toWorkerId, 'toWorkerId');
@@ -79,7 +80,7 @@ export class InterSessionMessageService {
       );
     }
 
-    const messagesDir = getMessagesDir();
+    const messagesDir = getMessagesDir(repositoryName);
     const dir = path.resolve(messagesDir, toSessionId, toWorkerId);
     assertWithinDir(dir, messagesDir);
 
@@ -111,10 +112,10 @@ export class InterSessionMessageService {
    * Remove all message files for a session.
    * Called when a session is deleted.
    */
-  async deleteSessionMessages(sessionId: string): Promise<void> {
+  async deleteSessionMessages(sessionId: string, repositoryName?: string): Promise<void> {
     validateId(sessionId, 'sessionId');
 
-    const messagesDir = getMessagesDir();
+    const messagesDir = getMessagesDir(repositoryName);
     const dir = path.resolve(messagesDir, sessionId);
     assertWithinDir(dir, messagesDir);
 
@@ -127,11 +128,11 @@ export class InterSessionMessageService {
    * Remove all message files for a specific worker within a session.
    * Called when a worker is deleted.
    */
-  async deleteWorkerMessages(sessionId: string, workerId: string): Promise<void> {
+  async deleteWorkerMessages(sessionId: string, workerId: string, repositoryName?: string): Promise<void> {
     validateId(sessionId, 'sessionId');
     validateId(workerId, 'workerId');
 
-    const messagesDir = getMessagesDir();
+    const messagesDir = getMessagesDir(repositoryName);
     const dir = path.resolve(messagesDir, sessionId, workerId);
     assertWithinDir(dir, messagesDir);
 

--- a/packages/server/src/services/memo-service.ts
+++ b/packages/server/src/services/memo-service.ts
@@ -30,14 +30,14 @@ export class MemoService {
    *
    * @returns The absolute file path of the written memo.
    */
-  async writeMemo(sessionId: string, content: string): Promise<string> {
+  async writeMemo(sessionId: string, content: string, repositoryName?: string): Promise<string> {
     this.validateSessionId(sessionId);
     const contentSize = Buffer.byteLength(content, 'utf-8');
     if (contentSize > MAX_MEMO_SIZE_BYTES) {
       throw new Error(`Memo content exceeds maximum size of ${MAX_MEMO_SIZE_BYTES} bytes (got ${contentSize})`);
     }
 
-    const memosDir = getMemosDir();
+    const memosDir = getMemosDir(repositoryName);
     await fs.mkdir(memosDir, { recursive: true });
 
     const filePath = path.join(memosDir, `${sessionId}.md`);
@@ -60,9 +60,9 @@ export class MemoService {
    *
    * @returns The memo content, or null if no memo exists.
    */
-  async readMemo(sessionId: string): Promise<string | null> {
+  async readMemo(sessionId: string, repositoryName?: string): Promise<string | null> {
     this.validateSessionId(sessionId);
-    const filePath = path.join(getMemosDir(), `${sessionId}.md`);
+    const filePath = path.join(getMemosDir(repositoryName), `${sessionId}.md`);
     try {
       return await fs.readFile(filePath, 'utf-8');
     } catch (err) {
@@ -76,9 +76,9 @@ export class MemoService {
   /**
    * Delete a memo for a session. Does not throw if the file does not exist.
    */
-  async deleteMemo(sessionId: string): Promise<void> {
+  async deleteMemo(sessionId: string, repositoryName?: string): Promise<void> {
     this.validateSessionId(sessionId);
-    const filePath = path.join(getMemosDir(), `${sessionId}.md`);
+    const filePath = path.join(getMemosDir(repositoryName), `${sessionId}.md`);
     await fs.rm(filePath, { force: true });
     logger.debug({ sessionId }, 'Memo deleted');
   }

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -171,6 +171,7 @@ export class SessionManager {
       getJobQueue: () => this.jobQueue,
       getSessionLifecycleCallbacks: () => this.sessionLifecycleCallbacks,
       resolveSpawnUsername: (createdBy) => resolveSpawnUsername(createdBy, this.userRepository),
+      getRepositoryName: (session) => this.getRepositoryNameForSession(session),
     });
   }
 
@@ -202,7 +203,7 @@ export class SessionManager {
     const persistedSessions = await this.sessionRepository.findAll();
     const currentServerPid = getServerPid();
     const sessionsToSave: PersistedSession[] = [];
-    const orphanSessionIds: string[] = [];
+    const orphanSessions: PersistedSession[] = [];
     let markedPausedCount = 0;
     let killedWorkerCount = 0;
     let pathNotFoundCount = 0;
@@ -233,7 +234,7 @@ export class SessionManager {
       if (!pathExistsResult) {
         logger.warn({ sessionId: session.id, locationPath: session.locationPath },
           'Session path no longer exists, marking as orphan');
-        orphanSessionIds.push(session.id);
+        orphanSessions.push(session);
         pathNotFoundCount++;
         continue;
       }
@@ -273,19 +274,20 @@ export class SessionManager {
     }
 
     // Delete orphan sessions (path no longer exists)
-    for (const sessionId of orphanSessionIds) {
+    for (const orphan of orphanSessions) {
+      const repositoryName = this.getRepositoryNameForPersistedSession(orphan);
       // Clean up worker output files
       try {
-        await workerOutputFileManager.deleteSessionOutputs(sessionId);
+        await workerOutputFileManager.deleteSessionOutputs(orphan.id, repositoryName);
       } catch (error) {
-        logger.error({ sessionId, err: error }, 'Failed to delete worker output files for orphan session');
+        logger.error({ sessionId: orphan.id, err: error }, 'Failed to delete worker output files for orphan session');
       }
       // Delete from database
       try {
-        await this.sessionRepository.delete(sessionId);
-        logger.info({ sessionId }, 'Removed orphan session with non-existent path');
+        await this.sessionRepository.delete(orphan.id);
+        logger.info({ sessionId: orphan.id }, 'Removed orphan session with non-existent path');
       } catch (error) {
-        logger.error({ sessionId, err: error }, 'Failed to delete orphan session from database');
+        logger.error({ sessionId: orphan.id, err: error }, 'Failed to delete orphan session from database');
       }
     }
 
@@ -453,7 +455,7 @@ export class SessionManager {
     const currentServerPid = getServerPid();
     let killedCount = 0;
     let preservedCount = 0;
-    const orphanSessionIds: string[] = [];
+    const orphanSessions: PersistedSession[] = [];
 
     for (const session of persistedSessions) {
       // Skip sessions that this server has inherited (already in memory)
@@ -474,7 +476,7 @@ export class SessionManager {
       }
 
       // This session's server is dead AND not inherited by this server - mark for removal
-      orphanSessionIds.push(session.id);
+      orphanSessions.push(session);
 
       // Kill all workers in this session (only PTY workers have pid)
       for (const worker of session.workers) {
@@ -502,22 +504,23 @@ export class SessionManager {
     }
 
     // Remove orphan sessions from persistence and delete output files
-    if (orphanSessionIds.length > 0) {
+    if (orphanSessions.length > 0) {
       // Verify jobQueue is available for cleanup operations
       if (!this.jobQueue) {
         throw new Error('JobQueue not available for orphan session cleanup. Ensure jobQueue is passed to SessionManager.create().');
       }
-      for (const sessionId of orphanSessionIds) {
-        await this.sessionRepository.delete(sessionId);
+      for (const orphan of orphanSessions) {
+        const repositoryName = this.getRepositoryNameForPersistedSession(orphan);
+        await this.sessionRepository.delete(orphan.id);
         // Delete output files for orphan session via job queue
-        await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId });
-        logger.info({ sessionId }, 'Removed orphan session from persistence');
+        await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: orphan.id, repositoryName });
+        logger.info({ sessionId: orphan.id }, 'Removed orphan session from persistence');
       }
     }
 
     logger.info({
       killedProcesses: killedCount,
-      removedSessions: orphanSessionIds.length,
+      removedSessions: orphanSessions.length,
       preservedSessions: preservedCount,
       serverPid: currentServerPid,
     }, 'Orphan cleanup completed');
@@ -630,11 +633,14 @@ export class SessionManager {
       throw new Error('JobQueue not available for session cleanup. Ensure SessionManager.create() was called with jobQueue.');
     }
 
+    // Resolve repository name before cleanup operations
+    const repositoryName = this.getRepositoryNameForSession(session);
+
     // Perform all deletion operations atomically
     // If any fail, restore in-memory state to maintain consistency
     try {
       // 1. Enqueue cleanup job (async but fire-and-forget, failure is non-critical)
-      await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: id });
+      await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: id, repositoryName });
 
       // 2. Clean up notification state (throttle timers, debounce timers)
       this.notificationManager?.cleanupSession(id);
@@ -647,14 +653,14 @@ export class SessionManager {
 
       // 2c. Clean up inter-session message files
       try {
-        await interSessionMessageService.deleteSessionMessages(id);
+        await interSessionMessageService.deleteSessionMessages(id, repositoryName);
       } catch (err) {
         logger.warn({ sessionId: id, err }, 'Failed to clean inter-session message files');
       }
 
       // 2d. Clean up memo file
       try {
-        await memoService.deleteMemo(id);
+        await memoService.deleteMemo(id, repositoryName);
       } catch (err) {
         logger.warn({ sessionId: id, err }, 'Failed to clean memo file');
       }
@@ -920,6 +926,7 @@ export class SessionManager {
     // Restore all PTY workers with continueConversation: true
     const repositoryEnvVars = await this.getRepositoryEnvVars(id);
     const repositoryId = internalSession.type === 'worktree' ? internalSession.repositoryId : undefined;
+    const repositoryName = this.getRepositoryNameForSession(internalSession);
     try {
       const username = await resolveSpawnUsername(internalSession.createdBy, this.userRepository);
       for (const worker of workers.values()) {
@@ -929,6 +936,7 @@ export class SessionManager {
             locationPath: persisted.locationPath,
             repositoryEnvVars,
             username,
+            repositoryName,
             agentId: worker.agentId,
             continueConversation: true,
             repositoryId,
@@ -942,6 +950,7 @@ export class SessionManager {
             locationPath: persisted.locationPath,
             repositoryEnvVars,
             username,
+            repositoryName,
           });
           activatedWorkers.push(worker);
         }
@@ -1024,9 +1033,10 @@ export class SessionManager {
     // Check persistence for orphaned session
     const persisted = await this.sessionRepository.findById(id);
     if (persisted) {
+      const repositoryName = this.getRepositoryNameForPersistedSession(persisted);
       // Enqueue cleanup of worker output files (same as deleteSession)
       if (this.jobQueue) {
-        await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: id });
+        await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: id, repositoryName });
       } else {
         logger.warn(
           { sessionId: id, method: 'forceDeleteSession', skippedJob: JOB_TYPES.CLEANUP_SESSION_OUTPUTS },
@@ -1036,7 +1046,7 @@ export class SessionManager {
       await this.sessionRepository.delete(id);
       // Clean up memo file
       try {
-        await memoService.deleteMemo(id);
+        await memoService.deleteMemo(id, repositoryName);
       } catch (err) {
         logger.warn({ sessionId: id, err }, 'Failed to clean memo file');
       }
@@ -1197,13 +1207,15 @@ export class SessionManager {
    * @returns The absolute file path of the written memo.
    */
   async writeMemo(sessionId: string, content: string): Promise<string> {
-    if (!this.sessions.has(sessionId)) {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
       throw new Error(`Session not found: ${sessionId}`);
     }
-    const filePath = await memoService.writeMemo(sessionId, content);
+    const repositoryName = this.getRepositoryNameForSession(session);
+    const filePath = await memoService.writeMemo(sessionId, content, repositoryName);
     // Re-check after async write: session may have been deleted during the write
     if (!this.sessions.has(sessionId)) {
-      await memoService.deleteMemo(sessionId).catch(() => {});
+      await memoService.deleteMemo(sessionId, repositoryName).catch(() => {});
       throw new Error(`Session deleted during memo write: ${sessionId}`);
     }
     this.sessionLifecycleCallbacks?.onMemoUpdated?.(sessionId, content);
@@ -1216,10 +1228,12 @@ export class SessionManager {
    * @returns The memo content, or null if no memo exists.
    */
   async readMemo(sessionId: string): Promise<string | null> {
-    if (!this.sessions.has(sessionId)) {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
       throw new Error(`Session not found: ${sessionId}`);
     }
-    return memoService.readMemo(sessionId);
+    const repositoryName = this.getRepositoryNameForSession(session);
+    return memoService.readMemo(sessionId, repositoryName);
   }
 
   /**
@@ -1476,6 +1490,26 @@ export class SessionManager {
     return session.type === 'worktree'
       ? { ...base, type: 'worktree', repositoryId: session.repositoryId, worktreeId: session.worktreeId }
       : { ...base, type: 'quick' };
+  }
+
+  /**
+   * Resolve the repository name for a session.
+   * Returns the org/repo name for worktree sessions, undefined for quick sessions.
+   */
+  private getRepositoryNameForSession(session: InternalSession): string | undefined {
+    if (session.type !== 'worktree') return undefined;
+    if (!this.repositoryCallbacks?.isInitialized()) return undefined;
+    return this.repositoryCallbacks.getRepository(session.repositoryId)?.name;
+  }
+
+  /**
+   * Resolve the repository name from a persisted session's repositoryId.
+   * Returns undefined for quick sessions or when repository callbacks are unavailable.
+   */
+  private getRepositoryNameForPersistedSession(persisted: PersistedSession): string | undefined {
+    if (persisted.type !== 'worktree') return undefined;
+    if (!this.repositoryCallbacks?.isInitialized()) return undefined;
+    return this.repositoryCallbacks.getRepository(persisted.repositoryId)?.name;
   }
 
   private toPublicSession(session: InternalSession): Session {

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -72,6 +72,11 @@ export interface WorkerLifecycleDeps {
    * If createdBy is null (pre-multi-user sessions), returns the server process username.
    */
   resolveSpawnUsername: (createdBy?: string) => Promise<string>;
+  /**
+   * Resolve the repository name (org/repo) for a session.
+   * Returns undefined for quick sessions or when repository lookup is unavailable.
+   */
+  getRepositoryName: (session: InternalSession) => string | undefined;
 }
 
 /**
@@ -108,6 +113,7 @@ export class WorkerLifecycleManager {
 
     let worker: InternalWorker;
     const repositoryId = session.type === 'worktree' ? session.repositoryId : undefined;
+    const repositoryName = this.deps.getRepositoryName(session);
 
     if (request.type === 'agent') {
       const repositoryEnvVars = await this.deps.getRepositoryEnvVars(sessionId);
@@ -123,6 +129,7 @@ export class WorkerLifecycleManager {
         locationPath: session.locationPath,
         repositoryEnvVars,
         username,
+        repositoryName,
         agentId: agentWorker.agentId,
         continueConversation,
         initialPrompt,
@@ -144,6 +151,7 @@ export class WorkerLifecycleManager {
         locationPath: session.locationPath,
         repositoryEnvVars,
         username,
+        repositoryName,
       });
       worker = terminalWorker;
     } else {
@@ -162,7 +170,8 @@ export class WorkerLifecycleManager {
     // Initialize output file immediately for PTY workers (agent/terminal)
     // This prevents race conditions where WebSocket connects before any output is buffered
     if (request.type === 'agent' || request.type === 'terminal') {
-      await workerOutputFileManager.initializeWorkerOutput(sessionId, workerId);
+      const repositoryName = this.deps.getRepositoryName(session);
+      await workerOutputFileManager.initializeWorkerOutput(sessionId, workerId, repositoryName);
     }
 
     await this.deps.persistSession(session);
@@ -208,6 +217,7 @@ export class WorkerLifecycleManager {
 
     const repositoryEnvVars = await this.deps.getRepositoryEnvVars(sessionId);
     const repositoryId = session.type === 'worktree' ? session.repositoryId : undefined;
+    const repositoryName = this.deps.getRepositoryName(session);
     const username = await this.deps.resolveSpawnUsername(session.createdBy);
 
     // Activate PTY based on worker type
@@ -218,6 +228,7 @@ export class WorkerLifecycleManager {
         locationPath: session.locationPath,
         repositoryEnvVars,
         username,
+        repositoryName,
         agentId: effectiveAgentId,
         continueConversation: true,
         repositoryId,
@@ -230,6 +241,7 @@ export class WorkerLifecycleManager {
         locationPath: session.locationPath,
         repositoryEnvVars,
         username,
+        repositoryName,
       });
     }
 
@@ -249,10 +261,12 @@ export class WorkerLifecycleManager {
     const worker = session.workers.get(workerId);
     if (!worker) return false;
 
+    const repositoryName = this.deps.getRepositoryName(session);
+
     // Clean up based on worker type
     if (worker.type === 'agent' || worker.type === 'terminal') {
       this.deps.workerManager.killWorker(worker);
-      await this.cleanupWorkerOutput(sessionId, workerId);
+      await this.cleanupWorkerOutput(sessionId, workerId, repositoryName);
     } else {
       // git-diff worker: stop file watcher (synchronous operation)
       stopWatching(session.locationPath);
@@ -266,7 +280,7 @@ export class WorkerLifecycleManager {
 
     // Clean up inter-session message files for this worker
     try {
-      await interSessionMessageService.deleteWorkerMessages(sessionId, workerId);
+      await interSessionMessageService.deleteWorkerMessages(sessionId, workerId, repositoryName);
     } catch (err) {
       logger.warn(
         { sessionId, workerId, err },
@@ -351,7 +365,8 @@ export class WorkerLifecycleManager {
     this.deps.workerManager.killWorker(existingWorker);
 
     // Reset the output file to prevent offset mismatch with client cache.
-    await workerOutputFileManager.resetWorkerOutput(sessionId, workerId);
+    const repositoryName = this.deps.getRepositoryName(session);
+    await workerOutputFileManager.resetWorkerOutput(sessionId, workerId, repositoryName);
 
     // Create new worker with same ID, preserving original createdAt for tab order
     const repositoryEnvVars = await this.deps.getRepositoryEnvVars(sessionId);
@@ -368,6 +383,7 @@ export class WorkerLifecycleManager {
       locationPath,
       repositoryEnvVars,
       username,
+      repositoryName,
       agentId: workerAgentId,
       continueConversation,
       repositoryId,
@@ -493,6 +509,7 @@ export class WorkerLifecycleManager {
     try {
       const repositoryEnvVars = await this.deps.getRepositoryEnvVars(sessionId);
       const repositoryId = session.type === 'worktree' ? session.repositoryId : undefined;
+      const repositoryName = this.deps.getRepositoryName(session);
       const username = await this.deps.resolveSpawnUsername(session.createdBy);
 
       if (existingWorker.type === 'agent') {
@@ -502,6 +519,7 @@ export class WorkerLifecycleManager {
           locationPath: session.locationPath,
           repositoryEnvVars,
           username,
+          repositoryName,
           agentId: effectiveAgentId,
           continueConversation: true,
           repositoryId,
@@ -514,6 +532,7 @@ export class WorkerLifecycleManager {
           locationPath: session.locationPath,
           repositoryEnvVars,
           username,
+          repositoryName,
         });
       }
     } catch (err) {
@@ -605,15 +624,18 @@ export class WorkerLifecycleManager {
     fromOffset?: number,
     maxLines?: number
   ): Promise<HistoryReadResult | null> {
+    const session = this.deps.getSession(sessionId);
     const worker = this.getWorker(sessionId, workerId);
     if (!worker || worker.type === 'git-diff') return null;
 
+    const repositoryName = session ? this.deps.getRepositoryName(session) : undefined;
+
     // Use line-limited read for initial connection (fromOffset is 0 or undefined)
     if (maxLines !== undefined && (fromOffset === undefined || fromOffset === 0)) {
-      return workerOutputFileManager.readLastNLines(sessionId, workerId, maxLines);
+      return workerOutputFileManager.readLastNLines(sessionId, workerId, maxLines, repositoryName);
     }
 
-    return workerOutputFileManager.readHistoryWithOffset(sessionId, workerId, fromOffset);
+    return workerOutputFileManager.readHistoryWithOffset(sessionId, workerId, fromOffset, repositoryName);
   }
 
   /**
@@ -622,10 +644,12 @@ export class WorkerLifecycleManager {
    * @returns Current file offset (0 if file doesn't exist)
    */
   async getCurrentOutputOffset(sessionId: string, workerId: string): Promise<number> {
+    const session = this.deps.getSession(sessionId);
     const worker = this.getWorker(sessionId, workerId);
     if (!worker || worker.type === 'git-diff') return 0;
 
-    return workerOutputFileManager.getCurrentOffset(sessionId, workerId);
+    const repositoryName = session ? this.deps.getRepositoryName(session) : undefined;
+    return workerOutputFileManager.getCurrentOffset(sessionId, workerId, repositoryName);
   }
 
   // ========== Private Helpers ==========
@@ -662,12 +686,12 @@ export class WorkerLifecycleManager {
    * Clean up worker output file via job queue.
    * If jobQueue is not available, logs a warning and skips cleanup gracefully.
    */
-  private async cleanupWorkerOutput(sessionId: string, workerId: string): Promise<void> {
+  private async cleanupWorkerOutput(sessionId: string, workerId: string, repositoryName?: string): Promise<void> {
     const jobQueue = this.deps.getJobQueue();
     if (!jobQueue) {
       logger.warn({ sessionId, workerId }, 'JobQueue not available, skipping async output cleanup');
       return;
     }
-    await jobQueue.enqueue(JOB_TYPES.CLEANUP_WORKER_OUTPUT, { sessionId, workerId });
+    await jobQueue.enqueue(JOB_TYPES.CLEANUP_WORKER_OUTPUT, { sessionId, workerId, repositoryName });
   }
 }

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -56,6 +56,8 @@ export interface WorkerContext {
   repositoryEnvVars: Record<string, string>;
   /** OS username for PTY process ownership. Used by MultiUserMode for sudo -u. */
   username: string;
+  /** Repository name (org/repo) for data directory resolution. Undefined for quick sessions. */
+  repositoryName?: string;
 }
 
 /**
@@ -354,7 +356,7 @@ export class WorkerManager {
     worker.activityState = 'idle';
     this.globalActivityCallback?.(sessionId, worker.id, 'idle');
 
-    this.setupWorkerEventHandlers(worker, sessionId);
+    this.setupWorkerEventHandlers(worker, sessionId, params.repositoryName);
   }
 
   /**
@@ -390,14 +392,14 @@ export class WorkerManager {
 
     worker.pty = ptyProcess;
 
-    this.setupWorkerEventHandlers(worker, sessionId);
+    this.setupWorkerEventHandlers(worker, sessionId, params.repositoryName);
   }
 
   /**
    * Setup event handlers for a PTY worker.
    * Stores disposables on the worker for cleanup when worker is killed.
    */
-  private setupWorkerEventHandlers(worker: InternalPtyWorker, sessionId: string): void {
+  private setupWorkerEventHandlers(worker: InternalPtyWorker, sessionId: string, repositoryName?: string): void {
     if (!sessionId || sessionId.trim() === '') {
       throw new Error(
         `Cannot setup event handlers: sessionId is required (got: ${sessionId === '' ? 'empty string' : String(sessionId)})`
@@ -419,7 +421,7 @@ export class WorkerManager {
 
       worker.outputOffset += Buffer.byteLength(data, 'utf-8');
 
-      workerOutputFileManager.bufferOutput(sessionId, worker.id, data);
+      workerOutputFileManager.bufferOutput(sessionId, worker.id, data, repositoryName);
 
       if (worker.type === 'agent' && worker.activityDetector) {
         worker.activityDetector.processOutput(data);

--- a/packages/shared/src/types/job.ts
+++ b/packages/shared/src/types/job.ts
@@ -65,6 +65,7 @@ export type JobType = (typeof JOB_TYPES)[keyof typeof JOB_TYPES];
  */
 export interface CleanupSessionOutputsPayload {
   sessionId: string;
+  repositoryName?: string;
 }
 
 /**
@@ -73,6 +74,7 @@ export interface CleanupSessionOutputsPayload {
 export interface CleanupWorkerOutputPayload {
   sessionId: string;
   workerId: string;
+  repositoryName?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Relocate session data (messages, outputs, memos) from top-level `~/.agent-console/` to repository-scoped paths `repositories/{org}/{repo}/`
- Quick sessions (no repository) use `_quick/` fallback directory
- No migration — old data at top-level paths is abandoned (ephemeral data)
- `data.db` remains at top level (cross-repository metadata)

## Changes
- **config.ts**: `getMessagesDir()`, `getMemosDir()`, `getOutputsDir()` now accept optional `repositoryName` parameter
- **InterSessionMessageService**: All methods accept `repositoryName` for scoped path resolution
- **MemoService**: All methods accept `repositoryName` for scoped path resolution
- **WorkerOutputFileManager**: All methods accept `repositoryName`; stored in `PendingFlush` for async flush operations
- **SessionManager**: Added `getRepositoryNameForSession()` and `getRepositoryNameForPersistedSession()` helpers; threads `repositoryName` through all service calls and job payloads
- **WorkerLifecycleManager**: Added `getRepositoryName` to deps interface; threads through worker output operations
- **WorkerManager**: Added `repositoryName` to `WorkerContext` for PTY data buffering
- **Job payloads**: `CleanupSessionOutputsPayload` and `CleanupWorkerOutputPayload` include `repositoryName`

## Test plan
- [x] Config path helpers return correct repository-scoped and quick-session paths
- [x] Messages directory under repository path — unit test
- [x] Outputs directory under repository path — unit test
- [x] Memos directory under repository path — unit test
- [x] Quick sessions use `_quick/` fallback — unit test
- [x] Session deletion cleans up from new paths — unit test
- [x] All existing tests updated and passing (1839 server + 9 integration)
- [x] Typecheck passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)