### PR TITLE
refactor: introduce context object to reduce parameter threading (#414)

### DIFF
--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -595,11 +595,13 @@ export function createMcpApp(deps: McpDependencies): Hono {
           agentId: selectedAgentId,
           initialPrompt: effectivePrompt,
           title: effectiveTitle,
-          parentSessionId,
-          parentWorkerId,
-          createdBy: parentCreatedBy,
           autoStartSession: true,
-          templateVars,
+          context: {
+            parentSessionId,
+            parentWorkerId,
+            createdBy: parentCreatedBy,
+            templateVars,
+          },
         }, sessionManager);
 
         if (!result.success) {

--- a/packages/server/src/routes/worktrees.ts
+++ b/packages/server/src/routes/worktrees.ts
@@ -131,8 +131,8 @@ const worktrees = new Hono<AppBindings>()
           agentId: selectedAgentId,
           initialPrompt,
           title: effectiveTitle,
-          createdBy: authUser.id,
           autoStartSession,
+          context: { createdBy: authUser.id },
         }, sessionManager);
 
         if (!result.success) {

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -140,6 +140,20 @@ describe('SessionManager', () => {
       expect(session.parentWorkerId).toBe('parent-wkr-456');
     });
 
+    it('should set createdBy from SessionCreationContext', async () => {
+      const manager = await getSessionManager();
+
+      const request: CreateSessionRequest = {
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      };
+
+      const session = await manager.createSession(request, { createdBy: 'user-abc' });
+
+      expect(session.createdBy).toBe('user-abc');
+    });
+
     it('should create a new quick session with correct properties', async () => {
       const manager = await getSessionManager();
 

--- a/packages/server/src/services/__tests__/worker-manager-env.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager-env.test.ts
@@ -263,7 +263,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         username: 'testuser',
         agentId: 'claude-code',
         continueConversation: false,
-        parentSessionId: 'parent-sess-abc',
+        context: { parentSessionId: 'parent-sess-abc' },
       });
 
       const env = getLastSpawnEnv();
@@ -280,14 +280,14 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         username: 'testuser',
         agentId: 'claude-code',
         continueConversation: false,
-        parentWorkerId: 'parent-wkr-xyz',
+        context: { parentWorkerId: 'parent-wkr-xyz' },
       });
 
       const env = getLastSpawnEnv();
       expect(env!.AGENT_CONSOLE_PARENT_WORKER_ID).toBe('parent-wkr-xyz');
     });
 
-    it('should NOT include parent env vars when parentSessionId/parentWorkerId are not provided', async () => {
+    it('should NOT include parent env vars when context is not provided', async () => {
       const worker = createTestAgentWorker();
 
       await workerManager.activateAgentWorkerPty(worker, {
@@ -297,7 +297,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         username: 'testuser',
         agentId: 'claude-code',
         continueConversation: false,
-        // parentSessionId and parentWorkerId are intentionally omitted
+        // context is intentionally omitted
       });
 
       const env = getLastSpawnEnv();
@@ -319,8 +319,10 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         username: 'testuser',
         agentId: 'claude-code',
         continueConversation: false,
-        parentSessionId: 'real-parent-session',
-        parentWorkerId: 'real-parent-worker',
+        context: {
+          parentSessionId: 'real-parent-session',
+          parentWorkerId: 'real-parent-worker',
+        },
       });
 
       const env = getLastSpawnEnv();

--- a/packages/server/src/services/__tests__/worktree-creation-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-creation-service.test.ts
@@ -229,6 +229,30 @@ describe('createWorktreeWithSession', () => {
     expect(sm.createSession).not.toHaveBeenCalled();
   });
 
+  it('passes context object (createdBy, parentSessionId, parentWorkerId, templateVars) to createSession', async () => {
+    const sm = createMockSessionManager();
+    const context = {
+      createdBy: 'user-123',
+      parentSessionId: 'parent-sess-1',
+      parentWorkerId: 'parent-wkr-1',
+      templateVars: { model: 'opus' },
+    };
+
+    await createWorktreeWithSession(
+      { ...DEFAULT_PARAMS, initialPrompt: 'do stuff', title: 'My Task', context },
+      sm,
+    );
+
+    expect(sm.createSession).toHaveBeenCalledTimes(1);
+    const [sessionRequest, passedContext] = sm.createSession.mock.calls[0];
+    // Context fields are mapped to the request for schema compatibility
+    expect(sessionRequest.parentSessionId).toBe('parent-sess-1');
+    expect(sessionRequest.parentWorkerId).toBe('parent-wkr-1');
+    expect(sessionRequest.templateVars).toEqual({ model: 'opus' });
+    // createdBy is passed via the context parameter
+    expect(passedContext).toEqual(context);
+  });
+
   it('returns original error even when rollback fails', async () => {
     const sm = createMockSessionManager();
     sm.createSession.mockImplementation(() => Promise.reject(new Error('original error')));

--- a/packages/server/src/services/internal-types.ts
+++ b/packages/server/src/services/internal-types.ts
@@ -7,6 +7,22 @@
 
 import type { InternalWorker } from './worker-types.js';
 
+/**
+ * Context object for session/worker creation chain.
+ * Constructed at entry points (REST/MCP handlers) and passed through:
+ *   worktree-creation-service → session-manager → worker-lifecycle-manager → worker-manager
+ */
+export interface SessionCreationContext {
+  /** User UUID (from users table) of the user who created this session */
+  createdBy?: string;
+  /** Parent session ID that delegated this session */
+  parentSessionId?: string;
+  /** Parent worker ID that delegated this session */
+  parentWorkerId?: string;
+  /** Custom template variable overrides for agent command templates */
+  templateVars?: Record<string, string>;
+}
+
 export interface InternalSessionBase {
   id: string;
   locationPath: string;

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -24,7 +24,7 @@ import type {
   InternalTerminalWorker,
   WorkerCallbacks,
 } from './worker-types.js';
-import type { InternalSession } from './internal-types.js';
+import type { InternalSession, SessionCreationContext } from './internal-types.js';
 import { WorkerManager } from './worker-manager.js';
 import { WorkerLifecycleManager, type RestoreWorkerResult } from './worker-lifecycle-manager.js';
 import { CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
@@ -528,7 +528,7 @@ export class SessionManager {
 
   // ========== Session Lifecycle ==========
 
-  async createSession(request: CreateSessionRequest, options?: { createdBy?: string }): Promise<Session> {
+  async createSession(request: CreateSessionRequest, context?: SessionCreationContext): Promise<Session> {
     const id = crypto.randomUUID();
     const createdAt = new Date().toISOString();
 
@@ -542,7 +542,7 @@ export class SessionManager {
       title: request.title,
       parentSessionId: request.parentSessionId,
       parentWorkerId: request.parentWorkerId,
-      createdBy: options?.createdBy,
+      createdBy: context?.createdBy,
     };
 
     const internalSession: InternalSession = request.type === 'worktree'
@@ -567,7 +567,7 @@ export class SessionManager {
         type: 'agent',
         agentId: effectiveAgentId,
         // name is not specified; generateWorkerName will use the agent's name
-      }, request.continueConversation ?? false, request.initialPrompt, request.templateVars),
+      }, request.continueConversation ?? false, request.initialPrompt, request.templateVars ?? context?.templateVars),
       this.createWorker(id, {
         type: 'git-diff',
         name: 'Diff',
@@ -940,8 +940,10 @@ export class SessionManager {
             agentId: worker.agentId,
             continueConversation: true,
             repositoryId,
-            parentSessionId: internalSession.parentSessionId,
-            parentWorkerId: internalSession.parentWorkerId,
+            context: {
+              parentSessionId: internalSession.parentSessionId,
+              parentWorkerId: internalSession.parentWorkerId,
+            },
           });
           activatedWorkers.push(worker);
         } else if (worker.type === 'terminal') {

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -102,7 +102,7 @@ export class WorkerLifecycleManager {
     request: CreateWorkerParams,
     continueConversation: boolean = false,
     initialPrompt?: string,
-    templateVars?: Record<string, string>
+    templateVars?: Record<string, string>,
   ): Promise<Worker | null> {
     const session = this.deps.getSession(sessionId);
     if (!session) return null;
@@ -135,9 +135,11 @@ export class WorkerLifecycleManager {
         continueConversation,
         initialPrompt,
         repositoryId,
-        parentSessionId: session.parentSessionId,
-        parentWorkerId: session.parentWorkerId,
-        templateVars,
+        context: {
+          parentSessionId: session.parentSessionId,
+          parentWorkerId: session.parentWorkerId,
+          templateVars,
+        },
       });
       worker = agentWorker;
     } else if (request.type === 'terminal') {
@@ -234,8 +236,10 @@ export class WorkerLifecycleManager {
         agentId: effectiveAgentId,
         continueConversation: true,
         repositoryId,
-        parentSessionId: session.parentSessionId,
-        parentWorkerId: session.parentWorkerId,
+        context: {
+          parentSessionId: session.parentSessionId,
+          parentWorkerId: session.parentWorkerId,
+        },
       });
     } else {
       this.deps.workerManager.activateTerminalWorkerPty(worker, {
@@ -389,8 +393,10 @@ export class WorkerLifecycleManager {
       agentId: workerAgentId,
       continueConversation,
       repositoryId,
-      parentSessionId: session.parentSessionId,
-      parentWorkerId: session.parentWorkerId,
+      context: {
+        parentSessionId: session.parentSessionId,
+        parentWorkerId: session.parentWorkerId,
+      },
     });
 
     // Re-check session still exists after async gap
@@ -525,8 +531,10 @@ export class WorkerLifecycleManager {
           agentId: effectiveAgentId,
           continueConversation: true,
           repositoryId,
-          parentSessionId: session.parentSessionId,
-          parentWorkerId: session.parentWorkerId,
+          context: {
+            parentSessionId: session.parentSessionId,
+            parentWorkerId: session.parentWorkerId,
+          },
         });
       } else {
         this.deps.workerManager.activateTerminalWorkerPty(existingWorker, {

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -34,6 +34,7 @@ import type {
   WorkerCallbacks,
   Disposable,
 } from './worker-types.js';
+import type { SessionCreationContext } from './internal-types.js';
 import type { UserMode, AgentConsoleContext } from './user-mode.js';
 import { ActivityDetector } from './activity-detector.js';
 import { CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
@@ -99,12 +100,8 @@ export interface AgentActivationParams extends WorkerContext {
   initialPrompt?: string;
   /** Repository ID for worktree sessions. Omit for quick sessions. */
   repositoryId?: string;
-  /** Parent session ID for delegated sessions */
-  parentSessionId?: string;
-  /** Parent worker ID for delegated sessions */
-  parentWorkerId?: string;
-  /** Custom template variable overrides for agent command templates */
-  templateVars?: Record<string, string>;
+  /** Session creation context holding delegation and template information */
+  context?: SessionCreationContext;
 }
 
 /**
@@ -284,7 +281,7 @@ export class WorkerManager {
       return;
     }
 
-    const { sessionId, locationPath, agentId, continueConversation, initialPrompt, repositoryEnvVars, repositoryId, parentSessionId, parentWorkerId, templateVars } = params;
+    const { sessionId, locationPath, agentId, continueConversation, initialPrompt, repositoryEnvVars, repositoryId, context } = params;
 
     const agentManager = this.agentManager;
     const requestedAgent = agentManager.getAgent(agentId);
@@ -304,7 +301,7 @@ export class WorkerManager {
       template,
       prompt: initialPrompt,
       cwd: locationPath,
-      templateVars,
+      templateVars: context?.templateVars,
     });
 
     // Build AgentConsole context so the agent knows its own identity.
@@ -314,8 +311,8 @@ export class WorkerManager {
       sessionId,
       workerId: worker.id,
       repositoryId,
-      parentSessionId,
-      parentWorkerId,
+      parentSessionId: context?.parentSessionId,
+      parentWorkerId: context?.parentWorkerId,
     };
 
     // additionalEnvVars: repository + template env vars

--- a/packages/server/src/services/worktree-creation-service.ts
+++ b/packages/server/src/services/worktree-creation-service.ts
@@ -1,6 +1,7 @@
 import type { Worktree, HookCommandResult } from '@agent-console/shared';
 import type { Session } from '@agent-console/shared';
 import type { SessionManager } from './session-manager.js';
+import type { SessionCreationContext } from './internal-types.js';
 import { worktreeService } from './worktree-service.js';
 import { fetchRemote } from '../lib/git.js';
 import { createLogger } from '../lib/logger.js';
@@ -29,11 +30,8 @@ export interface CreateWorktreeParams {
   agentId: string;
   initialPrompt?: string;
   title?: string;
-  parentSessionId?: string;
-  parentWorkerId?: string;
-  createdBy?: string;
   autoStartSession?: boolean;  // Defaults to true. When false, skip session creation.
-  templateVars?: Record<string, string>;
+  context?: SessionCreationContext;
 }
 
 export interface CreateWorktreeResult {
@@ -58,9 +56,8 @@ export async function createWorktreeWithSession(
   const {
     repoPath, repoId, repoName, setupCommand, branch, baseBranch,
     useRemote, agentId, initialPrompt, title,
-    parentSessionId, parentWorkerId, createdBy,
     autoStartSession = true,
-    templateVars,
+    context,
   } = params;
 
   // 1. Handle remote fetch if requested
@@ -127,10 +124,10 @@ export async function createWorktreeWithSession(
         agentId,
         initialPrompt,
         title,
-        parentSessionId,
-        parentWorkerId,
-        templateVars,
-      }, { createdBy });
+        parentSessionId: context?.parentSessionId,
+        parentWorkerId: context?.parentWorkerId,
+        templateVars: context?.templateVars,
+      }, context);
     }
 
     logger.info({ repoId, worktreePath: worktree.path, branch: worktree.branch }, 'Worktree creation completed');


### PR DESCRIPTION
## Summary
- Define `SessionCreationContext` type in `internal-types.ts` holding `createdBy`, `parentSessionId`, `parentWorkerId`, `templateVars`
- Replace individual parameter fields in `CreateWorktreeParams` with a single `context` field
- Thread the context object through the full creation chain: REST/MCP entry points → `worktree-creation-service` → `session-manager` → `worker-lifecycle-manager` → `worker-manager`
- Update `AgentActivationParams` to use `context` field instead of individual `parentSessionId`/`parentWorkerId`/`templateVars` fields

## Test plan
- [x] All existing unit tests pass (1857 server tests, 1157 client tests, 224 shared tests)
- [x] All existing integration tests pass (9 tests)
- [x] TypeScript typecheck passes for all packages
- [x] New test: verify context object is correctly threaded from `createWorktreeWithSession` to `createSession`
- [x] New test: verify `createdBy` is set from `SessionCreationContext` in `createSession`
- [x] Updated env tests: verify parent env vars use `context` field in `AgentActivationParams`

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)