### PR TITLE
docs: add orchestrator process improvements from cross-project retrospective

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -101,6 +101,7 @@ You are acting as the Orchestrator of this project. Your job is strategic decisi
   - `test-runner` — for running tests and analyzing failures
   - `code-quality-reviewer` — for evaluating design and maintainability
 - **Follow-up timer**: After delegating, create a timer (15-20 min interval) via `create_timer`. On each tick, run `get_session_status` — if the agent is idle/stuck, send a check-in via `send_session_message`. Delete the timer once the agent reports completion. If a timer fires 3+ times with no progress, escalate to the owner via memo.
+- **30% checkpoint**: Include in delegation instructions that the agent must send a progress report at ~30% implementation completion (e.g., after initial structure/approach is decided but before full implementation). This prevents "direction was wrong" discoveries at 100%. The checkpoint message should include: current approach, any concerns or deviations from the plan, and estimated remaining work.
 
 ### 4. First Responder for Dev Agent Questions
 - Receive and triage questions from coding agents
@@ -108,6 +109,7 @@ You are acting as the Orchestrator of this project. Your job is strategic decisi
 - Escalate to the owner when: business decisions are needed, scope changes are required, or you are uncertain
 
 ### 5. Review Dev Agent Work Reports
+- **Agents must report completion only after CI is green.** Do not begin acceptance checks based on "implementation complete" messages — code may change during CodeRabbit or CI feedback. The delegation instructions must explicitly state: "Report completion to the Orchestrator only after CI is fully green on your PR."
 - When a coding agent reports task completion, review the work:
   - Does the PR follow project conventions (title format, required sections)?
   - Are the changes scoped correctly (no unrelated changes mixed in)?

--- a/.claude/skills/orchestrator/delegation-prompt.js
+++ b/.claude/skills/orchestrator/delegation-prompt.js
@@ -177,8 +177,10 @@ ${
 1. Determine the appropriate test level based on CLAUDE.md rules and Orchestrator instructions. If your judgment differs from the Orchestrator's instruction, propose with reasoning. (e.g., docs-only changes may skip tests per CLAUDE.md)
 2. Run \`/review-loop\` if instructed by the Orchestrator (skip if not instructed)
 3. Create PR (title: \`[AI] closed #${issueNumber} ${issue.title.replace(/^\[AI\]\s*/, '')}\`)
-4. After your PR is merged, please report back to the Orchestrator with your retrospective report and the merge confirmation.
-5. If you resolved an issue by communicating directly with the owner, report the following to the Orchestrator:
+4. Wait for CI to be fully green. Address any CI failures or CodeRabbit review comments. Do NOT report completion until CI is green.
+5. After CI is green, report completion to the Orchestrator with your retrospective report. Include the PR URL and CI status.
+6. After your PR is merged, report back to the Orchestrator with the merge confirmation.
+7. If you resolved an issue by communicating directly with the owner, report the following to the Orchestrator:
    - What was the problem
    - How it was resolved
    - What is needed to prevent the same issue in the future

--- a/.claude/skills/orchestrator/sprint-lifecycle.md
+++ b/.claude/skills/orchestrator/sprint-lifecycle.md
@@ -83,6 +83,10 @@ The Orchestrator proposes ending the sprint, and when the owner approves, conduc
 - The Orchestrator reports the retrospective and aligns with the owner's perspective
 - **Present improvement proposals together with the merged PR list** (at the start of the retrospective, not the end). Presenting proposals early enables agreement during the owner dialogue and allows smooth transition to parallel execution in Step 4
 - Perspectives: what worked well / what needs improvement / time-consuming blockers
+- **Classify "what worked well" into 3 categories** to convert into actionable improvements:
+  1. **Worked by chance** — systematize by adding to skills/processes so it becomes reliable
+  2. **Worked because owner drove it** — incorporate into Orchestrator skills so the Orchestrator can do it independently
+  3. **Other** — analyze why it worked and consider if the conditions can be reproduced
 - Reach agreement on any skill/process improvement proposals on the spot
 
 **Step 4: Apply skill improvements (parallel execution)**


### PR DESCRIPTION
## Summary
- Add **30% checkpoint** rule to Parallel Task Coordination — agents must report progress at ~30% to catch direction issues early
- Add **CI green reporting rule** — agents must wait for CI green before reporting completion, with updated delegation template completion steps
- Add **retrospective 3-classification** — categorize "what worked well" into actionable improvement types (worked by chance / owner-driven / other)

## Test plan
- [ ] Verify SKILL.md changes render correctly in markdown
- [ ] Verify delegation-prompt.js generates updated completion steps
- [ ] Verify sprint-lifecycle.md retrospective section includes new classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)