### PR TITLE
refactor: replace inbound-event-notification-repository functions with DI class

### DIFF
--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -226,6 +226,7 @@ export async function createAppContext(
 
   // 8. Initialize inbound integration
   const inboundIntegration = initializeInboundIntegration({
+    db,
     jobQueue,
     sessionManager,
     repositoryManager,
@@ -360,6 +361,7 @@ export async function createTestContext(
 
   // Initialize inbound integration
   const inboundIntegration = initializeInboundIntegration({
+    db,
     jobQueue,
     sessionManager,
     repositoryManager,

--- a/packages/server/src/repositories/__tests__/inbound-event-notification-repository.test.ts
+++ b/packages/server/src/repositories/__tests__/inbound-event-notification-repository.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect } from 'bun:test';
 import type { Kysely } from 'kysely';
 import {
-  createPendingNotification,
-  markNotificationDelivered,
-  findInboundEventNotification,
+  InboundEventNotificationRepository,
   NOTIFICATION_STATUS,
 } from '../inbound-event-notification-repository.js';
 import type { Database } from '../../database/schema.js';
@@ -44,10 +42,11 @@ async function createTestSession(db: Kysely<Database>, sessionId: string = TEST_
 }
 
 describe('inbound-event-notification-repository', () => {
-  const withDb = async <T>(handler: (db: Kysely<Database>) => Promise<T>): Promise<T> => {
+  const withDb = async <T>(handler: (db: Kysely<Database>, repo: InboundEventNotificationRepository) => Promise<T>): Promise<T> => {
     const db = await createDatabaseForTest();
+    const repo = new InboundEventNotificationRepository(db);
     try {
-      return await handler(db);
+      return await handler(db, repo);
     } finally {
       await db.destroy();
     }
@@ -55,14 +54,14 @@ describe('inbound-event-notification-repository', () => {
 
   describe('createPendingNotification', () => {
     it('creates notification with pending status and null notified_at', async () => {
-      await withDb(async (db) => {
+      await withDb(async (db, repo) => {
         // Session required for FK constraint
         await createTestSession(db);
 
-        await createPendingNotification({
+        await repo.createPendingNotification({
           id: 'notification-1',
           ...BASE_NOTIFICATION,
-        }, db);
+        });
 
         const rows = await db
           .selectFrom('inbound_event_notifications')
@@ -76,19 +75,19 @@ describe('inbound-event-notification-repository', () => {
     });
 
     it('ignores duplicate pending notifications', async () => {
-      await withDb(async (db) => {
+      await withDb(async (db, repo) => {
         // Session required for FK constraint
         await createTestSession(db);
 
-        await createPendingNotification({
+        await repo.createPendingNotification({
           id: 'notification-1',
           ...BASE_NOTIFICATION,
-        }, db);
+        });
 
-        await createPendingNotification({
+        await repo.createPendingNotification({
           id: 'notification-2',
           ...BASE_NOTIFICATION,
-        }, db);
+        });
 
         const rows = await db
           .selectFrom('inbound_event_notifications')
@@ -103,21 +102,20 @@ describe('inbound-event-notification-repository', () => {
 
   describe('markNotificationDelivered', () => {
     it('updates status to delivered and sets notified_at', async () => {
-      await withDb(async (db) => {
+      await withDb(async (db, repo) => {
         // Session required for FK constraint
         await createTestSession(db);
 
-        await createPendingNotification({
+        await repo.createPendingNotification({
           id: 'notification-1',
           ...BASE_NOTIFICATION,
-        }, db);
+        });
 
-        await markNotificationDelivered(
+        await repo.markNotificationDelivered(
           BASE_NOTIFICATION.job_id,
           BASE_NOTIFICATION.session_id,
           BASE_NOTIFICATION.worker_id,
-          BASE_NOTIFICATION.handler_id,
-          db
+          BASE_NOTIFICATION.handler_id
         );
 
         const rows = await db
@@ -134,13 +132,12 @@ describe('inbound-event-notification-repository', () => {
 
   describe('findInboundEventNotification', () => {
     it('returns null when notification does not exist', async () => {
-      await withDb(async (db) => {
-        const result = await findInboundEventNotification(
+      await withDb(async (_db, repo) => {
+        const result = await repo.findInboundEventNotification(
           'non-existent-job',
           'session-1',
           'worker-1',
-          'handler-1',
-          db
+          'handler-1'
         );
 
         expect(result).toBeNull();
@@ -148,21 +145,20 @@ describe('inbound-event-notification-repository', () => {
     });
 
     it('returns notification when it exists', async () => {
-      await withDb(async (db) => {
+      await withDb(async (db, repo) => {
         // Session required for FK constraint
         await createTestSession(db);
 
-        await createPendingNotification({
+        await repo.createPendingNotification({
           id: 'notification-1',
           ...BASE_NOTIFICATION,
-        }, db);
+        });
 
-        const result = await findInboundEventNotification(
+        const result = await repo.findInboundEventNotification(
           BASE_NOTIFICATION.job_id,
           BASE_NOTIFICATION.session_id,
           BASE_NOTIFICATION.worker_id,
-          BASE_NOTIFICATION.handler_id,
-          db
+          BASE_NOTIFICATION.handler_id
         );
 
         expect(result).not.toBeNull();
@@ -174,23 +170,23 @@ describe('inbound-event-notification-repository', () => {
 
   describe('foreign key constraint', () => {
     it('rejects notifications with non-existent session_id', async () => {
-      await withDb(async (db) => {
+      await withDb(async (_db, repo) => {
         // Do NOT create session - notification should fail FK constraint
-        await expect(createPendingNotification({
+        await expect(repo.createPendingNotification({
           id: 'notification-1',
           ...BASE_NOTIFICATION,
-        }, db)).rejects.toThrow('FOREIGN KEY constraint failed');
+        })).rejects.toThrow('FOREIGN KEY constraint failed');
       });
     });
 
     it('cascades delete when session is deleted', async () => {
-      await withDb(async (db) => {
+      await withDb(async (db, repo) => {
         await createTestSession(db);
 
-        await createPendingNotification({
+        await repo.createPendingNotification({
           id: 'notification-1',
           ...BASE_NOTIFICATION,
-        }, db);
+        });
 
         // Verify notification exists
         let rows = await db

--- a/packages/server/src/repositories/inbound-event-notification-repository.ts
+++ b/packages/server/src/repositories/inbound-event-notification-repository.ts
@@ -1,5 +1,4 @@
 import type { Kysely } from 'kysely';
-import { getDatabase } from '../database/connection.js';
 import { createLogger } from '../lib/logger.js';
 import type {
   Database,
@@ -19,114 +18,106 @@ export const NOTIFICATION_STATUS = {
 
 export type NotificationStatus = (typeof NOTIFICATION_STATUS)[keyof typeof NOTIFICATION_STATUS];
 
-/**
- * Find an existing notification record for idempotency check.
- * Used to prevent duplicate handler execution on job retry.
- */
-export async function findInboundEventNotification(
-  jobId: string,
-  sessionId: string,
-  workerId: string,
-  handlerId: string,
-  dbOverride?: Kysely<Database>
-): Promise<InboundEventNotification | null> {
-  const db = dbOverride ?? getDatabase();
+export class InboundEventNotificationRepository {
+  constructor(private readonly db: Kysely<Database>) {}
 
-  const result = await db
-    .selectFrom('inbound_event_notifications')
-    .selectAll()
-    .where('job_id', '=', jobId)
-    .where('session_id', '=', sessionId)
-    .where('worker_id', '=', workerId)
-    .where('handler_id', '=', handlerId)
-    .executeTakeFirst();
+  /**
+   * Find an existing notification record for idempotency check.
+   * Used to prevent duplicate handler execution on job retry.
+   */
+  async findInboundEventNotification(
+    jobId: string,
+    sessionId: string,
+    workerId: string,
+    handlerId: string
+  ): Promise<InboundEventNotification | null> {
+    const result = await this.db
+      .selectFrom('inbound_event_notifications')
+      .selectAll()
+      .where('job_id', '=', jobId)
+      .where('session_id', '=', sessionId)
+      .where('worker_id', '=', workerId)
+      .where('handler_id', '=', handlerId)
+      .executeTakeFirst();
 
-  return result ?? null;
-}
+    return result ?? null;
+  }
 
-/**
- * Create a pending notification record BEFORE handler execution.
- * This ensures idempotency: if handler succeeds but update fails,
- * the pending record prevents duplicate execution on retry.
- *
- * Uses INSERT OR IGNORE (onConflict doNothing) so concurrent calls
- * for the same delivery target are safe.
- */
-export async function createPendingNotification(
-  notification: Omit<NewInboundEventNotification, 'status' | 'notified_at'>,
-  dbOverride?: Kysely<Database>
-): Promise<void> {
-  const db = dbOverride ?? getDatabase();
+  /**
+   * Create a pending notification record BEFORE handler execution.
+   * This ensures idempotency: if handler succeeds but update fails,
+   * the pending record prevents duplicate execution on retry.
+   *
+   * Uses INSERT OR IGNORE (onConflict doNothing) so concurrent calls
+   * for the same delivery target are safe.
+   */
+  async createPendingNotification(
+    notification: Omit<NewInboundEventNotification, 'status' | 'notified_at'>
+  ): Promise<void> {
+    await this.db
+      .insertInto('inbound_event_notifications')
+      .values({
+        ...notification,
+        status: NOTIFICATION_STATUS.PENDING,
+        notified_at: null,
+      })
+      .onConflict((oc) =>
+        oc.columns(['job_id', 'session_id', 'worker_id', 'handler_id']).doNothing()
+      )
+      .execute();
 
-  await db
-    .insertInto('inbound_event_notifications')
-    .values({
-      ...notification,
-      status: NOTIFICATION_STATUS.PENDING,
-      notified_at: null,
-    })
-    .onConflict((oc) =>
-      oc.columns(['job_id', 'session_id', 'worker_id', 'handler_id']).doNothing()
-    )
-    .execute();
-
-  logger.debug(
-    { id: notification.id, sessionId: notification.session_id, handlerId: notification.handler_id },
-    'Pending inbound event notification created'
-  );
-}
-
-/**
- * Mark a notification as delivered AFTER handler succeeds.
- * Sets status to 'delivered' and records the notified_at timestamp.
- */
-export async function markNotificationDelivered(
-  jobId: string,
-  sessionId: string,
-  workerId: string,
-  handlerId: string,
-  dbOverride?: Kysely<Database>
-): Promise<void> {
-  const db = dbOverride ?? getDatabase();
-
-  await db
-    .updateTable('inbound_event_notifications')
-    .set({
-      status: NOTIFICATION_STATUS.DELIVERED,
-      notified_at: new Date().toISOString(),
-    })
-    .where('job_id', '=', jobId)
-    .where('session_id', '=', sessionId)
-    .where('worker_id', '=', workerId)
-    .where('handler_id', '=', handlerId)
-    .execute();
-
-  logger.debug(
-    { jobId, sessionId, workerId, handlerId },
-    'Inbound event notification marked as delivered'
-  );
-}
-
-/**
- * Delete all notification records for a session.
- * Called when a session is deleted to clean up orphaned records.
- */
-export async function deleteNotificationsBySessionId(
-  sessionId: string,
-  dbOverride?: Kysely<Database>
-): Promise<void> {
-  const db = dbOverride ?? getDatabase();
-
-  const result = await db
-    .deleteFrom('inbound_event_notifications')
-    .where('session_id', '=', sessionId)
-    .execute();
-
-  const deletedCount = result[0]?.numDeletedRows ?? 0n;
-  if (deletedCount > 0) {
     logger.debug(
-      { sessionId, deletedCount: Number(deletedCount) },
-      'Deleted inbound event notifications for session'
+      { id: notification.id, sessionId: notification.session_id, handlerId: notification.handler_id },
+      'Pending inbound event notification created'
     );
+  }
+
+  /**
+   * Mark a notification as delivered AFTER handler succeeds.
+   * Sets status to 'delivered' and records the notified_at timestamp.
+   */
+  async markNotificationDelivered(
+    jobId: string,
+    sessionId: string,
+    workerId: string,
+    handlerId: string
+  ): Promise<void> {
+    await this.db
+      .updateTable('inbound_event_notifications')
+      .set({
+        status: NOTIFICATION_STATUS.DELIVERED,
+        notified_at: new Date().toISOString(),
+      })
+      .where('job_id', '=', jobId)
+      .where('session_id', '=', sessionId)
+      .where('worker_id', '=', workerId)
+      .where('handler_id', '=', handlerId)
+      .execute();
+
+    logger.debug(
+      { jobId, sessionId, workerId, handlerId },
+      'Inbound event notification marked as delivered'
+    );
+  }
+
+  /**
+   * Delete all notification records for a session.
+   * Called when a session is deleted to clean up orphaned records.
+   */
+  async deleteNotificationsBySessionId(
+    sessionId: string
+  ): Promise<void> {
+    const result = await this.db
+      .deleteFrom('inbound_event_notifications')
+      .where('session_id', '=', sessionId)
+      .execute();
+
+    const deletedCount = result[0]?.numDeletedRows ?? 0n;
+    if (deletedCount > 0) {
+      logger.debug(
+        { sessionId, deletedCount: Number(deletedCount) },
+        'Deleted inbound event notifications for session'
+      );
+    }
   }
 }

--- a/packages/server/src/services/inbound/index.ts
+++ b/packages/server/src/services/inbound/index.ts
@@ -1,21 +1,20 @@
+import type { Kysely } from 'kysely';
 import type { JobQueue } from '../../jobs/index.js';
 import { JOB_TYPES } from '../../jobs/index.js';
 import type { SessionManager } from '../session-manager.js';
 import type { RepositoryManager } from '../repository-manager.js';
 import type { InboundEventSummary } from '@agent-console/shared';
+import type { Database } from '../../database/schema.js';
 import { GitHubServiceParser } from './github-service-parser.js';
 import { createInboundEventJobHandler } from './job-handler.js';
 import { createInboundHandlers } from './handlers.js';
 import { ServiceParserRegistry } from './parser-registry.js';
 import { createCICompletionChecker } from './ci-completion-checker.js';
 import { resolveTargets as resolveTargetsImpl } from './resolve-targets.js';
-import {
-  createPendingNotification,
-  findInboundEventNotification,
-  markNotificationDelivered,
-} from '../../repositories/inbound-event-notification-repository.js';
+import { InboundEventNotificationRepository } from '../../repositories/inbound-event-notification-repository.js';
 
 export interface InboundIntegrationOptions {
+  db: Kysely<Database>;
   jobQueue: JobQueue;
   sessionManager: SessionManager;
   repositoryManager: RepositoryManager;
@@ -63,11 +62,7 @@ export function initializeInboundIntegration(options: InboundIntegrationOptions)
       getServiceParser: (serviceId) => parserRegistry.get(serviceId),
       resolveTargets,
       handlers,
-      notificationRepository: {
-        findInboundEventNotification,
-        createPendingNotification,
-        markNotificationDelivered,
-      },
+      notificationRepository: new InboundEventNotificationRepository(options.db),
       ciCompletionChecker: createCICompletionChecker(),
     })
   );


### PR DESCRIPTION
## Summary
- Converted module-level functions in `inbound-event-notification-repository.ts` to an `InboundEventNotificationRepository` class with constructor-injected `Kysely<Database>` instance
- Removed `getDatabase()` calls and `dbOverride` parameters from all methods
- Updated `InboundIntegrationOptions` to accept `db` and instantiate the repository class
- Updated tests to use the class-based API

Part of #479

## Test plan
- [x] `bun run test` — all 3,430 tests pass
- [x] `bun run typecheck` — no type errors
- [x] Verified structural typing compatibility with `InboundEventNotificationRepository` interface in `job-handler.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)