### PR TITLE
fix: fire PTY exit notifications during managed worker kills

### DIFF
--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -239,7 +239,7 @@ describe('SessionManager', () => {
       const pty = ptyFactory.instances[0];
       pty.simulateExit(0);
 
-      expect(onExit).toHaveBeenCalledWith(0, null);
+      expect(onExit).toHaveBeenCalledWith(0, null, 'unexpected');
     });
 
     it('should buffer output for reconnection', async () => {
@@ -896,7 +896,7 @@ describe('SessionManager', () => {
       pty.simulateExit(0);
 
       // Global exit callback should have been called with session and worker info
-      expect(exitCallback).toHaveBeenCalledWith(session.id, workerId, 0);
+      expect(exitCallback).toHaveBeenCalledWith(session.id, workerId, 0, 'unexpected');
     });
 
     it('should call global callback with non-zero exit code', async () => {
@@ -918,7 +918,7 @@ describe('SessionManager', () => {
       pty.simulateExit(1);
 
       // Global exit callback should have been called with the exit code
-      expect(exitCallback).toHaveBeenCalledWith(session.id, workerId, 1);
+      expect(exitCallback).toHaveBeenCalledWith(session.id, workerId, 1, 'unexpected');
     });
 
     it('should call global callback for terminal worker exit', async () => {
@@ -946,7 +946,7 @@ describe('SessionManager', () => {
       terminalPty.simulateExit(0);
 
       // Global exit callback should have been called for the terminal worker
-      expect(exitCallback).toHaveBeenCalledWith(session.id, terminalWorker!.id, 0);
+      expect(exitCallback).toHaveBeenCalledWith(session.id, terminalWorker!.id, 0, 'unexpected');
     });
   });
 
@@ -3238,7 +3238,7 @@ describe('SessionManager', () => {
       // Simulate PTY crash with non-zero exit (signal 9 = SIGKILL)
       ptyFactory.instances[0].simulateExit(1, 9);
 
-      expect(onExit).toHaveBeenCalledWith(1, '9');
+      expect(onExit).toHaveBeenCalledWith(1, '9', 'unexpected');
     });
 
     it('should continue operating after one session crashes', async () => {

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -1709,7 +1709,7 @@ describe('WorkerLifecycleManager', () => {
 
       ptyFactory.instances[0].simulateExit(0);
 
-      expect(onExit).toHaveBeenCalledWith(0, null);
+      expect(onExit).toHaveBeenCalledWith(0, null, 'unexpected');
     });
   });
 

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -400,7 +400,7 @@ describe('WorkerManager', () => {
       const mockPty = ptyFactory.instances[0];
       expect(mockPty.killed).toBe(false);
 
-      await workerManager.killWorker(worker);
+      await workerManager.killWorker(worker, 'test-session');
 
       expect(mockPty.killed).toBe(true);
     });
@@ -410,7 +410,7 @@ describe('WorkerManager', () => {
       workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const mockPty = ptyFactory.instances[0];
-      await workerManager.killWorker(worker);
+      await workerManager.killWorker(worker, 'test-session');
 
       expect(mockPty.killed).toBe(true);
     });
@@ -422,7 +422,7 @@ describe('WorkerManager', () => {
       // PTY is set before kill
       expect(worker.pty).not.toBeNull();
 
-      await workerManager.killWorker(worker);
+      await workerManager.killWorker(worker, 'test-session');
 
       // After awaiting, PTY should be detached (null)
       expect(worker.pty).toBeNull();
@@ -436,7 +436,7 @@ describe('WorkerManager', () => {
       expect(worker.disposables).toBeDefined();
       expect(worker.disposables!.length).toBeGreaterThan(0);
 
-      await workerManager.killWorker(worker);
+      await workerManager.killWorker(worker, 'test-session');
 
       // After kill, disposables should be cleared
       expect(worker.disposables).toBeUndefined();
@@ -447,7 +447,7 @@ describe('WorkerManager', () => {
       // Worker not activated -- pty is null
 
       // Should not throw
-      await workerManager.killWorker(worker);
+      await workerManager.killWorker(worker, 'test-session');
     });
 
     it('should resolve with timeout when PTY does not exit', async () => {
@@ -462,7 +462,7 @@ describe('WorkerManager', () => {
           this.killed = true;
         };
 
-        const killPromise = workerManager.killWorker(worker);
+        const killPromise = workerManager.killWorker(worker, 'test-session');
 
         // Advance past PTY_EXIT_TIMEOUT_MS (5000ms)
         jest.advanceTimersByTime(5000);
@@ -486,7 +486,7 @@ describe('WorkerManager', () => {
       };
 
       // Should not throw
-      await workerManager.killWorker(worker);
+      await workerManager.killWorker(worker, 'test-session');
     });
   });
 
@@ -587,7 +587,7 @@ describe('WorkerManager', () => {
       const mockPty = ptyFactory.instances[0];
       mockPty.simulateExit(0);
 
-      expect(globalExitCallback).toHaveBeenCalledWith('sess-exit', 'term-exit');
+      expect(globalExitCallback).toHaveBeenCalledWith('sess-exit', 'term-exit', 'unexpected');
     });
 
     it('should fire global worker exit callback', () => {
@@ -603,7 +603,7 @@ describe('WorkerManager', () => {
       const mockPty = ptyFactory.instances[0];
       mockPty.simulateExit(1);
 
-      expect(globalWorkerExitCallback).toHaveBeenCalledWith('sess-wexit', 'term-wexit', 1);
+      expect(globalWorkerExitCallback).toHaveBeenCalledWith('sess-wexit', 'term-wexit', 1, 'unexpected');
     });
   });
 

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -12,6 +12,7 @@ import type {
   SessionActivationState,
   WorkerMessage,
   AppServerMessage,
+  ExitReason,
 } from '@agent-console/shared';
 import type {
   PersistedSession,
@@ -317,7 +318,7 @@ export class SessionManager {
    * This broadcasts session-updated events to keep clients in sync.
    */
   setupPtyExitCallback(): void {
-    this.workerManager.setGlobalPtyExitCallback((sessionId, _workerId) => {
+    this.workerManager.setGlobalPtyExitCallback((sessionId, _workerId, _reason) => {
       const session = this.sessions.get(sessionId);
       if (session) {
         // Broadcast session update with new activation state
@@ -410,7 +411,7 @@ export class SessionManager {
   /**
    * Set a global callback for all worker exit events (for notifications)
    */
-  setGlobalWorkerExitCallback(callback: (sessionId: string, workerId: string, exitCode: number) => void): void {
+  setGlobalWorkerExitCallback(callback: (sessionId: string, workerId: string, exitCode: number, reason: ExitReason) => void): void {
     this.workerManager.setGlobalWorkerExitCallback(callback);
   }
 
@@ -607,7 +608,7 @@ export class SessionManager {
       if (worker.type === 'git-diff') {
         stopWatching(session.locationPath);
       } else {
-        killPromises.push(this.workerManager.killWorker(worker));
+        killPromises.push(this.workerManager.killWorker(worker, id));
       }
     }
     await Promise.all(killPromises);
@@ -629,7 +630,7 @@ export class SessionManager {
         stopWatching(session.locationPath);
       } else {
         // Kill PTY for agent/terminal workers
-        killPromises.push(this.workerManager.killWorker(worker));
+        killPromises.push(this.workerManager.killWorker(worker, id));
       }
     }
     await Promise.all(killPromises);
@@ -819,7 +820,7 @@ export class SessionManager {
         stopWatching(session.locationPath);
       } else {
         // Kill PTY for agent/terminal workers (don't delete output files)
-        killPromises.push(this.workerManager.killWorker(worker));
+        killPromises.push(this.workerManager.killWorker(worker, id));
       }
     }
     await Promise.all(killPromises);
@@ -971,7 +972,7 @@ export class SessionManager {
       logger.error({ sessionId: id, err }, 'Failed to activate PTY workers during session resume');
 
       // Kill all workers that were successfully activated
-      await Promise.all(activatedWorkers.map((worker) => this.workerManager.killWorker(worker)));
+      await Promise.all(activatedWorkers.map((worker) => this.workerManager.killWorker(worker, id)));
 
       // Remove session from memory
       this.sessions.delete(id);
@@ -996,7 +997,7 @@ export class SessionManager {
       logger.error({ sessionId: id, err }, 'Failed to persist resumed state, rolling back in-memory resume');
 
       // Kill all workers that were successfully activated
-      await Promise.all(activatedWorkers.map((worker) => this.workerManager.killWorker(worker)));
+      await Promise.all(activatedWorkers.map((worker) => this.workerManager.killWorker(worker, id)));
 
       // Remove session from memory
       this.sessions.delete(id);

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -273,7 +273,7 @@ export class WorkerLifecycleManager {
 
     // Clean up based on worker type
     if (worker.type === 'agent' || worker.type === 'terminal') {
-      await this.deps.workerManager.killWorker(worker);
+      await this.deps.workerManager.killWorker(worker, sessionId);
       await this.cleanupWorkerOutput(sessionId, workerId, resolver);
     } else {
       // git-diff worker: stop file watcher (synchronous operation)
@@ -370,7 +370,7 @@ export class WorkerLifecycleManager {
     const locationPath = session.locationPath;
 
     // Kill existing worker
-    await this.deps.workerManager.killWorker(existingWorker);
+    await this.deps.workerManager.killWorker(existingWorker, sessionId);
 
     // Reset the output file to prevent offset mismatch with client cache.
     const resolver = this.deps.getPathResolver(session);
@@ -407,7 +407,7 @@ export class WorkerLifecycleManager {
     const currentSession = this.deps.getSession(sessionId);
     if (!currentSession) {
       logger.warn({ sessionId, workerId }, 'Session deleted during worker restart, killing new worker');
-      await this.deps.workerManager.killWorker(newWorker);
+      await this.deps.workerManager.killWorker(newWorker, sessionId);
       return null;
     }
 

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -18,6 +18,7 @@ import type {
   TerminalWorker,
   GitDiffWorker,
   AgentActivityState,
+  ExitReason,
 } from '@agent-console/shared';
 import type {
   PersistedWorker,
@@ -131,7 +132,8 @@ export type GlobalActivityCallback = (
  */
 export type PtyExitCallback = (
   sessionId: string,
-  workerId: string
+  workerId: string,
+  reason: ExitReason
 ) => void;
 
 /**
@@ -140,7 +142,8 @@ export type PtyExitCallback = (
 export type GlobalWorkerExitCallback = (
   sessionId: string,
   workerId: string,
-  exitCode: number
+  exitCode: number,
+  reason: ExitReason
 ) => void;
 
 /**
@@ -455,12 +458,12 @@ export class WorkerManager {
 
       const callbacksSnapshot = Array.from(worker.connectionCallbacks.values());
       for (const callbacks of callbacksSnapshot) {
-        callbacks.onExit(exitCode, signalStr);
+        callbacks.onExit(exitCode, signalStr, 'unexpected');
       }
 
       // Notify listeners about worker exit
-      this.globalWorkerExitCallback?.(sessionId, worker.id, exitCode);
-      this.globalPtyExitCallback?.(sessionId, worker.id);
+      this.globalWorkerExitCallback?.(sessionId, worker.id, exitCode, 'unexpected');
+      this.globalPtyExitCallback?.(sessionId, worker.id, 'unexpected');
     });
     if (onExitDisposable) {
       disposables.push({ dispose: () => onExitDisposable.dispose() });
@@ -657,7 +660,7 @@ export class WorkerManager {
    * Awaits PTY process exit to ensure directory handles are released
    * before callers proceed (e.g., git worktree remove).
    */
-  async killWorker(worker: InternalWorker): Promise<void> {
+  async killWorker(worker: InternalWorker, sessionId: string): Promise<void> {
     if (worker.type === 'agent' || worker.type === 'terminal') {
       const pty = worker.pty;
 
@@ -700,6 +703,20 @@ export class WorkerManager {
             clearTimeout(timeoutHandle);
           }
         }
+
+        // Fire exit notifications for managed kill.
+        // The onExit handler in setupWorkerEventHandlers was disposed above,
+        // so we must explicitly notify WebSocket connections and global listeners.
+        const exitCode = 0; // Managed kills are intentional
+        const signal: string | null = null;
+
+        const callbacksSnapshot = Array.from(worker.connectionCallbacks.values());
+        for (const callbacks of callbacksSnapshot) {
+          callbacks.onExit(exitCode, signal, 'managed');
+        }
+
+        this.globalWorkerExitCallback?.(sessionId, worker.id, exitCode, 'managed');
+        this.globalPtyExitCallback?.(sessionId, worker.id, 'managed');
 
         this.detachPty(worker);
       } else {

--- a/packages/server/src/services/worker-types.ts
+++ b/packages/server/src/services/worker-types.ts
@@ -5,7 +5,7 @@
  * Public API types (Worker, AgentWorker, etc.) are defined in @agent-console/shared.
  */
 
-import type { AgentActivityState } from '@agent-console/shared';
+import type { AgentActivityState, ExitReason } from '@agent-console/shared';
 import type { PtyInstance } from '../lib/pty-provider.js';
 import type { ActivityDetector } from './activity-detector.js';
 
@@ -16,7 +16,7 @@ import type { ActivityDetector } from './activity-detector.js';
  */
 export interface WorkerCallbacks {
   onData: (data: string, offset: number) => void;
-  onExit: (exitCode: number, signal: string | null) => void;
+  onExit: (exitCode: number, signal: string | null, reason?: ExitReason) => void;
   onActivityChange?: (state: AgentActivityState) => void;
 }
 

--- a/packages/server/src/websocket/routes.ts
+++ b/packages/server/src/websocket/routes.ts
@@ -323,7 +323,7 @@ export async function setupWebSocketRoutes(
   completedSteps.add('setGlobalActivityCallback');
 
   // Set up global worker exit callback to send notifications
-  sessionManager.setGlobalWorkerExitCallback((sessionId, workerId, exitCode) => {
+  sessionManager.setGlobalWorkerExitCallback((sessionId, workerId, exitCode, _reason) => {
     const session = sessionManager.getSession(sessionId);
     if (session) {
       notificationManager.onWorkerExit(
@@ -574,8 +574,8 @@ export async function setupWebSocketRoutes(
           onData: (data, offset) => {
             sender?.send({ type: 'output', data, offset });
           },
-          onExit: (exitCode, signal) => {
-            sender?.send({ type: 'exit', exitCode, signal });
+          onExit: (exitCode, signal, reason) => {
+            sender?.send({ type: 'exit', exitCode, signal, reason });
           },
           onActivityChange: (state: AgentActivityState) => {
             sender?.send({ type: 'activity', state });

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -36,6 +36,13 @@ export type {
   RestartWorkerRequest,
 } from '../schemas/worker.js';
 
+/**
+ * Reason a worker's PTY exited.
+ * - 'managed': Intentional kill via API (delete, restart, pause, etc.)
+ * - 'unexpected': Process exited on its own (crash, user exit, signal)
+ */
+export type ExitReason = 'managed' | 'unexpected';
+
 export type SessionStatus = 'active' | 'inactive';
 
 /** Whether a session has active PTY processes running */
@@ -117,7 +124,7 @@ export type WorkerErrorCode =
 
 export type WorkerServerMessage =
   | { type: 'output'; data: string; offset: number }
-  | { type: 'exit'; exitCode: number; signal: string | null }
+  | { type: 'exit'; exitCode: number; signal: string | null; reason?: ExitReason }
   | { type: 'history'; data: string; offset: number; timedOut?: boolean }
   | { type: 'activity'; state: AgentActivityState }  // Agent workers only
   | { type: 'error'; message: string; code?: WorkerErrorCode }


### PR DESCRIPTION
## Summary
- `killWorker()` now explicitly fires exit notifications (WebSocket connections, Slack via globalWorkerExitCallback, session state via globalPtyExitCallback) after PTY exit is confirmed
- Added `ExitReason` type (`'managed' | 'unexpected'`) to distinguish intentional kills from crashes, propagated through callback types and WS exit message
- Updated `killWorker()` signature to accept `sessionId` for callback context

## Test plan
- [x] All 1919 existing tests pass
- [x] TypeScript type check passes for both server and shared packages
- [ ] Manual: kill a worker via UI and verify exit notification appears in WebSocket messages
- [ ] Manual: verify Slack notification fires on managed kill (if configured)

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)