### PR TITLE
refactor: replace annotationService singleton with DI via AppContext

### DIFF
--- a/packages/server/src/__tests__/review-queue-status.test.ts
+++ b/packages/server/src/__tests__/review-queue-status.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import type { Session } from '@agent-console/shared';
 import { setupTestEnvironment, cleanupTestEnvironment, createTestApp } from './test-utils.js';
-import { annotationService } from '../services/annotation-service.js';
+import { AnnotationService } from '../services/annotation-service.js';
 
 describe('PATCH /api/review-queue/:workerId/status', () => {
   const SOURCE_SESSION_ID = 'source-session-1';
   const TARGET_SESSION_ID = 'target-session-1';
   const WORKER_ID = 'worker-1';
   const AGENT_WORKER_ID = 'agent-worker-1';
+
+  let annotationService: AnnotationService;
 
   const mockWriteWorkerInput = mock((_sessionId: string, _workerId: string, _data: string) => true);
 
@@ -46,11 +48,11 @@ describe('PATCH /api/review-queue/:workerId/status', () => {
 
   beforeEach(async () => {
     await setupTestEnvironment();
+    annotationService = new AnnotationService();
     mockWriteWorkerInput.mockClear();
   });
 
   afterEach(async () => {
-    annotationService.clearAnnotations(WORKER_ID);
     await cleanupTestEnvironment();
   });
 
@@ -64,7 +66,7 @@ describe('PATCH /api/review-queue/:workerId/status', () => {
       [SOURCE_SESSION_ID]: sourceSession,
       [TARGET_SESSION_ID]: targetSession,
     });
-    const app = await createTestApp({ sessionManager: sessionManager as never });
+    const app = await createTestApp({ sessionManager: sessionManager as never, annotationService });
 
     const res = await app.request(`/api/review-queue/${WORKER_ID}/status`, {
       method: 'PATCH',
@@ -104,7 +106,7 @@ describe('PATCH /api/review-queue/:workerId/status', () => {
       [SOURCE_SESSION_ID]: sessionWithoutAgent,
       [TARGET_SESSION_ID]: targetSession,
     });
-    const app = await createTestApp({ sessionManager: sessionManager as never });
+    const app = await createTestApp({ sessionManager: sessionManager as never, annotationService });
 
     const res = await app.request(`/api/review-queue/${WORKER_ID}/status`, {
       method: 'PATCH',
@@ -120,7 +122,7 @@ describe('PATCH /api/review-queue/:workerId/status', () => {
     setupAnnotations();
 
     const sessionManager = createMockSessionManager({});
-    const app = await createTestApp({ sessionManager: sessionManager as never });
+    const app = await createTestApp({ sessionManager: sessionManager as never, annotationService });
 
     const res = await app.request(`/api/review-queue/${WORKER_ID}/status`, {
       method: 'PATCH',

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -24,6 +24,7 @@ import type { WorktreeService } from './services/worktree-service.js';
 import type { RepositorySlackIntegrationService } from './services/notifications/repository-slack-integration-service.js';
 import type { AuthUser } from '@agent-console/shared';
 import type { UserMode } from './services/user-mode.js';
+import type { AnnotationService } from './services/annotation-service.js';
 import type { InboundIntegrationInstance, InboundIntegrationOptions } from './services/inbound/index.js';
 import { initializeInboundIntegration } from './services/inbound/index.js';
 import { initializeDatabase, createDatabaseForTest, closeDatabase, getGlobalDatabase } from './database/connection.js';
@@ -47,6 +48,7 @@ import { TimerManager as TimerManagerClass } from './services/timer-manager.js';
 import { writePtyNotification } from './lib/pty-notification.js';
 import { WorktreeService as WorktreeServiceClass } from './services/worktree-service.js';
 import { RepositorySlackIntegrationService as RepositorySlackIntegrationServiceClass } from './services/notifications/repository-slack-integration-service.js';
+import { AnnotationService as AnnotationServiceClass } from './services/annotation-service.js';
 
 const logger = createLogger('app-context');
 
@@ -92,6 +94,9 @@ export interface AppContext {
 
   /** Periodic timer management (in-memory, volatile) */
   timerManager: TimerManager;
+
+  /** In-memory review annotation store */
+  annotationService: AnnotationService;
 
   /** Inbound integration for processing external events (webhooks) */
   inboundIntegration: InboundIntegrationInstance;
@@ -146,6 +151,7 @@ export async function createAppContext(
   const sessionRepository = new SqliteSessionRepository(db);
   const repositoryRepository = new SqliteRepositoryRepository(db);
   const worktreeService = new WorktreeServiceClass({ db });
+  const annotationService = new AnnotationServiceClass();
 
   // 4. Create agent manager (needed by SessionManager)
   const agentRepository = new SqliteAgentRepository(db);
@@ -171,6 +177,7 @@ export async function createAppContext(
     jobQueue,
     agentManager,
     notificationManager,
+    annotationService,
   });
 
   const repositoryManager = await RepositoryManagerClass.create({
@@ -250,6 +257,7 @@ export async function createAppContext(
     agentManager,
     worktreeService,
     repositorySlackIntegrationService,
+    annotationService,
     userMode,
     timerManager,
     inboundIntegration,
@@ -300,6 +308,7 @@ export async function createTestContext(
     overrides?.sessionRepository ?? new SqliteSessionRepository(db);
   const repositoryRepository = new SqliteRepositoryRepository(db);
   const worktreeService = new WorktreeServiceClass({ db });
+  const annotationService = new AnnotationServiceClass();
 
   // Create agent manager (needed by SessionManager)
   const agentRepository = new SqliteAgentRepository(db);
@@ -328,6 +337,7 @@ export async function createTestContext(
     jobQueue,
     agentManager,
     notificationManager,
+    annotationService,
   });
 
   const repositoryManager = await RepositoryManagerClass.create({
@@ -388,6 +398,7 @@ export async function createTestContext(
     agentManager,
     worktreeService,
     repositorySlackIntegrationService,
+    annotationService,
     userMode,
     timerManager,
     inboundIntegration,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -134,6 +134,7 @@ const mcpApp = createMcpApp({
   agentManager: appContext.agentManager,
   timerManager: appContext.timerManager,
   worktreeService: appContext.worktreeService,
+  annotationService: appContext.annotationService,
 });
 app.route('', mcpApp);
 

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -22,6 +22,7 @@ import { SqliteWorktreeRepository } from '../../repositories/sqlite-worktree-rep
 import { WorktreeService } from '../../services/worktree-service.js';
 import type { PtySpawnOptions } from '../../lib/pty-provider.js';
 import { TimerManager } from '../../services/timer-manager.js';
+import { AnnotationService } from '../../services/annotation-service.js';
 import { createMcpApp } from '../mcp-server.js';
 
 // Mock session-metadata-suggester to avoid spawning real agent processes.
@@ -167,6 +168,7 @@ describe('MCP Server Tools', () => {
   let repositoryManager: RepositoryManager;
   let timerManager: TimerManager;
   let worktreeService: WorktreeService;
+  let annotationService: AnnotationService;
   let testJobQueue: JobQueue;
   let mcpSessionId: string;
   // Track unique IDs for tool calls to avoid collisions in the shared transport
@@ -178,7 +180,7 @@ describe('MCP Server Tools', () => {
    * the MCP tools see the updated dependencies.
    */
   async function remountMcpApp(): Promise<void> {
-    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService });
+    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService });
     app = new Hono();
     app.route('', mcpApp);
     mcpSessionId = await initializeMcp(app);
@@ -231,6 +233,9 @@ describe('MCP Server Tools', () => {
     const db = getDatabase();
     agentManager = await AgentManager.create(new SqliteAgentRepository(db));
 
+    // Create AnnotationService
+    annotationService = new AnnotationService();
+
     // Create SessionManager directly
     sessionManager = await SessionManager.create({
       ptyProvider: ptyFactory.provider,
@@ -238,6 +243,7 @@ describe('MCP Server Tools', () => {
       sessionRepository,
       jobQueue: testJobQueue,
       agentManager,
+      annotationService,
     });
 
     // Create RepositoryManager (initially empty)

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -17,7 +17,7 @@ import type { RepositoryManager } from '../services/repository-manager.js';
 import type { AgentManager } from '../services/agent-manager.js';
 import type { TimerManager } from '../services/timer-manager.js';
 import type { WorktreeService } from '../services/worktree-service.js';
-import { annotationService } from '../services/annotation-service.js';
+import type { AnnotationService } from '../services/annotation-service.js';
 import { sendAnnotationsToClient } from '../websocket/git-diff-handler.js';
 import { broadcastToApp } from '../websocket/routes.js';
 import { deleteWorktree } from '../services/worktree-deletion-service.js';
@@ -159,6 +159,7 @@ export interface McpDependencies {
   agentManager: AgentManager;
   timerManager: TimerManager;
   worktreeService: WorktreeService;
+  annotationService: AnnotationService;
 }
 
 // ---------- Factory ----------
@@ -169,7 +170,7 @@ export interface McpDependencies {
  * All MCP tool handlers use the provided dependencies instead of singleton getters.
  */
 export function createMcpApp(deps: McpDependencies): Hono {
-  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService } = deps;
+  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService } = deps;
 
   /**
    * Map a public Session to the worker info format used by MCP tool responses.

--- a/packages/server/src/routes/__tests__/review-queue.test.ts
+++ b/packages/server/src/routes/__tests__/review-queue.test.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono';
 import type { AppBindings } from '../../app-context.js';
 import { onApiError } from '../../lib/error-handler.js';
 import { asAppContext } from '../../__tests__/test-utils.js';
-import { annotationService } from '../../services/annotation-service.js';
+import { AnnotationService } from '../../services/annotation-service.js';
 import type { ReviewAnnotationInput, ReviewComment, ReviewQueueGroup } from '@agent-console/shared';
 
 // Mock broadcastToApp to prevent WebSocket side effects in tests
@@ -44,13 +44,10 @@ function createMockSessionManager(sessions: Record<string, { title?: string; wor
 describe('Review Queue API', () => {
   let app: Hono<AppBindings>;
   let mockSessionManager: ReturnType<typeof createMockSessionManager>;
+  let annotationService: AnnotationService;
 
   beforeEach(() => {
-    // Clear all annotations between tests
-    // Access the private store via the public API
-    for (const workerId of ['worker-1', 'worker-2', 'worker-3', 'worker-4']) {
-      annotationService.clearAnnotations(workerId);
-    }
+    annotationService = new AnnotationService();
 
     mockBroadcastToApp.mockClear();
 
@@ -65,7 +62,7 @@ describe('Review Queue API', () => {
 
     app = new Hono<AppBindings>();
     app.use('*', async (c, next) => {
-      c.set('appContext', asAppContext({ sessionManager: mockSessionManager as never }));
+      c.set('appContext', asAppContext({ sessionManager: mockSessionManager as never, annotationService }));
       await next();
     });
     app.onError(onApiError);

--- a/packages/server/src/routes/review-queue.ts
+++ b/packages/server/src/routes/review-queue.ts
@@ -2,7 +2,6 @@ import { Hono } from 'hono';
 import * as v from 'valibot';
 import type { ReviewQueueGroup } from '@agent-console/shared';
 import type { AppBindings } from '../app-context.js';
-import { annotationService } from '../services/annotation-service.js';
 import { NotFoundError, ValidationError } from '../lib/errors.js';
 import { vValidator } from '../middleware/validation.js';
 import { broadcastToApp } from '../websocket/routes.js';
@@ -24,7 +23,7 @@ const UpdateStatusSchema = v.object({
 
 export const reviewQueue = new Hono<AppBindings>()
   .get('/', (c) => {
-    const { sessionManager } = c.get('appContext');
+    const { sessionManager, annotationService } = c.get('appContext');
     const getSessionTitle = (sessionId: string) => sessionManager.getSession(sessionId)?.title;
 
     const items = annotationService.listReviewQueue(getSessionTitle);
@@ -48,7 +47,7 @@ export const reviewQueue = new Hono<AppBindings>()
   })
   .post('/:workerId/comments', vValidator(AddCommentSchema), async (c) => {
     const workerId = c.req.param('workerId');
-    const { sessionManager } = c.get('appContext');
+    const { sessionManager, annotationService } = c.get('appContext');
     const { file, line, body } = c.req.valid('json');
 
     const annotationSet = annotationService.getAnnotations(workerId);
@@ -97,7 +96,7 @@ export const reviewQueue = new Hono<AppBindings>()
   })
   .patch('/:workerId/status', vValidator(UpdateStatusSchema), (c) => {
     const workerId = c.req.param('workerId');
-    const { sessionManager } = c.get('appContext');
+    const { sessionManager, annotationService } = c.get('appContext');
     const { status } = c.req.valid('json');
 
     const annotationSet = annotationService.getAnnotations(workerId);

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -22,6 +22,7 @@ import type { InternalSession } from '../internal-types.js';
 import type { SessionLifecycleCallbacks } from '../session-lifecycle-types.js';
 import { JobQueue } from '../../jobs/index.js';
 import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
+import { AnnotationService } from '../annotation-service.js';
 
 const TEST_CONFIG_DIR = '/test/config';
 
@@ -99,6 +100,7 @@ describe('WorkerLifecycleManager', () => {
       getJobQueue: () => testJobQueue,
       getSessionLifecycleCallbacks: () => mockCallbacks,
       getPathResolver: () => new SessionDataPathResolver(),
+      annotationService: new AnnotationService(),
       ...overrides,
     };
   }

--- a/packages/server/src/services/annotation-service.ts
+++ b/packages/server/src/services/annotation-service.ts
@@ -196,5 +196,3 @@ export class AnnotationService {
     }
   }
 }
-
-export const annotationService = new AnnotationService();

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -47,6 +47,7 @@ import { stopWatching, calculateBaseCommit } from './git-diff-service.js';
 import type { SessionLifecycleCallbacks } from './session-lifecycle-types.js';
 import { MessageService } from './message-service.js';
 import { interSessionMessageService } from './inter-session-message-service.js';
+import { AnnotationService } from './annotation-service.js';
 import { memoService } from './memo-service.js';
 import { createLogger } from '../lib/logger.js';
 import { workerOutputFileManager, type HistoryReadResult } from '../lib/worker-output-file.js';
@@ -108,6 +109,8 @@ interface SessionManagerOptions {
   /** User repository for resolving createdBy → username for PTY spawning */
   userRepository?: UserRepository;
   notificationManager?: NotificationManager | null;
+  /** In-memory review annotation store. Defaults to a fresh instance if not provided. */
+  annotationService?: AnnotationService;
   /** @deprecated Use userMode instead. Kept for backward compatibility in tests. */
   ptyProvider?: PtyProvider;
 }
@@ -174,6 +177,7 @@ export class SessionManager {
       getSessionLifecycleCallbacks: () => this.sessionLifecycleCallbacks,
       resolveSpawnUsername: (createdBy) => resolveSpawnUsername(createdBy, this.userRepository),
       getPathResolver: (session) => this.getPathResolverForSession(session),
+      annotationService: options.annotationService ?? new AnnotationService(),
     });
   }
 

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -38,7 +38,7 @@ import { CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
 import type { AgentManager } from './agent-manager.js';
 import type { NotificationManager } from './notifications/notification-manager.js';
 import { interSessionMessageService } from './inter-session-message-service.js';
-import { annotationService } from './annotation-service.js';
+import type { AnnotationService } from './annotation-service.js';
 import { stopWatching, calculateBaseCommit } from './git-diff-service.js';
 import {
   getCurrentBranch as gitGetCurrentBranch,
@@ -79,6 +79,8 @@ export interface WorkerLifecycleDeps {
    * or a quick-session resolver for quick sessions.
    */
   getPathResolver: (session: InternalSession) => SessionDataPathResolver;
+  /** In-memory review annotation store */
+  annotationService: AnnotationService;
 }
 
 /**
@@ -284,7 +286,7 @@ export class WorkerLifecycleManager {
     this.deps.notificationManager?.cleanupWorker(sessionId, workerId);
 
     // Clean up review annotations for this worker
-    annotationService.clearAnnotations(workerId);
+    this.deps.annotationService.clearAnnotations(workerId);
 
     // Clean up inter-session message files for this worker
     try {

--- a/packages/server/src/websocket/__tests__/git-diff-handler.test.ts
+++ b/packages/server/src/websocket/__tests__/git-diff-handler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import type { WSContext } from 'hono/ws';
 import type { GitDiffData, GitDiffServerMessage } from '@agent-console/shared';
 import { createGitDiffHandlers, type GitDiffHandlerDependencies } from '../git-diff-handler.js';
+import { AnnotationService } from '../../services/annotation-service.js';
 
 
 describe('GitDiffHandler', () => {
@@ -62,6 +63,7 @@ describe('GitDiffHandler', () => {
       startWatching: mockStartWatching,
       stopWatching: mockStopWatching,
       getFileLines: mock(() => Promise.resolve([])),
+      annotationService: new AnnotationService(),
     };
 
     handlers = createGitDiffHandlers(deps);
@@ -296,6 +298,7 @@ describe('GitDiffHandler', () => {
           startWatching: mockStartWatching,
           stopWatching: mockStopWatching,
           getFileLines: mock(() => Promise.resolve(['line1', 'line2', 'line3'])),
+          annotationService: new AnnotationService(),
         } satisfies GitDiffHandlerDependencies;
         const localHandlers = createGitDiffHandlers(deps);
 
@@ -341,6 +344,7 @@ describe('GitDiffHandler', () => {
           startWatching: mockStartWatching,
           stopWatching: mockStopWatching,
           getFileLines: mock(() => Promise.reject(new Error('Invalid file path: ../etc/passwd'))),
+          annotationService: new AnnotationService(),
         };
         const localHandlers = createGitDiffHandlers(deps);
 
@@ -383,6 +387,7 @@ describe('GitDiffHandler', () => {
           startWatching: mockStartWatching,
           stopWatching: mockStopWatching,
           getFileLines: mock(() => Promise.reject(new Error('File not found'))),
+          annotationService: new AnnotationService(),
         };
         const localHandlers = createGitDiffHandlers(deps);
 

--- a/packages/server/src/websocket/git-diff-handler.ts
+++ b/packages/server/src/websocket/git-diff-handler.ts
@@ -1,15 +1,7 @@
 import type { WSContext } from 'hono/ws';
 import { MERGE_BASE_REF_PREFIX } from '@agent-console/shared';
 import type { GitDiffClientMessage, GitDiffServerMessage, GitDiffData, GitDiffTarget, ReviewAnnotationSet } from '@agent-console/shared';
-import { annotationService } from '../services/annotation-service.js';
-import {
-  getDiffData as getDiffDataImpl,
-  getFileLines as getFileLinesImpl,
-  resolveRef as resolveRefImpl,
-  startWatching as startWatchingImpl,
-  stopWatching as stopWatchingImpl,
-} from '../services/git-diff-service.js';
-import { getMergeBaseSafe as getMergeBaseSafeImpl } from '../lib/git.js';
+import type { AnnotationService } from '../services/annotation-service.js';
 import { createLogger } from '../lib/logger.js';
 
 const log = createLogger('git-diff-handler');
@@ -25,17 +17,8 @@ export interface GitDiffHandlerDependencies {
   startWatching: (repoPath: string, onChange: () => void) => void;
   stopWatching: (repoPath: string) => void;
   getFileLines: (repoPath: string, filePath: string, startLine: number, endLine: number, ref: GitDiffTarget) => Promise<string[]>;
+  annotationService: AnnotationService;
 }
-
-// Default dependencies using real implementations
-const defaultDependencies: GitDiffHandlerDependencies = {
-  getDiffData: getDiffDataImpl,
-  resolveRef: resolveRefImpl,
-  getMergeBase: getMergeBaseSafeImpl,
-  startWatching: startWatchingImpl,
-  stopWatching: stopWatchingImpl,
-  getFileLines: getFileLinesImpl,
-};
 
 // ============================================================
 // Connection State Management
@@ -55,8 +38,8 @@ const activeConnections = new Map<string, ConnectionState>();
 // Factory Function for Dependency Injection (Testing)
 // ============================================================
 
-export function createGitDiffHandlers(deps: GitDiffHandlerDependencies = defaultDependencies) {
-  const { getDiffData, resolveRef, getMergeBase, startWatching, stopWatching, getFileLines } = deps;
+export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
+  const { getDiffData, resolveRef, getMergeBase, startWatching, stopWatching, getFileLines, annotationService } = deps;
 
   /**
    * Send diff data to the client.
@@ -297,13 +280,52 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies = default
 }
 
 // ============================================================
-// Default Exports (for production use)
+// Late-bound Exports (initialized via initializeGitDiffHandlers)
 // ============================================================
 
-const defaultHandlers = createGitDiffHandlers();
+let _handlers: ReturnType<typeof createGitDiffHandlers> | null = null;
 
-export const handleGitDiffConnection = defaultHandlers.handleConnection;
-export const handleGitDiffDisconnection = defaultHandlers.handleDisconnection;
-export const handleGitDiffMessage = defaultHandlers.handleMessage;
-export const updateGitDiffBaseCommit = defaultHandlers.updateBaseCommit;
-export const sendAnnotationsToClient = defaultHandlers.sendAnnotationsToClient;
+/**
+ * Initialize the default git-diff handlers with injected dependencies.
+ * Must be called once at startup before any WebSocket connections are accepted.
+ */
+export function initializeGitDiffHandlers(deps: GitDiffHandlerDependencies): void {
+  _handlers = createGitDiffHandlers(deps);
+}
+
+function getHandlers(): ReturnType<typeof createGitDiffHandlers> {
+  if (!_handlers) {
+    throw new Error('Git diff handlers not initialized. Call initializeGitDiffHandlers() first.');
+  }
+  return _handlers;
+}
+
+export function handleGitDiffConnection(
+  ...args: Parameters<ReturnType<typeof createGitDiffHandlers>['handleConnection']>
+): Promise<void> {
+  return getHandlers().handleConnection(...args);
+}
+
+export function handleGitDiffDisconnection(
+  ...args: Parameters<ReturnType<typeof createGitDiffHandlers>['handleDisconnection']>
+): Promise<void> {
+  return getHandlers().handleDisconnection(...args);
+}
+
+export function handleGitDiffMessage(
+  ...args: Parameters<ReturnType<typeof createGitDiffHandlers>['handleMessage']>
+): Promise<void> {
+  return getHandlers().handleMessage(...args);
+}
+
+export function updateGitDiffBaseCommit(
+  ...args: Parameters<ReturnType<typeof createGitDiffHandlers>['updateBaseCommit']>
+): Promise<void> {
+  return getHandlers().updateBaseCommit(...args);
+}
+
+export function sendAnnotationsToClient(
+  ...args: Parameters<ReturnType<typeof createGitDiffHandlers>['sendAnnotationsToClient']>
+): void {
+  return getHandlers().sendAnnotationsToClient(...args);
+}

--- a/packages/server/src/websocket/routes.ts
+++ b/packages/server/src/websocket/routes.ts
@@ -11,7 +11,7 @@ import type { WSContext, WSMessageReceive } from 'hono/ws';
 import type { UpgradeWebSocket } from 'hono/ws';
 import type { AppContext } from '../app-context.js';
 import { createWorkerMessageHandler } from './worker-handler.js';
-import { handleGitDiffConnection, handleGitDiffMessage, handleGitDiffDisconnection, updateGitDiffBaseCommit } from './git-diff-handler.js';
+import { handleGitDiffConnection, handleGitDiffMessage, handleGitDiffDisconnection, updateGitDiffBaseCommit, initializeGitDiffHandlers } from './git-diff-handler.js';
 import { getCookie } from 'hono/cookie';
 import type { Context } from 'hono';
 import { AUTH_COOKIE_NAME } from '../lib/auth-constants.js';
@@ -274,7 +274,20 @@ export async function setupWebSocketRoutes(
     registry = new WebSocketConnectionRegistry();
   }
 
-  const { sessionManager, notificationManager, agentManager, repositoryManager } = appContext;
+  const { sessionManager, notificationManager, agentManager, repositoryManager, annotationService } = appContext;
+
+  // Initialize git-diff handlers with injected dependencies
+  const { getDiffData, getFileLines, resolveRef, startWatching, stopWatching } = await import('../services/git-diff-service.js');
+  const { getMergeBaseSafe } = await import('../lib/git.js');
+  initializeGitDiffHandlers({
+    getDiffData,
+    resolveRef,
+    getMergeBase: getMergeBaseSafe,
+    startWatching,
+    stopWatching,
+    getFileLines,
+    annotationService,
+  });
 
   // Track which initialization steps have been completed
   const completedSteps = new Set<string>();


### PR DESCRIPTION
## Summary

- Remove module-level singleton `annotationService` from `annotation-service.ts`
- Add `annotationService: AnnotationService` to `AppContext` interface, `createAppContext()`, and `createTestContext()`
- Update `review-queue.ts` routes to get `annotationService` from Hono context
- Add `annotationService` to `McpDependencies` and inject in `createMcpApp()`
- Refactor `git-diff-handler.ts` to accept `annotationService` via `GitDiffHandlerDependencies`, using late-bound initialization pattern
- Update `worker-lifecycle-manager.ts` to receive `annotationService` via DI deps
- Migrate all tests to use local `AnnotationService` instances instead of the singleton

Part of #479

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (all 3428 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)