### PR TITLE
[AI] closed #428 feat: support agent name resolution in delegate_to_worktree

### DIFF
--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -1511,6 +1511,94 @@ describe('MCP Server Tools', () => {
     });
 
     // -----------------------------------------------------------------------
+    // Agent name resolution (agentName parameter)
+    // -----------------------------------------------------------------------
+
+    it('should resolve agentName to agentId', async () => {
+      await agentManager.registerAgent({
+        name: 'My Custom Agent',
+        commandTemplate: 'my-custom-agent {{prompt}}',
+      });
+
+      await setupDelegateEnvironment('feat/agent-name-test');
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test agentName resolution',
+        branch: 'feat/agent-name-test',
+        agentName: 'My Custom Agent',
+      }, nextId++);
+
+      expect(response.result?.isError).toBeUndefined();
+      expect(findSpawnCallByCommand('my-custom-agent')).toBeDefined();
+    });
+
+    it('should return error when agentName matches no agent', async () => {
+      await setupDelegateEnvironment('feat/no-match');
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test non-existent agentName',
+        branch: 'feat/no-match',
+        agentName: 'Non-Existent Agent',
+      }, nextId++);
+      const data = parseToolResult(response) as { error: string };
+
+      expect(response.result?.isError).toBe(true);
+      expect(data.error).toContain('No agent found with name: Non-Existent Agent');
+    });
+
+    it('should return error when agentName matches multiple agents', async () => {
+      await agentManager.registerAgent({
+        name: 'Ambiguous Agent',
+        commandTemplate: 'ambiguous-1 {{prompt}}',
+      });
+      await agentManager.registerAgent({
+        name: 'Ambiguous Agent',
+        commandTemplate: 'ambiguous-2 {{prompt}}',
+      });
+
+      await setupDelegateEnvironment('feat/ambiguous');
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test ambiguous agentName',
+        branch: 'feat/ambiguous',
+        agentName: 'Ambiguous Agent',
+      }, nextId++);
+      const data = parseToolResult(response) as { error: string };
+
+      expect(response.result?.isError).toBe(true);
+      expect(data.error).toContain('Multiple agents match name "Ambiguous Agent"');
+      expect(data.error).toContain('Use agentId to specify');
+    });
+
+    it('should use agentId when both agentId and agentName are provided', async () => {
+      const agentById = await agentManager.registerAgent({
+        name: 'Agent By Id',
+        commandTemplate: 'agent-by-id {{prompt}}',
+      });
+      await agentManager.registerAgent({
+        name: 'Agent By Name',
+        commandTemplate: 'agent-by-name {{prompt}}',
+      });
+
+      await setupDelegateEnvironment('feat/both-params');
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test agentId takes precedence over agentName',
+        branch: 'feat/both-params',
+        agentId: agentById.id,
+        agentName: 'Agent By Name',
+      }, nextId++);
+
+      expect(response.result?.isError).toBeUndefined();
+      expect(findSpawnCallByCommand('agent-by-id')).toBeDefined();
+      expect(findSpawnCallByCommand('agent-by-name')).toBeUndefined();
+    });
+
+    // -----------------------------------------------------------------------
     // Message callback prompt (parentSessionId / parentWorkerId)
     // -----------------------------------------------------------------------
 

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -467,6 +467,14 @@ export function createMcpApp(deps: McpDependencies): Hono {
           `Agent to use. If omitted, falls back to the repository's configured default agent, ` +
             `then to ${CLAUDE_CODE_AGENT_ID}.`,
         ),
+      agentName: z
+        .string()
+        .optional()
+        .describe(
+          'Agent name to use. Resolved to agentId by exact match. ' +
+            'Ignored when agentId is also provided. ' +
+            'Errors if zero or multiple agents match the name.',
+        ),
       title: z.string().optional().describe('Human-readable session title'),
       useRemote: z
         .boolean()
@@ -518,6 +526,7 @@ export function createMcpApp(deps: McpDependencies): Hono {
       baseBranch,
       branch,
       agentId,
+      agentName,
       title,
       useRemote,
       parentSessionId,
@@ -543,8 +552,25 @@ export function createMcpApp(deps: McpDependencies): Hono {
           return errorResult(`Repository not found: ${repositoryId}`);
         }
 
-        // Validate agent
-        const selectedAgentId = agentId ?? repo.defaultAgentId ?? CLAUDE_CODE_AGENT_ID;
+        // Resolve agent: agentId takes precedence over agentName
+        let selectedAgentId: string;
+        if (agentId) {
+          selectedAgentId = agentId;
+        } else if (agentName) {
+          const matches = agentManager.getAgentsByName(agentName);
+          if (matches.length === 0) {
+            return errorResult(`No agent found with name: ${agentName}`);
+          }
+          if (matches.length > 1) {
+            const ids = matches.map((a) => `${a.name} (${a.id})`).join(', ');
+            return errorResult(
+              `Multiple agents match name "${agentName}": ${ids}. Use agentId to specify.`,
+            );
+          }
+          selectedAgentId = matches[0].id;
+        } else {
+          selectedAgentId = repo.defaultAgentId ?? CLAUDE_CODE_AGENT_ID;
+        }
         const agent = agentManager.getAgent(selectedAgentId);
         if (!agent) {
           return errorResult(`Agent not found: ${selectedAgentId}`);

--- a/packages/server/src/services/__tests__/agent-manager.test.ts
+++ b/packages/server/src/services/__tests__/agent-manager.test.ts
@@ -513,6 +513,45 @@ describe('AgentManager', () => {
     });
   });
 
+  describe('getAgentsByName', () => {
+    it('should find agent by exact name', async () => {
+      const { manager } = await getAgentManager();
+      const results = manager.getAgentsByName('Claude Code');
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('Claude Code');
+    });
+
+    it('should return empty array when no agent matches', async () => {
+      const { manager } = await getAgentManager();
+      const results = manager.getAgentsByName('Non-Existent Agent');
+      expect(results).toHaveLength(0);
+    });
+
+    it('should return multiple agents when names match', async () => {
+      const { manager } = await getAgentManager();
+      await manager.registerAgent({
+        name: 'Duplicate Name',
+        commandTemplate: 'cmd1 {{prompt}}',
+      });
+      await manager.registerAgent({
+        name: 'Duplicate Name',
+        commandTemplate: 'cmd2 {{prompt}}',
+      });
+      const results = manager.getAgentsByName('Duplicate Name');
+      expect(results).toHaveLength(2);
+    });
+
+    it('should be case-sensitive', async () => {
+      const { manager } = await getAgentManager();
+      await manager.registerAgent({
+        name: 'My Agent',
+        commandTemplate: 'cmd {{prompt}}',
+      });
+      expect(manager.getAgentsByName('my agent')).toHaveLength(0);
+      expect(manager.getAgentsByName('My Agent')).toHaveLength(1);
+    });
+  });
+
   describe('unregisterAgent', () => {
     it('should unregister a custom agent', async () => {
       const { manager } = await getAgentManager();

--- a/packages/server/src/services/agent-manager.ts
+++ b/packages/server/src/services/agent-manager.ts
@@ -91,6 +91,14 @@ export class AgentManager {
   }
 
   /**
+   * Find agents by name (exact, case-sensitive match).
+   * Returns matching agents array to distinguish 0/1/multiple matches.
+   */
+  getAgentsByName(name: string): AgentDefinition[] {
+    return this.getAllAgents().filter((agent) => agent.name === name);
+  }
+
+  /**
    * Get the default agent (Claude Code)
    */
   getDefaultAgent(): AgentDefinition {


### PR DESCRIPTION
## Summary
- Add `agentName` parameter to `delegate_to_worktree` MCP tool for name-based agent resolution
- Add `getAgentsByName()` method to AgentManager for exact, case-sensitive name lookup
- Resolution priority: `agentId` > `agentName` > repo default > `claude-code-builtin`
- Clear error messages for zero matches and ambiguous (multiple) matches

Closes #428

## Test plan
- [x] `agentName` resolves to correct `agentId` (unit + integration test)
- [x] Error when `agentName` matches no agent (unit + integration test)
- [x] Error when `agentName` matches multiple agents (unit + integration test)
- [x] `agentId` takes precedence when both provided (integration test)
- [x] Case-sensitive matching (unit test)
- [x] Existing `agentId` behavior unchanged (existing regression tests pass)
- [x] `bun run typecheck` passes
- [x] All 118 tests pass across modified test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)