### PR TITLE
refactor: unify session data path resolution into a single resolver (#415)

### DIFF
--- a/packages/server/src/jobs/handlers.ts
+++ b/packages/server/src/jobs/handlers.ts
@@ -13,6 +13,7 @@ import {
   type CleanupRepositoryPayload,
 } from './job-types.js';
 import { workerOutputFileManager } from '../lib/worker-output-file.js';
+import { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import { createLogger } from '../lib/logger.js';
 
 const logger = createLogger('job-handlers');
@@ -26,8 +27,9 @@ export function registerJobHandlers(jobQueue: JobQueue): void {
   jobQueue.registerHandler<CleanupSessionOutputsPayload>(
     JOB_TYPES.CLEANUP_SESSION_OUTPUTS,
     async ({ sessionId, repositoryName }) => {
+      const resolver = new SessionDataPathResolver(repositoryName);
       logger.debug({ sessionId, repositoryName }, 'Executing cleanup:session-outputs job');
-      await workerOutputFileManager.deleteSessionOutputs(sessionId, repositoryName);
+      await workerOutputFileManager.deleteSessionOutputs(sessionId, resolver);
       logger.info({ sessionId }, 'Session outputs cleanup completed');
     }
   );
@@ -36,8 +38,9 @@ export function registerJobHandlers(jobQueue: JobQueue): void {
   jobQueue.registerHandler<CleanupWorkerOutputPayload>(
     JOB_TYPES.CLEANUP_WORKER_OUTPUT,
     async ({ sessionId, workerId, repositoryName }) => {
+      const resolver = new SessionDataPathResolver(repositoryName);
       logger.debug({ sessionId, workerId, repositoryName }, 'Executing cleanup:worker-output job');
-      await workerOutputFileManager.deleteWorkerOutput(sessionId, workerId, repositoryName);
+      await workerOutputFileManager.deleteWorkerOutput(sessionId, workerId, resolver);
       logger.info({ sessionId, workerId }, 'Worker output cleanup completed');
     }
   );

--- a/packages/server/src/lib/__tests__/config.test.ts
+++ b/packages/server/src/lib/__tests__/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as os from 'os';
 import * as path from 'path';
-import { getConfigDir, getRepositoriesDir, getRepositoryDir, getMessagesDir, getOutputsDir, getMemosDir, getServerPid } from '../config.js';
+import { getConfigDir, getRepositoriesDir, getRepositoryDir, getServerPid } from '../config.js';
 
 describe('config', () => {
   const originalEnv = process.env.AGENT_CONSOLE_HOME;
@@ -62,48 +62,6 @@ describe('config', () => {
       process.env.AGENT_CONSOLE_HOME = '/custom/path';
 
       expect(getRepositoriesDir()).toBe('/custom/path/repositories');
-    });
-  });
-
-  describe('getMessagesDir', () => {
-    it('should return _quick/messages when repositoryName is not provided', () => {
-      process.env.AGENT_CONSOLE_HOME = '/custom/path';
-
-      expect(getMessagesDir()).toBe('/custom/path/_quick/messages');
-    });
-
-    it('should return repository-scoped messages dir when repositoryName is provided', () => {
-      process.env.AGENT_CONSOLE_HOME = '/custom/path';
-
-      expect(getMessagesDir('org/repo')).toBe('/custom/path/repositories/org/repo/messages');
-    });
-  });
-
-  describe('getOutputsDir', () => {
-    it('should return _quick/outputs when repositoryName is not provided', () => {
-      process.env.AGENT_CONSOLE_HOME = '/custom/path';
-
-      expect(getOutputsDir()).toBe('/custom/path/_quick/outputs');
-    });
-
-    it('should return repository-scoped outputs dir when repositoryName is provided', () => {
-      process.env.AGENT_CONSOLE_HOME = '/custom/path';
-
-      expect(getOutputsDir('org/repo')).toBe('/custom/path/repositories/org/repo/outputs');
-    });
-  });
-
-  describe('getMemosDir', () => {
-    it('should return _quick/memos when repositoryName is not provided', () => {
-      process.env.AGENT_CONSOLE_HOME = '/custom/path';
-
-      expect(getMemosDir()).toBe('/custom/path/_quick/memos');
-    });
-
-    it('should return repository-scoped memos dir when repositoryName is provided', () => {
-      process.env.AGENT_CONSOLE_HOME = '/custom/path';
-
-      expect(getMemosDir('org/repo')).toBe('/custom/path/repositories/org/repo/memos');
     });
   });
 

--- a/packages/server/src/lib/__tests__/session-data-path-resolver.test.ts
+++ b/packages/server/src/lib/__tests__/session-data-path-resolver.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { SessionDataPathResolver } from '../session-data-path-resolver.js';
+
+const TEST_CONFIG_DIR = '/test/config';
+const ORIGINAL_AGENT_CONSOLE_HOME = process.env.AGENT_CONSOLE_HOME;
+
+describe('SessionDataPathResolver', () => {
+  beforeEach(() => {
+    process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_AGENT_CONSOLE_HOME === undefined) {
+      delete process.env.AGENT_CONSOLE_HOME;
+    } else {
+      process.env.AGENT_CONSOLE_HOME = ORIGINAL_AGENT_CONSOLE_HOME;
+    }
+  });
+
+  describe('with repositoryName', () => {
+    it('should resolve messages dir under repository path', () => {
+      const resolver = new SessionDataPathResolver('myorg/myrepo');
+      expect(resolver.getMessagesDir()).toBe(`${TEST_CONFIG_DIR}/repositories/myorg/myrepo/messages`);
+    });
+
+    it('should resolve memos dir under repository path', () => {
+      const resolver = new SessionDataPathResolver('myorg/myrepo');
+      expect(resolver.getMemosDir()).toBe(`${TEST_CONFIG_DIR}/repositories/myorg/myrepo/memos`);
+    });
+
+    it('should resolve memos path with .md extension', () => {
+      const resolver = new SessionDataPathResolver('myorg/myrepo');
+      expect(resolver.getMemosPath('session-1')).toBe(
+        `${TEST_CONFIG_DIR}/repositories/myorg/myrepo/memos/session-1.md`,
+      );
+    });
+
+    it('should resolve outputs dir under repository path', () => {
+      const resolver = new SessionDataPathResolver('myorg/myrepo');
+      expect(resolver.getOutputsDir()).toBe(`${TEST_CONFIG_DIR}/repositories/myorg/myrepo/outputs`);
+    });
+
+    it('should resolve output file path with .log extension', () => {
+      const resolver = new SessionDataPathResolver('myorg/myrepo');
+      expect(resolver.getOutputFilePath('session-1', 'worker-1')).toBe(
+        `${TEST_CONFIG_DIR}/repositories/myorg/myrepo/outputs/session-1/worker-1.log`,
+      );
+    });
+  });
+
+  describe('without repositoryName', () => {
+    it('should resolve messages dir under _quick path', () => {
+      const resolver = new SessionDataPathResolver();
+      expect(resolver.getMessagesDir()).toBe(`${TEST_CONFIG_DIR}/_quick/messages`);
+    });
+
+    it('should resolve memos dir under _quick path', () => {
+      const resolver = new SessionDataPathResolver();
+      expect(resolver.getMemosDir()).toBe(`${TEST_CONFIG_DIR}/_quick/memos`);
+    });
+
+    it('should resolve memos path with .md extension under _quick', () => {
+      const resolver = new SessionDataPathResolver();
+      expect(resolver.getMemosPath('session-abc')).toBe(
+        `${TEST_CONFIG_DIR}/_quick/memos/session-abc.md`,
+      );
+    });
+
+    it('should resolve outputs dir under _quick path', () => {
+      const resolver = new SessionDataPathResolver();
+      expect(resolver.getOutputsDir()).toBe(`${TEST_CONFIG_DIR}/_quick/outputs`);
+    });
+
+    it('should resolve output file path under _quick', () => {
+      const resolver = new SessionDataPathResolver();
+      expect(resolver.getOutputFilePath('session-1', 'worker-1')).toBe(
+        `${TEST_CONFIG_DIR}/_quick/outputs/session-1/worker-1.log`,
+      );
+    });
+  });
+
+  describe('with undefined repositoryName', () => {
+    it('should behave the same as no argument', () => {
+      const resolver = new SessionDataPathResolver(undefined);
+      expect(resolver.getMessagesDir()).toBe(`${TEST_CONFIG_DIR}/_quick/messages`);
+      expect(resolver.getOutputsDir()).toBe(`${TEST_CONFIG_DIR}/_quick/outputs`);
+    });
+  });
+});

--- a/packages/server/src/lib/__tests__/worker-output-file.test.ts
+++ b/packages/server/src/lib/__tests__/worker-output-file.test.ts
@@ -2,12 +2,16 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { vol } from 'memfs';
 import { WorkerOutputFileManager } from '../worker-output-file.js';
+import { SessionDataPathResolver } from '../session-data-path-resolver.js';
 
 // Test-specific config values for worker output file tests
 // Note: These are used directly in the tests that need smaller values
 const TEST_WORKER_OUTPUT_FILE_MAX_SIZE = 1024; // 1KB for easier testing
 const TEST_WORKER_OUTPUT_FLUSH_INTERVAL = 100; // 100ms (same as default)
 const TEST_WORKER_OUTPUT_FLUSH_THRESHOLD = 256; // 256 bytes for easier testing
+
+const quickResolver = new SessionDataPathResolver();
+const repoResolver = new SessionDataPathResolver('org/repo');
 
 describe('WorkerOutputFileManager', () => {
   const TEST_CONFIG_DIR = '/test/config';
@@ -29,12 +33,12 @@ describe('WorkerOutputFileManager', () => {
 
   describe('getOutputFilePath', () => {
     it('should return correct path structure', () => {
-      const path = manager.getOutputFilePath('session-1', 'worker-1');
+      const path = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       expect(path).toBe(`${TEST_CONFIG_DIR}/_quick/outputs/session-1/worker-1.log`);
     });
 
     it('should handle special characters in IDs', () => {
-      const path = manager.getOutputFilePath('session_123', 'worker-abc');
+      const path = manager.getOutputFilePath('session_123', 'worker-abc', quickResolver);
       expect(path).toBe(`${TEST_CONFIG_DIR}/_quick/outputs/session_123/worker-abc.log`);
     });
   });
@@ -42,20 +46,20 @@ describe('WorkerOutputFileManager', () => {
   describe('bufferOutput and flush', () => {
     it('should buffer output data', () => {
       // Use unique IDs to avoid interference with other tests
-      manager.bufferOutput('session-buffer', 'worker-buffer', 'test data');
+      manager.bufferOutput('session-buffer', 'worker-buffer', 'test data', quickResolver);
 
       // Data is buffered, not yet written to file
-      const filePath = manager.getOutputFilePath('session-buffer', 'worker-buffer');
+      const filePath = manager.getOutputFilePath('session-buffer', 'worker-buffer', quickResolver);
       expect(vol.existsSync(filePath)).toBe(false);
     });
 
     it('should flush buffer after interval', async () => {
-      manager.bufferOutput('session-flush', 'worker-flush', 'test data');
+      manager.bufferOutput('session-flush', 'worker-flush', 'test data', quickResolver);
 
       // Wait for flush interval to trigger
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const filePath = manager.getOutputFilePath('session-flush', 'worker-flush');
+      const filePath = manager.getOutputFilePath('session-flush', 'worker-flush', quickResolver);
       expect(vol.existsSync(filePath)).toBe(true);
 
       const content = vol.readFileSync(filePath, 'utf-8');
@@ -63,14 +67,14 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should accumulate multiple buffers before flush', async () => {
-      manager.bufferOutput('session-1', 'worker-1', 'part1');
-      manager.bufferOutput('session-1', 'worker-1', 'part2');
-      manager.bufferOutput('session-1', 'worker-1', 'part3');
+      manager.bufferOutput('session-1', 'worker-1', 'part1', quickResolver);
+      manager.bufferOutput('session-1', 'worker-1', 'part2', quickResolver);
+      manager.bufferOutput('session-1', 'worker-1', 'part3', quickResolver);
 
       // Wait for flush
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       const content = vol.readFileSync(filePath, 'utf-8');
       expect(content).toBe('part1part2part3');
     });
@@ -78,12 +82,12 @@ describe('WorkerOutputFileManager', () => {
     it('should flush immediately when buffer exceeds threshold', async () => {
       // Create data larger than threshold (256 bytes)
       const largeData = 'x'.repeat(300);
-      manager.bufferOutput('session-1', 'worker-1', largeData);
+      manager.bufferOutput('session-1', 'worker-1', largeData, quickResolver);
 
       // Small delay to allow async flush to complete
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       expect(vol.existsSync(filePath)).toBe(true);
 
       const content = vol.readFileSync(filePath, 'utf-8');
@@ -92,39 +96,39 @@ describe('WorkerOutputFileManager', () => {
 
     it('should append to existing file', async () => {
       // First flush
-      manager.bufferOutput('session-1', 'worker-1', 'first');
+      manager.bufferOutput('session-1', 'worker-1', 'first', quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
       // Second flush
-      manager.bufferOutput('session-1', 'worker-1', 'second');
+      manager.bufferOutput('session-1', 'worker-1', 'second', quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       const content = vol.readFileSync(filePath, 'utf-8');
       expect(content).toBe('firstsecond');
     });
 
     it('should handle multiple workers independently', async () => {
-      manager.bufferOutput('session-1', 'worker-1', 'worker1-data');
-      manager.bufferOutput('session-1', 'worker-2', 'worker2-data');
+      manager.bufferOutput('session-1', 'worker-1', 'worker1-data', quickResolver);
+      manager.bufferOutput('session-1', 'worker-2', 'worker2-data', quickResolver);
 
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const path1 = manager.getOutputFilePath('session-1', 'worker-1');
-      const path2 = manager.getOutputFilePath('session-1', 'worker-2');
+      const path1 = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
+      const path2 = manager.getOutputFilePath('session-1', 'worker-2', quickResolver);
 
       expect(vol.readFileSync(path1, 'utf-8')).toBe('worker1-data');
       expect(vol.readFileSync(path2, 'utf-8')).toBe('worker2-data');
     });
 
     it('should handle multiple sessions independently', async () => {
-      manager.bufferOutput('session-1', 'worker-1', 'session1-data');
-      manager.bufferOutput('session-2', 'worker-1', 'session2-data');
+      manager.bufferOutput('session-1', 'worker-1', 'session1-data', quickResolver);
+      manager.bufferOutput('session-2', 'worker-1', 'session2-data', quickResolver);
 
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const path1 = manager.getOutputFilePath('session-1', 'worker-1');
-      const path2 = manager.getOutputFilePath('session-2', 'worker-1');
+      const path1 = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
+      const path2 = manager.getOutputFilePath('session-2', 'worker-1', quickResolver);
 
       expect(vol.readFileSync(path1, 'utf-8')).toBe('session1-data');
       expect(vol.readFileSync(path2, 'utf-8')).toBe('session2-data');
@@ -134,11 +138,11 @@ describe('WorkerOutputFileManager', () => {
   describe('readHistoryWithOffset', () => {
     it('should read full history when no offset specified', async () => {
       // Create file with content
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world');
 
-      const result = await manager.readHistoryWithOffset('session-1', 'worker-1');
+      const result = await manager.readHistoryWithOffset('session-1', 'worker-1', quickResolver);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('hello world');
@@ -146,12 +150,12 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should read history from specific offset', async () => {
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world');
 
       // Read from offset 6 (skip 'hello ')
-      const result = await manager.readHistoryWithOffset('session-1', 'worker-1', 6);
+      const result = await manager.readHistoryWithOffset('session-1', 'worker-1', quickResolver, 6);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('world');
@@ -159,11 +163,11 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should return empty data when offset equals file size', async () => {
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world');
 
-      const result = await manager.readHistoryWithOffset('session-1', 'worker-1', 11);
+      const result = await manager.readHistoryWithOffset('session-1', 'worker-1', quickResolver, 11);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('');
@@ -171,12 +175,12 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should return full history when offset exceeds file size (truncation resync)', async () => {
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world');
 
       // Client has offset 100 but file is only 11 bytes — file was truncated
-      const result = await manager.readHistoryWithOffset('session-1', 'worker-1', 100);
+      const result = await manager.readHistoryWithOffset('session-1', 'worker-1', quickResolver, 100);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('hello world');
@@ -184,7 +188,7 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should return empty history for non-existent file', async () => {
-      const result = await manager.readHistoryWithOffset('nonexistent', 'worker-1');
+      const result = await manager.readHistoryWithOffset('nonexistent', 'worker-1', quickResolver);
       // Returns empty history instead of null to support newly created workers
       expect(result).not.toBeNull();
       expect(result!.data).toBe('');
@@ -192,10 +196,10 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should return pending buffer when file does not exist', async () => {
-      manager.bufferOutput('session-1', 'worker-1', 'pending data');
+      manager.bufferOutput('session-1', 'worker-1', 'pending data', quickResolver);
 
       // File doesn't exist yet, but buffer has data
-      const result = await manager.readHistoryWithOffset('session-1', 'worker-1');
+      const result = await manager.readHistoryWithOffset('session-1', 'worker-1', quickResolver);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('pending data');
@@ -206,9 +210,9 @@ describe('WorkerOutputFileManager', () => {
       // Japanese characters: 3 bytes each in UTF-8
       // 'テスト' = 3 characters, but 9 bytes in UTF-8
       const multiByteData = 'テスト';
-      manager.bufferOutput('session-1', 'worker-1', multiByteData);
+      manager.bufferOutput('session-1', 'worker-1', multiByteData, quickResolver);
 
-      const result = await manager.readHistoryWithOffset('session-1', 'worker-1');
+      const result = await manager.readHistoryWithOffset('session-1', 'worker-1', quickResolver);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('テスト');
@@ -220,35 +224,35 @@ describe('WorkerOutputFileManager', () => {
 
   describe('getCurrentOffset', () => {
     it('should return file size when file exists', async () => {
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world');
 
-      const offset = await manager.getCurrentOffset('session-1', 'worker-1');
+      const offset = await manager.getCurrentOffset('session-1', 'worker-1', quickResolver);
       expect(offset).toBe(11);
     });
 
     it('should return 0 for non-existent file', async () => {
-      const offset = await manager.getCurrentOffset('nonexistent', 'worker-1');
+      const offset = await manager.getCurrentOffset('nonexistent', 'worker-1', quickResolver);
       expect(offset).toBe(0);
     });
 
     it('should flush pending buffer before returning offset', async () => {
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'hello'); // 5 bytes
 
-      manager.bufferOutput('session-1', 'worker-1', ' world'); // 6 bytes pending
+      manager.bufferOutput('session-1', 'worker-1', ' world', quickResolver); // 6 bytes pending
 
       // getCurrentOffset flushes buffer first, so we get total file size
-      const offset = await manager.getCurrentOffset('session-1', 'worker-1');
+      const offset = await manager.getCurrentOffset('session-1', 'worker-1', quickResolver);
       expect(offset).toBe(11); // 5 + 6
     });
 
     it('should return pending buffer size when only buffer exists', async () => {
-      manager.bufferOutput('session-1', 'worker-1', 'pending');
+      manager.bufferOutput('session-1', 'worker-1', 'pending', quickResolver);
 
-      const offset = await manager.getCurrentOffset('session-1', 'worker-1');
+      const offset = await manager.getCurrentOffset('session-1', 'worker-1', quickResolver);
       expect(offset).toBe(7);
     });
   });
@@ -260,15 +264,15 @@ describe('WorkerOutputFileManager', () => {
 
       // Write 500 bytes first
       const chunk1 = 'A'.repeat(500);
-      manager.bufferOutput('session-1', 'worker-1', chunk1);
+      manager.bufferOutput('session-1', 'worker-1', chunk1, quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
       // Write another 600 bytes (total: 1100 bytes, exceeds 1024 limit)
       const chunk2 = 'B'.repeat(600);
-      manager.bufferOutput('session-1', 'worker-1', chunk2);
+      manager.bufferOutput('session-1', 'worker-1', chunk2, quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       const content = vol.readFileSync(filePath, 'utf-8') as string;
 
       // File should be truncated to ~80% of max size (819 bytes)
@@ -280,14 +284,14 @@ describe('WorkerOutputFileManager', () => {
     it('should keep most recent data after truncation', async () => {
       // Write enough data to trigger truncation
       const oldData = 'OLD_'.repeat(300); // 1200 bytes
-      manager.bufferOutput('session-1', 'worker-1', oldData);
+      manager.bufferOutput('session-1', 'worker-1', oldData, quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
       const newData = 'NEW_'.repeat(50); // 200 bytes
-      manager.bufferOutput('session-1', 'worker-1', newData);
+      manager.bufferOutput('session-1', 'worker-1', newData, quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       const content = vol.readFileSync(filePath, 'utf-8') as string;
 
       // New data should be preserved
@@ -297,42 +301,42 @@ describe('WorkerOutputFileManager', () => {
 
   describe('deleteWorkerOutput', () => {
     it('should delete worker output file', async () => {
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'content');
 
-      await manager.deleteWorkerOutput('session-1', 'worker-1');
+      await manager.deleteWorkerOutput('session-1', 'worker-1', quickResolver);
 
       expect(vol.existsSync(filePath)).toBe(false);
     });
 
     it('should clear pending buffer when deleting', async () => {
-      manager.bufferOutput('session-1', 'worker-1', 'pending');
+      manager.bufferOutput('session-1', 'worker-1', 'pending', quickResolver);
 
-      await manager.deleteWorkerOutput('session-1', 'worker-1');
+      await manager.deleteWorkerOutput('session-1', 'worker-1', quickResolver);
 
       // After deletion, offset should be 0
-      const offset = await manager.getCurrentOffset('session-1', 'worker-1');
+      const offset = await manager.getCurrentOffset('session-1', 'worker-1', quickResolver);
       expect(offset).toBe(0);
     });
 
     it('should not throw for non-existent file', async () => {
       await expect(
-        manager.deleteWorkerOutput('nonexistent', 'worker-1')
+        manager.deleteWorkerOutput('nonexistent', 'worker-1', quickResolver)
       ).resolves.toBeUndefined();
     });
 
     it('should cancel pending flush timer when deleting', async () => {
-      manager.bufferOutput('session-1', 'worker-1', 'pending');
+      manager.bufferOutput('session-1', 'worker-1', 'pending', quickResolver);
 
       // Delete before flush timer fires
-      await manager.deleteWorkerOutput('session-1', 'worker-1');
+      await manager.deleteWorkerOutput('session-1', 'worker-1', quickResolver);
 
       // Wait for what would be the flush interval
       await new Promise(resolve => setTimeout(resolve, 150));
 
       // File should not exist since we deleted before flush
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       expect(vol.existsSync(filePath)).toBe(false);
     });
   });
@@ -345,7 +349,7 @@ describe('WorkerOutputFileManager', () => {
       vol.writeFileSync(`${sessionDir}/worker-2.log`, 'content2');
       vol.writeFileSync(`${sessionDir}/worker-3.log`, 'content3');
 
-      await manager.deleteSessionOutputs('session-1');
+      await manager.deleteSessionOutputs('session-1', quickResolver);
 
       expect(vol.existsSync(sessionDir)).toBe(false);
     });
@@ -358,7 +362,7 @@ describe('WorkerOutputFileManager', () => {
       vol.writeFileSync(`${session1Dir}/worker-1.log`, 'content1');
       vol.writeFileSync(`${session2Dir}/worker-1.log`, 'content2');
 
-      await manager.deleteSessionOutputs('session-1');
+      await manager.deleteSessionOutputs('session-1', quickResolver);
 
       expect(vol.existsSync(session1Dir)).toBe(false);
       expect(vol.existsSync(session2Dir)).toBe(true);
@@ -366,37 +370,37 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should clear all pending buffers for the session', async () => {
-      manager.bufferOutput('session-1', 'worker-1', 'pending1');
-      manager.bufferOutput('session-1', 'worker-2', 'pending2');
-      manager.bufferOutput('session-2', 'worker-1', 'pending3');
+      manager.bufferOutput('session-1', 'worker-1', 'pending1', quickResolver);
+      manager.bufferOutput('session-1', 'worker-2', 'pending2', quickResolver);
+      manager.bufferOutput('session-2', 'worker-1', 'pending3', quickResolver);
 
-      await manager.deleteSessionOutputs('session-1');
+      await manager.deleteSessionOutputs('session-1', quickResolver);
 
       // Session-1 workers should have 0 offset
-      expect(await manager.getCurrentOffset('session-1', 'worker-1')).toBe(0);
-      expect(await manager.getCurrentOffset('session-1', 'worker-2')).toBe(0);
+      expect(await manager.getCurrentOffset('session-1', 'worker-1', quickResolver)).toBe(0);
+      expect(await manager.getCurrentOffset('session-1', 'worker-2', quickResolver)).toBe(0);
 
       // Session-2 should still have pending data
-      expect(await manager.getCurrentOffset('session-2', 'worker-1')).toBe(8);
+      expect(await manager.getCurrentOffset('session-2', 'worker-1', quickResolver)).toBe(8);
     });
 
     it('should not throw for non-existent session', async () => {
       await expect(
-        manager.deleteSessionOutputs('nonexistent')
+        manager.deleteSessionOutputs('nonexistent', quickResolver)
       ).resolves.toBeUndefined();
     });
   });
 
   describe('flushAll', () => {
     it('should flush all pending buffers', async () => {
-      manager.bufferOutput('session-1', 'worker-1', 'data1');
-      manager.bufferOutput('session-2', 'worker-1', 'data2');
+      manager.bufferOutput('session-1', 'worker-1', 'data1', quickResolver);
+      manager.bufferOutput('session-2', 'worker-1', 'data2', quickResolver);
 
       // Flush all without waiting for timers
       await manager.flushAll();
 
-      const path1 = manager.getOutputFilePath('session-1', 'worker-1');
-      const path2 = manager.getOutputFilePath('session-2', 'worker-1');
+      const path1 = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
+      const path2 = manager.getOutputFilePath('session-2', 'worker-1', quickResolver);
 
       expect(vol.readFileSync(path1, 'utf-8')).toBe('data1');
       expect(vol.readFileSync(path2, 'utf-8')).toBe('data2');
@@ -409,44 +413,44 @@ describe('WorkerOutputFileManager', () => {
 
   describe('edge cases', () => {
     it('should handle empty data buffer', async () => {
-      manager.bufferOutput('session-1', 'worker-1', '');
+      manager.bufferOutput('session-1', 'worker-1', '', quickResolver);
 
       await new Promise(resolve => setTimeout(resolve, 150));
 
       // Empty buffer should not create file
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       expect(vol.existsSync(filePath)).toBe(false);
     });
 
     it('should handle unicode characters', async () => {
       const unicodeData = 'Hello \u4e16\u754c \ud83c\udf0d'; // Hello World in Chinese + globe emoji
-      manager.bufferOutput('session-1', 'worker-1', unicodeData);
+      manager.bufferOutput('session-1', 'worker-1', unicodeData, quickResolver);
 
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       const content = vol.readFileSync(filePath, 'utf-8');
       expect(content).toBe(unicodeData);
     });
 
     it('should handle ANSI escape sequences', async () => {
       const ansiData = '\x1b[31mRed text\x1b[0m and \x1b[32mgreen\x1b[0m';
-      manager.bufferOutput('session-1', 'worker-1', ansiData);
+      manager.bufferOutput('session-1', 'worker-1', ansiData, quickResolver);
 
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       const content = vol.readFileSync(filePath, 'utf-8');
       expect(content).toBe(ansiData);
     });
 
     it('should handle newlines and carriage returns', async () => {
       const textWithNewlines = 'line1\nline2\r\nline3\rline4';
-      manager.bufferOutput('session-1', 'worker-1', textWithNewlines);
+      manager.bufferOutput('session-1', 'worker-1', textWithNewlines, quickResolver);
 
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       const content = vol.readFileSync(filePath, 'utf-8');
       expect(content).toBe(textWithNewlines);
     });
@@ -454,12 +458,12 @@ describe('WorkerOutputFileManager', () => {
     it('should handle rapid sequential writes', async () => {
       // Simulate rapid terminal output
       for (let i = 0; i < 100; i++) {
-        manager.bufferOutput('session-1', 'worker-1', `line${i}\n`);
+        manager.bufferOutput('session-1', 'worker-1', `line${i}\n`, quickResolver);
       }
 
       await new Promise(resolve => setTimeout(resolve, 200));
 
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       const content = vol.readFileSync(filePath, 'utf-8') as string;
 
       // Should contain all lines (or be truncated but consistent)
@@ -469,15 +473,15 @@ describe('WorkerOutputFileManager', () => {
 
     it('should include pending buffer when reading with file existing', async () => {
       // Write some data to file first
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'existing');
 
       // Buffer more data (not flushed yet)
-      manager.bufferOutput('session-1', 'worker-1', ' new');
+      manager.bufferOutput('session-1', 'worker-1', ' new', quickResolver);
 
       // Read should return file content + pending buffer
-      const result = await manager.readHistoryWithOffset('session-1', 'worker-1');
+      const result = await manager.readHistoryWithOffset('session-1', 'worker-1', quickResolver);
 
       expect(result).not.toBeNull();
       // Both file content and pending buffer should be included
@@ -487,15 +491,15 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should return only pending buffer when offset equals file size', async () => {
-      const filePath = manager.getOutputFilePath('session-offset-eq', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-offset-eq', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-offset-eq`, { recursive: true });
       vol.writeFileSync(filePath, 'existing'); // 8 bytes
 
       // Buffer more data (not flushed yet)
-      manager.bufferOutput('session-offset-eq', 'worker-1', ' new'); // 4 bytes
+      manager.bufferOutput('session-offset-eq', 'worker-1', ' new', quickResolver); // 4 bytes
 
       // Read from offset 8 (file size) should return only pending buffer
-      const result = await manager.readHistoryWithOffset('session-offset-eq', 'worker-1', 8);
+      const result = await manager.readHistoryWithOffset('session-offset-eq', 'worker-1', quickResolver, 8);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe(' new');
@@ -503,15 +507,15 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should return partial pending buffer when offset is within pending buffer range', async () => {
-      const filePath = manager.getOutputFilePath('session-partial', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-partial', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-partial`, { recursive: true });
       vol.writeFileSync(filePath, 'file'); // 4 bytes
 
       // Buffer more data (not flushed yet)
-      manager.bufferOutput('session-partial', 'worker-1', 'buffer'); // 6 bytes
+      manager.bufferOutput('session-partial', 'worker-1', 'buffer', quickResolver); // 6 bytes
 
       // Read from offset 6 (2 bytes into pending buffer) should return partial pending buffer
-      const result = await manager.readHistoryWithOffset('session-partial', 'worker-1', 6);
+      const result = await manager.readHistoryWithOffset('session-partial', 'worker-1', quickResolver, 6);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('ffer'); // skipped 'bu' (2 bytes)
@@ -519,15 +523,15 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should return empty when offset equals total size (file + pending)', async () => {
-      const filePath = manager.getOutputFilePath('session-total', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-total', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-total`, { recursive: true });
       vol.writeFileSync(filePath, 'file'); // 4 bytes
 
       // Buffer more data (not flushed yet)
-      manager.bufferOutput('session-total', 'worker-1', 'buffer'); // 6 bytes
+      manager.bufferOutput('session-total', 'worker-1', 'buffer', quickResolver); // 6 bytes
 
       // Read from offset 10 (total size) should return empty
-      const result = await manager.readHistoryWithOffset('session-total', 'worker-1', 10);
+      const result = await manager.readHistoryWithOffset('session-total', 'worker-1', quickResolver, 10);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('');
@@ -535,14 +539,14 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should return full history when offset exceeds total size (file + pending) after truncation', async () => {
-      const filePath = manager.getOutputFilePath('session-total-exceed', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-total-exceed', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-total-exceed`, { recursive: true });
       vol.writeFileSync(filePath, 'file'); // 4 bytes
 
-      manager.bufferOutput('session-total-exceed', 'worker-1', 'buffer'); // 6 bytes
+      manager.bufferOutput('session-total-exceed', 'worker-1', 'buffer', quickResolver); // 6 bytes
 
       // Client has offset 50 but total is only 10 bytes — file was truncated
-      const result = await manager.readHistoryWithOffset('session-total-exceed', 'worker-1', 50);
+      const result = await manager.readHistoryWithOffset('session-total-exceed', 'worker-1', quickResolver, 50);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('filebuffer');
@@ -550,15 +554,15 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should return file data from offset + full pending buffer', async () => {
-      const filePath = manager.getOutputFilePath('session-mid', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-mid', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-mid`, { recursive: true });
       vol.writeFileSync(filePath, 'hello world'); // 11 bytes
 
       // Buffer more data (not flushed yet)
-      manager.bufferOutput('session-mid', 'worker-1', '!!!'); // 3 bytes
+      manager.bufferOutput('session-mid', 'worker-1', '!!!', quickResolver); // 3 bytes
 
       // Read from offset 6 should return 'world' + '!!!'
-      const result = await manager.readHistoryWithOffset('session-mid', 'worker-1', 6);
+      const result = await manager.readHistoryWithOffset('session-mid', 'worker-1', quickResolver, 6);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('world!!!');
@@ -566,22 +570,22 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should handle multi-byte UTF-8 in pending buffer with offset', async () => {
-      const filePath = manager.getOutputFilePath('session-utf8-pending', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-utf8-pending', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-utf8-pending`, { recursive: true });
       vol.writeFileSync(filePath, 'ABC'); // 3 bytes
 
       // Buffer Japanese characters (3 bytes each)
-      manager.bufferOutput('session-utf8-pending', 'worker-1', '日本語'); // 9 bytes
+      manager.bufferOutput('session-utf8-pending', 'worker-1', '日本語', quickResolver); // 9 bytes
 
       // Read from offset 3 (file size) should return full pending buffer
-      const result = await manager.readHistoryWithOffset('session-utf8-pending', 'worker-1', 3);
+      const result = await manager.readHistoryWithOffset('session-utf8-pending', 'worker-1', quickResolver, 3);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('日本語');
       expect(result!.offset).toBe(12); // 3 + 9
 
       // Read from offset 6 (3 bytes into pending buffer) should return '本語'
-      const result2 = await manager.readHistoryWithOffset('session-utf8-pending', 'worker-1', 6);
+      const result2 = await manager.readHistoryWithOffset('session-utf8-pending', 'worker-1', quickResolver, 6);
 
       expect(result2).not.toBeNull();
       expect(result2!.data).toBe('本語');
@@ -592,16 +596,16 @@ describe('WorkerOutputFileManager', () => {
   describe('concurrent operations', () => {
     it('should handle concurrent reads and writes', async () => {
       // Write initial data
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-1`, { recursive: true });
       vol.writeFileSync(filePath, 'initial');
 
       // Perform concurrent operations
       const promises = [
-        manager.readHistoryWithOffset('session-1', 'worker-1'),
-        manager.getCurrentOffset('session-1', 'worker-1'),
+        manager.readHistoryWithOffset('session-1', 'worker-1', quickResolver),
+        manager.getCurrentOffset('session-1', 'worker-1', quickResolver),
         (async () => {
-          manager.bufferOutput('session-1', 'worker-1', 'more');
+          manager.bufferOutput('session-1', 'worker-1', 'more', quickResolver);
           await manager.flushAll();
         })(),
       ];
@@ -614,15 +618,15 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should handle concurrent flushes to different workers', async () => {
-      manager.bufferOutput('session-1', 'worker-1', 'data1');
-      manager.bufferOutput('session-1', 'worker-2', 'data2');
-      manager.bufferOutput('session-1', 'worker-3', 'data3');
+      manager.bufferOutput('session-1', 'worker-1', 'data1', quickResolver);
+      manager.bufferOutput('session-1', 'worker-2', 'data2', quickResolver);
+      manager.bufferOutput('session-1', 'worker-3', 'data3', quickResolver);
 
       await manager.flushAll();
 
-      const content1 = vol.readFileSync(manager.getOutputFilePath('session-1', 'worker-1'), 'utf-8');
-      const content2 = vol.readFileSync(manager.getOutputFilePath('session-1', 'worker-2'), 'utf-8');
-      const content3 = vol.readFileSync(manager.getOutputFilePath('session-1', 'worker-3'), 'utf-8');
+      const content1 = vol.readFileSync(manager.getOutputFilePath('session-1', 'worker-1', quickResolver), 'utf-8');
+      const content2 = vol.readFileSync(manager.getOutputFilePath('session-1', 'worker-2', quickResolver), 'utf-8');
+      const content3 = vol.readFileSync(manager.getOutputFilePath('session-1', 'worker-3', quickResolver), 'utf-8');
 
       expect(content1).toBe('data1');
       expect(content2).toBe('data2');
@@ -634,11 +638,11 @@ describe('WorkerOutputFileManager', () => {
     it('should correctly slice at byte offset with multi-byte characters', async () => {
       // Write data with emoji (4-byte UTF-8)
       const data = 'Hello 🎉 World'; // 🎉 is 4 bytes
-      manager.bufferOutput('session-utf8-emoji', 'worker-1', data);
+      manager.bufferOutput('session-utf8-emoji', 'worker-1', data, quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
       // Get offset after 'Hello ' (6 bytes)
-      const result = await manager.readHistoryWithOffset('session-utf8-emoji', 'worker-1', 6);
+      const result = await manager.readHistoryWithOffset('session-utf8-emoji', 'worker-1', quickResolver, 6);
       // Should get '🎉 World' (emoji + rest)
       expect(result?.data).toBe('🎉 World');
     });
@@ -646,30 +650,30 @@ describe('WorkerOutputFileManager', () => {
     it('should correctly handle CJK characters with offset', async () => {
       // Japanese: 日本語 (3 chars, 9 bytes in UTF-8)
       const data = 'ABC日本語DEF'; // A=1, B=1, C=1, 日=3, 本=3, 語=3, D=1, E=1, F=1
-      manager.bufferOutput('session-utf8-cjk', 'worker-1', data);
+      manager.bufferOutput('session-utf8-cjk', 'worker-1', data, quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
       // Offset at 3 should give us '日本語DEF'
-      const result = await manager.readHistoryWithOffset('session-utf8-cjk', 'worker-1', 3);
+      const result = await manager.readHistoryWithOffset('session-utf8-cjk', 'worker-1', quickResolver, 3);
       expect(result?.data).toBe('日本語DEF');
     });
 
     it('should handle mixed multi-byte characters correctly', async () => {
       // Mix of ASCII, CJK (3 bytes), and emoji (4 bytes)
       const data = 'A日🎉B'; // A=1, 日=3, 🎉=4, B=1 -> total 9 bytes
-      manager.bufferOutput('session-utf8-mixed', 'worker-1', data);
+      manager.bufferOutput('session-utf8-mixed', 'worker-1', data, quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
       // Offset at 1 should give us '日🎉B'
-      const result1 = await manager.readHistoryWithOffset('session-utf8-mixed', 'worker-1', 1);
+      const result1 = await manager.readHistoryWithOffset('session-utf8-mixed', 'worker-1', quickResolver, 1);
       expect(result1?.data).toBe('日🎉B');
 
       // Offset at 4 (after A and 日) should give us '🎉B'
-      const result2 = await manager.readHistoryWithOffset('session-utf8-mixed', 'worker-1', 4);
+      const result2 = await manager.readHistoryWithOffset('session-utf8-mixed', 'worker-1', quickResolver, 4);
       expect(result2?.data).toBe('🎉B');
 
       // Offset at 8 (after A, 日, and 🎉) should give us 'B'
-      const result3 = await manager.readHistoryWithOffset('session-utf8-mixed', 'worker-1', 8);
+      const result3 = await manager.readHistoryWithOffset('session-utf8-mixed', 'worker-1', quickResolver, 8);
       expect(result3?.data).toBe('B');
     });
   });
@@ -677,38 +681,38 @@ describe('WorkerOutputFileManager', () => {
   describe('race condition prevention', () => {
     it('getCurrentOffset should flush pending buffer first', async () => {
       // Buffer data without waiting for flush
-      manager.bufferOutput('session-race-1', 'worker-1', 'test data');
+      manager.bufferOutput('session-race-1', 'worker-1', 'test data', quickResolver);
 
       // getCurrentOffset should flush first, so offset includes the buffered data
-      const offset = await manager.getCurrentOffset('session-race-1', 'worker-1');
+      const offset = await manager.getCurrentOffset('session-race-1', 'worker-1', quickResolver);
       expect(offset).toBe(9); // 'test data'.length
 
       // Verify data is in file (not in pending buffer)
-      const result = await manager.readHistoryWithOffset('session-race-1', 'worker-1');
+      const result = await manager.readHistoryWithOffset('session-race-1', 'worker-1', quickResolver);
       expect(result?.data).toBe('test data');
       expect(result?.offset).toBe(9);
     });
 
     it('should return consistent offset even with rapid buffer writes', async () => {
       // Rapidly write multiple chunks
-      manager.bufferOutput('session-race-2', 'worker-1', 'chunk1');
-      manager.bufferOutput('session-race-2', 'worker-1', 'chunk2');
-      manager.bufferOutput('session-race-2', 'worker-1', 'chunk3');
+      manager.bufferOutput('session-race-2', 'worker-1', 'chunk1', quickResolver);
+      manager.bufferOutput('session-race-2', 'worker-1', 'chunk2', quickResolver);
+      manager.bufferOutput('session-race-2', 'worker-1', 'chunk3', quickResolver);
 
       // getCurrentOffset should flush and return accurate total
-      const offset = await manager.getCurrentOffset('session-race-2', 'worker-1');
+      const offset = await manager.getCurrentOffset('session-race-2', 'worker-1', quickResolver);
       expect(offset).toBe(18); // 'chunk1chunk2chunk3'.length
     });
 
     it('should handle interleaved buffer and getCurrentOffset calls', async () => {
       // First write
-      manager.bufferOutput('session-race-3', 'worker-1', 'first');
-      const offset1 = await manager.getCurrentOffset('session-race-3', 'worker-1');
+      manager.bufferOutput('session-race-3', 'worker-1', 'first', quickResolver);
+      const offset1 = await manager.getCurrentOffset('session-race-3', 'worker-1', quickResolver);
       expect(offset1).toBe(5);
 
       // Second write
-      manager.bufferOutput('session-race-3', 'worker-1', 'second');
-      const offset2 = await manager.getCurrentOffset('session-race-3', 'worker-1');
+      manager.bufferOutput('session-race-3', 'worker-1', 'second', quickResolver);
+      const offset2 = await manager.getCurrentOffset('session-race-3', 'worker-1', quickResolver);
       expect(offset2).toBe(11); // 'firstsecond'.length
     });
   });
@@ -718,11 +722,11 @@ describe('WorkerOutputFileManager', () => {
       // Create a string that when truncated might cut through a multi-byte char
       // Use Japanese characters (3 bytes each)
       const chars = 'あ'.repeat(100); // 300 bytes
-      manager.bufferOutput('session-trunc-utf8', 'worker-1', chars);
+      manager.bufferOutput('session-trunc-utf8', 'worker-1', chars, quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
       // Verify file exists and read it
-      const result = await manager.readHistoryWithOffset('session-trunc-utf8', 'worker-1');
+      const result = await manager.readHistoryWithOffset('session-trunc-utf8', 'worker-1', quickResolver);
       expect(result?.data).toBe(chars);
     });
 
@@ -732,10 +736,10 @@ describe('WorkerOutputFileManager', () => {
       const repeatedPattern = 'テスト'; // 9 bytes per iteration (3 chars x 3 bytes)
       const largeData = repeatedPattern.repeat(150); // 1350 bytes, exceeds 1024
 
-      manager.bufferOutput('session-trunc-mixed', 'worker-1', largeData);
+      manager.bufferOutput('session-trunc-mixed', 'worker-1', largeData, quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const filePath = manager.getOutputFilePath('session-trunc-mixed', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-trunc-mixed', 'worker-1', quickResolver);
       const content = vol.readFileSync(filePath, 'utf-8') as string;
 
       // File should be truncated
@@ -753,10 +757,10 @@ describe('WorkerOutputFileManager', () => {
       const emoji = '🎉'; // 4 bytes
       const largeData = emoji.repeat(300); // 1200 bytes, exceeds 1024
 
-      manager.bufferOutput('session-trunc-emoji', 'worker-1', largeData);
+      manager.bufferOutput('session-trunc-emoji', 'worker-1', largeData, quickResolver);
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const filePath = manager.getOutputFilePath('session-trunc-emoji', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-trunc-emoji', 'worker-1', quickResolver);
       const content = vol.readFileSync(filePath, 'utf-8') as string;
 
       // File should be truncated
@@ -778,14 +782,14 @@ describe('WorkerOutputFileManager', () => {
 
       // This should trigger immediate flush due to threshold
       expect(() => {
-        manager.bufferOutput('session-error-1', 'worker-1', largeData);
+        manager.bufferOutput('session-error-1', 'worker-1', largeData, quickResolver);
       }).not.toThrow();
 
       // Wait for async flush to complete
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // Verify data was written correctly
-      const filePath = manager.getOutputFilePath('session-error-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-error-1', 'worker-1', quickResolver);
       expect(vol.existsSync(filePath)).toBe(true);
     });
 
@@ -795,34 +799,34 @@ describe('WorkerOutputFileManager', () => {
 
       // Multiple rapid writes - should not throw
       expect(() => {
-        manager.bufferOutput('session-error-2', 'worker-1', largeChunk);
-        manager.bufferOutput('session-error-2', 'worker-1', largeChunk);
-        manager.bufferOutput('session-error-2', 'worker-1', largeChunk);
+        manager.bufferOutput('session-error-2', 'worker-1', largeChunk, quickResolver);
+        manager.bufferOutput('session-error-2', 'worker-1', largeChunk, quickResolver);
+        manager.bufferOutput('session-error-2', 'worker-1', largeChunk, quickResolver);
       }).not.toThrow();
 
       // Wait for async flushes to complete
       await new Promise(resolve => setTimeout(resolve, 200));
 
       // File should exist with data (may be truncated due to max size)
-      const filePath = manager.getOutputFilePath('session-error-2', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-error-2', 'worker-1', quickResolver);
       expect(vol.existsSync(filePath)).toBe(true);
     });
 
     it('should continue buffering after threshold flush completes', async () => {
       // Write data exceeding threshold
       const largeData = 'z'.repeat(TEST_WORKER_OUTPUT_FLUSH_THRESHOLD + 1);
-      manager.bufferOutput('session-error-3', 'worker-1', largeData);
+      manager.bufferOutput('session-error-3', 'worker-1', largeData, quickResolver);
 
       // Wait for threshold flush
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // Buffer more data
-      manager.bufferOutput('session-error-3', 'worker-1', 'additional');
+      manager.bufferOutput('session-error-3', 'worker-1', 'additional', quickResolver);
 
       // Wait for timer flush
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const filePath = manager.getOutputFilePath('session-error-3', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-error-3', 'worker-1', quickResolver);
       const content = vol.readFileSync(filePath, 'utf-8') as string;
 
       // Should contain both the large data and additional data
@@ -832,11 +836,11 @@ describe('WorkerOutputFileManager', () => {
 
   describe('readLastNLines', () => {
     it('should return last N lines from file', async () => {
-      const filePath = manager.getOutputFilePath('session-lines', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-lines', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-lines`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\nline2\nline3\nline4\nline5');
 
-      const result = await manager.readLastNLines('session-lines', 'worker-1', 3);
+      const result = await manager.readLastNLines('session-lines', 'worker-1', 3, quickResolver);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('line3\nline4\nline5');
@@ -845,33 +849,33 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should return all lines if file has fewer than maxLines', async () => {
-      const filePath = manager.getOutputFilePath('session-lines-2', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-lines-2', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-lines-2`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\nline2');
 
-      const result = await manager.readLastNLines('session-lines-2', 'worker-1', 10);
+      const result = await manager.readLastNLines('session-lines-2', 'worker-1', 10, quickResolver);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('line1\nline2');
     });
 
     it('should handle CRLF line endings', async () => {
-      const filePath = manager.getOutputFilePath('session-crlf', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-crlf', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-crlf`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\r\nline2\r\nline3\r\nline4');
 
-      const result = await manager.readLastNLines('session-crlf', 'worker-1', 2);
+      const result = await manager.readLastNLines('session-crlf', 'worker-1', 2, quickResolver);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('line3\r\nline4');
     });
 
     it('should handle empty lines in count', async () => {
-      const filePath = manager.getOutputFilePath('session-empty', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-empty', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-empty`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\n\nline3\nline4');
 
-      const result = await manager.readLastNLines('session-empty', 'worker-1', 3);
+      const result = await manager.readLastNLines('session-empty', 'worker-1', 3, quickResolver);
 
       expect(result).not.toBeNull();
       // Empty line counts as a line
@@ -879,7 +883,7 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should return empty history for non-existent file with no buffer', async () => {
-      const result = await manager.readLastNLines('nonexistent', 'worker-1', 5);
+      const result = await manager.readLastNLines('nonexistent', 'worker-1', 5, quickResolver);
       // Returns empty history instead of null to support newly created workers
       expect(result).not.toBeNull();
       expect(result!.data).toBe('');
@@ -887,31 +891,31 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should apply line limit to pending buffer', async () => {
-      manager.bufferOutput('session-buffer-lines', 'worker-1', 'line1\nline2\nline3\nline4');
+      manager.bufferOutput('session-buffer-lines', 'worker-1', 'line1\nline2\nline3\nline4', quickResolver);
 
-      const result = await manager.readLastNLines('session-buffer-lines', 'worker-1', 2);
+      const result = await manager.readLastNLines('session-buffer-lines', 'worker-1', 2, quickResolver);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('line3\nline4');
     });
 
     it('should return 0 lines when maxLines is 0', async () => {
-      const filePath = manager.getOutputFilePath('session-zero', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-zero', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-zero`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\nline2');
 
-      const result = await manager.readLastNLines('session-zero', 'worker-1', 0);
+      const result = await manager.readLastNLines('session-zero', 'worker-1', 0, quickResolver);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('');
     });
 
     it('should preserve newline at end of content', async () => {
-      const filePath = manager.getOutputFilePath('session-trailing', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-trailing', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-trailing`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\nline2\nline3\n');
 
-      const result = await manager.readLastNLines('session-trailing', 'worker-1', 2);
+      const result = await manager.readLastNLines('session-trailing', 'worker-1', 2, quickResolver);
 
       expect(result).not.toBeNull();
       // Last 2 lines: "line3" and empty line after last \n
@@ -919,14 +923,14 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should include pending buffer when file exists', async () => {
-      const filePath = manager.getOutputFilePath('session-pending-file', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-pending-file', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-pending-file`, { recursive: true });
       vol.writeFileSync(filePath, 'line1\nline2\nline3'); // 17 bytes
 
       // Buffer more data (not flushed yet)
-      manager.bufferOutput('session-pending-file', 'worker-1', '\nline4\nline5'); // 12 bytes
+      manager.bufferOutput('session-pending-file', 'worker-1', '\nline4\nline5', quickResolver); // 12 bytes
 
-      const result = await manager.readLastNLines('session-pending-file', 'worker-1', 3);
+      const result = await manager.readLastNLines('session-pending-file', 'worker-1', 3, quickResolver);
 
       expect(result).not.toBeNull();
       // Should get last 3 lines from combined content (file + pending)
@@ -936,15 +940,15 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should include pending buffer even when fewer lines requested', async () => {
-      const filePath = manager.getOutputFilePath('session-pending-fewer', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-pending-fewer', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-pending-fewer`, { recursive: true });
       vol.writeFileSync(filePath, 'old1\nold2\nold3'); // 14 bytes
 
       // Buffer more data that contains the most recent output (not flushed yet)
-      manager.bufferOutput('session-pending-fewer', 'worker-1', '\nnew1\nnew2'); // 10 bytes
+      manager.bufferOutput('session-pending-fewer', 'worker-1', '\nnew1\nnew2', quickResolver); // 10 bytes
 
       // Request only last 2 lines - should be from pending buffer
-      const result = await manager.readLastNLines('session-pending-fewer', 'worker-1', 2);
+      const result = await manager.readLastNLines('session-pending-fewer', 'worker-1', 2, quickResolver);
 
       expect(result).not.toBeNull();
       expect(result!.data).toBe('new1\nnew2');
@@ -953,14 +957,14 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should handle pending buffer with multi-byte UTF-8 characters', async () => {
-      const filePath = manager.getOutputFilePath('session-pending-utf8', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-pending-utf8', 'worker-1', quickResolver);
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/outputs/session-pending-utf8`, { recursive: true });
       vol.writeFileSync(filePath, 'hello\n'); // 6 bytes
 
       // Buffer Japanese characters (3 bytes each)
-      manager.bufferOutput('session-pending-utf8', 'worker-1', 'テスト'); // 9 bytes
+      manager.bufferOutput('session-pending-utf8', 'worker-1', 'テスト', quickResolver); // 9 bytes
 
-      const result = await manager.readLastNLines('session-pending-utf8', 'worker-1', 2);
+      const result = await manager.readLastNLines('session-pending-utf8', 'worker-1', 2, quickResolver);
 
       expect(result).not.toBeNull();
       // Last 2 lines: "hello" and "テスト"
@@ -972,19 +976,19 @@ describe('WorkerOutputFileManager', () => {
 
   describe('repository-scoped paths', () => {
     it('should return repository-scoped path when repositoryName is provided', () => {
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1', 'org/repo');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', repoResolver);
       expect(filePath).toBe(`${TEST_CONFIG_DIR}/repositories/org/repo/outputs/session-1/worker-1.log`);
     });
 
     it('should initialize worker output under repository path when repositoryName is provided', async () => {
-      await manager.initializeWorkerOutput('session-1', 'worker-1', 'org/repo');
+      await manager.initializeWorkerOutput('session-1', 'worker-1', repoResolver);
 
       const filePath = `${TEST_CONFIG_DIR}/repositories/org/repo/outputs/session-1/worker-1.log`;
       expect(vol.existsSync(filePath)).toBe(true);
     });
 
     it('should flush buffered output to repository-scoped path when repositoryName is provided', async () => {
-      manager.bufferOutput('session-1', 'worker-1', 'repo data', 'org/repo');
+      manager.bufferOutput('session-1', 'worker-1', 'repo data', repoResolver);
 
       // Wait for flush interval
       await new Promise(resolve => setTimeout(resolve, 150));
@@ -997,16 +1001,16 @@ describe('WorkerOutputFileManager', () => {
     });
 
     it('should delete session outputs from repository-scoped path when repositoryName is provided', async () => {
-      await manager.initializeWorkerOutput('session-1', 'worker-1', 'org/repo');
+      await manager.initializeWorkerOutput('session-1', 'worker-1', repoResolver);
       const sessionDir = `${TEST_CONFIG_DIR}/repositories/org/repo/outputs/session-1`;
       expect(vol.existsSync(sessionDir)).toBe(true);
 
-      await manager.deleteSessionOutputs('session-1', 'org/repo');
+      await manager.deleteSessionOutputs('session-1', repoResolver);
       expect(vol.existsSync(sessionDir)).toBe(false);
     });
 
     it('should use _quick fallback when repositoryName is not provided', () => {
-      const filePath = manager.getOutputFilePath('session-1', 'worker-1');
+      const filePath = manager.getOutputFilePath('session-1', 'worker-1', quickResolver);
       expect(filePath).toBe(`${TEST_CONFIG_DIR}/_quick/outputs/session-1/worker-1.log`);
     });
   });

--- a/packages/server/src/lib/config.ts
+++ b/packages/server/src/lib/config.ts
@@ -36,39 +36,6 @@ export function getDbPath(): string {
 }
 
 /**
- * Get the directory for inter-session message files.
- * @param repositoryName - org/repo string for worktree sessions, undefined for quick sessions
- */
-export function getMessagesDir(repositoryName?: string): string {
-  if (repositoryName) {
-    return path.join(getRepositoriesDir(), repositoryName, 'messages');
-  }
-  return path.join(getConfigDir(), '_quick', 'messages');
-}
-
-/**
- * Get the directory for memo files.
- * @param repositoryName - org/repo string for worktree sessions, undefined for quick sessions
- */
-export function getMemosDir(repositoryName?: string): string {
-  if (repositoryName) {
-    return path.join(getRepositoriesDir(), repositoryName, 'memos');
-  }
-  return path.join(getConfigDir(), '_quick', 'memos');
-}
-
-/**
- * Get the directory for worker output files.
- * @param repositoryName - org/repo string for worktree sessions, undefined for quick sessions
- */
-export function getOutputsDir(repositoryName?: string): string {
-  if (repositoryName) {
-    return path.join(getRepositoriesDir(), repositoryName, 'outputs');
-  }
-  return path.join(getConfigDir(), '_quick', 'outputs');
-}
-
-/**
  * Get the current server's PID for session ownership tracking.
  */
 export function getServerPid(): number {

--- a/packages/server/src/lib/session-data-path-resolver.ts
+++ b/packages/server/src/lib/session-data-path-resolver.ts
@@ -1,0 +1,53 @@
+/**
+ * SessionDataPathResolver - Centralizes session data path resolution.
+ *
+ * Encapsulates the repository-scoped vs quick-session path branching
+ * so callers never need to handle the conditional logic themselves.
+ *
+ * Path structure:
+ *   Worktree sessions: ~/.agent-console/repositories/{org}/{repo}/[messages|memos|outputs]/
+ *   Quick sessions:    ~/.agent-console/_quick/[messages|memos|outputs]/
+ */
+
+import * as path from 'path';
+import { getConfigDir, getRepositoriesDir } from './config.js';
+
+export class SessionDataPathResolver {
+  constructor(private readonly repositoryName?: string) {}
+
+  /**
+   * Get the repository name used for path resolution.
+   * Needed for serializable job payloads that cannot accept a resolver instance.
+   */
+  getRepositoryName(): string | undefined {
+    return this.repositoryName;
+  }
+
+  /** Base directory for session data (repository-scoped or quick session) */
+  private getBaseDir(): string {
+    if (this.repositoryName) {
+      return path.join(getRepositoriesDir(), this.repositoryName);
+    }
+    return path.join(getConfigDir(), '_quick');
+  }
+
+  getMessagesDir(): string {
+    return path.join(this.getBaseDir(), 'messages');
+  }
+
+  getMemosDir(): string {
+    return path.join(this.getBaseDir(), 'memos');
+  }
+
+  getMemosPath(sessionId: string): string {
+    return path.join(this.getMemosDir(), `${sessionId}.md`);
+  }
+
+  getOutputsDir(): string {
+    return path.join(this.getBaseDir(), 'outputs');
+  }
+
+  getOutputFilePath(sessionId: string, workerId: string): string {
+    return path.join(this.getOutputsDir(), sessionId, `${workerId}.log`);
+  }
+}

--- a/packages/server/src/lib/worker-output-file.ts
+++ b/packages/server/src/lib/worker-output-file.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { gunzipSync } from 'bun';
-import { getOutputsDir } from './config.js';
+import { SessionDataPathResolver } from './session-data-path-resolver.js';
 import { serverConfig } from './server-config.js';
 import { createLogger } from './logger.js';
 
@@ -45,7 +45,7 @@ export interface HistoryReadResult {
 interface PendingFlush {
   buffer: string;
   timer: ReturnType<typeof setTimeout> | null;
-  repositoryName?: string;
+  resolver: SessionDataPathResolver;
 }
 
 /**
@@ -79,8 +79,8 @@ export class WorkerOutputFileManager {
   /**
    * Get the output file path for a worker.
    */
-  getOutputFilePath(sessionId: string, workerId: string, repositoryName?: string): string {
-    return path.join(getOutputsDir(repositoryName), sessionId, `${workerId}.log`);
+  getOutputFilePath(sessionId: string, workerId: string, resolver: SessionDataPathResolver): string {
+    return resolver.getOutputFilePath(sessionId, workerId);
   }
 
   /**
@@ -102,8 +102,8 @@ export class WorkerOutputFileManager {
    *
    * Note: Legacy .log.gz files are still supported for reading (migration compatibility).
    */
-  private async getActualFilePath(sessionId: string, workerId: string, repositoryName?: string): Promise<{ path: string; isCompressed: boolean } | null> {
-    const outputsDir = getOutputsDir(repositoryName);
+  private async getActualFilePath(sessionId: string, workerId: string, resolver: SessionDataPathResolver): Promise<{ path: string; isCompressed: boolean } | null> {
+    const outputsDir = resolver.getOutputsDir();
     const uncompressedPath = path.join(outputsDir, sessionId, `${workerId}.log`);
     const compressedPath = path.join(outputsDir, sessionId, `${workerId}.log.gz`);
 
@@ -132,15 +132,15 @@ export class WorkerOutputFileManager {
    * Call this immediately when creating a new worker to ensure history file exists.
    * This prevents race conditions where WebSocket connects before any output is buffered.
    */
-  async initializeWorkerOutput(sessionId: string, workerId: string, repositoryName?: string): Promise<void> {
-    const filePath = this.getOutputFilePath(sessionId, workerId, repositoryName);
+  async initializeWorkerOutput(sessionId: string, workerId: string, resolver: SessionDataPathResolver): Promise<void> {
+    const filePath = this.getOutputFilePath(sessionId, workerId, resolver);
 
     try {
       // Ensure directory exists
       await fs.mkdir(path.dirname(filePath), { recursive: true });
 
       // Check if file already exists (e.g., from previous run)
-      const actualFile = await this.getActualFilePath(sessionId, workerId, repositoryName);
+      const actualFile = await this.getActualFilePath(sessionId, workerId, resolver);
       if (actualFile) {
         // File already exists, no need to initialize
         return;
@@ -159,12 +159,12 @@ export class WorkerOutputFileManager {
    * Buffer output data for periodic flushing to file.
    * Flushes immediately if buffer exceeds threshold.
    */
-  bufferOutput(sessionId: string, workerId: string, data: string, repositoryName?: string): void {
+  bufferOutput(sessionId: string, workerId: string, data: string, resolver: SessionDataPathResolver): void {
     const key = this.getKey(sessionId, workerId);
     let pending = this.pendingFlushes.get(key);
 
     if (!pending) {
-      pending = { buffer: '', timer: null, repositoryName };
+      pending = { buffer: '', timer: null, resolver };
       this.pendingFlushes.set(key, pending);
     }
 
@@ -210,15 +210,15 @@ export class WorkerOutputFileManager {
     const dataToWrite = pending.buffer;
     pending.buffer = '';
 
-    const repositoryName = pending.repositoryName;
-    const filePath = this.getOutputFilePath(sessionId, workerId, repositoryName);
+    const resolver = pending.resolver;
+    const filePath = this.getOutputFilePath(sessionId, workerId, resolver);
 
     try {
       // Ensure directory exists
       await fs.mkdir(path.dirname(filePath), { recursive: true });
 
       // Check if we need to migrate from legacy compressed file
-      const actualFile = await this.getActualFilePath(sessionId, workerId, repositoryName);
+      const actualFile = await this.getActualFilePath(sessionId, workerId, resolver);
       if (actualFile?.isCompressed) {
         // Migrate from compressed to uncompressed
         const rawBuffer = await fs.readFile(actualFile.path);
@@ -318,8 +318,8 @@ export class WorkerOutputFileManager {
   async readHistoryWithOffset(
     sessionId: string,
     workerId: string,
+    resolver: SessionDataPathResolver,
     fromOffset?: number,
-    repositoryName?: string
   ): Promise<HistoryReadResult> {
     try {
       // Get pending buffer for this worker
@@ -329,7 +329,7 @@ export class WorkerOutputFileManager {
       const pendingByteLength = Buffer.byteLength(pendingBuffer, 'utf-8');
 
       // Find the actual file (uncompressed or legacy compressed)
-      const actualFile = await this.getActualFilePath(sessionId, workerId, repositoryName);
+      const actualFile = await this.getActualFilePath(sessionId, workerId, resolver);
 
       if (!actualFile) {
         // No file exists, return only pending buffer
@@ -419,7 +419,7 @@ export class WorkerOutputFileManager {
     sessionId: string,
     workerId: string,
     maxLines: number,
-    repositoryName?: string
+    resolver: SessionDataPathResolver,
   ): Promise<HistoryReadResult> {
     try {
       // Get pending buffer for this worker
@@ -429,7 +429,7 @@ export class WorkerOutputFileManager {
       const pendingByteLength = Buffer.byteLength(pendingBuffer, 'utf-8');
 
       // Find the actual file (uncompressed or legacy compressed)
-      const actualFile = await this.getActualFilePath(sessionId, workerId, repositoryName);
+      const actualFile = await this.getActualFilePath(sessionId, workerId, resolver);
 
       if (!actualFile) {
         // No file exists, return only pending buffer
@@ -532,13 +532,13 @@ export class WorkerOutputFileManager {
    * Returns 0 if file doesn't exist.
    * Supports legacy .log.gz files for backward compatibility.
    */
-  async getCurrentOffset(sessionId: string, workerId: string, repositoryName?: string): Promise<number> {
+  async getCurrentOffset(sessionId: string, workerId: string, resolver: SessionDataPathResolver): Promise<number> {
     // Flush any pending buffer first to ensure accurate offset
     // This prevents race conditions where offset is read before buffer is flushed
     await this.flushBuffer(sessionId, workerId);
 
     try {
-      const actualFile = await this.getActualFilePath(sessionId, workerId, repositoryName);
+      const actualFile = await this.getActualFilePath(sessionId, workerId, resolver);
       if (!actualFile) {
         return 0;
       }
@@ -567,7 +567,7 @@ export class WorkerOutputFileManager {
    * Used when restarting a worker to prevent offset mismatch with client cache.
    * Clears pending buffers and creates an empty file.
    */
-  async resetWorkerOutput(sessionId: string, workerId: string, repositoryName?: string): Promise<void> {
+  async resetWorkerOutput(sessionId: string, workerId: string, resolver: SessionDataPathResolver): Promise<void> {
     // Clear any pending flush
     const key = this.getKey(sessionId, workerId);
     const pending = this.pendingFlushes.get(key);
@@ -578,7 +578,7 @@ export class WorkerOutputFileManager {
       this.pendingFlushes.delete(key);
     }
 
-    const filePath = this.getOutputFilePath(sessionId, workerId, repositoryName);
+    const filePath = this.getOutputFilePath(sessionId, workerId, resolver);
 
     try {
       // Ensure directory exists
@@ -610,7 +610,7 @@ export class WorkerOutputFileManager {
    * Delete output file for a worker.
    * Also deletes legacy .log.gz files if present.
    */
-  async deleteWorkerOutput(sessionId: string, workerId: string, repositoryName?: string): Promise<void> {
+  async deleteWorkerOutput(sessionId: string, workerId: string, resolver: SessionDataPathResolver): Promise<void> {
     // Clear any pending flush
     const key = this.getKey(sessionId, workerId);
     const pending = this.pendingFlushes.get(key);
@@ -622,7 +622,7 @@ export class WorkerOutputFileManager {
     }
 
     // Delete both possible file formats
-    const outputsDir = getOutputsDir(repositoryName);
+    const outputsDir = resolver.getOutputsDir();
     const compressedPath = path.join(outputsDir, sessionId, `${workerId}.log.gz`);
     const uncompressedPath = path.join(outputsDir, sessionId, `${workerId}.log`);
 
@@ -651,7 +651,7 @@ export class WorkerOutputFileManager {
   /**
    * Delete all output files for a session.
    */
-  async deleteSessionOutputs(sessionId: string, repositoryName?: string): Promise<void> {
+  async deleteSessionOutputs(sessionId: string, resolver: SessionDataPathResolver): Promise<void> {
     // Clear any pending flushes for this session
     const keysToDelete: string[] = [];
     for (const [key, pending] of this.pendingFlushes) {
@@ -666,7 +666,7 @@ export class WorkerOutputFileManager {
       this.pendingFlushes.delete(key);
     }
 
-    const sessionDir = path.join(getOutputsDir(repositoryName), sessionId);
+    const sessionDir = path.join(resolver.getOutputsDir(), sessionId);
 
     try {
       await fs.rm(sessionDir, { recursive: true, force: true });

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -26,6 +26,7 @@ import { getCurrentBranch } from '../lib/git.js';
 import { CLAUDE_CODE_AGENT_ID } from '../services/agent-manager.js';
 import { suggestSessionMetadata } from '../services/session-metadata-suggester.js';
 import { interSessionMessageService } from '../services/inter-session-message-service.js';
+import { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import { writePtyNotification } from '../lib/pty-notification.js';
 import { getRemoteUrl, GitError } from '../lib/git.js';
 import { createLogger } from '../lib/logger.js';
@@ -379,13 +380,15 @@ export function createMcpApp(deps: McpDependencies): Hono {
         }
 
         // 3. Write message file
-        const repositoryName = targetSession.type === 'worktree' ? targetSession.repositoryName : undefined;
+        const resolver = new SessionDataPathResolver(
+          targetSession.type === 'worktree' ? targetSession.repositoryName : undefined,
+        );
         const result = await interSessionMessageService.sendMessage({
           toSessionId,
           toWorkerId: resolvedWorkerId,
           fromSessionId,
           content,
-          repositoryName,
+          resolver,
         });
 
         // 4. PTY notification (best-effort -- message file is already written)

--- a/packages/server/src/services/__tests__/inter-session-message-service.test.ts
+++ b/packages/server/src/services/__tests__/inter-session-message-service.test.ts
@@ -6,8 +6,11 @@ import {
   validateId,
   MAX_MESSAGE_CONTENT_BYTES,
 } from '../inter-session-message-service.js';
+import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
 
 const TEST_CONFIG_DIR = '/test/config';
+const quickResolver = new SessionDataPathResolver();
+const repoResolver = new SessionDataPathResolver('org/repo');
 
 describe('InterSessionMessageService', () => {
   let service: InterSessionMessageService;
@@ -29,6 +32,7 @@ describe('InterSessionMessageService', () => {
         toWorkerId: 'worker-1',
         fromSessionId: 'session-sender',
         content: 'hello',
+        resolver: quickResolver,
       });
 
       const dirPath = `${TEST_CONFIG_DIR}/_quick/messages/session-target/worker-1`;
@@ -42,6 +46,7 @@ describe('InterSessionMessageService', () => {
         toWorkerId: 'worker-1',
         fromSessionId: 'session-sender',
         content: 'hello',
+        resolver: quickResolver,
       });
 
       // messageId should match the pattern {timestamp}-{fromSessionId}-{randomHex}.json
@@ -55,6 +60,7 @@ describe('InterSessionMessageService', () => {
         toWorkerId: 'worker-1',
         fromSessionId: 'session-sender',
         content,
+        resolver: quickResolver,
       });
 
       const fileContent = vol.readFileSync(result.path, 'utf-8');
@@ -67,6 +73,7 @@ describe('InterSessionMessageService', () => {
         toWorkerId: 'worker-1',
         fromSessionId: 'session-sender',
         content: 'test',
+        resolver: quickResolver,
       });
 
       expect(result.messageId).toBeDefined();
@@ -81,6 +88,7 @@ describe('InterSessionMessageService', () => {
         toWorkerId: 'worker-1',
         fromSessionId: 'session-sender',
         content: 'test',
+        resolver: quickResolver,
       });
 
       const dirPath = `${TEST_CONFIG_DIR}/_quick/messages/session-target/worker-1`;
@@ -98,6 +106,7 @@ describe('InterSessionMessageService', () => {
           toWorkerId: 'worker-1',
           fromSessionId: 'session-sender',
           content: oversizedContent,
+          resolver: quickResolver,
         }),
       ).rejects.toThrow('Message content too large');
     });
@@ -110,6 +119,7 @@ describe('InterSessionMessageService', () => {
         toWorkerId: 'worker-1',
         fromSessionId: 'session-sender',
         content: exactContent,
+        resolver: quickResolver,
       });
 
       expect(result.messageId).toBeDefined();
@@ -123,12 +133,14 @@ describe('InterSessionMessageService', () => {
           toWorkerId: 'worker-1',
           fromSessionId: 'sender-a',
           content: 'message from a',
+          resolver: quickResolver,
         }),
         service.sendMessage({
           toSessionId: 'session-target',
           toWorkerId: 'worker-1',
           fromSessionId: 'sender-b',
           content: 'message from b',
+          resolver: quickResolver,
         }),
       ]);
 
@@ -151,18 +163,20 @@ describe('InterSessionMessageService', () => {
         toWorkerId: 'worker-1',
         fromSessionId: 'sender',
         content: 'msg1',
+        resolver: quickResolver,
       });
       await service.sendMessage({
         toSessionId: 'session-1',
         toWorkerId: 'worker-2',
         fromSessionId: 'sender',
         content: 'msg2',
+        resolver: quickResolver,
       });
 
       // Verify directory exists
       expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/messages/session-1`)).toBe(true);
 
-      await service.deleteSessionMessages('session-1');
+      await service.deleteSessionMessages('session-1', quickResolver);
 
       expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/messages/session-1`)).toBe(false);
     });
@@ -170,7 +184,7 @@ describe('InterSessionMessageService', () => {
     it('should not throw when directory does not exist', async () => {
       // Should complete without error
       await expect(
-        service.deleteSessionMessages('non-existent-session'),
+        service.deleteSessionMessages('non-existent-session', quickResolver),
       ).resolves.toBeUndefined();
     });
   });
@@ -183,15 +197,17 @@ describe('InterSessionMessageService', () => {
         toWorkerId: 'worker-1',
         fromSessionId: 'sender',
         content: 'keep this',
+        resolver: quickResolver,
       });
       await service.sendMessage({
         toSessionId: 'session-1',
         toWorkerId: 'worker-2',
         fromSessionId: 'sender',
         content: 'delete this',
+        resolver: quickResolver,
       });
 
-      await service.deleteWorkerMessages('session-1', 'worker-2');
+      await service.deleteWorkerMessages('session-1', 'worker-2', quickResolver);
 
       // worker-1 messages should remain
       expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/messages/session-1/worker-1`)).toBe(true);
@@ -201,7 +217,7 @@ describe('InterSessionMessageService', () => {
 
     it('should not throw when directory does not exist', async () => {
       await expect(
-        service.deleteWorkerMessages('non-existent-session', 'non-existent-worker'),
+        service.deleteWorkerMessages('non-existent-session', 'non-existent-worker', quickResolver),
       ).resolves.toBeUndefined();
     });
   });
@@ -239,59 +255,61 @@ describe('InterSessionMessageService', () => {
           toWorkerId: 'worker-1',
           fromSessionId: '../../../etc',
           content: 'malicious',
+          resolver: quickResolver,
         }),
       ).rejects.toThrow('Invalid fromSessionId');
     });
 
     it('should reject deleteSessionMessages with traversal in sessionId', async () => {
       await expect(
-        service.deleteSessionMessages('../../../etc'),
+        service.deleteSessionMessages('../../../etc', quickResolver),
       ).rejects.toThrow('Invalid sessionId');
     });
 
     it('should reject deleteWorkerMessages with traversal in workerId', async () => {
       await expect(
-        service.deleteWorkerMessages('valid-session', '../../../etc'),
+        service.deleteWorkerMessages('valid-session', '../../../etc', quickResolver),
       ).rejects.toThrow('Invalid workerId');
     });
   });
 
   describe('repository-scoped paths', () => {
-    it('should write to repository-scoped path when repositoryName is provided', async () => {
+    it('should write to repository-scoped path when resolver has repositoryName', async () => {
       const result = await service.sendMessage({
         toSessionId: 'session-target',
         toWorkerId: 'worker-1',
         fromSessionId: 'session-sender',
         content: 'hello',
-        repositoryName: 'org/repo',
+        resolver: repoResolver,
       });
 
       expect(result.path).toContain(`${TEST_CONFIG_DIR}/repositories/org/repo/messages/session-target/worker-1`);
       expect(vol.existsSync(`${TEST_CONFIG_DIR}/repositories/org/repo/messages/session-target/worker-1`)).toBe(true);
     });
 
-    it('should delete from repository-scoped path when repositoryName is provided', async () => {
+    it('should delete from repository-scoped path when resolver has repositoryName', async () => {
       await service.sendMessage({
         toSessionId: 'session-1',
         toWorkerId: 'worker-1',
         fromSessionId: 'sender',
         content: 'msg',
-        repositoryName: 'org/repo',
+        resolver: repoResolver,
       });
 
       expect(vol.existsSync(`${TEST_CONFIG_DIR}/repositories/org/repo/messages/session-1`)).toBe(true);
 
-      await service.deleteSessionMessages('session-1', 'org/repo');
+      await service.deleteSessionMessages('session-1', repoResolver);
 
       expect(vol.existsSync(`${TEST_CONFIG_DIR}/repositories/org/repo/messages/session-1`)).toBe(false);
     });
 
-    it('should write to _quick fallback path when repositoryName is not provided', async () => {
+    it('should write to _quick fallback path when resolver has no repositoryName', async () => {
       const result = await service.sendMessage({
         toSessionId: 'session-target',
         toWorkerId: 'worker-1',
         fromSessionId: 'session-sender',
         content: 'hello',
+        resolver: quickResolver,
       });
 
       expect(result.path).toContain(`${TEST_CONFIG_DIR}/_quick/messages/session-target/worker-1`);
@@ -306,12 +324,14 @@ describe('InterSessionMessageService', () => {
           toWorkerId: 'worker-1',
           fromSessionId: 'same-sender',
           content: 'message 1',
+          resolver: quickResolver,
         }),
         service.sendMessage({
           toSessionId: 'session-target',
           toWorkerId: 'worker-1',
           fromSessionId: 'same-sender',
           content: 'message 2',
+          resolver: quickResolver,
         }),
       ]);
 

--- a/packages/server/src/services/__tests__/memo-service.test.ts
+++ b/packages/server/src/services/__tests__/memo-service.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { vol } from 'memfs';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { MemoService } from '../memo-service.js';
+import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
 
 const TEST_CONFIG_DIR = '/test/config';
 const ORIGINAL_AGENT_CONSOLE_HOME = process.env.AGENT_CONSOLE_HOME;
+const quickResolver = new SessionDataPathResolver();
+const repoResolver = new SessionDataPathResolver('org/repo');
 
 describe('MemoService', () => {
   let service: MemoService;
@@ -26,7 +29,7 @@ describe('MemoService', () => {
 
   describe('writeMemo', () => {
     it('should create the memos directory and write the file', async () => {
-      const filePath = await service.writeMemo('session-1', '# My Memo');
+      const filePath = await service.writeMemo('session-1', '# My Memo', quickResolver);
 
       expect(filePath).toBe(`${TEST_CONFIG_DIR}/_quick/memos/session-1.md`);
       expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/memos`)).toBe(true);
@@ -36,8 +39,8 @@ describe('MemoService', () => {
     });
 
     it('should overwrite an existing memo', async () => {
-      await service.writeMemo('session-1', 'first version');
-      await service.writeMemo('session-1', 'second version');
+      await service.writeMemo('session-1', 'first version', quickResolver);
+      await service.writeMemo('session-1', 'second version', quickResolver);
 
       const content = vol.readFileSync(`${TEST_CONFIG_DIR}/_quick/memos/session-1.md`, 'utf-8');
       expect(content).toBe('second version');
@@ -45,14 +48,14 @@ describe('MemoService', () => {
 
     it('should reject content exceeding 256KB', async () => {
       const oversized = 'x'.repeat(256 * 1024 + 1);
-      await expect(service.writeMemo('session-1', oversized)).rejects.toThrow(
+      await expect(service.writeMemo('session-1', oversized, quickResolver)).rejects.toThrow(
         /exceeds maximum size/,
       );
     });
 
     it('should handle multiple sessions independently', async () => {
-      await service.writeMemo('session-a', 'memo A');
-      await service.writeMemo('session-b', 'memo B');
+      await service.writeMemo('session-a', 'memo A', quickResolver);
+      await service.writeMemo('session-b', 'memo B', quickResolver);
 
       const contentA = vol.readFileSync(`${TEST_CONFIG_DIR}/_quick/memos/session-a.md`, 'utf-8');
       const contentB = vol.readFileSync(`${TEST_CONFIG_DIR}/_quick/memos/session-b.md`, 'utf-8');
@@ -63,24 +66,24 @@ describe('MemoService', () => {
 
   describe('readMemo', () => {
     it('should return content for an existing memo', async () => {
-      await service.writeMemo('session-1', '# Hello');
+      await service.writeMemo('session-1', '# Hello', quickResolver);
 
-      const content = await service.readMemo('session-1');
+      const content = await service.readMemo('session-1', quickResolver);
       expect(content).toBe('# Hello');
     });
 
     it('should return null when no memo exists', async () => {
-      const content = await service.readMemo('nonexistent');
+      const content = await service.readMemo('nonexistent', quickResolver);
       expect(content).toBeNull();
     });
   });
 
   describe('deleteMemo', () => {
     it('should remove an existing memo file', async () => {
-      await service.writeMemo('session-1', 'content');
+      await service.writeMemo('session-1', 'content', quickResolver);
       expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/memos/session-1.md`)).toBe(true);
 
-      await service.deleteMemo('session-1');
+      await service.deleteMemo('session-1', quickResolver);
       expect(vol.existsSync(`${TEST_CONFIG_DIR}/_quick/memos/session-1.md`)).toBe(false);
     });
 
@@ -88,13 +91,13 @@ describe('MemoService', () => {
       // Ensure memos dir exists so rm doesn't fail on missing parent
       vol.mkdirSync(`${TEST_CONFIG_DIR}/_quick/memos`, { recursive: true });
 
-      await expect(service.deleteMemo('nonexistent')).resolves.toBeUndefined();
+      await expect(service.deleteMemo('nonexistent', quickResolver)).resolves.toBeUndefined();
     });
   });
 
   describe('repository-scoped paths', () => {
-    it('should write memo to repository-scoped path when repositoryName is provided', async () => {
-      const filePath = await service.writeMemo('session-1', '# Repo Memo', 'org/repo');
+    it('should write memo to repository-scoped path when resolver has repositoryName', async () => {
+      const filePath = await service.writeMemo('session-1', '# Repo Memo', repoResolver);
 
       expect(filePath).toBe(`${TEST_CONFIG_DIR}/repositories/org/repo/memos/session-1.md`);
       expect(vol.existsSync(filePath)).toBe(true);
@@ -103,24 +106,24 @@ describe('MemoService', () => {
       expect(content).toBe('# Repo Memo');
     });
 
-    it('should read memo from repository-scoped path when repositoryName is provided', async () => {
-      await service.writeMemo('session-1', '# Repo Memo', 'org/repo');
+    it('should read memo from repository-scoped path when resolver has repositoryName', async () => {
+      await service.writeMemo('session-1', '# Repo Memo', repoResolver);
 
-      const content = await service.readMemo('session-1', 'org/repo');
+      const content = await service.readMemo('session-1', repoResolver);
       expect(content).toBe('# Repo Memo');
     });
 
-    it('should delete memo from repository-scoped path when repositoryName is provided', async () => {
-      await service.writeMemo('session-1', 'content', 'org/repo');
+    it('should delete memo from repository-scoped path when resolver has repositoryName', async () => {
+      await service.writeMemo('session-1', 'content', repoResolver);
       const filePath = `${TEST_CONFIG_DIR}/repositories/org/repo/memos/session-1.md`;
       expect(vol.existsSync(filePath)).toBe(true);
 
-      await service.deleteMemo('session-1', 'org/repo');
+      await service.deleteMemo('session-1', repoResolver);
       expect(vol.existsSync(filePath)).toBe(false);
     });
 
-    it('should use _quick fallback when repositoryName is not provided', async () => {
-      const filePath = await service.writeMemo('session-1', '# Quick Memo');
+    it('should use _quick fallback when resolver has no repositoryName', async () => {
+      const filePath = await service.writeMemo('session-1', '# Quick Memo', quickResolver);
 
       expect(filePath).toBe(`${TEST_CONFIG_DIR}/_quick/memos/session-1.md`);
     });
@@ -128,15 +131,15 @@ describe('MemoService', () => {
 
   describe('sessionId validation', () => {
     it('should reject sessionId with path traversal (..)', async () => {
-      await expect(service.writeMemo('../etc/passwd', 'hack')).rejects.toThrow(/Invalid sessionId/);
-      await expect(service.readMemo('../etc/passwd')).rejects.toThrow(/Invalid sessionId/);
-      await expect(service.deleteMemo('../etc/passwd')).rejects.toThrow(/Invalid sessionId/);
+      await expect(service.writeMemo('../etc/passwd', 'hack', quickResolver)).rejects.toThrow(/Invalid sessionId/);
+      await expect(service.readMemo('../etc/passwd', quickResolver)).rejects.toThrow(/Invalid sessionId/);
+      await expect(service.deleteMemo('../etc/passwd', quickResolver)).rejects.toThrow(/Invalid sessionId/);
     });
 
     it('should reject sessionId with slashes', async () => {
-      await expect(service.writeMemo('foo/bar', 'hack')).rejects.toThrow(/Invalid sessionId/);
-      await expect(service.readMemo('foo/bar')).rejects.toThrow(/Invalid sessionId/);
-      await expect(service.deleteMemo('foo/bar')).rejects.toThrow(/Invalid sessionId/);
+      await expect(service.writeMemo('foo/bar', 'hack', quickResolver)).rejects.toThrow(/Invalid sessionId/);
+      await expect(service.readMemo('foo/bar', quickResolver)).rejects.toThrow(/Invalid sessionId/);
+      await expect(service.deleteMemo('foo/bar', quickResolver)).rejects.toThrow(/Invalid sessionId/);
     });
   });
 });

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -21,6 +21,7 @@ import type { InternalAgentWorker, InternalTerminalWorker, InternalGitDiffWorker
 import type { InternalSession } from '../internal-types.js';
 import type { SessionLifecycleCallbacks } from '../session-lifecycle-types.js';
 import { JobQueue } from '../../jobs/index.js';
+import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
 
 const TEST_CONFIG_DIR = '/test/config';
 
@@ -97,7 +98,7 @@ describe('WorkerLifecycleManager', () => {
       resolveSpawnUsername: async () => 'testuser',
       getJobQueue: () => testJobQueue,
       getSessionLifecycleCallbacks: () => mockCallbacks,
-      getRepositoryName: () => undefined,
+      getPathResolver: () => new SessionDataPathResolver(),
       ...overrides,
     };
   }

--- a/packages/server/src/services/__tests__/worker-manager-env.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager-env.test.ts
@@ -8,6 +8,7 @@ import { WorkerManager } from '../worker-manager.js';
 import { SingleUserMode } from '../user-mode.js';
 import type { InternalAgentWorker, InternalTerminalWorker } from '../worker-types.js';
 import type { PtySpawnOptions } from '../../lib/pty-provider.js';
+import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
 
 /**
  * Tests for AgentConsole context environment variable injection.
@@ -95,6 +96,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
       });
@@ -113,6 +115,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
       });
@@ -129,6 +132,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
       });
@@ -145,6 +149,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
         repositoryId: 'repo-456',
@@ -162,6 +167,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
         // repositoryId is not provided (quick session)
@@ -179,6 +185,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/worktree/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
         repositoryId: 'repo-all-four',
@@ -199,6 +206,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
       });
@@ -218,6 +226,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
         repositoryId: 'org/repo-name',
@@ -239,6 +248,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
           AGENT_CONSOLE_SESSION_ID: 'spoofed-session',
         },
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
         repositoryId: 'repo-1',
@@ -261,6 +271,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
         context: { parentSessionId: 'parent-sess-abc' },
@@ -278,6 +289,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
         context: { parentWorkerId: 'parent-wkr-xyz' },
@@ -295,6 +307,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
         // context is intentionally omitted
@@ -317,6 +330,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
           AGENT_CONSOLE_PARENT_WORKER_ID: 'spoofed-parent-worker',
         },
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
         agentId: 'claude-code',
         continueConversation: false,
         context: {
@@ -341,6 +355,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         locationPath: '/test/path',
         repositoryEnvVars: {},
         username: 'testuser',
+        resolver: new SessionDataPathResolver(),
       });
 
       const env = getLastSpawnEnv();

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -21,6 +21,7 @@ import type {
 } from '../worker-types.js';
 import type { PersistedAgentWorker, PersistedTerminalWorker, PersistedGitDiffWorker } from '../persistence-service.js';
 import { CLAUDE_CODE_AGENT_ID } from '../agent-manager.js';
+import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
 
 const TEST_CONFIG_DIR = '/test/config';
 
@@ -69,11 +70,14 @@ describe('WorkerManager', () => {
     });
   }
 
+  const defaultResolver = new SessionDataPathResolver();
+
   const defaultAgentActivationParams = {
     sessionId: 'session-1',
     locationPath: '/test/project',
     repositoryEnvVars: {},
     username: 'testuser',
+    resolver: defaultResolver,
     agentId: CLAUDE_CODE_AGENT_ID,
     continueConversation: false,
   };
@@ -83,6 +87,7 @@ describe('WorkerManager', () => {
     locationPath: '/test/project',
     repositoryEnvVars: {},
     username: 'testuser',
+    resolver: defaultResolver,
   };
 
   // ========== Worker Initialization ==========

--- a/packages/server/src/services/inter-session-message-service.ts
+++ b/packages/server/src/services/inter-session-message-service.ts
@@ -12,7 +12,7 @@
 import { randomBytes } from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { getMessagesDir } from '../lib/config.js';
+import type { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import { createLogger } from '../lib/logger.js';
 
 const logger = createLogger('inter-session-message');
@@ -47,7 +47,7 @@ export interface SendMessageParams {
   toWorkerId: string;
   fromSessionId: string;
   content: string;
-  repositoryName?: string;
+  resolver: SessionDataPathResolver;
 }
 
 export interface SendMessageResult {
@@ -67,7 +67,7 @@ export class InterSessionMessageService {
    * 4. Return { messageId, path }
    */
   async sendMessage(params: SendMessageParams): Promise<SendMessageResult> {
-    const { toSessionId, toWorkerId, fromSessionId, content, repositoryName } = params;
+    const { toSessionId, toWorkerId, fromSessionId, content, resolver } = params;
 
     validateId(toSessionId, 'toSessionId');
     validateId(toWorkerId, 'toWorkerId');
@@ -80,7 +80,7 @@ export class InterSessionMessageService {
       );
     }
 
-    const messagesDir = getMessagesDir(repositoryName);
+    const messagesDir = resolver.getMessagesDir();
     const dir = path.resolve(messagesDir, toSessionId, toWorkerId);
     assertWithinDir(dir, messagesDir);
 
@@ -112,10 +112,10 @@ export class InterSessionMessageService {
    * Remove all message files for a session.
    * Called when a session is deleted.
    */
-  async deleteSessionMessages(sessionId: string, repositoryName?: string): Promise<void> {
+  async deleteSessionMessages(sessionId: string, resolver: SessionDataPathResolver): Promise<void> {
     validateId(sessionId, 'sessionId');
 
-    const messagesDir = getMessagesDir(repositoryName);
+    const messagesDir = resolver.getMessagesDir();
     const dir = path.resolve(messagesDir, sessionId);
     assertWithinDir(dir, messagesDir);
 
@@ -128,11 +128,11 @@ export class InterSessionMessageService {
    * Remove all message files for a specific worker within a session.
    * Called when a worker is deleted.
    */
-  async deleteWorkerMessages(sessionId: string, workerId: string, repositoryName?: string): Promise<void> {
+  async deleteWorkerMessages(sessionId: string, workerId: string, resolver: SessionDataPathResolver): Promise<void> {
     validateId(sessionId, 'sessionId');
     validateId(workerId, 'workerId');
 
-    const messagesDir = getMessagesDir(repositoryName);
+    const messagesDir = resolver.getMessagesDir();
     const dir = path.resolve(messagesDir, sessionId, workerId);
     assertWithinDir(dir, messagesDir);
 

--- a/packages/server/src/services/memo-service.ts
+++ b/packages/server/src/services/memo-service.ts
@@ -9,7 +9,7 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { getMemosDir } from '../lib/config.js';
+import type { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import { createLogger } from '../lib/logger.js';
 
 const logger = createLogger('memo-service');
@@ -30,14 +30,14 @@ export class MemoService {
    *
    * @returns The absolute file path of the written memo.
    */
-  async writeMemo(sessionId: string, content: string, repositoryName?: string): Promise<string> {
+  async writeMemo(sessionId: string, content: string, resolver: SessionDataPathResolver): Promise<string> {
     this.validateSessionId(sessionId);
     const contentSize = Buffer.byteLength(content, 'utf-8');
     if (contentSize > MAX_MEMO_SIZE_BYTES) {
       throw new Error(`Memo content exceeds maximum size of ${MAX_MEMO_SIZE_BYTES} bytes (got ${contentSize})`);
     }
 
-    const memosDir = getMemosDir(repositoryName);
+    const memosDir = resolver.getMemosDir();
     await fs.mkdir(memosDir, { recursive: true });
 
     const filePath = path.join(memosDir, `${sessionId}.md`);
@@ -60,9 +60,9 @@ export class MemoService {
    *
    * @returns The memo content, or null if no memo exists.
    */
-  async readMemo(sessionId: string, repositoryName?: string): Promise<string | null> {
+  async readMemo(sessionId: string, resolver: SessionDataPathResolver): Promise<string | null> {
     this.validateSessionId(sessionId);
-    const filePath = path.join(getMemosDir(repositoryName), `${sessionId}.md`);
+    const filePath = resolver.getMemosPath(sessionId);
     try {
       return await fs.readFile(filePath, 'utf-8');
     } catch (err) {
@@ -76,9 +76,9 @@ export class MemoService {
   /**
    * Delete a memo for a session. Does not throw if the file does not exist.
    */
-  async deleteMemo(sessionId: string, repositoryName?: string): Promise<void> {
+  async deleteMemo(sessionId: string, resolver: SessionDataPathResolver): Promise<void> {
     this.validateSessionId(sessionId);
-    const filePath = path.join(getMemosDir(repositoryName), `${sessionId}.md`);
+    const filePath = resolver.getMemosPath(sessionId);
     await fs.rm(filePath, { force: true });
     logger.debug({ sessionId }, 'Memo deleted');
   }

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -34,6 +34,7 @@ import { filterRepositoryEnvVars } from './env-filter.js';
 import { parseEnvVars } from '../lib/env-parser.js';
 import { substituteVariables } from '../lib/template-variables.js';
 import { getConfigDir, getServerPid } from '../lib/config.js';
+import { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import { bunPtyProvider, type PtyProvider } from '../lib/pty-provider.js';
 import { SingleUserMode, type UserMode } from './user-mode.js';
 import { processKill, isProcessAlive } from '../lib/process-utils.js';
@@ -171,7 +172,7 @@ export class SessionManager {
       getJobQueue: () => this.jobQueue,
       getSessionLifecycleCallbacks: () => this.sessionLifecycleCallbacks,
       resolveSpawnUsername: (createdBy) => resolveSpawnUsername(createdBy, this.userRepository),
-      getRepositoryName: (session) => this.getRepositoryNameForSession(session),
+      getPathResolver: (session) => this.getPathResolverForSession(session),
     });
   }
 
@@ -275,10 +276,10 @@ export class SessionManager {
 
     // Delete orphan sessions (path no longer exists)
     for (const orphan of orphanSessions) {
-      const repositoryName = this.getRepositoryNameForPersistedSession(orphan);
+      const resolver = this.getPathResolverForPersistedSession(orphan);
       // Clean up worker output files
       try {
-        await workerOutputFileManager.deleteSessionOutputs(orphan.id, repositoryName);
+        await workerOutputFileManager.deleteSessionOutputs(orphan.id, resolver);
       } catch (error) {
         logger.error({ sessionId: orphan.id, err: error }, 'Failed to delete worker output files for orphan session');
       }
@@ -510,10 +511,10 @@ export class SessionManager {
         throw new Error('JobQueue not available for orphan session cleanup. Ensure jobQueue is passed to SessionManager.create().');
       }
       for (const orphan of orphanSessions) {
-        const repositoryName = this.getRepositoryNameForPersistedSession(orphan);
+        const resolver = this.getPathResolverForPersistedSession(orphan);
         await this.sessionRepository.delete(orphan.id);
         // Delete output files for orphan session via job queue
-        await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: orphan.id, repositoryName });
+        await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: orphan.id, repositoryName: resolver.getRepositoryName() });
         logger.info({ sessionId: orphan.id }, 'Removed orphan session from persistence');
       }
     }
@@ -633,14 +634,14 @@ export class SessionManager {
       throw new Error('JobQueue not available for session cleanup. Ensure SessionManager.create() was called with jobQueue.');
     }
 
-    // Resolve repository name before cleanup operations
-    const repositoryName = this.getRepositoryNameForSession(session);
+    // Resolve path resolver before cleanup operations
+    const resolver = this.getPathResolverForSession(session);
 
     // Perform all deletion operations atomically
     // If any fail, restore in-memory state to maintain consistency
     try {
       // 1. Enqueue cleanup job (async but fire-and-forget, failure is non-critical)
-      await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: id, repositoryName });
+      await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: id, repositoryName: resolver.getRepositoryName() });
 
       // 2. Clean up notification state (throttle timers, debounce timers)
       this.notificationManager?.cleanupSession(id);
@@ -653,14 +654,14 @@ export class SessionManager {
 
       // 2c. Clean up inter-session message files
       try {
-        await interSessionMessageService.deleteSessionMessages(id, repositoryName);
+        await interSessionMessageService.deleteSessionMessages(id, resolver);
       } catch (err) {
         logger.warn({ sessionId: id, err }, 'Failed to clean inter-session message files');
       }
 
       // 2d. Clean up memo file
       try {
-        await memoService.deleteMemo(id, repositoryName);
+        await memoService.deleteMemo(id, resolver);
       } catch (err) {
         logger.warn({ sessionId: id, err }, 'Failed to clean memo file');
       }
@@ -926,7 +927,7 @@ export class SessionManager {
     // Restore all PTY workers with continueConversation: true
     const repositoryEnvVars = await this.getRepositoryEnvVars(id);
     const repositoryId = internalSession.type === 'worktree' ? internalSession.repositoryId : undefined;
-    const repositoryName = this.getRepositoryNameForSession(internalSession);
+    const resolver = this.getPathResolverForSession(internalSession);
     try {
       const username = await resolveSpawnUsername(internalSession.createdBy, this.userRepository);
       for (const worker of workers.values()) {
@@ -936,7 +937,7 @@ export class SessionManager {
             locationPath: persisted.locationPath,
             repositoryEnvVars,
             username,
-            repositoryName,
+            resolver,
             agentId: worker.agentId,
             continueConversation: true,
             repositoryId,
@@ -952,7 +953,7 @@ export class SessionManager {
             locationPath: persisted.locationPath,
             repositoryEnvVars,
             username,
-            repositoryName,
+            resolver,
           });
           activatedWorkers.push(worker);
         }
@@ -1035,10 +1036,10 @@ export class SessionManager {
     // Check persistence for orphaned session
     const persisted = await this.sessionRepository.findById(id);
     if (persisted) {
-      const repositoryName = this.getRepositoryNameForPersistedSession(persisted);
+      const resolver = this.getPathResolverForPersistedSession(persisted);
       // Enqueue cleanup of worker output files (same as deleteSession)
       if (this.jobQueue) {
-        await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: id, repositoryName });
+        await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_SESSION_OUTPUTS, { sessionId: id, repositoryName: resolver.getRepositoryName() });
       } else {
         logger.warn(
           { sessionId: id, method: 'forceDeleteSession', skippedJob: JOB_TYPES.CLEANUP_SESSION_OUTPUTS },
@@ -1048,7 +1049,7 @@ export class SessionManager {
       await this.sessionRepository.delete(id);
       // Clean up memo file
       try {
-        await memoService.deleteMemo(id, repositoryName);
+        await memoService.deleteMemo(id, resolver);
       } catch (err) {
         logger.warn({ sessionId: id, err }, 'Failed to clean memo file');
       }
@@ -1214,11 +1215,11 @@ export class SessionManager {
     if (!session) {
       throw new Error(`Session not found: ${sessionId}`);
     }
-    const repositoryName = this.getRepositoryNameForSession(session);
-    const filePath = await memoService.writeMemo(sessionId, content, repositoryName);
+    const resolver = this.getPathResolverForSession(session);
+    const filePath = await memoService.writeMemo(sessionId, content, resolver);
     // Re-check after async write: session may have been deleted during the write
     if (!this.sessions.has(sessionId)) {
-      await memoService.deleteMemo(sessionId, repositoryName).catch(() => {});
+      await memoService.deleteMemo(sessionId, resolver).catch(() => {});
       throw new Error(`Session deleted during memo write: ${sessionId}`);
     }
     this.sessionLifecycleCallbacks?.onMemoUpdated?.(sessionId, content);
@@ -1235,8 +1236,8 @@ export class SessionManager {
     if (!session) {
       throw new Error(`Session not found: ${sessionId}`);
     }
-    const repositoryName = this.getRepositoryNameForSession(session);
-    return memoService.readMemo(sessionId, repositoryName);
+    const resolver = this.getPathResolverForSession(session);
+    return memoService.readMemo(sessionId, resolver);
   }
 
   /**
@@ -1496,23 +1497,24 @@ export class SessionManager {
   }
 
   /**
-   * Resolve the repository name for a session.
-   * Returns the org/repo name for worktree sessions, undefined for quick sessions.
+   * Resolve the session data path resolver for a session.
+   * Returns a resolver scoped to the repository for worktree sessions,
+   * or a quick-session resolver for quick sessions.
    */
-  private getRepositoryNameForSession(session: InternalSession): string | undefined {
-    if (session.type !== 'worktree') return undefined;
-    if (!this.repositoryCallbacks?.isInitialized()) return undefined;
-    return this.repositoryCallbacks.getRepository(session.repositoryId)?.name;
+  private getPathResolverForSession(session: InternalSession): SessionDataPathResolver {
+    if (session.type !== 'worktree') return new SessionDataPathResolver();
+    if (!this.repositoryCallbacks?.isInitialized()) return new SessionDataPathResolver();
+    return new SessionDataPathResolver(this.repositoryCallbacks.getRepository(session.repositoryId)?.name);
   }
 
   /**
-   * Resolve the repository name from a persisted session's repositoryId.
-   * Returns undefined for quick sessions or when repository callbacks are unavailable.
+   * Resolve the session data path resolver from a persisted session's repositoryId.
+   * Returns a quick-session resolver for quick sessions or when repository callbacks are unavailable.
    */
-  private getRepositoryNameForPersistedSession(persisted: PersistedSession): string | undefined {
-    if (persisted.type !== 'worktree') return undefined;
-    if (!this.repositoryCallbacks?.isInitialized()) return undefined;
-    return this.repositoryCallbacks.getRepository(persisted.repositoryId)?.name;
+  private getPathResolverForPersistedSession(persisted: PersistedSession): SessionDataPathResolver {
+    if (persisted.type !== 'worktree') return new SessionDataPathResolver();
+    if (!this.repositoryCallbacks?.isInitialized()) return new SessionDataPathResolver();
+    return new SessionDataPathResolver(this.repositoryCallbacks.getRepository(persisted.repositoryId)?.name);
   }
 
   private toPublicSession(session: InternalSession): Session {

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -45,6 +45,7 @@ import {
   renameBranch as gitRenameBranch,
 } from '../lib/git.js';
 import { workerOutputFileManager, type HistoryReadResult } from '../lib/worker-output-file.js';
+import { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import { createLogger } from '../lib/logger.js';
 
 import type { SessionLifecycleCallbacks } from './session-lifecycle-types.js';
@@ -73,10 +74,11 @@ export interface WorkerLifecycleDeps {
    */
   resolveSpawnUsername: (createdBy?: string) => Promise<string>;
   /**
-   * Resolve the repository name (org/repo) for a session.
-   * Returns undefined for quick sessions or when repository lookup is unavailable.
+   * Resolve the session data path resolver for a session.
+   * Returns a resolver scoped to the repository for worktree sessions,
+   * or a quick-session resolver for quick sessions.
    */
-  getRepositoryName: (session: InternalSession) => string | undefined;
+  getPathResolver: (session: InternalSession) => SessionDataPathResolver;
 }
 
 /**
@@ -114,7 +116,7 @@ export class WorkerLifecycleManager {
 
     let worker: InternalWorker;
     const repositoryId = session.type === 'worktree' ? session.repositoryId : undefined;
-    const repositoryName = this.deps.getRepositoryName(session);
+    const resolver = this.deps.getPathResolver(session);
 
     if (request.type === 'agent') {
       const repositoryEnvVars = await this.deps.getRepositoryEnvVars(sessionId);
@@ -130,7 +132,7 @@ export class WorkerLifecycleManager {
         locationPath: session.locationPath,
         repositoryEnvVars,
         username,
-        repositoryName,
+        resolver,
         agentId: agentWorker.agentId,
         continueConversation,
         initialPrompt,
@@ -155,7 +157,7 @@ export class WorkerLifecycleManager {
         locationPath: session.locationPath,
         repositoryEnvVars,
         username,
-        repositoryName,
+        resolver,
       });
       worker = terminalWorker;
     } else {
@@ -174,8 +176,7 @@ export class WorkerLifecycleManager {
     // Initialize output file immediately for PTY workers (agent/terminal)
     // This prevents race conditions where WebSocket connects before any output is buffered
     if (request.type === 'agent' || request.type === 'terminal') {
-      const repositoryName = this.deps.getRepositoryName(session);
-      await workerOutputFileManager.initializeWorkerOutput(sessionId, workerId, repositoryName);
+      await workerOutputFileManager.initializeWorkerOutput(sessionId, workerId, resolver);
     }
 
     await this.deps.persistSession(session);
@@ -221,7 +222,7 @@ export class WorkerLifecycleManager {
 
     const repositoryEnvVars = await this.deps.getRepositoryEnvVars(sessionId);
     const repositoryId = session.type === 'worktree' ? session.repositoryId : undefined;
-    const repositoryName = this.deps.getRepositoryName(session);
+    const resolver = this.deps.getPathResolver(session);
     const username = await this.deps.resolveSpawnUsername(session.createdBy);
 
     // Activate PTY based on worker type
@@ -232,7 +233,7 @@ export class WorkerLifecycleManager {
         locationPath: session.locationPath,
         repositoryEnvVars,
         username,
-        repositoryName,
+        resolver,
         agentId: effectiveAgentId,
         continueConversation: true,
         repositoryId,
@@ -247,7 +248,7 @@ export class WorkerLifecycleManager {
         locationPath: session.locationPath,
         repositoryEnvVars,
         username,
-        repositoryName,
+        resolver,
       });
     }
 
@@ -267,12 +268,12 @@ export class WorkerLifecycleManager {
     const worker = session.workers.get(workerId);
     if (!worker) return false;
 
-    const repositoryName = this.deps.getRepositoryName(session);
+    const resolver = this.deps.getPathResolver(session);
 
     // Clean up based on worker type
     if (worker.type === 'agent' || worker.type === 'terminal') {
       this.deps.workerManager.killWorker(worker);
-      await this.cleanupWorkerOutput(sessionId, workerId, repositoryName);
+      await this.cleanupWorkerOutput(sessionId, workerId, resolver);
     } else {
       // git-diff worker: stop file watcher (synchronous operation)
       stopWatching(session.locationPath);
@@ -286,7 +287,7 @@ export class WorkerLifecycleManager {
 
     // Clean up inter-session message files for this worker
     try {
-      await interSessionMessageService.deleteWorkerMessages(sessionId, workerId, repositoryName);
+      await interSessionMessageService.deleteWorkerMessages(sessionId, workerId, resolver);
     } catch (err) {
       logger.warn(
         { sessionId, workerId, err },
@@ -371,8 +372,8 @@ export class WorkerLifecycleManager {
     this.deps.workerManager.killWorker(existingWorker);
 
     // Reset the output file to prevent offset mismatch with client cache.
-    const repositoryName = this.deps.getRepositoryName(session);
-    await workerOutputFileManager.resetWorkerOutput(sessionId, workerId, repositoryName);
+    const resolver = this.deps.getPathResolver(session);
+    await workerOutputFileManager.resetWorkerOutput(sessionId, workerId, resolver);
 
     // Create new worker with same ID, preserving original createdAt for tab order
     const repositoryEnvVars = await this.deps.getRepositoryEnvVars(sessionId);
@@ -389,7 +390,7 @@ export class WorkerLifecycleManager {
       locationPath,
       repositoryEnvVars,
       username,
-      repositoryName,
+      resolver,
       agentId: workerAgentId,
       continueConversation,
       repositoryId,
@@ -517,7 +518,7 @@ export class WorkerLifecycleManager {
     try {
       const repositoryEnvVars = await this.deps.getRepositoryEnvVars(sessionId);
       const repositoryId = session.type === 'worktree' ? session.repositoryId : undefined;
-      const repositoryName = this.deps.getRepositoryName(session);
+      const resolver = this.deps.getPathResolver(session);
       const username = await this.deps.resolveSpawnUsername(session.createdBy);
 
       if (existingWorker.type === 'agent') {
@@ -527,7 +528,7 @@ export class WorkerLifecycleManager {
           locationPath: session.locationPath,
           repositoryEnvVars,
           username,
-          repositoryName,
+          resolver,
           agentId: effectiveAgentId,
           continueConversation: true,
           repositoryId,
@@ -542,7 +543,7 @@ export class WorkerLifecycleManager {
           locationPath: session.locationPath,
           repositoryEnvVars,
           username,
-          repositoryName,
+          resolver,
         });
       }
     } catch (err) {
@@ -638,14 +639,14 @@ export class WorkerLifecycleManager {
     const worker = this.getWorker(sessionId, workerId);
     if (!worker || worker.type === 'git-diff') return null;
 
-    const repositoryName = session ? this.deps.getRepositoryName(session) : undefined;
+    const resolver = session ? this.deps.getPathResolver(session) : new SessionDataPathResolver();
 
     // Use line-limited read for initial connection (fromOffset is 0 or undefined)
     if (maxLines !== undefined && (fromOffset === undefined || fromOffset === 0)) {
-      return workerOutputFileManager.readLastNLines(sessionId, workerId, maxLines, repositoryName);
+      return workerOutputFileManager.readLastNLines(sessionId, workerId, maxLines, resolver);
     }
 
-    return workerOutputFileManager.readHistoryWithOffset(sessionId, workerId, fromOffset, repositoryName);
+    return workerOutputFileManager.readHistoryWithOffset(sessionId, workerId, resolver, fromOffset);
   }
 
   /**
@@ -658,8 +659,8 @@ export class WorkerLifecycleManager {
     const worker = this.getWorker(sessionId, workerId);
     if (!worker || worker.type === 'git-diff') return 0;
 
-    const repositoryName = session ? this.deps.getRepositoryName(session) : undefined;
-    return workerOutputFileManager.getCurrentOffset(sessionId, workerId, repositoryName);
+    const resolver = session ? this.deps.getPathResolver(session) : new SessionDataPathResolver();
+    return workerOutputFileManager.getCurrentOffset(sessionId, workerId, resolver);
   }
 
   // ========== Private Helpers ==========
@@ -696,12 +697,12 @@ export class WorkerLifecycleManager {
    * Clean up worker output file via job queue.
    * If jobQueue is not available, logs a warning and skips cleanup gracefully.
    */
-  private async cleanupWorkerOutput(sessionId: string, workerId: string, repositoryName?: string): Promise<void> {
+  private async cleanupWorkerOutput(sessionId: string, workerId: string, resolver: SessionDataPathResolver): Promise<void> {
     const jobQueue = this.deps.getJobQueue();
     if (!jobQueue) {
       logger.warn({ sessionId, workerId }, 'JobQueue not available, skipping async output cleanup');
       return;
     }
-    await jobQueue.enqueue(JOB_TYPES.CLEANUP_WORKER_OUTPUT, { sessionId, workerId, repositoryName });
+    await jobQueue.enqueue(JOB_TYPES.CLEANUP_WORKER_OUTPUT, { sessionId, workerId, repositoryName: resolver.getRepositoryName() });
   }
 }

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -35,6 +35,7 @@ import type {
   Disposable,
 } from './worker-types.js';
 import type { SessionCreationContext } from './internal-types.js';
+import type { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import type { UserMode, AgentConsoleContext } from './user-mode.js';
 import { ActivityDetector } from './activity-detector.js';
 import { CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
@@ -57,8 +58,8 @@ export interface WorkerContext {
   repositoryEnvVars: Record<string, string>;
   /** OS username for PTY process ownership. Used by MultiUserMode for sudo -u. */
   username: string;
-  /** Repository name (org/repo) for data directory resolution. Undefined for quick sessions. */
-  repositoryName?: string;
+  /** Path resolver for session data directories (messages, memos, outputs). */
+  resolver: SessionDataPathResolver;
 }
 
 /**
@@ -356,7 +357,7 @@ export class WorkerManager {
     worker.activityState = 'idle';
     this.globalActivityCallback?.(sessionId, worker.id, 'idle');
 
-    this.setupWorkerEventHandlers(worker, sessionId, params.repositoryName);
+    this.setupWorkerEventHandlers(worker, sessionId, params.resolver);
   }
 
   /**
@@ -392,14 +393,14 @@ export class WorkerManager {
 
     worker.pty = ptyProcess;
 
-    this.setupWorkerEventHandlers(worker, sessionId, params.repositoryName);
+    this.setupWorkerEventHandlers(worker, sessionId, params.resolver);
   }
 
   /**
    * Setup event handlers for a PTY worker.
    * Stores disposables on the worker for cleanup when worker is killed.
    */
-  private setupWorkerEventHandlers(worker: InternalPtyWorker, sessionId: string, repositoryName?: string): void {
+  private setupWorkerEventHandlers(worker: InternalPtyWorker, sessionId: string, resolver: SessionDataPathResolver): void {
     if (!sessionId || sessionId.trim() === '') {
       throw new Error(
         `Cannot setup event handlers: sessionId is required (got: ${sessionId === '' ? 'empty string' : String(sessionId)})`
@@ -421,7 +422,7 @@ export class WorkerManager {
 
       worker.outputOffset += Buffer.byteLength(data, 'utf-8');
 
-      workerOutputFileManager.bufferOutput(sessionId, worker.id, data, repositoryName);
+      workerOutputFileManager.bufferOutput(sessionId, worker.id, data, resolver);
 
       if (worker.type === 'agent' && worker.activityDetector) {
         worker.activityDetector.processOutput(data);


### PR DESCRIPTION
## Summary

- Introduce `SessionDataPathResolver` class that centralizes the `repositoryName` conditional branching (worktree vs quick session) previously duplicated across `getMessagesDir`, `getMemosDir`, and `getOutputsDir` in config.ts
- Migrate `inter-session-message-service`, `memo-service`, and `worker-output-file` to accept a resolver instance instead of threading `repositoryName?: string` through every method
- Remove the three path functions from `config.ts` — the branching logic now lives exclusively in the resolver

## Test plan

- [x] New unit tests for `SessionDataPathResolver` covering repository-scoped and quick-session paths
- [x] Updated existing tests for all three services to use resolver pattern
- [x] All 3252 tests pass (0 failures)
- [x] TypeScript typecheck passes for all packages

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)