### PR TITLE
docs: add CodeRabbit CLI pre-review step to delegation workflow

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -152,12 +152,15 @@ You are acting as the Orchestrator of this project. Your job is strategic decisi
   2. If issues found -> send specific feedback to the agent with concrete fix instructions
   3. If uncertain -> escalate to the owner
   4. If all checks pass -> report to the owner as ready for review (use `write_memo` so the owner sees it)
-- **CodeRabbit Rate Limit handling**: Before requesting a CodeRabbit re-review (`@coderabbitai review`), ALWAYS check the rate limit status first:
-  1. Check recent CodeRabbit comments on the PR and nearby PRs:
+- **CodeRabbit review strategy**: Two layers of CodeRabbit review are used:
+  1. **Pre-PR: CLI self-review by the coding agent** — delegation instructions include a step to run `coderabbit review --agent --base main` before creating the PR (if CLI is installed). This catches CRITICAL/HIGH issues early without rate limit concerns.
+  2. **Post-PR: GitHub bot auto-review** — triggered automatically when the PR is created. May hit rate limits.
+- **CodeRabbit Rate Limit handling** (for the GitHub bot): Before requesting a CodeRabbit re-review (`@coderabbitai review`), ALWAYS check the rate limit status first:
+  1. Check recent CodeRabbit comments on the PR:
      ```bash
      gh api repos/{owner}/{repo}/issues/{pr}/comments --jq '.[] | select(.user.login == "coderabbitai[bot]") | {created_at, body: .body[:300]}'
      ```
-  2. Look for "Rate limit exceeded" and "wait **XX minutes**" in the comment body
+  2. Look for "Rate limit exceeded" and "wait **XX minutes and YY seconds**" in the comment body
   3. Calculate when the limit expires: `comment.created_at + wait_minutes`
   4. Create a timer via `create_timer` for the remaining wait duration
   5. When the timer fires, post `@coderabbitai review` as a PR comment

--- a/.claude/skills/orchestrator/delegation-prompt.js
+++ b/.claude/skills/orchestrator/delegation-prompt.js
@@ -176,11 +176,20 @@ ${
 ## Completion Steps
 1. Determine the appropriate test level based on CLAUDE.md rules and Orchestrator instructions. If your judgment differs from the Orchestrator's instruction, propose with reasoning. (e.g., docs-only changes may skip tests per CLAUDE.md)
 2. Run \`/review-loop\` if instructed by the Orchestrator (skip if not instructed)
-3. Create PR (title: \`[AI] closed #${issueNumber} ${issue.title.replace(/^\[AI\]\s*/, '')}\`)
-4. Wait for CI to be fully green. Address any CI failures or CodeRabbit review comments. Do NOT report completion until CI is green.
-5. After CI is green, report completion to the Orchestrator with your retrospective report. Include the PR URL and CI status.
-6. After your PR is merged, report back to the Orchestrator with the merge confirmation.
-7. If you resolved an issue by communicating directly with the owner, report the following to the Orchestrator:
+3. Run CodeRabbit CLI self-review before creating the PR (skip if CLI is not installed):
+   \`\`\`bash
+   if command -v coderabbit >/dev/null 2>&1 || test -x ~/.local/bin/coderabbit; then
+     coderabbit review --agent --base main
+   fi
+   \`\`\`
+   - Fix any CRITICAL or HIGH severity issues found
+   - MEDIUM/LOW issues: fix if straightforward, otherwise note in the PR description
+   - If CLI is not installed, skip this step entirely
+4. Create PR (title: \`[AI] closed #${issueNumber} ${issue.title.replace(/^\[AI\]\s*/, '')}\`)
+5. Wait for CI to be fully green. Address any CI failures or CodeRabbit review comments. Do NOT report completion until CI is green.
+6. After CI is green, report completion to the Orchestrator with your retrospective report. Include the PR URL and CI status.
+7. After your PR is merged, report back to the Orchestrator with the merge confirmation.
+8. If you resolved an issue by communicating directly with the owner, report the following to the Orchestrator:
    - What was the problem
    - How it was resolved
    - What is needed to prevent the same issue in the future


### PR DESCRIPTION
## Summary
- Delegation prompt に CodeRabbit CLI 自己レビューステップを追加（PR作成前、CLI未インストール時はスキップ）
- Orchestrator スキルの CodeRabbit セクションを2層レビュー戦略として整理（CLI事前レビュー + GitHub bot事後レビュー）

## Motivation
- GitHub bot の rate limit を回避しつつ、PR品質を向上
- 作業者が PR 作成前に自己レビューすることで手戻りを削減

## Test plan
- [ ] `node .claude/skills/orchestrator/delegation-prompt.js <issue>` の出力にステップ3（CodeRabbit CLI）が含まれること
- [ ] Orchestrator SKILL.md に2層レビュー戦略の記述があること

🤖 Generated with [Claude Code](https://claude.com/claude-code)