### PR TITLE
feat: persist templateVars in session for resume/restart/recover paths (#412)

### DIFF
--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -3258,4 +3258,84 @@ describe('SessionManager', () => {
       expect(manager.writeWorkerInput(session2.id, workerId2, 'test')).toBe(true);
     });
   });
+
+  // ========== templateVars persistence ==========
+
+  describe('templateVars persistence', () => {
+    it('should persist templateVars when creating a session with templateVars in request', async () => {
+      const manager = await getSessionManager();
+
+      const request: CreateSessionRequest = {
+        type: 'worktree',
+        locationPath: '/test/path',
+        repositoryId: 'repo-1',
+        worktreeId: 'main',
+        agentId: 'claude-code',
+        templateVars: { model: 'gpt-4', temperature: '0.7' },
+      };
+
+      const session = await manager.createSession(request);
+
+      // Verify templateVars is persisted via the repository
+      const repo = manager.getSessionRepository();
+      const persisted = await repo.findById(session.id);
+      expect(persisted).not.toBeNull();
+      expect(persisted!.templateVars).toEqual({ model: 'gpt-4', temperature: '0.7' });
+    });
+
+    it('should persist templateVars from SessionCreationContext', async () => {
+      const manager = await getSessionManager();
+
+      const request: CreateSessionRequest = {
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      };
+
+      const session = await manager.createSession(request, {
+        templateVars: { branch: 'feature-x' },
+      });
+
+      const repo = manager.getSessionRepository();
+      const persisted = await repo.findById(session.id);
+      expect(persisted).not.toBeNull();
+      expect(persisted!.templateVars).toEqual({ branch: 'feature-x' });
+    });
+
+    it('should restore templateVars when resuming a paused session', async () => {
+      const manager = await getSessionManager();
+
+      const session = await manager.createSession({
+        type: 'worktree',
+        locationPath: '/test/path',
+        repositoryId: 'repo-1',
+        worktreeId: 'feature-branch',
+        agentId: 'claude-code',
+        templateVars: { env: 'staging' },
+      });
+
+      // Pause the session
+      await manager.pauseSession(session.id);
+
+      // Verify session is removed from memory
+      expect(manager.getSession(session.id)).toBeUndefined();
+
+      // PTY count before resume
+      const ptyCountBefore = ptyFactory.instances.length;
+
+      // Resume the session
+      const resumed = await manager.resumeSession(session.id);
+
+      expect(resumed).not.toBeNull();
+      expect(resumed?.id).toBe(session.id);
+
+      // New PTY should be created for the agent worker (proving resume activated PTY)
+      expect(ptyFactory.instances.length).toBe(ptyCountBefore + 1);
+
+      // Verify templateVars is still persisted after resume
+      const repo = manager.getSessionRepository();
+      const persisted = await repo.findById(session.id);
+      expect(persisted!.templateVars).toEqual({ env: 'staging' });
+    });
+  });
 });

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -5,7 +5,7 @@
  * by using a real WorkerManager with mock PTY provider and
  * mocking the session-related dependencies (getSession, persistSession, etc.).
  */
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import type { CreateWorkerParams, Session } from '@agent-console/shared';
 import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
@@ -1671,6 +1671,115 @@ describe('WorkerLifecycleManager', () => {
       ptyFactory.instances[0].simulateExit(0);
 
       expect(onExit).toHaveBeenCalledWith(0, null);
+    });
+  });
+
+  // ========== templateVars propagation ==========
+
+  describe('templateVars propagation', () => {
+    it('should pass session templateVars in context during restartAgentWorker', async () => {
+      const templateVars = { model: 'gpt-4', temperature: '0.7' };
+      const session = createTestSession({ templateVars });
+      sessions.set(session.id, session);
+
+      const worker = await lifecycleManager.createWorker(session.id, {
+        type: 'agent',
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      const activateSpy = spyOn(workerManager, 'activateAgentWorkerPty');
+
+      await lifecycleManager.restartAgentWorker(session.id, worker!.id, true);
+
+      expect(activateSpy).toHaveBeenCalledTimes(1);
+      const params = activateSpy.mock.calls[0][1];
+      expect(params.context?.templateVars).toEqual(templateVars);
+
+      activateSpy.mockRestore();
+    });
+
+    it('should pass session templateVars in context during restoreWorker', async () => {
+      const templateVars = { branch: 'feature-x' };
+      const session = createTestSession({ templateVars });
+      sessions.set(session.id, session);
+
+      // Create a worker without PTY (simulating persistence restore)
+      const agentWorker: InternalAgentWorker = {
+        id: 'restored-worker-tv',
+        type: 'agent',
+        name: 'Restored Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+        pty: null,
+        outputBuffer: '',
+        outputOffset: 0,
+        activityState: 'unknown',
+        activityDetector: null,
+        connectionCallbacks: new Map(),
+      };
+      session.workers.set(agentWorker.id, agentWorker);
+
+      const activateSpy = spyOn(workerManager, 'activateAgentWorkerPty');
+
+      await lifecycleManager.restoreWorker(session.id, agentWorker.id);
+
+      expect(activateSpy).toHaveBeenCalledTimes(1);
+      const params = activateSpy.mock.calls[0][1];
+      expect(params.context?.templateVars).toEqual(templateVars);
+
+      activateSpy.mockRestore();
+    });
+
+    it('should pass session templateVars in context during getAvailableWorker', async () => {
+      const templateVars = { env: 'staging' };
+      const session = createTestSession({ templateVars });
+      sessions.set(session.id, session);
+
+      // Create a worker without PTY (simulating hibernated state)
+      const agentWorker: InternalAgentWorker = {
+        id: 'avail-worker-tv',
+        type: 'agent',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+        pty: null,
+        outputBuffer: '',
+        outputOffset: 0,
+        activityState: 'unknown',
+        activityDetector: null,
+        connectionCallbacks: new Map(),
+      };
+      session.workers.set(agentWorker.id, agentWorker);
+
+      const activateSpy = spyOn(workerManager, 'activateAgentWorkerPty');
+
+      await lifecycleManager.getAvailableWorker(session.id, agentWorker.id);
+
+      expect(activateSpy).toHaveBeenCalledTimes(1);
+      const params = activateSpy.mock.calls[0][1];
+      expect(params.context?.templateVars).toEqual(templateVars);
+
+      activateSpy.mockRestore();
+    });
+
+    it('should pass undefined templateVars when session has no templateVars', async () => {
+      const session = createTestSession(); // no templateVars
+      sessions.set(session.id, session);
+
+      const worker = await lifecycleManager.createWorker(session.id, {
+        type: 'agent',
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      const activateSpy = spyOn(workerManager, 'activateAgentWorkerPty');
+
+      await lifecycleManager.restartAgentWorker(session.id, worker!.id, true);
+
+      expect(activateSpy).toHaveBeenCalledTimes(1);
+      const params = activateSpy.mock.calls[0][1];
+      expect(params.context?.templateVars).toBeUndefined();
+
+      activateSpy.mockRestore();
     });
   });
 });

--- a/packages/server/src/services/internal-types.ts
+++ b/packages/server/src/services/internal-types.ts
@@ -37,6 +37,8 @@ export interface InternalSessionBase {
   parentWorkerId?: string;
   /** User UUID (from users table) of the user who created this session */
   createdBy?: string;
+  /** Custom template variable overrides for agent command templates */
+  templateVars?: Record<string, string>;
 }
 
 export interface InternalWorktreeSession extends InternalSessionBase {

--- a/packages/server/src/services/persistence-service.ts
+++ b/packages/server/src/services/persistence-service.ts
@@ -73,6 +73,8 @@ interface PersistedSessionBase {
   parentWorkerId?: string;
   /** User UUID (from users table) of the user who created this session */
   createdBy?: string;
+  /** Custom template variable overrides for agent command templates */
+  templateVars?: Record<string, string>;
 }
 
 export interface PersistedWorktreeSession extends PersistedSessionBase {

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -544,6 +544,7 @@ export class SessionManager {
       parentSessionId: request.parentSessionId,
       parentWorkerId: request.parentWorkerId,
       createdBy: context?.createdBy,
+      templateVars: request.templateVars ?? context?.templateVars,
     };
 
     const internalSession: InternalSession = request.type === 'worktree'
@@ -904,6 +905,7 @@ export class SessionManager {
       parentSessionId: persisted.parentSessionId,
       parentWorkerId: persisted.parentWorkerId,
       createdBy: persisted.createdBy,
+      templateVars: persisted.templateVars,
     };
 
     const internalSession: InternalSession = persisted.type === 'worktree'
@@ -944,6 +946,7 @@ export class SessionManager {
             context: {
               parentSessionId: internalSession.parentSessionId,
               parentWorkerId: internalSession.parentWorkerId,
+              templateVars: internalSession.templateVars,
             },
           });
           activatedWorkers.push(worker);
@@ -1489,6 +1492,7 @@ export class SessionManager {
       parentSessionId: session.parentSessionId,
       parentWorkerId: session.parentWorkerId,
       createdBy: session.createdBy,
+      templateVars: session.templateVars,
     };
 
     return session.type === 'worktree'

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -240,6 +240,7 @@ export class WorkerLifecycleManager {
         context: {
           parentSessionId: session.parentSessionId,
           parentWorkerId: session.parentWorkerId,
+          templateVars: session.templateVars,
         },
       });
     } else {
@@ -397,6 +398,7 @@ export class WorkerLifecycleManager {
       context: {
         parentSessionId: session.parentSessionId,
         parentWorkerId: session.parentWorkerId,
+        templateVars: session.templateVars,
       },
     });
 
@@ -535,6 +537,7 @@ export class WorkerLifecycleManager {
           context: {
             parentSessionId: session.parentSessionId,
             parentWorkerId: session.parentWorkerId,
+            templateVars: session.templateVars,
           },
         });
       } else {


### PR DESCRIPTION
## Summary
- Add `templateVars` field to `InternalSessionBase` and `PersistedSessionBase` so template variables survive server restarts
- Store `templateVars` at session creation and restore them on resume
- Pass `templateVars` through `context` in all worker reactivation paths: `restartAgentWorker`, `restoreWorker`, `getAvailableWorker`, and `resumeSessionInternal`

Closes #412

## Test plan
- [x] Unit test: templateVars persisted when session created via request
- [x] Unit test: templateVars persisted when session created via SessionCreationContext
- [x] Unit test: templateVars survives pause + resume round-trip
- [x] Unit test: templateVars passed in context during restartAgentWorker
- [x] Unit test: templateVars passed in context during restoreWorker
- [x] Unit test: templateVars passed in context during getAvailableWorker
- [x] Unit test: undefined templateVars when session has none

🤖 Generated with [Claude Code](https://claude.com/claude-code)