### PR TITLE
docs: clarify language policy for user-facing vs public artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,9 +116,11 @@ Project-defined skills (in `.claude/skills/`):
 
 ## Language Policy
 
-**Code and documentation:** Write all code comments, commit messages, issues, pull requests, and documentation (including files under `docs/`) in English.
+**Public artifacts:** Write all code comments, commit messages, issues, pull requests, and documentation (including files under `docs/`) in English. These are visible to the broader community.
 
-**Communication with Claude:** Adapt to the user's preferred language. Respond in the same language the user uses.
+**User-facing artifacts:** Review annotations, memos, and other content visible only to the user should follow the user's preferred language. Adapt to the same language the user uses.
+
+**Communication with Claude:** Respond in the same language the user uses. Technical terms and code identifiers can remain in English.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- Clarify Language Policy: public artifacts (commits, PRs, issues, docs) → English; user-facing artifacts (annotations, memos) → user's preferred language
- Based on owner feedback during review queue usage

## Test plan
- [ ] Review CLAUDE.md diff for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)