### PR TITLE
fix: generate route tree before typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Build shared package
         run: bun run --filter @agent-console/shared build
 
+      - name: Generate route tree
+        working-directory: packages/client
+        run: bunx --bun vite build
+        # routeTree.gen.ts is gitignored; Vite's TanStack Router plugin generates it
+
       - name: Test
         run: bun run test
 


### PR DESCRIPTION
## Summary
- After #461 removed `routeTree.gen.ts` from git tracking, CI typecheck fails because the file doesn't exist
- Add a step that runs `bunx --bun vite build` directly in `packages/client/` to generate `routeTree.gen.ts` before typecheck
- This bypasses the package script's `tsc --noEmit` (which would also fail without the file)

**Priority: main branch is currently broken**

## Test plan
- [ ] CI passes on this PR (proves the fix works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)