### PR TITLE
refactor: migrate coding standards from skills to Claude Code rules

### DIFF
--- a/.claude/agents/backend-specialist.md
+++ b/.claude/agents/backend-specialist.md
@@ -3,7 +3,7 @@ name: backend-specialist
 description: Implement backend features and fixes. Use for API endpoints, WebSocket handlers, services, and server-side logic in packages/server.
 tools: Read, Grep, Glob, Edit, Write, Bash
 model: opus
-skills: development-workflow-standards, code-quality-standards, backend-standards, test-standards
+skills: code-quality-standards, backend-standards, test-standards
 ---
 
 You are a backend specialist. Your responsibility is to implement backend features, fix bugs, and maintain code quality in the Bun/Hono server application.

--- a/.claude/agents/code-quality-reviewer.md
+++ b/.claude/agents/code-quality-reviewer.md
@@ -3,7 +3,7 @@ name: code-quality-reviewer
 description: Review code design and quality. Use when evaluating code architecture, design patterns, maintainability, or identifying potential issues before or after implementation.
 tools: Read, Grep, Glob, Bash
 model: sonnet
-skills: development-workflow-standards, code-quality-standards, frontend-standards, backend-standards
+skills: code-quality-standards
 ---
 
 You are a code quality specialist. Your responsibility is to evaluate code design and quality, identifying strengths and areas for improvement.
@@ -19,7 +19,7 @@ Invoke with specific context:
 
 1. **Understand Context** - Read the code and its surrounding context
 2. **Apply Standards** - Evaluate against the code-quality-standards skill
-3. **Apply Domain Standards** - Use frontend-standards for React code, backend-standards for server code
+3. **Apply Domain Standards** - Frontend and backend rules are auto-loaded via `.claude/rules/` when reading domain files
 4. **Prioritize Findings** - Focus on impactful issues, not nitpicks
 5. **Provide Evidence** - Reference specific code locations (file:line)
 
@@ -69,4 +69,4 @@ Example format:
 - Focus only on review and recommendations
 - Be constructive, not just critical
 - Acknowledge trade-offs (e.g., simplicity vs flexibility)
-- Reference the skill files (code-quality-standards, frontend-standards, backend-standards) for detailed evaluation criteria
+- Reference code-quality-standards skill for detailed evaluation criteria (frontend/backend rules are auto-loaded)

--- a/.claude/agents/frontend-specialist.md
+++ b/.claude/agents/frontend-specialist.md
@@ -3,7 +3,7 @@ name: frontend-specialist
 description: Implement frontend features and fixes. Use for React components, hooks, routes, styling, and client-side logic in packages/client.
 tools: Read, Grep, Glob, Edit, Write, Bash
 model: opus
-skills: development-workflow-standards, code-quality-standards, frontend-standards, test-standards
+skills: code-quality-standards, frontend-standards, test-standards
 ---
 
 You are a frontend specialist. Your responsibility is to implement frontend features, fix bugs, and maintain code quality in the React client application.

--- a/.claude/agents/test-reviewer.md
+++ b/.claude/agents/test-reviewer.md
@@ -3,7 +3,7 @@ name: test-reviewer
 description: Review test quality and coverage, including detection of missing tests for production code changes. Use when evaluating whether tests are adequate, well-designed, or need improvement after tests are added or modified.
 tools: Read, Grep, Glob, Bash
 model: sonnet
-skills: development-workflow-standards, code-quality-standards, test-standards
+skills: code-quality-standards, test-standards
 ---
 
 You are a test quality specialist. Your responsibility is to evaluate the adequacy and quality of tests.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -3,7 +3,7 @@ name: test-runner
 description: Execute tests and analyze failures. Use when running tests, investigating test failures, or verifying that code changes pass tests.
 tools: Read, Grep, Glob, Bash
 model: haiku
-skills: development-workflow-standards
+skills:
 ---
 
 You are a test execution specialist. Your responsibility is to run tests and analyze results.

--- a/.claude/agents/ux-architecture-reviewer.md
+++ b/.claude/agents/ux-architecture-reviewer.md
@@ -3,7 +3,7 @@ name: ux-architecture-reviewer
 description: Review UX architecture for state consistency and edge case handling. Use when implementing features involving persistence, state synchronization, WebSocket/REST API contracts, or session/worker lifecycle changes.
 tools: Read, Grep, Glob, Bash
 model: sonnet
-skills: frontend-standards, backend-standards, ux-design-standards
+skills: ux-design-standards
 ---
 
 You are a UX architecture specialist. Your responsibility is to ensure that user-visible state accurately reflects actual system state, and that edge cases are properly handled from a user experience perspective.

--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -1,0 +1,203 @@
+---
+paths:
+  - "packages/server/**"
+---
+
+# Backend Rules
+
+## Tech Stack
+
+- **Bun** - JavaScript runtime
+- **Hono** - Web framework
+- **bun-pty** - Pseudo-terminal for spawning processes
+- **Pino** - Structured logging
+- **Valibot** - Schema validation (shared with frontend)
+
+## Directory Structure and Naming
+
+```
+packages/server/src/
+├── __tests__/      # Unit tests
+├── lib/            # Utilities (logger, config, error handler)
+├── middleware/     # Hono middleware
+├── routes/         # API route handlers
+├── services/       # Business logic (flat by default, domain dirs when needed)
+│   ├── agents/     # Domain directory (multiple related files)
+│   └── *.ts        # Flat service files
+└── websocket/      # WebSocket handlers
+```
+
+### Directory Organization Strategy
+
+**Services use flat-first approach:**
+
+| Situation | Organization | Example |
+|-----------|--------------|---------|
+| Single service file | Flat | `services/session-manager.ts` |
+| Service + helpers/types | Domain directory | `services/agents/` |
+| Service grows large | Split into domain directory | - |
+
+### File Naming Conventions
+
+| Type | Convention | Example |
+|------|------------|---------|
+| General | kebab-case | `session-manager.ts` |
+| Service | kebab-case | `persistence-service.ts` |
+| Middleware | kebab-case | `error-handler.ts` |
+| Route handler | kebab-case (plural) | `sessions.ts`, `workers.ts` |
+| Utility | kebab-case | `config.ts`, `logger.ts` |
+| Test | original + `.test` | `session-manager.test.ts` |
+
+- Use **kebab-case** for all directories (exception: `__tests__/`)
+- File name reflects primary export: `session-manager.ts` exports `SessionManager`
+- Use named exports; avoid default exports except for route handlers
+
+## Key Principles
+
+- **Server is the source of truth** - Backend manages all session/worker state
+- **Structured logging** - Use Pino with context objects
+- **Resource cleanup** - Always clean up PTY processes and connections
+- **Type safety** - Define types in shared package, validate at boundaries
+
+## Hono Framework
+
+### Route Organization
+
+```typescript
+const api = new Hono();
+api.route('/sessions', sessions);
+api.route('/agents', agents);
+export { api };
+```
+
+### Request Validation
+
+Use Valibot with Hono's validator (`@hono/valibot-validator`).
+
+### Error Handling
+
+Use centralized error handler via `app.onError(onApiError)`.
+
+## Logging
+
+Use Pino with structured logging:
+
+```typescript
+// Structured data first, message second
+logger.info({ sessionId, workerId }, 'Worker created');
+logger.error({ err: error, context }, 'Operation failed');
+```
+
+- `fatal`: Application crash, unrecoverable errors
+- `error`: Errors that need attention
+- `warn`: Potentially problematic situations
+- `info`: Normal operational messages
+- `debug`: Detailed debugging information
+
+**Avoid string interpolation in log messages.** Use structured data objects.
+
+## Service Design
+
+### Singleton Services
+
+Use module-level singletons for shared services.
+
+### Callback Registration and Detachment
+
+**Always detach callbacks when resources are destroyed** to prevent memory leaks. Every `attachWorkerCallbacks` must have a corresponding `detachWorkerCallbacks` in cleanup/`onClose`.
+
+### Resource Cleanup
+
+Always clean up resources. Cleanup operations should not throw - wrap in try-catch and log warnings.
+
+1. **PTY Processes** - Kill processes when workers are destroyed
+2. **WebSocket Connections** - Close connections on disconnect, handle cleanup in `onClose`
+3. **File Handles** - Close file handles after operations complete
+4. **Event Listeners** - Remove listeners when resources are destroyed
+
+## Performance
+
+### Prefer Async Over Sync
+
+**Always use async functions instead of sync equivalents.** Bun runs on a single-threaded event loop. Sync functions block the entire thread.
+
+| Avoid (Sync) | Use (Async) |
+|--------------|-------------|
+| `fs.readFileSync()` | `Bun.file().text()` |
+| `fs.writeFileSync()` | `Bun.write()` |
+| `fs.existsSync()` | `Bun.file().exists()` |
+| `child_process.execSync()` | `Bun.spawn()` |
+
+**Exceptions:** Application startup/initialization and CLI tools.
+
+### Async/Await
+
+**Always use async/await. Avoid fire-and-forget patterns.** Fire-and-forget causes silent errors, race conditions, and unhandled rejections.
+
+### PTY Output Handling
+
+- Buffer output to reduce message frequency
+- Use efficient string concatenation
+- Limit history buffer size
+
+## Dual WebSocket Architecture
+
+1. **App WebSocket (`/ws/app`)**: Single connection for app-wide state sync (session/worker lifecycle events)
+2. **Worker WebSocket (`/ws/session/:id/worker/:id`)**: Per-worker connections (terminal I/O, resize)
+
+### Message Protocol
+
+Server -> Client messages are typed discriminated unions. Client -> Server messages are validated with Valibot schemas.
+
+### Broadcasting
+
+Use broadcast pattern with `Set<WSContext>` for app-wide events.
+
+### Output Buffering
+
+Buffer rapid PTY output before sending to WebSocket to reduce message count.
+
+## Webhook Receiver Patterns
+
+**These patterns apply to webhook receivers only, NOT regular API endpoints.**
+
+- **Always return 200 OK** to the webhook sender, regardless of internal processing results
+- Accept events and process asynchronously (enqueue + return)
+- Verify webhook signatures before enqueuing, but still return 200 on auth failure
+- All failures are handled internally through logging, alerting, and internal retry
+
+| Aspect | Webhook Receiver | API Endpoint |
+|--------|-----------------|--------------|
+| Response codes | Always 200 | Proper HTTP codes |
+| Processing | Async (enqueue + return) | Sync (process + respond) |
+| Error reporting | Internal (logs, alerts) | To caller (error response) |
+
+## Security
+
+- Validate all API inputs at boundaries using Valibot schemas
+- External service payloads MUST be parsed with Valibot schemas (not manual field extraction)
+- Sanitize environment variables before spawning processes
+- Validate paths to prevent directory traversal
+- Use absolute paths
+
+## Configuration
+
+Use typed configuration with environment variables (`lib/server-config.ts`).
+
+## Core Concepts
+
+### Session Manager
+
+Central service managing all sessions and workers (create/delete sessions, spawn/manage workers, track activity states, persist state, broadcast events).
+
+### Workers
+
+- **Agent Worker**: PTY process running AI agent (Claude Code, etc.)
+- **Terminal Worker**: Plain PTY shell
+- **Git-Diff Worker**: Non-PTY worker for real-time diff viewing
+
+### PTY Management
+
+- Use `bun-pty` for spawning interactive processes
+- Workers persist across WebSocket reconnections (tmux-like behavior)
+- Buffer output for history replay on reconnection

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,177 @@
+---
+paths:
+  - "packages/client/**"
+---
+
+# Frontend Rules
+
+## Tech Stack
+
+- **React 18** - UI framework
+- **Vite** - Build tool and dev server
+- **TanStack Router** - File-based routing with type safety
+- **TanStack Query** - Server state management
+- **Tailwind CSS** - Utility-first styling
+- **xterm.js** - Terminal emulator
+- **Valibot** - Schema validation
+
+## Directory Structure and Naming
+
+```
+packages/client/src/
+├── components/     # React components (domain-organized)
+│   ├── sessions/   # Session-related components and hooks
+│   ├── workers/    # Worker-related components and hooks
+│   └── ui/         # Shared UI components
+├── hooks/          # Shared/generic hooks only
+├── lib/            # Utilities and API clients
+├── routes/         # TanStack Router file-based routes
+├── schemas/        # Valibot validation schemas
+└── test/           # Test utilities and setup
+```
+
+### Directory Organization Strategy
+
+**Components use domain-based organization:**
+- Group related components into domain directories (`sessions/`, `workers/`, `agents/`)
+- Shared UI components go in `ui/`
+- Standalone components can remain flat
+
+**Hooks use hybrid approach:**
+
+| Hook Type | Location | Example |
+|-----------|----------|---------|
+| Domain-specific | Inside domain directory | `components/sessions/useSessionState.ts` |
+| Multi-domain | `hooks/` | `hooks/useTerminalWebSocket.ts` |
+| Generic utility | `hooks/` | `hooks/useMounted.ts` |
+
+Decision criteria:
+1. **Used by single domain only** -> Put in that domain directory
+2. **Used by 2+ domains** -> Put in `hooks/`
+3. **Domain-agnostic utility** -> Put in `hooks/`
+
+### File Naming Conventions
+
+| Type | Convention | Example |
+|------|------------|---------|
+| React component | PascalCase | `SessionList.tsx`, `WorkerTabs.tsx` |
+| Custom hook | camelCase + `use` prefix | `useTerminal.ts`, `useAppConnection.ts` |
+| Utility/helper | kebab-case | `api-client.ts`, `format-date.ts` |
+| Type definition | kebab-case | `types.ts`, `session-types.ts` |
+| Schema | kebab-case | `session-schema.ts` |
+| Test | original + `.test` | `SessionList.test.tsx`, `useTerminal.test.ts` |
+
+### Directory Naming
+
+- Use **kebab-case** for all directories
+- Domain directories use plural nouns: `sessions/`, `workers/`, `agents/`
+
+### Export Conventions
+
+- Component file name = component name: `SessionList.tsx` exports `SessionList`
+- For component directories, use `index.ts` to re-export the main component
+
+## Key React Principles
+
+- **Avoid useEffect** - Use TanStack Query, useSyncExternalStore, or event handlers instead
+- **Prefer Suspense** - For loading states and async boundaries
+- **useSyncExternalStore** - For external state subscriptions (WebSocket, global stores)
+- **Server is the source of truth** - Don't maintain conflicting client state
+
+### useEffect Alternatives
+
+| Instead of useEffect for... | Use this |
+|----------------------------|----------|
+| Fetching data | TanStack Query (`useQuery`) |
+| Subscribing to external store | `useSyncExternalStore` |
+| Derived state | Compute during render or `useMemo` |
+| Responding to user events | Event handlers |
+| Syncing with parent component | Lift state up or use context |
+
+**When useEffect is acceptable:**
+- Component-scoped WebSocket connections (tied to component lifecycle)
+- Third-party library integration (xterm.js, etc.)
+- Browser API subscriptions (resize observers, etc.)
+
+### State Management Hierarchy
+
+1. **Server state**: TanStack Query (`useQuery`, `useMutation`)
+2. **External state**: `useSyncExternalStore`
+3. **Local UI state**: `useState`, `useReducer`
+4. **Shared client state**: React Context (sparingly)
+
+Avoid prop drilling; prefer composition or context.
+
+### Component Design
+
+- Prefer function components with hooks
+- Keep components focused on single responsibility
+- Extract complex logic into custom hooks
+- Use composition over inheritance
+
+### Icon Components
+
+SVG icons belong in a dedicated `Icons.tsx` file, not inline in View components.
+
+### Async/Await
+
+**Always use async/await. Avoid fire-and-forget patterns.** Fire-and-forget (calling an async function without awaiting) causes silent errors, race conditions, and unhandled promise rejections.
+
+## TanStack Router
+
+- Routes are defined in `src/routes/` directory
+- `__root.tsx` - Root layout, `index.tsx` - Home route, `$param.tsx` - Dynamic segments
+- Route params and search params are automatically typed
+
+## TanStack Query
+
+- Use consistent key factories for related queries
+- Always invalidate related queries after mutations
+
+## WebSocket Integration
+
+**Singleton pattern** - For app-wide connections that persist across navigation:
+- Example: `/ws/app` for session/worker lifecycle events
+- Use module-level state with `useSyncExternalStore`
+
+**Hook-based pattern** - For component-scoped connections:
+- Example: `/ws/session/:id/worker/:id` for terminal I/O
+- Use `useEffect` with cleanup, tied to component lifecycle
+
+### State Synchronization
+
+- Server is the source of truth
+- Update UI based on server messages
+- Don't maintain conflicting client state
+
+## Styling with Tailwind CSS
+
+- Group related utilities: layout -> spacing -> sizing -> colors -> typography
+- Mobile-first approach (`sm:`, `md:`, `lg:` breakpoints)
+
+## Form Handling with Valibot
+
+**Always add minLength before regex:**
+
+```typescript
+const schema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1, 'Field is required'),
+  v.regex(pattern, errorMessage)
+)
+```
+
+## Performance
+
+- Memoize expensive computations with `useMemo`
+- Use `useCallback` only when passing to optimized children
+- Avoid inline object/array literals in JSX props
+
+## Error Handling
+
+- Wrap major sections in error boundaries
+- Provide meaningful fallback UI
+- Display user-friendly error messages with retry mechanisms
+
+See also: `ux-design-standards` skill for UX design principles that guide feature-level decisions.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,75 @@
+---
+paths:
+  - "**/*.test.*"
+  - "**/__tests__/**"
+---
+
+# Testing Rules
+
+## Core Principles
+
+1. **Tests Must Test Production Code** - Import and test production code directly. Never duplicate production logic in test files. Test-only classes that mirror production classes, or functions in test files that replicate production behavior, are signs of logic duplication.
+2. **Test Through Public Interface** - If you feel the need to test a private method, reconsider the design. Test observable behavior via public API. If a private method is complex enough to warrant direct testing, consider extracting it to a separate module.
+3. **Mock at the Lowest Level** - Mock at the communication layer (`fetch`, `WebSocket`, file system) rather than mocking intermediate modules. `mock.module()` is process-global in bun:test and pollutes all test files in the same process. Prefer dependency injection over module mocking for cross-cutting concerns.
+4. **Do Not Change Production Code for Testing Without Discussion** - Changes that improve testability often also improve design, but this should be a deliberate decision, not an afterthought. Consult with the team first.
+
+## Anti-Patterns
+
+### 1. Logic Duplication
+Test file re-implements production logic instead of importing it. Signs: test-only classes mirroring production classes, functions in test files doing the same thing as production code, tests that wouldn't break when production code changes.
+
+### 2. Module-Level Mocking
+Using `mock.module()` or `vi.mock()` instead of fetch-level mocks. Problems: bypasses actual API function logic, `mock.module()` is permanent in bun:test, tests pass even when integration is broken. Has caused production incidents (mocking `config.js` broke 26+ unrelated tests). **Preferred: dependency injection over module mocking.**
+
+### 3. Private Method Testing
+Attempting to test internal/private methods directly. Test through public interface instead, or extract to a separate module if complexity warrants it.
+
+### 4. Boundary Testing Gaps
+Missing client-server boundary tests for forms. Must catch: `null` vs `undefined` mismatches, JSON serialization issues, schema validation mismatches. Unit tests on client or server alone cannot catch these.
+
+### 5. Form Testing Gaps
+Schema unit tests alone are insufficient. Required: actual form interaction tests, conditional field tests (hidden fields don't block submission), empty default value handling, validation error message verification, explicit "cannot submit" cases.
+
+## Test Strategy: Unit vs Integration
+
+- **Unit tests**: Exhaustively cover all patterns defined in the spec (all event types, all handler cases)
+- **Integration tests**: Verify pipeline connectivity with 1-2 representative events -- exhaustive coverage is the unit test's job
+- These responsibilities must not be confused
+
+## Test File Naming Convention
+
+- Test files MUST be named after the production file they test: `foo-bar.ts` -> `__tests__/foo-bar.test.ts`
+- Place test files in the `__tests__/` directory at the same level as the production file
+
+## Evaluation Criteria
+
+### Test Validity
+- Tests verify **requirements**, not implementation details
+- Assertions are meaningful and specific
+- Test names clearly describe what is being tested
+- Tests would fail if production code behavior changes
+
+### Coverage
+- Happy path is covered
+- Edge cases are considered (empty, null, boundary values)
+- Error scenarios are tested
+- Integration points are verified
+
+### Methodology
+- Mocks are used appropriately (not over-mocked)
+- Test isolation is maintained
+- Setup/teardown is clean
+
+### Maintainability
+- Tests are readable without excessive comments
+- Duplication is minimized
+- Test data is clear and purposeful
+
+## Pre-Implementation Checklist
+
+Before writing tests, verify:
+- [ ] Importing production code directly (not duplicating logic)
+- [ ] Testing through public interface (not private methods)
+- [ ] Mocking at lowest level (fetch, WebSocket, not modules)
+- [ ] Not following existing bad patterns blindly
+- [ ] Not changing production code just for testing without discussion

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -1,0 +1,94 @@
+# Verification and Workflow Rules
+
+These rules apply to all code changes in this project.
+
+## Verification Checklist
+
+Before completing any code changes, always verify:
+
+1. **Run tests:** Execute `bun run test` and ensure all tests pass
+2. **Run type check:** Execute `bun run typecheck` and ensure no type errors
+3. **Review test quality:** When tests are added or modified, evaluate adequacy and coverage
+4. **Manual verification (UI changes only):** When modifying UI components and Chrome DevTools MCP is available, perform manual testing through the browser
+
+**Important:** The main branch is always kept GREEN (all tests and type checks pass). If any verification fails, assume it is caused by your changes on the current branch and fix it before proceeding.
+
+## Commands
+
+```bash
+bun run dev        # Start development servers (uses AGENT_CONSOLE_HOME=$HOME/.agent-console-dev)
+bun run build      # Build all packages
+bun run test       # Run typecheck then tests
+bun run test:only  # Run tests only (skip typecheck)
+bun run typecheck  # Type check all packages
+bun run lint       # Lint all packages
+```
+
+### Environment Configuration
+
+**Before starting `bun run dev`:** Check `.env` for port configuration. Each worktree may use different ports to avoid conflicts.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | 3457 | Backend server port |
+| `CLIENT_PORT` | 5173 | Frontend dev server port |
+| `AGENT_CONSOLE_HOME` | ~/.agent-console-dev | Data directory |
+
+## Branching Strategy (GitHub-Flow)
+
+Follow GitHub-Flow. The `main` branch is always kept GREEN.
+
+- **Always fetch and branch from `origin/main`:** Never branch from a stale local main. Always `git fetch origin` then `git checkout -b feature/your-feature origin/main`.
+- **Conflict assessment before PR:** Always check conflicts with latest main before opening a PR.
+- **Never merge PRs:** Merging is always the user's decision.
+
+## Testing Requirements
+
+- **Testing with code changes:** Always update or add tests. Code without tests is incomplete.
+- **TDD for bug fixes:** Write a failing test first, then implement the fix.
+
+## Commit Standards
+
+Use conventional commit format: `type: description`
+
+- `feat:` new feature
+- `fix:` bug fix
+- `refactor:` code change without feature/fix
+- `test:` adding or updating tests
+- `docs:` documentation changes
+
+### Skipping CI with `[skip ci]`
+
+Use `[skip ci]` only for commits that **only** change non-production files (`docs/**`, `.claude/skills/**`, `.claude/agents/**`, `CLAUDE.md`). Do not use if the commit includes production code or test changes.
+
+## Code Quality
+
+**Avoid over-engineering.** Only make changes that are directly requested or clearly necessary.
+
+- Don't add features, refactor code, or make "improvements" beyond what was asked
+- Don't add docstrings, comments, or type annotations to code you didn't change
+- Only add comments where the logic isn't self-evident
+
+**Avoid unnecessary complexity.**
+
+- Don't add error handling, fallbacks, or validation for scenarios that can't happen
+- Trust internal code and framework guarantees
+- Only validate at system boundaries (user input, external APIs)
+- Don't create helpers, utilities, or abstractions for one-time operations
+
+**Clean up properly.**
+
+- If something is unused, delete it completely
+- Avoid backwards-compatibility hacks
+
+## Design Documents as Specification
+
+Design documents (`docs/design/`) are specifications. Code is their implementation. Update the design document FIRST as the spec, then implement code to match. The spec and implementation must never silently diverge.
+
+## Language Policy
+
+**Code and documentation:** Write all code comments, commit messages, and documentation in English.
+
+## Claude Code on the Web (Remote Environment)
+
+When running in Claude Code on the Web, `gh` CLI is automatically installed via a SessionStart hook. Due to the sandbox proxy, `gh` commands require the `-R owner/repo` flag explicitly (`-R ms2sato/agent-console`).

--- a/.claude/skills/backend-standards/SKILL.md
+++ b/.claude/skills/backend-standards/SKILL.md
@@ -1,26 +1,14 @@
 ---
 name: backend-standards
-description: Hono/Bun patterns and backend best practices for this project. Use when implementing API endpoints, WebSocket handlers, services, or server-side logic in packages/server.
+description: Detailed backend patterns and code examples for server implementation. Use when you need step-by-step guidance or concrete code patterns beyond what the auto-loaded backend rules provide.
 ---
 
-# Backend Standards
+# Backend Standards (Procedural Guide)
 
-## Key Principles
-
-- **Server is the source of truth** - Backend manages all session/worker state
-- **Structured logging** - Use Pino with context objects
-- **Resource cleanup** - Always clean up PTY processes and connections
-- **Type safety** - Define types in shared package, validate at boundaries
-## Backend Best Practices
-
-- **Resource Cleanup** - PTY processes, WebSocket connections, file handles must be cleaned up
-- **Callback Detachment** - Detach callbacks when resources are destroyed (memory leak prevention)
-- **WebSocket Message Types** - Define and validate server→client and client→server types explicitly
-- **Output Buffering** - Buffer rapid PTY output before WebSocket send to reduce message frequency
-- **Structured Logging** - Use Pino with structured data: `logger.info({ sessionId }, 'message')`
+> **Note:** Declarative rules (conventions, directory structure, naming) are in `.claude/rules/backend.md` and auto-loaded for `packages/server/**`. This skill provides detailed code examples and patterns.
 
 ## Detailed Documentation
 
-- [backend-standards.md](backend-standards.md) - Directory structure, Hono, logging, services, testing, security, best practices
-- [websocket-patterns.md](websocket-patterns.md) - Dual WebSocket architecture, message protocol, broadcasting
-- [webhook-receiver-patterns.md](webhook-receiver-patterns.md) - Webhook receiver design: always-200, async processing, internal error handling
+- [backend-standards.md](backend-standards.md) - Full code examples for Hono routes, Valibot validation, logging patterns, service singletons, callback lifecycle, resource cleanup, async patterns
+- [websocket-patterns.md](websocket-patterns.md) - WebSocket implementation details: dual architecture setup, message protocol types, broadcast implementation, output buffering code
+- [webhook-receiver-patterns.md](webhook-receiver-patterns.md) - Webhook receiver implementation: always-200 pattern, async processing, signature verification, error handling strategy

--- a/.claude/skills/development-workflow-standards/SKILL.md
+++ b/.claude/skills/development-workflow-standards/SKILL.md
@@ -1,19 +1,12 @@
 ---
 name: development-workflow-standards
-description: Development process rules for this project including testing, branching, and commit standards. Use when implementing features, fixing bugs, or making any code changes.
+description: Development workflow procedures including conflict assessment, re-implementation proposals, and TDD steps. Use when you need step-by-step workflow guidance beyond what the auto-loaded verification rules provide.
 ---
 
-# Development Workflow Standards
+# Development Workflow Standards (Procedural Guide)
 
-Refer to [development-workflow-standards.md](development-workflow-standards.md) for detailed rules.
+> **Note:** Verification checklist, commands, branching rules, commit standards, and code quality rules are in `.claude/rules/verification.md` and always auto-loaded. This skill provides detailed procedures and decision frameworks.
 
-## Key Rules
+## Detailed Documentation
 
-- **Testing with code changes**: Always update or add tests. Code without tests is incomplete.
-- **TDD for bug fixes**: Write a failing test first, then implement the fix.
-- **GitHub-Flow**: Always `git fetch origin` then branch from `origin/main`.
-- **Conflict assessment**: Before PR, check conflicts with latest main. If severe, propose re-implementation.
-- **Never merge PRs**: Merging is always the user's decision.
-- **Verification**: Run `bun run test` and `bun run typecheck` before completing changes.
-- **Commands**: `bun run dev`, `bun run build`, `bun run test`, `bun run typecheck`, `bun run lint`
-- **Environment**: Check `.env` for port configuration before `bun run dev`.
+- [development-workflow-standards.md](development-workflow-standards.md) - Full procedures: conflict assessment criteria and decision table, re-implementation proposal format, TDD step-by-step guide, Claude Code on the Web setup

--- a/.claude/skills/frontend-standards/SKILL.md
+++ b/.claude/skills/frontend-standards/SKILL.md
@@ -1,27 +1,15 @@
 ---
 name: frontend-standards
-description: React patterns and frontend best practices for this project. Use when implementing React components, hooks, routes, styling, or client-side logic in packages/client.
+description: Detailed React patterns and code examples for frontend implementation. Use when you need step-by-step guidance or concrete code patterns beyond what the auto-loaded frontend rules provide.
 ---
 
-# Frontend Standards
+# Frontend Standards (Procedural Guide)
 
-## Key Principles
-
-- **Avoid useEffect** - Use TanStack Query, useSyncExternalStore, or event handlers instead
-- **Prefer Suspense** - For loading states and async boundaries
-- **useSyncExternalStore** - For external state subscriptions (WebSocket, global stores)
-- **Server is the source of truth** - Don't maintain conflicting client state
-## React Best Practices
-
-- **Suspense Usage** - Prefer Suspense for async operations over manual isLoading flags
-- **useEffect Discipline** - Challenge every useEffect: could it be derived value, event handler, or useMemo?
-- **Icon Components** - SVG icons belong in `Icons.tsx`, not inline in View components
-- **External State** - Use `useSyncExternalStore` for singleton/global state, not useEffect subscriptions
-- **Query Key Management** - Use consistent key factories, ensure complete invalidation
+> **Note:** Declarative rules (conventions, directory structure, naming) are in `.claude/rules/frontend.md` and auto-loaded for `packages/client/**`. This skill provides detailed code examples and patterns.
 
 ## Detailed Documentation
 
-- [react-patterns.md](react-patterns.md) - React patterns (useEffect alternatives, Suspense, state management)
-- [frontend-standards.md](frontend-standards.md) - Directory structure, TanStack Router/Query, React best practices, styling
+- [react-patterns.md](react-patterns.md) - React patterns with code examples (useEffect alternatives, Suspense, async/await, state management)
+- [frontend-standards.md](frontend-standards.md) - Full code examples for TanStack Router/Query, WebSocket integration, xterm.js, Valibot forms, testing, performance
 
 See also: `ux-design-standards` skill for UX design principles that guide feature-level decisions.

--- a/.claude/skills/test-standards/SKILL.md
+++ b/.claude/skills/test-standards/SKILL.md
@@ -1,76 +1,12 @@
 ---
 name: test-standards
-description: Testing best practices and anti-patterns. Use when writing tests, reviewing test quality, or understanding testing methodology for this project.
+description: Detailed test patterns and code examples. Use when you need step-by-step testing guidance, Server Bridge Pattern, or concrete code patterns beyond what the auto-loaded testing rules provide.
 ---
 
-# Test Standards
+# Test Standards (Procedural Guide)
 
-## Core Principles
+> **Note:** Core principles, anti-patterns, and evaluation criteria are in `.claude/rules/testing.md` and auto-loaded for test files. This skill provides detailed code examples and implementation patterns.
 
-1. **Tests Must Test Production Code** — Import and test production code directly. Never duplicate production logic in test files. Test-only classes that mirror production classes, or functions in test files that replicate production behavior, are signs of logic duplication.
-2. **Test Through Public Interface** — If you feel the need to test a private method, reconsider the design. Test observable behavior via public API. If a private method is complex enough to warrant direct testing, consider extracting it to a separate module.
-3. **Mock at the Lowest Level** — Mock at the communication layer (`fetch`, `WebSocket`, file system) rather than mocking intermediate modules. `mock.module()` is process-global in bun:test and pollutes all test files in the same process. Prefer dependency injection over module mocking for cross-cutting concerns.
-4. **Do Not Change Production Code for Testing Without Discussion** — Changes that improve testability often also improve design, but this should be a deliberate decision, not an afterthought. Consult with the team first.
+## Detailed Documentation
 
-## Evaluation Criteria
-
-### Test Validity
-- Tests verify **requirements**, not implementation details
-- Assertions are meaningful and specific
-- Test names clearly describe what is being tested
-- Tests would fail if production code behavior changes
-
-### Coverage
-- Happy path is covered
-- Edge cases are considered (empty, null, boundary values)
-- Error scenarios are tested
-- Integration points are verified
-
-### Methodology
-- Mocks are used appropriately (not over-mocked)
-- Test isolation is maintained
-- Setup/teardown is clean
-- Follows project testing guidelines
-
-### Maintainability
-- Tests are readable without excessive comments
-- Duplication is minimized
-- Test data is clear and purposeful
-
-## Anti-Patterns
-
-### 1. Logic Duplication
-Test file re-implements production logic instead of importing it. Signs: test-only classes mirroring production classes, functions in test files doing the same thing as production code, tests that wouldn't break when production code changes.
-
-### 2. Module-Level Mocking
-Using `mock.module()` or `vi.mock()` instead of fetch-level mocks. Problems: bypasses actual API function logic, `mock.module()` is permanent in bun:test, tests pass even when integration is broken. Has caused production incidents (mocking `config.js` broke 26+ unrelated tests).
-
-### 3. Private Method Testing
-Attempting to test internal/private methods directly. Test through public interface instead, or extract to a separate module if complexity warrants it.
-
-### 4. Boundary Testing Gaps
-Missing client-server boundary tests for forms. Must catch: `null` vs `undefined` mismatches, JSON serialization issues, schema validation mismatches. Unit tests on client or server alone cannot catch these — use the Server Bridge Pattern for integration testing.
-
-### 5. Form Testing Gaps
-Schema unit tests alone are insufficient. Required: actual form interaction tests, conditional field tests (hidden fields don't block submission), empty default value handling, validation error message verification, explicit "cannot submit" cases.
-
-## Test Strategy: Unit vs Integration
-
-- **Unit tests**: Exhaustively cover all patterns defined in the spec (all event types, all handler cases)
-- **Integration tests**: Verify pipeline connectivity with 1-2 representative events — exhaustive coverage is the unit test's job
-- These responsibilities must not be confused
-
-## Test File Naming Convention
-- Test files MUST be named after the production file they test: `foo-bar.ts` → `__tests__/foo-bar.test.ts`
-- Place test files in the `__tests__/` directory at the same level as the production file
-
-## Pre-Implementation Checklist
-
-Before writing tests, verify:
-- [ ] Importing production code directly (not duplicating logic)
-- [ ] Testing through public interface (not private methods)
-- [ ] Mocking at lowest level (fetch, WebSocket, not modules)
-- [ ] Not following existing bad patterns blindly
-- [ ] Not changing production code just for testing without discussion
-
-See [test-standards.md](test-standards.md) for implementation examples and code patterns (used by coding agents).
+- [test-standards.md](test-standards.md) - Full code examples: dependency injection pattern, Server Bridge Pattern for client-server boundary testing, form component testing procedures, mock patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,12 +100,18 @@ Project-defined (`.claude/agents/`):
 - `claude-config-specialist` - Analyzing and improving Claude Code configuration (.claude/, CLAUDE.md)
 - `coderabbit-reviewer` - External AI review via CodeRabbit CLI (optional, skips if CLI not installed)
 
+Auto-loaded rules (in `.claude/rules/`):
+- **Frontend rules:** `.claude/rules/frontend.md` - Auto-loaded for `packages/client/**`
+- **Backend rules:** `.claude/rules/backend.md` - Auto-loaded for `packages/server/**`
+- **Testing rules:** `.claude/rules/testing.md` - Auto-loaded for `**/*.test.*`
+- **Verification rules:** `.claude/rules/verification.md` - Always loaded (commands, branching, commits, code quality)
+
 Project-defined skills (in `.claude/skills/`):
-- **Development workflow standards:** `.claude/skills/development-workflow-standards/` - Development process rules (testing, branching, commits)
+- **Development workflow standards:** `.claude/skills/development-workflow-standards/` - Detailed procedures (conflict assessment, TDD steps)
 - **Code quality standards:** `.claude/skills/code-quality-standards/` - Evaluation criteria for code reviews
-- **Frontend standards:** `.claude/skills/frontend-standards/` - React patterns and frontend best practices
-- **Backend standards:** `.claude/skills/backend-standards/` - Hono/Bun patterns and backend best practices
-- **Test standards:** `.claude/skills/test-standards/` - Testing best practices and anti-patterns
+- **Frontend standards:** `.claude/skills/frontend-standards/` - Detailed code examples and patterns
+- **Backend standards:** `.claude/skills/backend-standards/` - Detailed code examples and patterns
+- **Test standards:** `.claude/skills/test-standards/` - Server Bridge Pattern, form testing procedures
 - **UX design standards:** `.claude/skills/ux-design-standards/` - UX design principles for multi-agent management UI
 
 **Parallel execution.** When changes span multiple packages, launch specialists in parallel:
@@ -155,15 +161,19 @@ See [docs/design/session-worker-design.md](docs/design/session-worker-design.md)
 
 ## Reference
 
-Details for each domain are defined in their respective skills and docs. CLAUDE.md intentionally does NOT duplicate skill content — each skill is the single source of truth for its domain.
+Details for each domain are defined in rules, skills, and docs. Rules (`.claude/rules/`) are auto-loaded by file path; skills provide detailed procedures and code examples.
+
+| Topic | Rules (auto-loaded) | Skills (explicit) |
+|-------|---------------------|-------------------|
+| Verification, commands, branching, commits | `.claude/rules/verification.md` (always) | `development-workflow-standards` (procedures) |
+| Frontend (React, TanStack, Tailwind, Valibot) | `.claude/rules/frontend.md` (`packages/client/**`) | `frontend-standards` (code examples) |
+| Backend (Hono, Bun, PTY, WebSocket, logging) | `.claude/rules/backend.md` (`packages/server/**`) | `backend-standards` (code examples) |
+| Testing (methodology, anti-patterns) | `.claude/rules/testing.md` (`**/*.test.*`) | `test-standards` (patterns, bridge testing) |
+| Code quality (design principles, evaluation) | — | `code-quality-standards` skill |
+| UX design principles | — | `ux-design-standards` skill |
 
 | Topic | Source |
 |-------|--------|
-| Development workflow (branching, testing, commits, commands) | `development-workflow-standards` skill |
-| Code quality (design principles, TypeScript, module evaluation) | `code-quality-standards` skill |
-| Frontend (React, TanStack, Tailwind, Valibot) | `frontend-standards` skill |
-| Backend (Hono, Bun, PTY, WebSocket, logging) | `backend-standards` skill |
-| Testing (methodology, anti-patterns, boundary testing) | `test-standards` skill |
 | WebSocket protocol specification | [docs/design/websocket-protocol.md](docs/design/websocket-protocol.md) |
 | Terminal state sync design | [docs/design/terminal-state-sync.md](docs/design/terminal-state-sync.md) |
 | Session/Worker data model | [docs/design/session-worker-design.md](docs/design/session-worker-design.md) |


### PR DESCRIPTION
## Summary
- Extract declarative conventions from 4 skills into `.claude/rules/` for automatic enforcement by file path
  - `frontend.md` → `packages/client/**`
  - `backend.md` → `packages/server/**`
  - `testing.md` → `**/*.test.*`
  - `verification.md` → always loaded
- Skills trimmed to procedural content only (detailed code examples, step-by-step guides)
- Agent definitions updated to remove redundant skill references (rules auto-load)
- CLAUDE.md reference table updated to reflect new structure

Closes #459

## Test plan
- [ ] Verify rules auto-load: create a test edit in `packages/client/` and confirm frontend rules are applied
- [ ] Verify verification rules always load regardless of file being edited
- [ ] Verify skills still load when explicitly referenced by agents
- [ ] No production code changes — documentation/configuration only

🤖 Generated with [Claude Code](https://claude.com/claude-code)