### PR TITLE
feat: send PTY notification to orchestrator on review completed

### DIFF
--- a/packages/server/src/__tests__/review-queue-status.test.ts
+++ b/packages/server/src/__tests__/review-queue-status.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import type { Session } from '@agent-console/shared';
+import { setupTestEnvironment, cleanupTestEnvironment, createTestApp } from './test-utils.js';
+import { annotationService } from '../services/annotation-service.js';
+
+describe('PATCH /api/review-queue/:workerId/status', () => {
+  const SOURCE_SESSION_ID = 'source-session-1';
+  const TARGET_SESSION_ID = 'target-session-1';
+  const WORKER_ID = 'worker-1';
+  const AGENT_WORKER_ID = 'agent-worker-1';
+
+  const mockWriteWorkerInput = mock((_sessionId: string, _workerId: string, _data: string) => true);
+
+  const sourceSession = {
+    id: SOURCE_SESSION_ID,
+    title: 'Orchestrator Session',
+    workers: [{ id: AGENT_WORKER_ID, type: 'agent' }],
+  } as unknown as Session;
+
+  const targetSession = {
+    id: TARGET_SESSION_ID,
+    title: 'Feature Session',
+    workers: [],
+  } as unknown as Session;
+
+  function createMockSessionManager(sessions: Record<string, Session> = {}) {
+    return {
+      getSession: mock((id: string) => sessions[id]),
+      writeWorkerInput: mockWriteWorkerInput,
+    };
+  }
+
+  function setupAnnotations(comments: Array<{ file: string; line: number; body: string }> = []) {
+    annotationService.setAnnotations(
+      WORKER_ID,
+      {
+        annotations: [{ file: 'src/index.ts', startLine: 1, endLine: 5, reason: 'Review needed' }],
+        summary: { totalFiles: 1, reviewFiles: 1, mechanicalFiles: 0, confidence: 'high' },
+      },
+      { sessionId: TARGET_SESSION_ID, sourceSessionId: SOURCE_SESSION_ID },
+    );
+    for (const comment of comments) {
+      annotationService.addComment(WORKER_ID, comment);
+    }
+  }
+
+  beforeEach(async () => {
+    await setupTestEnvironment();
+    mockWriteWorkerInput.mockClear();
+  });
+
+  afterEach(async () => {
+    annotationService.clearAnnotations(WORKER_ID);
+    await cleanupTestEnvironment();
+  });
+
+  it('sends PTY notification to source session agent worker on completed', async () => {
+    setupAnnotations([
+      { file: 'src/index.ts', line: 3, body: 'Consider refactoring' },
+      { file: 'src/index.ts', line: 5, body: 'Add error handling' },
+    ]);
+
+    const sessionManager = createMockSessionManager({
+      [SOURCE_SESSION_ID]: sourceSession,
+      [TARGET_SESSION_ID]: targetSession,
+    });
+    const app = await createTestApp({ sessionManager: sessionManager as never });
+
+    const res = await app.request(`/api/review-queue/${WORKER_ID}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'completed' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ workerId: WORKER_ID, status: 'completed' });
+
+    // Verify writeWorkerInput was called with notification containing expected tag and fields
+    expect(mockWriteWorkerInput).toHaveBeenCalled();
+    const callArgs = mockWriteWorkerInput.mock.calls[0];
+    expect(callArgs[0]).toBe(SOURCE_SESSION_ID);
+    expect(callArgs[1]).toBe(AGENT_WORKER_ID);
+
+    const notificationText = callArgs[2] as string;
+    expect(notificationText).toContain('[internal:reviewed]');
+    expect(notificationText).toContain('session=');
+    expect(notificationText).toContain('Feature Session');
+    expect(notificationText).toContain(`workerId=${WORKER_ID}`);
+    expect(notificationText).toContain('status=completed');
+    expect(notificationText).toContain('comments=2');
+    expect(notificationText).toContain('intent=triage');
+  });
+
+  it('does not throw when source session has no agent worker', async () => {
+    setupAnnotations();
+
+    const sessionWithoutAgent = {
+      ...sourceSession,
+      workers: [{ id: 'terminal-1', type: 'terminal' }],
+    } as unknown as Session;
+
+    const sessionManager = createMockSessionManager({
+      [SOURCE_SESSION_ID]: sessionWithoutAgent,
+      [TARGET_SESSION_ID]: targetSession,
+    });
+    const app = await createTestApp({ sessionManager: sessionManager as never });
+
+    const res = await app.request(`/api/review-queue/${WORKER_ID}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'completed' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockWriteWorkerInput).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when source session does not exist', async () => {
+    setupAnnotations();
+
+    const sessionManager = createMockSessionManager({});
+    const app = await createTestApp({ sessionManager: sessionManager as never });
+
+    const res = await app.request(`/api/review-queue/${WORKER_ID}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'completed' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockWriteWorkerInput).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/lib/pty-notification.ts
+++ b/packages/server/src/lib/pty-notification.ts
@@ -85,11 +85,24 @@ export interface InternalReviewCommentPtyNotification extends BasePtyNotificatio
   intent: PtyNotificationIntent;
 }
 
+export interface InternalReviewedPtyNotification extends BasePtyNotificationParams {
+  kind: 'internal-reviewed';
+  tag: 'internal:reviewed';
+  fields: {
+    session: string;
+    workerId: string;
+    status: string;
+    comments: string;
+  };
+  intent: PtyNotificationIntent;
+}
+
 export type WritePtyNotificationParams =
   | InboundEventPtyNotification
   | InternalMessagePtyNotification
   | InternalTimerPtyNotification
-  | InternalReviewCommentPtyNotification;
+  | InternalReviewCommentPtyNotification
+  | InternalReviewedPtyNotification;
 
 /**
  * Build and send a structured notification to a PTY process.

--- a/packages/server/src/routes/review-queue.ts
+++ b/packages/server/src/routes/review-queue.ts
@@ -97,6 +97,7 @@ export const reviewQueue = new Hono<AppBindings>()
   })
   .patch('/:workerId/status', vValidator(UpdateStatusSchema), (c) => {
     const workerId = c.req.param('workerId');
+    const { sessionManager } = c.get('appContext');
     const { status } = c.req.valid('json');
 
     const annotationSet = annotationService.getAnnotations(workerId);
@@ -104,6 +105,40 @@ export const reviewQueue = new Hono<AppBindings>()
     if (!annotationSet.sourceSessionId) throw new ValidationError('Worker is not a review queue item');
 
     annotationService.updateStatus(workerId, status);
+
+    // Send PTY notification to source session's agent worker (best-effort)
+    try {
+      const sourceSession = sessionManager.getSession(annotationSet.sourceSessionId);
+      if (sourceSession) {
+        const agentWorker = sourceSession.workers.find((w) => w.type === 'agent');
+        if (agentWorker) {
+          const meta = annotationService.getMetadata(workerId);
+          const targetSession = meta ? sessionManager.getSession(meta.sessionId) : undefined;
+          const targetTitle = targetSession?.title ?? 'Unknown session';
+
+          const writeInput = (data: string) =>
+            sessionManager.writeWorkerInput(annotationSet.sourceSessionId!, agentWorker.id, data);
+
+          writePtyNotification({
+            kind: 'internal-reviewed',
+            tag: 'internal:reviewed',
+            fields: {
+              session: targetTitle,
+              workerId,
+              status,
+              comments: String(annotationSet.comments.length),
+            },
+            intent: 'triage',
+            writeInput,
+          });
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        { err, workerId, sourceSessionId: annotationSet.sourceSessionId },
+        'Failed to send reviewed notification to source session',
+      );
+    }
 
     broadcastToApp({ type: 'review-queue-updated' });
 


### PR DESCRIPTION
## Summary

- When a review is marked as completed via `PATCH /:workerId/status`, send an `[internal:reviewed]` PTY notification to the source session's agent worker
- Follows the same best-effort pattern as the existing `[internal:review-comment]` notification
- Notification includes: session title, workerId, status, and comment count

Closes #455

## Changes

| File | Description |
|------|-------------|
| `packages/server/src/lib/pty-notification.ts` | Add `InternalReviewedPtyNotification` type |
| `packages/server/src/routes/review-queue.ts` | Send notification in PATCH handler |
| `packages/server/src/__tests__/review-queue-status.test.ts` | 3 test cases (success, no agent worker, no session) |

## Test plan

- [x] All 3347 tests pass, 0 failures
- [x] Typecheck passes across all packages
- [x] Notification sent to correct session/worker with expected fields
- [x] Best-effort: no error when source session or agent worker is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)