### PR TITLE
[AI] closed #427 refactor: extract shared page layout components (Breadcrumb, PageBoundary)

### DIFF
--- a/packages/client/src/components/PageBreadcrumb.tsx
+++ b/packages/client/src/components/PageBreadcrumb.tsx
@@ -1,0 +1,33 @@
+import { Link } from '@tanstack/react-router';
+
+interface BreadcrumbItem {
+  label: string;
+  to?: string;
+  params?: Record<string, string>;
+}
+
+interface PageBreadcrumbProps {
+  items: BreadcrumbItem[];
+}
+
+export function PageBreadcrumb({ items }: PageBreadcrumbProps) {
+  return (
+    <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        return (
+          <span key={index} className="contents">
+            {index > 0 && <span>/</span>}
+            {isLast ? (
+              <span className="text-white">{item.label}</span>
+            ) : (
+              <Link to={item.to as string} params={item.params} className="hover:text-white">
+                {item.label}
+              </Link>
+            )}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/client/src/components/PageErrorFallback.tsx
+++ b/packages/client/src/components/PageErrorFallback.tsx
@@ -1,0 +1,38 @@
+import { Link } from '@tanstack/react-router';
+import { PageBreadcrumb } from './PageBreadcrumb';
+
+interface PageErrorFallbackProps {
+  error: Error;
+  reset: () => void;
+  breadcrumbItems: Array<{ label: string; to?: string; params?: Record<string, string> }>;
+  errorMessage: string;
+  backTo: string;
+  backLabel: string;
+}
+
+export function PageErrorFallback({
+  error,
+  reset,
+  breadcrumbItems,
+  errorMessage,
+  backTo,
+  backLabel,
+}: PageErrorFallbackProps) {
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <PageBreadcrumb items={breadcrumbItems} />
+      <div className="card text-center py-10">
+        <p className="text-red-400 mb-2">{errorMessage}</p>
+        <p className="text-gray-500 text-sm mb-4">{error.message}</p>
+        <div className="flex justify-center gap-2">
+          <button onClick={reset} className="btn btn-secondary">
+            Retry
+          </button>
+          <Link to={backTo as string} className="btn btn-primary">
+            {backLabel}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/PagePendingFallback.tsx
+++ b/packages/client/src/components/PagePendingFallback.tsx
@@ -1,0 +1,16 @@
+import { Spinner } from './ui/Spinner';
+
+interface PagePendingFallbackProps {
+  message: string;
+}
+
+export function PagePendingFallback({ message }: PagePendingFallbackProps) {
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <div className="flex items-center gap-2 text-gray-500">
+        <Spinner size="sm" />
+        <span>{message}</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/agents/$agentId/edit.tsx
+++ b/packages/client/src/routes/agents/$agentId/edit.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
-import { createFileRoute, Link, useNavigate, type ErrorComponentProps } from '@tanstack/react-router';
+import { createFileRoute, useNavigate, type ErrorComponentProps } from '@tanstack/react-router';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { fetchAgent } from '../../../lib/api';
 import { agentKeys } from '../../../lib/query-keys';
+import { PageBreadcrumb } from '../../../components/PageBreadcrumb';
+import { PagePendingFallback } from '../../../components/PagePendingFallback';
+import { PageErrorFallback } from '../../../components/PageErrorFallback';
 import { EditAgentForm } from '../../../components/agents';
-import { Spinner } from '../../../components/ui/Spinner';
 
 export const Route = createFileRoute('/agents/$agentId/edit')({
   component: AgentEditPage,
@@ -13,39 +15,23 @@ export const Route = createFileRoute('/agents/$agentId/edit')({
 });
 
 export function AgentEditPending() {
-  return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <div className="flex items-center gap-2 text-gray-500">
-        <Spinner size="sm" />
-        <span>Loading agent...</span>
-      </div>
-    </div>
-  );
+  return <PagePendingFallback message="Loading agent..." />;
 }
 
 export function AgentEditError({ error, reset }: ErrorComponentProps) {
   return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <Link to="/agents" className="hover:text-white">Agents</Link>
-        <span>/</span>
-        <span className="text-white">Error</span>
-      </div>
-      <div className="card text-center py-10">
-        <p className="text-red-400 mb-2">Failed to load agent</p>
-        <p className="text-gray-500 text-sm mb-4">{error.message}</p>
-        <div className="flex justify-center gap-2">
-          <button onClick={reset} className="btn btn-secondary">
-            Retry
-          </button>
-          <Link to="/agents" className="btn btn-primary">
-            Back to Agents
-          </Link>
-        </div>
-      </div>
-    </div>
+    <PageErrorFallback
+      error={error}
+      reset={reset}
+      breadcrumbItems={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Agents', to: '/agents' },
+        { label: 'Error' },
+      ]}
+      errorMessage="Failed to load agent"
+      backTo="/agents"
+      backLabel="Back to Agents"
+    />
   );
 }
 
@@ -78,17 +64,12 @@ function AgentEditPage() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <Link to="/agents" className="hover:text-white">Agents</Link>
-        <span>/</span>
-        <Link to="/agents/$agentId" params={{ agentId }} className="hover:text-white">
-          {agent.name}
-        </Link>
-        <span>/</span>
-        <span className="text-white">Edit</span>
-      </div>
+      <PageBreadcrumb items={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Agents', to: '/agents' },
+        { label: agent.name, to: '/agents/$agentId', params: { agentId } },
+        { label: 'Edit' },
+      ]} />
 
       <h1 className="text-2xl font-semibold mb-6">Edit Agent</h1>
 

--- a/packages/client/src/routes/agents/$agentId/index.tsx
+++ b/packages/client/src/routes/agents/$agentId/index.tsx
@@ -8,11 +8,13 @@ import {
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { fetchAgent, unregisterAgent } from '../../../lib/api';
 import { agentKeys } from '../../../lib/query-keys';
+import { PageBreadcrumb } from '../../../components/PageBreadcrumb';
+import { PagePendingFallback } from '../../../components/PagePendingFallback';
+import { PageErrorFallback } from '../../../components/PageErrorFallback';
 import { CapabilityIndicator } from '../../../components/agents';
 import { ConfirmDialog } from '../../../components/ui/confirm-dialog';
 import { SectionHeader, DetailRow } from '../../../components/ui/detail-layout';
 import { ErrorDialog, useErrorDialog } from '../../../components/ui/error-dialog';
-import { Spinner } from '../../../components/ui/Spinner';
 
 export const Route = createFileRoute('/agents/$agentId/')({
   component: AgentDetailPage,
@@ -21,39 +23,23 @@ export const Route = createFileRoute('/agents/$agentId/')({
 });
 
 export function AgentDetailPending() {
-  return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <div className="flex items-center gap-2 text-gray-500">
-        <Spinner size="sm" />
-        <span>Loading agent...</span>
-      </div>
-    </div>
-  );
+  return <PagePendingFallback message="Loading agent..." />;
 }
 
 export function AgentDetailError({ error, reset }: ErrorComponentProps) {
   return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <Link to="/agents" className="hover:text-white">Agents</Link>
-        <span>/</span>
-        <span className="text-white">Error</span>
-      </div>
-      <div className="card text-center py-10">
-        <p className="text-red-400 mb-2">Failed to load agent</p>
-        <p className="text-gray-500 text-sm mb-4">{error.message}</p>
-        <div className="flex justify-center gap-2">
-          <button onClick={reset} className="btn btn-secondary">
-            Retry
-          </button>
-          <Link to="/agents" className="btn btn-primary">
-            Back to Agents
-          </Link>
-        </div>
-      </div>
-    </div>
+    <PageErrorFallback
+      error={error}
+      reset={reset}
+      breadcrumbItems={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Agents', to: '/agents' },
+        { label: 'Error' },
+      ]}
+      errorMessage="Failed to load agent"
+      backTo="/agents"
+      backLabel="Back to Agents"
+    />
   );
 }
 
@@ -92,13 +78,11 @@ function AgentDetailPage() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <Link to="/agents" className="hover:text-white">Agents</Link>
-        <span>/</span>
-        <span className="text-white">{agent.name}</span>
-      </div>
+      <PageBreadcrumb items={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Agents', to: '/agents' },
+        { label: agent.name },
+      ]} />
 
       {/* Header */}
       <div className="flex items-center justify-between mb-6">

--- a/packages/client/src/routes/agents/index.tsx
+++ b/packages/client/src/routes/agents/index.tsx
@@ -5,6 +5,7 @@ import type { AgentDefinition } from '@agent-console/shared';
 import { unregisterAgent } from '../../lib/api';
 import { agentKeys } from '../../lib/query-keys';
 import { useAgents } from '../../components/AgentSelector';
+import { PageBreadcrumb } from '../../components/PageBreadcrumb';
 import { AddAgentForm, CapabilityIndicator } from '../../components/agents';
 import { ConfirmDialog } from '../../components/ui/confirm-dialog';
 import { ErrorDialog, useErrorDialog } from '../../components/ui/error-dialog';
@@ -55,11 +56,10 @@ function AgentsPage() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <span className="text-white">Agents</span>
-      </div>
+      <PageBreadcrumb items={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Agents' },
+      ]} />
 
       {/* Header */}
       <div className="flex items-center justify-between mb-6">

--- a/packages/client/src/routes/jobs/$jobId/index.tsx
+++ b/packages/client/src/routes/jobs/$jobId/index.tsx
@@ -10,10 +10,12 @@ import { JOB_STATUS } from '@agent-console/shared';
 import { fetchJob, retryJob, cancelJob } from '../../../lib/api';
 import { jobKeys } from '../../../lib/query-keys';
 import { formatAbsoluteTimestamp } from '../../../lib/format';
+import { PageBreadcrumb } from '../../../components/PageBreadcrumb';
+import { PagePendingFallback } from '../../../components/PagePendingFallback';
+import { PageErrorFallback } from '../../../components/PageErrorFallback';
 import { ConfirmDialog } from '../../../components/ui/confirm-dialog';
 import { SectionHeader, DetailRow } from '../../../components/ui/detail-layout';
 import { ErrorDialog, useErrorDialog } from '../../../components/ui/error-dialog';
-import { Spinner } from '../../../components/ui/Spinner';
 import { StatusBadge } from '../../../components/jobs';
 
 export const Route = createFileRoute('/jobs/$jobId/')({
@@ -24,39 +26,23 @@ export const Route = createFileRoute('/jobs/$jobId/')({
 });
 
 export function JobDetailPending() {
-  return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <div className="flex items-center gap-2 text-gray-500">
-        <Spinner size="sm" />
-        <span>Loading job...</span>
-      </div>
-    </div>
-  );
+  return <PagePendingFallback message="Loading job..." />;
 }
 
 export function JobDetailError({ error, reset }: ErrorComponentProps) {
   return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <Link to="/jobs" className="hover:text-white">Jobs</Link>
-        <span>/</span>
-        <span className="text-white">Error</span>
-      </div>
-      <div className="card text-center py-10">
-        <p className="text-red-400 mb-2">Failed to load job</p>
-        <p className="text-gray-500 text-sm mb-4">{error.message}</p>
-        <div className="flex justify-center gap-2">
-          <button onClick={reset} className="btn btn-secondary">
-            Retry
-          </button>
-          <Link to="/jobs" className="btn btn-primary">
-            Back to Jobs
-          </Link>
-        </div>
-      </div>
-    </div>
+    <PageErrorFallback
+      error={error}
+      reset={reset}
+      breadcrumbItems={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Jobs', to: '/jobs' },
+        { label: 'Error' },
+      ]}
+      errorMessage="Failed to load job"
+      backTo="/jobs"
+      backLabel="Back to Jobs"
+    />
   );
 }
 
@@ -108,13 +94,11 @@ function JobDetailPage() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <Link to="/jobs" className="hover:text-white">Jobs</Link>
-        <span>/</span>
-        <span className="text-white">{job.type}</span>
-      </div>
+      <PageBreadcrumb items={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Jobs', to: '/jobs' },
+        { label: job.type },
+      ]} />
 
       {/* Header */}
       <div className="flex items-center justify-between mb-6">

--- a/packages/client/src/routes/jobs/index.tsx
+++ b/packages/client/src/routes/jobs/index.tsx
@@ -5,6 +5,7 @@ import { JOB_STATUS, JOB_TYPES, type Job, type JobStatus, type JobType } from '@
 import { fetchJobs, fetchJobStats, retryJob, cancelJob, type FetchJobsParams } from '../../lib/api';
 import { jobKeys } from '../../lib/query-keys';
 import { formatTimestamp } from '../../lib/format';
+import { PageBreadcrumb } from '../../components/PageBreadcrumb';
 import { ConfirmDialog } from '../../components/ui/confirm-dialog';
 import { StatusBadge } from '../../components/jobs';
 import { ErrorDialog, useErrorDialog } from '../../components/ui/error-dialog';
@@ -113,13 +114,10 @@ function JobsPage() {
   return (
     <div className="p-6 max-w-6xl mx-auto">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">
-          Agent Console
-        </Link>
-        <span>/</span>
-        <span className="text-white">Jobs</span>
-      </div>
+      <PageBreadcrumb items={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Jobs' },
+      ]} />
 
       {/* Header */}
       <div className="flex items-center justify-between mb-6">

--- a/packages/client/src/routes/settings/index.tsx
+++ b/packages/client/src/routes/settings/index.tsx
@@ -5,6 +5,7 @@ import type { AgentDefinition } from '@agent-console/shared';
 import { unregisterAgent } from '../../lib/api';
 import { agentKeys } from '../../lib/query-keys';
 import { useAgents } from '../../components/AgentSelector';
+import { PageBreadcrumb } from '../../components/PageBreadcrumb';
 import { AddAgentForm, CapabilityIndicator } from '../../components/agents';
 import { ConfirmDialog } from '../../components/ui/confirm-dialog';
 import { ErrorDialog, useErrorDialog } from '../../components/ui/error-dialog';
@@ -54,11 +55,10 @@ function SettingsPage() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <span className="text-white">Settings</span>
-      </div>
+      <PageBreadcrumb items={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Settings' },
+      ]} />
 
       {/* Header with Add button */}
       <div className="flex items-center justify-between mb-6">

--- a/packages/client/src/routes/settings/repositories/$repositoryId/edit.tsx
+++ b/packages/client/src/routes/settings/repositories/$repositoryId/edit.tsx
@@ -1,14 +1,15 @@
 import {
   createFileRoute,
-  Link,
   useNavigate,
   type ErrorComponentProps,
 } from '@tanstack/react-router';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { fetchRepositories } from '../../../../lib/api';
 import { repositoryKeys } from '../../../../lib/query-keys';
+import { PageBreadcrumb } from '../../../../components/PageBreadcrumb';
+import { PagePendingFallback } from '../../../../components/PagePendingFallback';
+import { PageErrorFallback } from '../../../../components/PageErrorFallback';
 import { EditRepositoryForm } from '../../../../components/repositories/EditRepositoryForm';
-import { Spinner } from '../../../../components/ui/Spinner';
 
 export const Route = createFileRoute('/settings/repositories/$repositoryId/edit')({
   component: RepositoryEditPage,
@@ -17,39 +18,23 @@ export const Route = createFileRoute('/settings/repositories/$repositoryId/edit'
 });
 
 export function RepositoryEditPending() {
-  return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <div className="flex items-center gap-2 text-gray-500">
-        <Spinner size="sm" />
-        <span>Loading repository...</span>
-      </div>
-    </div>
-  );
+  return <PagePendingFallback message="Loading repository..." />;
 }
 
 export function RepositoryEditError({ error, reset }: ErrorComponentProps) {
   return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <Link to="/settings/repositories" className="hover:text-white">Repositories</Link>
-        <span>/</span>
-        <span className="text-white">Error</span>
-      </div>
-      <div className="card text-center py-10">
-        <p className="text-red-400 mb-2">Failed to load repository</p>
-        <p className="text-gray-500 text-sm mb-4">{error.message}</p>
-        <div className="flex justify-center gap-2">
-          <button onClick={reset} className="btn btn-secondary">
-            Retry
-          </button>
-          <Link to="/settings/repositories" className="btn btn-primary">
-            Back to Repositories
-          </Link>
-        </div>
-      </div>
-    </div>
+    <PageErrorFallback
+      error={error}
+      reset={reset}
+      breadcrumbItems={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Repositories', to: '/settings/repositories' },
+        { label: 'Error' },
+      ]}
+      errorMessage="Failed to load repository"
+      backTo="/settings/repositories"
+      backLabel="Back to Repositories"
+    />
   );
 }
 
@@ -74,17 +59,12 @@ function RepositoryEditPage() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <Link to="/settings/repositories" className="hover:text-white">Repositories</Link>
-        <span>/</span>
-        <Link to="/settings/repositories/$repositoryId" params={{ repositoryId }} className="hover:text-white">
-          {repository.name}
-        </Link>
-        <span>/</span>
-        <span className="text-white">Edit</span>
-      </div>
+      <PageBreadcrumb items={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Repositories', to: '/settings/repositories' },
+        { label: repository.name, to: '/settings/repositories/$repositoryId', params: { repositoryId } },
+        { label: 'Edit' },
+      ]} />
 
       <h1 className="text-2xl font-semibold mb-6">Edit Repository</h1>
 

--- a/packages/client/src/routes/settings/repositories/$repositoryId/index.tsx
+++ b/packages/client/src/routes/settings/repositories/$repositoryId/index.tsx
@@ -8,10 +8,12 @@ import {
 import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
 import { fetchRepositories, unregisterRepository, fetchAgents } from '../../../../lib/api';
 import { repositoryKeys, agentKeys } from '../../../../lib/query-keys';
+import { PageBreadcrumb } from '../../../../components/PageBreadcrumb';
+import { PagePendingFallback } from '../../../../components/PagePendingFallback';
+import { PageErrorFallback } from '../../../../components/PageErrorFallback';
 import { ConfirmDialog } from '../../../../components/ui/confirm-dialog';
 import { SectionHeader, DetailRow } from '../../../../components/ui/detail-layout';
 import { ErrorDialog, useErrorDialog } from '../../../../components/ui/error-dialog';
-import { Spinner } from '../../../../components/ui/Spinner';
 
 export const Route = createFileRoute('/settings/repositories/$repositoryId/')({
   component: RepositoryDetailPage,
@@ -20,39 +22,23 @@ export const Route = createFileRoute('/settings/repositories/$repositoryId/')({
 });
 
 export function RepositoryDetailPending() {
-  return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <div className="flex items-center gap-2 text-gray-500">
-        <Spinner size="sm" />
-        <span>Loading repository...</span>
-      </div>
-    </div>
-  );
+  return <PagePendingFallback message="Loading repository..." />;
 }
 
 export function RepositoryDetailError({ error, reset }: ErrorComponentProps) {
   return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <Link to="/settings/repositories" className="hover:text-white">Repositories</Link>
-        <span>/</span>
-        <span className="text-white">Error</span>
-      </div>
-      <div className="card text-center py-10">
-        <p className="text-red-400 mb-2">Failed to load repository</p>
-        <p className="text-gray-500 text-sm mb-4">{error.message}</p>
-        <div className="flex justify-center gap-2">
-          <button onClick={reset} className="btn btn-secondary">
-            Retry
-          </button>
-          <Link to="/settings/repositories" className="btn btn-primary">
-            Back to Repositories
-          </Link>
-        </div>
-      </div>
-    </div>
+    <PageErrorFallback
+      error={error}
+      reset={reset}
+      breadcrumbItems={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Repositories', to: '/settings/repositories' },
+        { label: 'Error' },
+      ]}
+      errorMessage="Failed to load repository"
+      backTo="/settings/repositories"
+      backLabel="Back to Repositories"
+    />
   );
 }
 
@@ -99,13 +85,11 @@ function RepositoryDetailPage() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <Link to="/settings/repositories" className="hover:text-white">Repositories</Link>
-        <span>/</span>
-        <span className="text-white">{repository.name}</span>
-      </div>
+      <PageBreadcrumb items={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Repositories', to: '/settings/repositories' },
+        { label: repository.name },
+      ]} />
 
       {/* Header */}
       <div className="flex items-center justify-between mb-6">

--- a/packages/client/src/routes/settings/repositories/index.tsx
+++ b/packages/client/src/routes/settings/repositories/index.tsx
@@ -1,4 +1,5 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
+import { PageBreadcrumb } from '../../../components/PageBreadcrumb';
 import { RepositoryList } from '../../../components/repositories/RepositoryList';
 
 export const Route = createFileRoute('/settings/repositories/')({
@@ -9,11 +10,10 @@ function RepositoriesPage() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       {/* Breadcrumb */}
-      <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
-        <Link to="/" className="hover:text-white">Agent Console</Link>
-        <span>/</span>
-        <span className="text-white">Repositories</span>
-      </div>
+      <PageBreadcrumb items={[
+        { label: 'Agent Console', to: '/' },
+        { label: 'Repositories' },
+      ]} />
 
       {/* Header */}
       <h1 className="text-2xl font-semibold mb-2">Repository Settings</h1>


### PR DESCRIPTION
## Summary
- Extracted 3 shared components (`PageBreadcrumb`, `PagePendingFallback`, `PageErrorFallback`) from duplicated patterns across 9 route files
- Refactored all agent, job, settings, and repository route files to use the shared components
- Net reduction of ~89 lines of duplicated code while preserving identical visual output

## Changes
### New components (`packages/client/src/components/`)
- **`PageBreadcrumb`** — Accepts `items` array with `label`, optional `to` and `params`. Last item rendered as current page (white text), others as links.
- **`PagePendingFallback`** — Spinner + message in standard page layout wrapper.
- **`PageErrorFallback`** — Breadcrumb + error card with retry button and back link.

### Refactored routes
- `routes/agents/index.tsx` — breadcrumb
- `routes/agents/$agentId/index.tsx` — breadcrumb, pending, error
- `routes/agents/$agentId/edit.tsx` — breadcrumb, pending, error
- `routes/settings/index.tsx` — breadcrumb
- `routes/settings/repositories/index.tsx` — breadcrumb
- `routes/settings/repositories/$repositoryId/index.tsx` — breadcrumb, pending, error
- `routes/settings/repositories/$repositoryId/edit.tsx` — breadcrumb, pending, error
- `routes/jobs/index.tsx` — breadcrumb
- `routes/jobs/$jobId/index.tsx` — breadcrumb, pending, error

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (all 1875+ tests)
- [ ] Visual confirmation: verify pages render identically (breadcrumbs, loading states, error states)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #427