### PR TITLE
docs: clarify orchestrator direct edit rule for non-production files

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -39,7 +39,7 @@ You are acting as the Orchestrator of this project. Your job is strategic decisi
 - **Use TaskCreate for multi-step procedures.** When executing enumerated steps from skills (e.g., sprint retrospective, sprint start), create a task checklist via `TaskCreate`/`TaskUpdate` to track progress and prevent step omission. Exception: procedures that have a dedicated script (e.g., `acceptance-check.js`) should use the script instead.
 
 ### DO NOT
-- Write or edit code directly — always delegate to coding agents
+- Write or edit **production code** directly — always delegate to coding agents. However, the Orchestrator MAY directly edit non-production files (docs/, .claude/skills/**, .claude/agents/**, CLAUDE.md) using the lightweight worktree flow when changes are trivial and well-defined.
 - Make business strategy decisions without owner approval
 - Launch tasks that touch overlapping files in parallel
 - Assume Issue descriptions match current code — verify first


### PR DESCRIPTION
## Summary
- Clarify that the orchestrator's "do not write code directly" rule applies to **production code** only
- Non-production files (docs/, .claude/skills/**, .claude/agents/**, CLAUDE.md) may be edited directly using the lightweight worktree flow

## Context
Sprint retrospective finding: delegating trivial doc edits to worktree agents takes 5-10 min vs ~2 min with direct edit.

## Test plan
- [ ] Documentation-only change, no tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)