### PR TITLE
[AI] closed #394 refactor: improve repository management UI with router-based detail pages

### DIFF
--- a/packages/client/src/__tests__/routes/settings/repositories/$repositoryId/edit.error-pending.test.tsx
+++ b/packages/client/src/__tests__/routes/settings/repositories/$repositoryId/edit.error-pending.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithRouter } from '../../../../../test/renderWithRouter';
+import { RepositoryEditPending, RepositoryEditError } from '../../../../../routes/settings/repositories/$repositoryId/edit';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('RepositoryEditPending', () => {
+  it('renders loading text with spinner', async () => {
+    await renderWithRouter(<RepositoryEditPending />);
+
+    expect(screen.getByText('Loading repository...')).toBeTruthy();
+    expect(screen.getByRole('status')).toBeTruthy();
+  });
+});
+
+describe('RepositoryEditError', () => {
+  it('renders the error message', async () => {
+    const reset = mock(() => {});
+    const error = new Error('Repository not found: repo-456');
+    await renderWithRouter(<RepositoryEditError error={error} reset={reset} />);
+
+    expect(screen.getByText('Failed to load repository')).toBeTruthy();
+    expect(screen.getByText('Repository not found: repo-456')).toBeTruthy();
+  });
+
+  it('calls reset when Retry is clicked', async () => {
+    const reset = mock(() => {});
+    await renderWithRouter(
+      <RepositoryEditError error={new Error('error')} reset={reset} />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Back to Repositories link', async () => {
+    await renderWithRouter(
+      <RepositoryEditError error={new Error('error')} reset={mock(() => {})} />
+    );
+
+    const link = screen.getByRole('link', { name: 'Back to Repositories' });
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBe('/settings/repositories');
+  });
+});

--- a/packages/client/src/__tests__/routes/settings/repositories/$repositoryId/index.error-pending.test.tsx
+++ b/packages/client/src/__tests__/routes/settings/repositories/$repositoryId/index.error-pending.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithRouter } from '../../../../../test/renderWithRouter';
+import { RepositoryDetailPending, RepositoryDetailError } from '../../../../../routes/settings/repositories/$repositoryId/index';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('RepositoryDetailPending', () => {
+  it('renders loading text with spinner', async () => {
+    await renderWithRouter(<RepositoryDetailPending />);
+
+    expect(screen.getByText('Loading repository...')).toBeTruthy();
+    expect(screen.getByRole('status')).toBeTruthy();
+  });
+});
+
+describe('RepositoryDetailError', () => {
+  it('renders the error message', async () => {
+    const reset = mock(() => {});
+    const error = new Error('Repository not found: repo-123');
+    await renderWithRouter(<RepositoryDetailError error={error} reset={reset} />);
+
+    expect(screen.getByText('Failed to load repository')).toBeTruthy();
+    expect(screen.getByText('Repository not found: repo-123')).toBeTruthy();
+  });
+
+  it('calls reset when Retry is clicked', async () => {
+    const reset = mock(() => {});
+    await renderWithRouter(
+      <RepositoryDetailError error={new Error('error')} reset={reset} />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Back to Repositories link', async () => {
+    await renderWithRouter(
+      <RepositoryDetailError error={new Error('error')} reset={mock(() => {})} />
+    );
+
+    const link = screen.getByRole('link', { name: 'Back to Repositories' });
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBe('/settings/repositories');
+  });
+});

--- a/packages/client/src/components/repositories/RepositoryList.tsx
+++ b/packages/client/src/components/repositories/RepositoryList.tsx
@@ -1,17 +1,12 @@
-import { useState } from 'react';
+import { Link } from '@tanstack/react-router';
 import type { Repository } from '@agent-console/shared';
 import { useRepositories } from './hooks/use-repositories';
 import { Spinner } from '../ui/Spinner';
-import { EditRepositoryForm } from './EditRepositoryForm';
 
 export function RepositoryList() {
   const { repositories, isLoading, error, refetch } = useRepositories();
-  const [editingRepoId, setEditingRepoId] = useState<string | null>(null);
 
-  // Show loading state only while initial fetch is in progress
-  const showLoading = isLoading;
-
-  if (showLoading) {
+  if (isLoading) {
     return (
       <div className="flex items-center gap-2 text-gray-500">
         <Spinner size="sm" />
@@ -44,86 +39,49 @@ export function RepositoryList() {
 
   return (
     <div className="flex flex-col gap-3">
-      {repositories.map((repo) => {
-        const isEditing = editingRepoId === repo.id;
-
-        if (isEditing) {
-          return (
-            <EditRepositoryForm
-              key={repo.id}
-              repository={repo}
-              onSuccess={() => setEditingRepoId(null)}
-              onCancel={() => setEditingRepoId(null)}
-            />
-          );
-        }
-
-        return (
-          <RepositoryCard
-            key={repo.id}
-            repository={repo}
-            onEdit={() => setEditingRepoId(repo.id)}
-          />
-        );
-      })}
+      {repositories.map((repo) => (
+        <RepositoryCard key={repo.id} repository={repo} />
+      ))}
     </div>
   );
 }
 
 interface RepositoryCardProps {
   repository: Repository;
-  onEdit: () => void;
 }
 
-function RepositoryCard({ repository, onEdit }: RepositoryCardProps) {
+function RepositoryCard({ repository }: RepositoryCardProps) {
   const { setupCommand } = repository;
   const hasSetupCommand = Boolean(setupCommand?.trim());
 
   return (
-    <div className="card">
-      <div className="flex items-start gap-4">
-        <div className="flex-1 min-w-0">
-          {/* Name */}
-          <div className="text-lg font-medium mb-1">{repository.name}</div>
-
-          {/* Path */}
-          <div className="text-sm text-gray-400 font-mono mb-2">{repository.path}</div>
-
-          {/* Description */}
-          {repository.description && (
-            <div className="text-sm mb-2">
-              <span className="text-gray-500">Description: </span>
-              <span className="text-gray-300">{repository.description}</span>
-            </div>
-          )}
-
-          {/* Setup command */}
-          <div className="text-sm">
-            <span className="text-gray-500">Setup command: </span>
-            {hasSetupCommand ? (
-              <span
-                className="font-mono text-gray-300 truncate inline-block max-w-[400px] align-bottom"
-                title={setupCommand || undefined}
-              >
-                {truncateCommand(setupCommand!, 60)}
-              </span>
-            ) : (
-              <span className="text-gray-600 italic">Not configured</span>
-            )}
-          </div>
+    <Link
+      to="/settings/repositories/$repositoryId"
+      params={{ repositoryId: repository.id }}
+      className="card hover:border-slate-600 transition-colors cursor-pointer no-underline block"
+    >
+      <div className="text-lg font-medium mb-1">{repository.name}</div>
+      <div className="text-sm text-gray-400 font-mono mb-2">{repository.path}</div>
+      {repository.description && (
+        <div className="text-sm mb-2">
+          <span className="text-gray-500">Description: </span>
+          <span className="text-gray-300">{repository.description}</span>
         </div>
-
-        {/* Action buttons */}
-        <div className="flex gap-2 shrink-0">
-          <button
-            onClick={onEdit}
-            className="btn btn-primary text-sm"
+      )}
+      <div className="text-sm">
+        <span className="text-gray-500">Setup command: </span>
+        {hasSetupCommand ? (
+          <span
+            className="font-mono text-gray-300 truncate inline-block max-w-[400px] align-bottom"
+            title={setupCommand || undefined}
           >
-            Edit
-          </button>
-        </div>
+            {truncateCommand(setupCommand!, 60)}
+          </span>
+        ) : (
+          <span className="text-gray-600 italic">Not configured</span>
+        )}
       </div>
-    </div>
+    </Link>
   );
 }
 

--- a/packages/client/src/components/repositories/__tests__/RepositoryList.test.tsx
+++ b/packages/client/src/components/repositories/__tests__/RepositoryList.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, mock, afterEach, afterAll, beforeEach } from 'bun:test';
+import { screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithRouter } from '../../../test/renderWithRouter';
+import { RepositoryList } from '../RepositoryList';
+import type { Repository } from '@agent-console/shared';
+
+// Save original fetch and set up mock
+const originalFetch = globalThis.fetch;
+const mockFetch = mock((_input: RequestInfo | URL, _init?: RequestInit) => Promise.resolve(new Response()));
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function createMockResponse(body: unknown, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 400,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function createTestRepository(overrides: Partial<Repository> = {}): Repository {
+  return {
+    id: 'repo-1',
+    name: 'test-repo',
+    path: '/path/to/test-repo',
+    createdAt: new Date().toISOString(),
+    remoteUrl: 'https://github.com/test/test-repo.git',
+    setupCommand: null,
+    cleanupCommand: null,
+    description: null,
+    defaultAgentId: null,
+    ...overrides,
+  };
+}
+
+function setupMockFetch(repositories: Repository[]) {
+  mockFetch.mockImplementation((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('/api/repositories')) {
+      return Promise.resolve(createMockResponse({ repositories }));
+    }
+    return Promise.resolve(new Response('Not found', { status: 404 }));
+  });
+}
+
+function setupMockFetchError() {
+  mockFetch.mockImplementation((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('/api/repositories')) {
+      return Promise.resolve(createMockResponse({ error: 'Network error' }, false));
+    }
+    return Promise.resolve(new Response('Not found', { status: 404 }));
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('RepositoryList', () => {
+  describe('loading state', () => {
+    it('shows loading spinner while fetching', async () => {
+      // Make fetch hang to observe loading state
+      mockFetch.mockImplementation(() => new Promise(() => {}));
+
+      await renderWithRouter(<RepositoryList />);
+
+      expect(screen.getByText('Loading repositories...')).toBeTruthy();
+    });
+  });
+
+  describe('error state', () => {
+    it('renders error message and retry button', async () => {
+      setupMockFetchError();
+
+      await renderWithRouter(<RepositoryList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load repositories')).toBeTruthy();
+      });
+
+      const retryButton = screen.getByRole('button', { name: 'Retry' });
+      expect(retryButton).toBeTruthy();
+
+      // Set up a successful response for the retry
+      setupMockFetch([createTestRepository()]);
+      await userEvent.click(retryButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('test-repo')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows empty message when no repositories exist', async () => {
+      setupMockFetch([]);
+
+      await renderWithRouter(<RepositoryList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('No repositories registered')).toBeTruthy();
+      });
+      expect(
+        screen.getByText('Register repositories from the Dashboard to manage their setup commands.')
+      ).toBeTruthy();
+    });
+  });
+
+  describe('repository cards', () => {
+    it('renders each repository as a link to its detail page', async () => {
+      const repos = [
+        createTestRepository({ id: 'repo-1', name: 'First Repo' }),
+        createTestRepository({ id: 'repo-2', name: 'Second Repo' }),
+      ];
+
+      setupMockFetch(repos);
+
+      await renderWithRouter(<RepositoryList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('First Repo')).toBeTruthy();
+      });
+
+      const firstLink = screen.getByText('First Repo').closest('a');
+      const secondLink = screen.getByText('Second Repo').closest('a');
+
+      expect(firstLink?.getAttribute('href')).toBe('/settings/repositories/repo-1');
+      expect(secondLink?.getAttribute('href')).toBe('/settings/repositories/repo-2');
+    });
+
+    it('displays repository name, path, and setup command summary', async () => {
+      const repo = createTestRepository({
+        name: 'My Project',
+        path: '/home/user/my-project',
+        setupCommand: 'bun install && bun run build',
+      });
+
+      setupMockFetch([repo]);
+
+      await renderWithRouter(<RepositoryList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('My Project')).toBeTruthy();
+      });
+      expect(screen.getByText('/home/user/my-project')).toBeTruthy();
+      expect(screen.getByText('bun install && bun run build')).toBeTruthy();
+    });
+
+    it('shows "Not configured" when setupCommand is null', async () => {
+      const repo = createTestRepository({ setupCommand: null });
+
+      setupMockFetch([repo]);
+
+      await renderWithRouter(<RepositoryList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Not configured')).toBeTruthy();
+      });
+    });
+
+    it('shows "Not configured" when setupCommand is empty string', async () => {
+      const repo = createTestRepository({ setupCommand: '' });
+
+      setupMockFetch([repo]);
+
+      await renderWithRouter(<RepositoryList />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Not configured')).toBeTruthy();
+      });
+    });
+  });
+});

--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -17,12 +17,14 @@ import { Route as JobsIndexRouteImport } from './routes/jobs/index'
 import { Route as AgentsIndexRouteImport } from './routes/agents/index'
 import { Route as WorktreeDeletionTasksTaskIdRouteImport } from './routes/worktree-deletion-tasks/$taskId'
 import { Route as WorktreeCreationTasksTaskIdRouteImport } from './routes/worktree-creation-tasks/$taskId'
-import { Route as SettingsRepositoriesRouteImport } from './routes/settings/repositories'
+import { Route as SettingsRepositoriesIndexRouteImport } from './routes/settings/repositories/index'
 import { Route as SessionsSessionIdIndexRouteImport } from './routes/sessions/$sessionId/index'
 import { Route as JobsJobIdIndexRouteImport } from './routes/jobs/$jobId/index'
 import { Route as AgentsAgentIdIndexRouteImport } from './routes/agents/$agentId/index'
 import { Route as SessionsSessionIdWorkerIdRouteImport } from './routes/sessions/$sessionId/$workerId'
 import { Route as AgentsAgentIdEditRouteImport } from './routes/agents/$agentId/edit'
+import { Route as SettingsRepositoriesRepositoryIdIndexRouteImport } from './routes/settings/repositories/$repositoryId/index'
+import { Route as SettingsRepositoriesRepositoryIdEditRouteImport } from './routes/settings/repositories/$repositoryId/edit'
 
 const MaintenanceRoute = MaintenanceRouteImport.update({
   id: '/maintenance',
@@ -66,11 +68,12 @@ const WorktreeCreationTasksTaskIdRoute =
     path: '/worktree-creation-tasks/$taskId',
     getParentRoute: () => rootRouteImport,
   } as any)
-const SettingsRepositoriesRoute = SettingsRepositoriesRouteImport.update({
-  id: '/settings/repositories',
-  path: '/settings/repositories',
-  getParentRoute: () => rootRouteImport,
-} as any)
+const SettingsRepositoriesIndexRoute =
+  SettingsRepositoriesIndexRouteImport.update({
+    id: '/settings/repositories/',
+    path: '/settings/repositories/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const SessionsSessionIdIndexRoute = SessionsSessionIdIndexRouteImport.update({
   id: '/sessions/$sessionId/',
   path: '/sessions/$sessionId/',
@@ -97,45 +100,23 @@ const AgentsAgentIdEditRoute = AgentsAgentIdEditRouteImport.update({
   path: '/agents/$agentId/edit',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SettingsRepositoriesRepositoryIdIndexRoute =
+  SettingsRepositoriesRepositoryIdIndexRouteImport.update({
+    id: '/settings/repositories/$repositoryId/',
+    path: '/settings/repositories/$repositoryId/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const SettingsRepositoriesRepositoryIdEditRoute =
+  SettingsRepositoriesRepositoryIdEditRouteImport.update({
+    id: '/settings/repositories/$repositoryId/edit',
+    path: '/settings/repositories/$repositoryId/edit',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/maintenance': typeof MaintenanceRoute
-  '/settings/repositories': typeof SettingsRepositoriesRoute
-  '/worktree-creation-tasks/$taskId': typeof WorktreeCreationTasksTaskIdRoute
-  '/worktree-deletion-tasks/$taskId': typeof WorktreeDeletionTasksTaskIdRoute
-  '/agents': typeof AgentsIndexRoute
-  '/jobs': typeof JobsIndexRoute
-  '/settings': typeof SettingsIndexRoute
-  '/agents/$agentId/edit': typeof AgentsAgentIdEditRoute
-  '/sessions/$sessionId/$workerId': typeof SessionsSessionIdWorkerIdRoute
-  '/agents/$agentId': typeof AgentsAgentIdIndexRoute
-  '/jobs/$jobId': typeof JobsJobIdIndexRoute
-  '/sessions/$sessionId': typeof SessionsSessionIdIndexRoute
-}
-export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/login': typeof LoginRoute
-  '/maintenance': typeof MaintenanceRoute
-  '/settings/repositories': typeof SettingsRepositoriesRoute
-  '/worktree-creation-tasks/$taskId': typeof WorktreeCreationTasksTaskIdRoute
-  '/worktree-deletion-tasks/$taskId': typeof WorktreeDeletionTasksTaskIdRoute
-  '/agents': typeof AgentsIndexRoute
-  '/jobs': typeof JobsIndexRoute
-  '/settings': typeof SettingsIndexRoute
-  '/agents/$agentId/edit': typeof AgentsAgentIdEditRoute
-  '/sessions/$sessionId/$workerId': typeof SessionsSessionIdWorkerIdRoute
-  '/agents/$agentId': typeof AgentsAgentIdIndexRoute
-  '/jobs/$jobId': typeof JobsJobIdIndexRoute
-  '/sessions/$sessionId': typeof SessionsSessionIdIndexRoute
-}
-export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/login': typeof LoginRoute
-  '/maintenance': typeof MaintenanceRoute
-  '/settings/repositories': typeof SettingsRepositoriesRoute
   '/worktree-creation-tasks/$taskId': typeof WorktreeCreationTasksTaskIdRoute
   '/worktree-deletion-tasks/$taskId': typeof WorktreeDeletionTasksTaskIdRoute
   '/agents/': typeof AgentsIndexRoute
@@ -146,6 +127,46 @@ export interface FileRoutesById {
   '/agents/$agentId/': typeof AgentsAgentIdIndexRoute
   '/jobs/$jobId/': typeof JobsJobIdIndexRoute
   '/sessions/$sessionId/': typeof SessionsSessionIdIndexRoute
+  '/settings/repositories/': typeof SettingsRepositoriesIndexRoute
+  '/settings/repositories/$repositoryId/edit': typeof SettingsRepositoriesRepositoryIdEditRoute
+  '/settings/repositories/$repositoryId/': typeof SettingsRepositoriesRepositoryIdIndexRoute
+}
+export interface FileRoutesByTo {
+  '/': typeof IndexRoute
+  '/login': typeof LoginRoute
+  '/maintenance': typeof MaintenanceRoute
+  '/worktree-creation-tasks/$taskId': typeof WorktreeCreationTasksTaskIdRoute
+  '/worktree-deletion-tasks/$taskId': typeof WorktreeDeletionTasksTaskIdRoute
+  '/agents': typeof AgentsIndexRoute
+  '/jobs': typeof JobsIndexRoute
+  '/settings': typeof SettingsIndexRoute
+  '/agents/$agentId/edit': typeof AgentsAgentIdEditRoute
+  '/sessions/$sessionId/$workerId': typeof SessionsSessionIdWorkerIdRoute
+  '/agents/$agentId': typeof AgentsAgentIdIndexRoute
+  '/jobs/$jobId': typeof JobsJobIdIndexRoute
+  '/sessions/$sessionId': typeof SessionsSessionIdIndexRoute
+  '/settings/repositories': typeof SettingsRepositoriesIndexRoute
+  '/settings/repositories/$repositoryId/edit': typeof SettingsRepositoriesRepositoryIdEditRoute
+  '/settings/repositories/$repositoryId': typeof SettingsRepositoriesRepositoryIdIndexRoute
+}
+export interface FileRoutesById {
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/login': typeof LoginRoute
+  '/maintenance': typeof MaintenanceRoute
+  '/worktree-creation-tasks/$taskId': typeof WorktreeCreationTasksTaskIdRoute
+  '/worktree-deletion-tasks/$taskId': typeof WorktreeDeletionTasksTaskIdRoute
+  '/agents/': typeof AgentsIndexRoute
+  '/jobs/': typeof JobsIndexRoute
+  '/settings/': typeof SettingsIndexRoute
+  '/agents/$agentId/edit': typeof AgentsAgentIdEditRoute
+  '/sessions/$sessionId/$workerId': typeof SessionsSessionIdWorkerIdRoute
+  '/agents/$agentId/': typeof AgentsAgentIdIndexRoute
+  '/jobs/$jobId/': typeof JobsJobIdIndexRoute
+  '/sessions/$sessionId/': typeof SessionsSessionIdIndexRoute
+  '/settings/repositories/': typeof SettingsRepositoriesIndexRoute
+  '/settings/repositories/$repositoryId/edit': typeof SettingsRepositoriesRepositoryIdEditRoute
+  '/settings/repositories/$repositoryId/': typeof SettingsRepositoriesRepositoryIdIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -153,39 +174,6 @@ export interface FileRouteTypes {
     | '/'
     | '/login'
     | '/maintenance'
-    | '/settings/repositories'
-    | '/worktree-creation-tasks/$taskId'
-    | '/worktree-deletion-tasks/$taskId'
-    | '/agents'
-    | '/jobs'
-    | '/settings'
-    | '/agents/$agentId/edit'
-    | '/sessions/$sessionId/$workerId'
-    | '/agents/$agentId'
-    | '/jobs/$jobId'
-    | '/sessions/$sessionId'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/login'
-    | '/maintenance'
-    | '/settings/repositories'
-    | '/worktree-creation-tasks/$taskId'
-    | '/worktree-deletion-tasks/$taskId'
-    | '/agents'
-    | '/jobs'
-    | '/settings'
-    | '/agents/$agentId/edit'
-    | '/sessions/$sessionId/$workerId'
-    | '/agents/$agentId'
-    | '/jobs/$jobId'
-    | '/sessions/$sessionId'
-  id:
-    | '__root__'
-    | '/'
-    | '/login'
-    | '/maintenance'
-    | '/settings/repositories'
     | '/worktree-creation-tasks/$taskId'
     | '/worktree-deletion-tasks/$taskId'
     | '/agents/'
@@ -196,13 +184,51 @@ export interface FileRouteTypes {
     | '/agents/$agentId/'
     | '/jobs/$jobId/'
     | '/sessions/$sessionId/'
+    | '/settings/repositories/'
+    | '/settings/repositories/$repositoryId/edit'
+    | '/settings/repositories/$repositoryId/'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/login'
+    | '/maintenance'
+    | '/worktree-creation-tasks/$taskId'
+    | '/worktree-deletion-tasks/$taskId'
+    | '/agents'
+    | '/jobs'
+    | '/settings'
+    | '/agents/$agentId/edit'
+    | '/sessions/$sessionId/$workerId'
+    | '/agents/$agentId'
+    | '/jobs/$jobId'
+    | '/sessions/$sessionId'
+    | '/settings/repositories'
+    | '/settings/repositories/$repositoryId/edit'
+    | '/settings/repositories/$repositoryId'
+  id:
+    | '__root__'
+    | '/'
+    | '/login'
+    | '/maintenance'
+    | '/worktree-creation-tasks/$taskId'
+    | '/worktree-deletion-tasks/$taskId'
+    | '/agents/'
+    | '/jobs/'
+    | '/settings/'
+    | '/agents/$agentId/edit'
+    | '/sessions/$sessionId/$workerId'
+    | '/agents/$agentId/'
+    | '/jobs/$jobId/'
+    | '/sessions/$sessionId/'
+    | '/settings/repositories/'
+    | '/settings/repositories/$repositoryId/edit'
+    | '/settings/repositories/$repositoryId/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
   MaintenanceRoute: typeof MaintenanceRoute
-  SettingsRepositoriesRoute: typeof SettingsRepositoriesRoute
   WorktreeCreationTasksTaskIdRoute: typeof WorktreeCreationTasksTaskIdRoute
   WorktreeDeletionTasksTaskIdRoute: typeof WorktreeDeletionTasksTaskIdRoute
   AgentsIndexRoute: typeof AgentsIndexRoute
@@ -213,6 +239,9 @@ export interface RootRouteChildren {
   AgentsAgentIdIndexRoute: typeof AgentsAgentIdIndexRoute
   JobsJobIdIndexRoute: typeof JobsJobIdIndexRoute
   SessionsSessionIdIndexRoute: typeof SessionsSessionIdIndexRoute
+  SettingsRepositoriesIndexRoute: typeof SettingsRepositoriesIndexRoute
+  SettingsRepositoriesRepositoryIdEditRoute: typeof SettingsRepositoriesRepositoryIdEditRoute
+  SettingsRepositoriesRepositoryIdIndexRoute: typeof SettingsRepositoriesRepositoryIdIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -241,21 +270,21 @@ declare module '@tanstack/react-router' {
     '/settings/': {
       id: '/settings/'
       path: '/settings'
-      fullPath: '/settings'
+      fullPath: '/settings/'
       preLoaderRoute: typeof SettingsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/jobs/': {
       id: '/jobs/'
       path: '/jobs'
-      fullPath: '/jobs'
+      fullPath: '/jobs/'
       preLoaderRoute: typeof JobsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agents/': {
       id: '/agents/'
       path: '/agents'
-      fullPath: '/agents'
+      fullPath: '/agents/'
       preLoaderRoute: typeof AgentsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -273,31 +302,31 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorktreeCreationTasksTaskIdRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/settings/repositories': {
-      id: '/settings/repositories'
+    '/settings/repositories/': {
+      id: '/settings/repositories/'
       path: '/settings/repositories'
-      fullPath: '/settings/repositories'
-      preLoaderRoute: typeof SettingsRepositoriesRouteImport
+      fullPath: '/settings/repositories/'
+      preLoaderRoute: typeof SettingsRepositoriesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/sessions/$sessionId/': {
       id: '/sessions/$sessionId/'
       path: '/sessions/$sessionId'
-      fullPath: '/sessions/$sessionId'
+      fullPath: '/sessions/$sessionId/'
       preLoaderRoute: typeof SessionsSessionIdIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/jobs/$jobId/': {
       id: '/jobs/$jobId/'
       path: '/jobs/$jobId'
-      fullPath: '/jobs/$jobId'
+      fullPath: '/jobs/$jobId/'
       preLoaderRoute: typeof JobsJobIdIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agents/$agentId/': {
       id: '/agents/$agentId/'
       path: '/agents/$agentId'
-      fullPath: '/agents/$agentId'
+      fullPath: '/agents/$agentId/'
       preLoaderRoute: typeof AgentsAgentIdIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -315,6 +344,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AgentsAgentIdEditRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/settings/repositories/$repositoryId/': {
+      id: '/settings/repositories/$repositoryId/'
+      path: '/settings/repositories/$repositoryId'
+      fullPath: '/settings/repositories/$repositoryId/'
+      preLoaderRoute: typeof SettingsRepositoriesRepositoryIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/repositories/$repositoryId/edit': {
+      id: '/settings/repositories/$repositoryId/edit'
+      path: '/settings/repositories/$repositoryId/edit'
+      fullPath: '/settings/repositories/$repositoryId/edit'
+      preLoaderRoute: typeof SettingsRepositoriesRepositoryIdEditRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -322,7 +365,6 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
   MaintenanceRoute: MaintenanceRoute,
-  SettingsRepositoriesRoute: SettingsRepositoriesRoute,
   WorktreeCreationTasksTaskIdRoute: WorktreeCreationTasksTaskIdRoute,
   WorktreeDeletionTasksTaskIdRoute: WorktreeDeletionTasksTaskIdRoute,
   AgentsIndexRoute: AgentsIndexRoute,
@@ -333,6 +375,11 @@ const rootRouteChildren: RootRouteChildren = {
   AgentsAgentIdIndexRoute: AgentsAgentIdIndexRoute,
   JobsJobIdIndexRoute: JobsJobIdIndexRoute,
   SessionsSessionIdIndexRoute: SessionsSessionIdIndexRoute,
+  SettingsRepositoriesIndexRoute: SettingsRepositoriesIndexRoute,
+  SettingsRepositoriesRepositoryIdEditRoute:
+    SettingsRepositoriesRepositoryIdEditRoute,
+  SettingsRepositoriesRepositoryIdIndexRoute:
+    SettingsRepositoriesRepositoryIdIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/packages/client/src/routes/settings/repositories/$repositoryId/edit.tsx
+++ b/packages/client/src/routes/settings/repositories/$repositoryId/edit.tsx
@@ -1,0 +1,98 @@
+import {
+  createFileRoute,
+  Link,
+  useNavigate,
+  type ErrorComponentProps,
+} from '@tanstack/react-router';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { fetchRepositories } from '../../../../lib/api';
+import { repositoryKeys } from '../../../../lib/query-keys';
+import { EditRepositoryForm } from '../../../../components/repositories/EditRepositoryForm';
+import { Spinner } from '../../../../components/ui/Spinner';
+
+export const Route = createFileRoute('/settings/repositories/$repositoryId/edit')({
+  component: RepositoryEditPage,
+  pendingComponent: RepositoryEditPending,
+  errorComponent: RepositoryEditError,
+});
+
+export function RepositoryEditPending() {
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <div className="flex items-center gap-2 text-gray-500">
+        <Spinner size="sm" />
+        <span>Loading repository...</span>
+      </div>
+    </div>
+  );
+}
+
+export function RepositoryEditError({ error, reset }: ErrorComponentProps) {
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
+        <Link to="/" className="hover:text-white">Agent Console</Link>
+        <span>/</span>
+        <Link to="/settings/repositories" className="hover:text-white">Repositories</Link>
+        <span>/</span>
+        <span className="text-white">Error</span>
+      </div>
+      <div className="card text-center py-10">
+        <p className="text-red-400 mb-2">Failed to load repository</p>
+        <p className="text-gray-500 text-sm mb-4">{error.message}</p>
+        <div className="flex justify-center gap-2">
+          <button onClick={reset} className="btn btn-secondary">
+            Retry
+          </button>
+          <Link to="/settings/repositories" className="btn btn-primary">
+            Back to Repositories
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RepositoryEditPage() {
+  const { repositoryId } = Route.useParams();
+  const navigate = useNavigate();
+
+  const { data } = useSuspenseQuery({
+    queryKey: repositoryKeys.all(),
+    queryFn: fetchRepositories,
+  });
+
+  const repository = data.repositories.find((r) => r.id === repositoryId);
+  if (!repository) {
+    throw new Error(`Repository not found: ${repositoryId}`);
+  }
+
+  const navigateToDetail = () => {
+    navigate({ to: '/settings/repositories/$repositoryId', params: { repositoryId } });
+  };
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
+        <Link to="/" className="hover:text-white">Agent Console</Link>
+        <span>/</span>
+        <Link to="/settings/repositories" className="hover:text-white">Repositories</Link>
+        <span>/</span>
+        <Link to="/settings/repositories/$repositoryId" params={{ repositoryId }} className="hover:text-white">
+          {repository.name}
+        </Link>
+        <span>/</span>
+        <span className="text-white">Edit</span>
+      </div>
+
+      <h1 className="text-2xl font-semibold mb-6">Edit Repository</h1>
+
+      <EditRepositoryForm
+        repository={repository}
+        onSuccess={navigateToDetail}
+        onCancel={navigateToDetail}
+      />
+    </div>
+  );
+}

--- a/packages/client/src/routes/settings/repositories/$repositoryId/index.tsx
+++ b/packages/client/src/routes/settings/repositories/$repositoryId/index.tsx
@@ -1,0 +1,201 @@
+import { useState } from 'react';
+import {
+  createFileRoute,
+  Link,
+  useNavigate,
+  type ErrorComponentProps,
+} from '@tanstack/react-router';
+import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
+import { fetchRepositories, unregisterRepository, fetchAgents } from '../../../../lib/api';
+import { repositoryKeys, agentKeys } from '../../../../lib/query-keys';
+import { ConfirmDialog } from '../../../../components/ui/confirm-dialog';
+import { SectionHeader, DetailRow } from '../../../../components/ui/detail-layout';
+import { ErrorDialog, useErrorDialog } from '../../../../components/ui/error-dialog';
+import { Spinner } from '../../../../components/ui/Spinner';
+
+export const Route = createFileRoute('/settings/repositories/$repositoryId/')({
+  component: RepositoryDetailPage,
+  pendingComponent: RepositoryDetailPending,
+  errorComponent: RepositoryDetailError,
+});
+
+export function RepositoryDetailPending() {
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <div className="flex items-center gap-2 text-gray-500">
+        <Spinner size="sm" />
+        <span>Loading repository...</span>
+      </div>
+    </div>
+  );
+}
+
+export function RepositoryDetailError({ error, reset }: ErrorComponentProps) {
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
+        <Link to="/" className="hover:text-white">Agent Console</Link>
+        <span>/</span>
+        <Link to="/settings/repositories" className="hover:text-white">Repositories</Link>
+        <span>/</span>
+        <span className="text-white">Error</span>
+      </div>
+      <div className="card text-center py-10">
+        <p className="text-red-400 mb-2">Failed to load repository</p>
+        <p className="text-gray-500 text-sm mb-4">{error.message}</p>
+        <div className="flex justify-center gap-2">
+          <button onClick={reset} className="btn btn-secondary">
+            Retry
+          </button>
+          <Link to="/settings/repositories" className="btn btn-primary">
+            Back to Repositories
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RepositoryDetailPage() {
+  const { repositoryId } = Route.useParams();
+  const navigate = useNavigate();
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const { errorDialogProps, showError } = useErrorDialog();
+
+  const { data } = useSuspenseQuery({
+    queryKey: repositoryKeys.all(),
+    queryFn: fetchRepositories,
+  });
+
+  const repository = data.repositories.find((r) => r.id === repositoryId);
+
+  // Look up agent name for defaultAgentId
+  // Must be called before the conditional throw to maintain hook order
+  const { data: agentsData } = useQuery({
+    queryKey: agentKeys.all(),
+    queryFn: fetchAgents,
+    enabled: !!repository?.defaultAgentId,
+  });
+
+  const defaultAgentName = repository?.defaultAgentId
+    ? agentsData?.agents.find((a) => a.id === repository.defaultAgentId)?.name
+    : undefined;
+
+  if (!repository) {
+    throw new Error(`Repository not found: ${repositoryId}`);
+  }
+
+  const deleteMutation = useMutation({
+    mutationFn: unregisterRepository,
+    onSuccess: () => {
+      navigate({ to: '/settings/repositories' });
+    },
+    onError: (error) => {
+      setShowDeleteConfirm(false);
+      showError('Cannot Delete Repository', error.message);
+    },
+  });
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
+        <Link to="/" className="hover:text-white">Agent Console</Link>
+        <span>/</span>
+        <Link to="/settings/repositories" className="hover:text-white">Repositories</Link>
+        <span>/</span>
+        <span className="text-white">{repository.name}</span>
+      </div>
+
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-semibold">{repository.name}</h1>
+        <div className="flex gap-2">
+          <Link
+            to="/settings/repositories/$repositoryId/edit"
+            params={{ repositoryId }}
+            className="btn btn-primary text-sm no-underline"
+          >
+            Edit
+          </Link>
+          <button
+            onClick={() => setShowDeleteConfirm(true)}
+            className="btn btn-danger text-sm"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+
+      {/* Repository Details */}
+      <div className="card">
+        {/* Description */}
+        {repository.description && (
+          <div className="mb-6">
+            <p className="text-gray-300">{repository.description}</p>
+          </div>
+        )}
+
+        {/* Configuration Section */}
+        <SectionHeader title="Configuration" />
+        <div className="space-y-4 mb-6">
+          <DetailRow label="Path" value={repository.path} mono />
+          <DetailRow
+            label="Setup Command"
+            value={repository.setupCommand || '(not set)'}
+            mono
+            muted={!repository.setupCommand}
+          />
+          <DetailRow
+            label="Cleanup Command"
+            value={repository.cleanupCommand || '(not set)'}
+            mono
+            muted={!repository.cleanupCommand}
+          />
+          <DetailRow
+            label="Env Variables"
+            value={repository.envVars || '(not set)'}
+            mono
+            muted={!repository.envVars}
+          />
+        </div>
+
+        {/* Default Agent Section */}
+        <SectionHeader title="Default Agent" />
+        <div className="space-y-4 mb-6">
+          <DetailRow
+            label="Agent"
+            value={defaultAgentName || '(not set)'}
+            muted={!defaultAgentName}
+          />
+        </div>
+
+        {/* Metadata Section */}
+        <SectionHeader title="Metadata" />
+        <div className="space-y-2 text-sm text-gray-500">
+          <div>
+            <span className="text-gray-400">ID:</span>{' '}
+            <span className="font-mono">{repository.id}</span>
+          </div>
+          <div>
+            <span className="text-gray-400">Created:</span>{' '}
+            {new Date(repository.createdAt).toLocaleString()}
+          </div>
+        </div>
+      </div>
+
+      {/* Delete Confirmation */}
+      <ConfirmDialog
+        open={showDeleteConfirm}
+        onOpenChange={setShowDeleteConfirm}
+        title="Delete Repository"
+        description={`Are you sure you want to delete "${repository.name}"?`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => deleteMutation.mutate(repositoryId)}
+        isLoading={deleteMutation.isPending}
+      />
+      <ErrorDialog {...errorDialogProps} />
+    </div>
+  );
+}

--- a/packages/client/src/routes/settings/repositories/index.tsx
+++ b/packages/client/src/routes/settings/repositories/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { RepositoryList } from '../../components/repositories/RepositoryList';
+import { RepositoryList } from '../../../components/repositories/RepositoryList';
 
-export const Route = createFileRoute('/settings/repositories')({
+export const Route = createFileRoute('/settings/repositories/')({
   component: RepositoriesPage,
 });
 


### PR DESCRIPTION
## Summary
- Add `/settings/repositories/:id` detail page displaying repository info (name, path, description, setup/cleanup commands, default agent, metadata)
- Add `/settings/repositories/:id/edit` page wrapping existing `EditRepositoryForm`
- Make repository cards in list clickable `Link`s navigating to detail pages
- Remove in-place editing from repository list
- Follow the existing Agent detail page pattern for consistency (breadcrumbs, SectionHeader, DetailRow, ConfirmDialog)

Closes #394

## Test plan
- [x] All existing tests pass (1170 pass, 0 fail)
- [x] New error/pending boundary tests for detail and edit pages
- [x] New RepositoryList component tests (loading, error, empty, navigation, display)
- [x] TypeScript type check passes
- [ ] Visual confirmation: repository cards are clickable and navigate to detail page
- [ ] Visual confirmation: detail page displays all repository info correctly
- [ ] Visual confirmation: edit page loads form and navigates back on save/cancel
- [ ] Visual confirmation: delete button shows ConfirmDialog and navigates to list after deletion
- [ ] Visual confirmation: breadcrumb navigation follows Agent detail page pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)