### PR TITLE
[AI] closed #406 fix: worktree deletion WebSocket broadcast only reports first session ID

### DIFF
--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -1947,21 +1947,12 @@ describe('API Routes Integration', () => {
           expect(bunSpawnCalls.length).toBe(1);
           expect(bunSpawnCalls[0].args[2]).toBe('docker compose down');
 
-          // Verify broadcastToApp was called with deletion-completed and cleanup result
+          // No sessions exist for this worktree, so no broadcast should occur
           const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
-          const completedCall = broadcastSpy.mock.calls.find(
+          const completedCalls = broadcastSpy.mock.calls.filter(
             (call: unknown[]) => (call[0] as { type: string }).type === 'worktree-deletion-completed'
           );
-          expect(completedCall).toBeDefined();
-          const msg = completedCall![0] as {
-            type: string;
-            taskId: string;
-            cleanupCommandResult?: HookCommandResult;
-          };
-          expect(msg.taskId).toBe('test-task-id');
-          expect(msg.cleanupCommandResult).toBeDefined();
-          expect(msg.cleanupCommandResult!.success).toBe(true);
-          expect(msg.cleanupCommandResult!.output).toBe('containers stopped');
+          expect(completedCalls.length).toBe(0);
         } finally {
           restoreBunSpawn();
         }
@@ -2195,6 +2186,162 @@ describe('API Routes Integration', () => {
         const sessions = testSessionManager!.getAllSessions();
         const sessionStillExists = sessions.some(s => s.locationPath === worktreePath);
         expect(sessionStillExists).toBe(true);
+      });
+
+      it('should broadcast worktree-deletion-completed for all deleted sessions', async () => {
+        const app = await createApp();
+        const { repo, repoPath } = await registerTestRepo(app);
+        const { worktreePath } = await setupWorktreeForDeletion(repo, repoPath);
+
+        // Create worktree directory in memfs so session creation succeeds
+        fs.mkdirSync(worktreePath, { recursive: true });
+
+        // Create TWO sessions with the same locationPath
+        const sessionRes1 = await app.request('/api/sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            type: 'quick',
+            locationPath: worktreePath,
+            agentId: CLAUDE_CODE_AGENT_ID,
+          }),
+        });
+        expect(sessionRes1.status).toBe(201);
+        const { session: session1 } = (await sessionRes1.json()) as { session: Session };
+
+        const sessionRes2 = await app.request('/api/sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            type: 'quick',
+            locationPath: worktreePath,
+            agentId: CLAUDE_CODE_AGENT_ID,
+          }),
+        });
+        expect(sessionRes2.status).toBe(201);
+        const { session: session2 } = (await sessionRes2.json()) as { session: Session };
+
+        // Delete worktree via async path (with taskId)
+        const encodedPath = encodeURIComponent(worktreePath);
+        const res = await app.request(
+          `/api/repositories/${repo.id}/worktrees/${encodedPath}?taskId=test-broadcast-all&force=true`,
+          { method: 'DELETE' }
+        );
+        expect(res.status).toBe(202);
+
+        // Wait for background operation to complete
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        // Verify broadcastToApp was called with worktree-deletion-completed for EACH session ID
+        const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+        const completedCalls = broadcastSpy.mock.calls.filter(
+          (call: unknown[]) => {
+            const message = call[0] as { type: string; taskId?: string };
+            return message.type === 'worktree-deletion-completed' && message.taskId === 'test-broadcast-all';
+          }
+        );
+        expect(completedCalls.length).toBe(2);
+
+        const broadcastSessionIds = completedCalls.map(
+          (call: unknown[]) => (call[0] as { sessionId: string }).sessionId
+        );
+        expect(broadcastSessionIds).toContain(session1.id);
+        expect(broadcastSessionIds).toContain(session2.id);
+      });
+
+      it('should not broadcast worktree-deletion-completed when no sessions exist for deleted worktree', async () => {
+        const app = await createApp();
+        const { repo, repoPath } = await registerTestRepo(app);
+        const { worktreePath } = await setupWorktreeForDeletion(repo, repoPath);
+
+        // Do NOT create any sessions for this worktree path
+
+        // Delete worktree via async path (with taskId)
+        const encodedPath = encodeURIComponent(worktreePath);
+        const res = await app.request(
+          `/api/repositories/${repo.id}/worktrees/${encodedPath}?taskId=test-no-sessions&force=true`,
+          { method: 'DELETE' }
+        );
+        expect(res.status).toBe(202);
+
+        // Wait for background operation to complete
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        // Verify broadcastToApp was NOT called with worktree-deletion-completed for this taskId
+        const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+        const completedCalls = broadcastSpy.mock.calls.filter(
+          (call: unknown[]) => {
+            const message = call[0] as { type: string; taskId?: string };
+            return message.type === 'worktree-deletion-completed' && message.taskId === 'test-no-sessions';
+          }
+        );
+        expect(completedCalls.length).toBe(0);
+      });
+
+      it('should broadcast worktree-deletion-failed for all sessions when deletion fails', async () => {
+        const app = await createApp();
+        const { repo, repoPath } = await registerTestRepo(app);
+        const { worktreePath } = await setupWorktreeForDeletion(repo, repoPath);
+
+        // Create worktree directory in memfs so session creation succeeds
+        fs.mkdirSync(worktreePath, { recursive: true });
+
+        // Create TWO sessions with the same locationPath
+        const sessionRes1 = await app.request('/api/sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            type: 'quick',
+            locationPath: worktreePath,
+            agentId: CLAUDE_CODE_AGENT_ID,
+          }),
+        });
+        expect(sessionRes1.status).toBe(201);
+        const { session: session1 } = (await sessionRes1.json()) as { session: Session };
+
+        const sessionRes2 = await app.request('/api/sessions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            type: 'quick',
+            locationPath: worktreePath,
+            agentId: CLAUDE_CODE_AGENT_ID,
+          }),
+        });
+        expect(sessionRes2.status).toBe(201);
+        const { session: session2 } = (await sessionRes2.json()) as { session: Session };
+
+        // Make removeWorktree fail with a GitError
+        mockGit.removeWorktree.mockRejectedValue(
+          new GitError('worktree has uncommitted changes', 1, 'worktree has uncommitted changes')
+        );
+
+        // Delete worktree via async path (with taskId)
+        const encodedPath = encodeURIComponent(worktreePath);
+        const res = await app.request(
+          `/api/repositories/${repo.id}/worktrees/${encodedPath}?taskId=test-fail-broadcast-all&force=true`,
+          { method: 'DELETE' }
+        );
+        expect(res.status).toBe(202);
+
+        // Wait for background operation to complete
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        // Verify broadcastToApp was called with worktree-deletion-failed for EACH session ID
+        const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+        const failedCalls = broadcastSpy.mock.calls.filter(
+          (call: unknown[]) => {
+            const message = call[0] as { type: string; taskId?: string };
+            return message.type === 'worktree-deletion-failed' && message.taskId === 'test-fail-broadcast-all';
+          }
+        );
+        expect(failedCalls.length).toBe(2);
+
+        const broadcastSessionIds = failedCalls.map(
+          (call: unknown[]) => (call[0] as { sessionId: string }).sessionId
+        );
+        expect(broadcastSessionIds).toContain(session1.id);
+        expect(broadcastSessionIds).toContain(session2.id);
       });
 
       it('should block deletion when branch has an open PR (sync path)', async () => {

--- a/packages/server/src/routes/worktrees.ts
+++ b/packages/server/src/routes/worktrees.ts
@@ -323,28 +323,30 @@ const worktrees = new Hono<AppBindings>()
       (async () => {
         try {
           const result = await deleteWorktree({ repoId, worktreePath, force }, deletionDeps);
-
-          // Use first session ID for backward-compatible WebSocket broadcast
-          const broadcastSessionId = result.sessionIds?.[0] || '';
+          const sessionIds = result.sessionIds ?? [];
 
           if (!result.success) {
-            broadcastToApp({
-              type: 'worktree-deletion-failed',
-              taskId,
-              sessionId: broadcastSessionId,
-              error: result.error || 'Failed to remove worktree',
-              gitStatus: result.gitStatus,
-            });
+            for (const sid of sessionIds) {
+              broadcastToApp({
+                type: 'worktree-deletion-failed',
+                taskId,
+                sessionId: sid,
+                error: result.error || 'Failed to remove worktree',
+                gitStatus: result.gitStatus,
+              });
+            }
             logger.error({ taskId, repoId, worktreePath, error: result.error }, 'Worktree deletion failed');
             return;
           }
 
-          broadcastToApp({
-            type: 'worktree-deletion-completed',
-            taskId,
-            sessionId: broadcastSessionId,
-            cleanupCommandResult: result.cleanupCommandResult,
-          });
+          for (const sid of sessionIds) {
+            broadcastToApp({
+              type: 'worktree-deletion-completed',
+              taskId,
+              sessionId: sid,
+              cleanupCommandResult: result.cleanupCommandResult,
+            });
+          }
           logger.info({ taskId, repoId, worktreePath, sessionIds: result.sessionIds }, 'Worktree and session deletion completed');
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error during worktree deletion';


### PR DESCRIPTION
## Summary
- Loop over all `result.sessionIds` to broadcast one `worktree-deletion-completed` / `worktree-deletion-failed` event per deleted session (previously only the first session ID was broadcast)
- Skip broadcast entirely when no sessions exist (previously broadcast with empty `sessionId: ''`)
- Add 3 unit tests covering multi-session broadcast, no-session edge case, and multi-session failure broadcast

## Test plan
- [x] All 1872 tests pass
- [x] Typecheck passes
- [ ] Visual confirmation: delete a worktree with multiple sessions and verify all are removed from the UI

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)