### PR TITLE
refactor: replace workerOutputFileManager singleton with DI

### DIFF
--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -118,6 +118,7 @@ import { SqliteAgentRepository } from '../repositories/sqlite-agent-repository.j
 import { initializeDatabase, closeDatabase, getDatabase } from '../database/connection.js';
 import { JobQueue } from '../jobs/job-queue.js';
 import { registerJobHandlers } from '../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../lib/worker-output-file.js';
 import { SystemCapabilitiesService } from '../services/system-capabilities-service.js';
 import { WorktreeService } from '../services/worktree-service.js';
 import type { AppBindings } from '../app-context.js';
@@ -184,7 +185,7 @@ describe('API Routes Integration', () => {
 
     // Create a test JobQueue with the shared database connection
     testJobQueue = new JobQueue(getDatabase(), { concurrency: 1 });
-    registerJobHandlers(testJobQueue);
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
 
     // Setup memfs with config directory, mock git repo, and common test paths
     setupMemfs({

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -49,6 +49,7 @@ import { writePtyNotification } from './lib/pty-notification.js';
 import { WorktreeService as WorktreeServiceClass } from './services/worktree-service.js';
 import { RepositorySlackIntegrationService as RepositorySlackIntegrationServiceClass } from './services/notifications/repository-slack-integration-service.js';
 import { AnnotationService as AnnotationServiceClass } from './services/annotation-service.js';
+import { WorkerOutputFileManager } from './lib/worker-output-file.js';
 
 const logger = createLogger('app-context');
 
@@ -141,9 +142,10 @@ export async function createAppContext(
   const db = await initializeDatabase(dbPath);
   logger.info({ dbPath: dbPath ?? 'default' }, 'Database initialized');
 
-  // 2. Create job queue
+  // 2. Create job queue and worker output file manager
+  const workerOutputFileManager = new WorkerOutputFileManager();
   const jobQueue = new JobQueueClass(db, { concurrency: jobConcurrency });
-  registerJobHandlers(jobQueue);
+  registerJobHandlers(jobQueue, workerOutputFileManager);
   await jobQueue.start();
   logger.info('JobQueue initialized and started');
 
@@ -178,6 +180,7 @@ export async function createAppContext(
     agentManager,
     notificationManager,
     annotationService,
+    workerOutputFileManager,
   });
 
   const repositoryManager = await RepositoryManagerClass.create({
@@ -296,9 +299,10 @@ export async function createTestContext(
   // This does NOT modify the global db variable, preventing test interference
   const db = await createDatabaseForTest();
 
-  // Create job queue
+  // Create job queue and worker output file manager
+  const workerOutputFileManager = new WorkerOutputFileManager();
   const jobQueue = new JobQueueClass(db, { concurrency: 1 });
-  registerJobHandlers(jobQueue);
+  registerJobHandlers(jobQueue, workerOutputFileManager);
   if (!overrides?.skipJobQueueStart) {
     await jobQueue.start();
   }
@@ -338,6 +342,7 @@ export async function createTestContext(
     agentManager,
     notificationManager,
     annotationService,
+    workerOutputFileManager,
   });
 
   const repositoryManager = await RepositoryManagerClass.create({

--- a/packages/server/src/jobs/handlers.ts
+++ b/packages/server/src/jobs/handlers.ts
@@ -12,7 +12,7 @@ import {
   type CleanupWorkerOutputPayload,
   type CleanupRepositoryPayload,
 } from './job-types.js';
-import { workerOutputFileManager } from '../lib/worker-output-file.js';
+import type { WorkerOutputFileManager } from '../lib/worker-output-file.js';
 import { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import { createLogger } from '../lib/logger.js';
 
@@ -22,7 +22,7 @@ const logger = createLogger('job-handlers');
  * Register all job handlers with the job queue.
  * @param jobQueue The JobQueue instance to register handlers with
  */
-export function registerJobHandlers(jobQueue: JobQueue): void {
+export function registerJobHandlers(jobQueue: JobQueue, workerOutputFileManager: WorkerOutputFileManager): void {
   // Handler for deleting all output files for a session
   jobQueue.registerHandler<CleanupSessionOutputsPayload>(
     JOB_TYPES.CLEANUP_SESSION_OUTPUTS,

--- a/packages/server/src/lib/worker-output-file.ts
+++ b/packages/server/src/lib/worker-output-file.ts
@@ -695,5 +695,3 @@ export class WorkerOutputFileManager {
   }
 }
 
-// Singleton instance
-export const workerOutputFileManager = new WorkerOutputFileManager();

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -8,6 +8,7 @@ import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { JobQueue } from '../../jobs/job-queue.js';
 import { registerJobHandlers } from '../../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import {
   SessionManager,
 } from '../../services/session-manager.js';
@@ -200,7 +201,7 @@ describe('MCP Server Tools', () => {
 
     // Create job queue with the in-memory database
     testJobQueue = new JobQueue(getDatabase(), { concurrency: 1 });
-    registerJobHandlers(testJobQueue);
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
 
     // Reset process mock and mark current process as alive
     resetProcessMock();

--- a/packages/server/src/routes/__tests__/api-notifications.test.ts
+++ b/packages/server/src/routes/__tests__/api-notifications.test.ts
@@ -13,6 +13,7 @@ import type { Kysely } from 'kysely';
 import type { Database } from '../../database/schema.js';
 import { JobQueue } from '../../jobs/job-queue.js';
 import { registerJobHandlers } from '../../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import { RepositoryManager } from '../../services/repository-manager.js';
 import { SqliteRepositoryRepository } from '../../repositories/index.js';
 
@@ -39,7 +40,7 @@ describe('Notifications API', () => {
 
     // Create job queue with the in-memory database
     testJobQueue = new JobQueue(db, { concurrency: 1 });
-    registerJobHandlers(testJobQueue);
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
 
     // Create repository repository backed by in-memory SQLite
     repositoryRepository = new SqliteRepositoryRepository(db);

--- a/packages/server/src/routes/__tests__/api-repository-slack-integration.test.ts
+++ b/packages/server/src/routes/__tests__/api-repository-slack-integration.test.ts
@@ -6,6 +6,7 @@ import type { Database } from '../../database/schema.js';
 import { createDatabaseForTest } from '../../database/connection.js';
 import { JobQueue } from '../../jobs/job-queue.js';
 import { registerJobHandlers } from '../../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import { RepositoryManager } from '../../services/repository-manager.js';
 import { RepositorySlackIntegrationService } from '../../services/notifications/repository-slack-integration-service.js';
 import type { AppBindings } from '../../app-context.js';
@@ -36,7 +37,7 @@ describe('Repository Slack Integration API', () => {
 
     // Create job queue with the in-memory database
     testJobQueue = new JobQueue(db, { concurrency: 1 });
-    registerJobHandlers(testJobQueue);
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
 
     // Create repository repository backed by in-memory SQLite
     repositoryRepository = new SqliteRepositoryRepository(db);

--- a/packages/server/src/routes/__tests__/jobs-api.test.ts
+++ b/packages/server/src/routes/__tests__/jobs-api.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { JobQueue } from '../../jobs/job-queue.js';
 import { registerJobHandlers } from '../../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import { api } from '../api.js';
 import { onApiError } from '../../lib/error-handler.js';
 import type { AppBindings } from '../../app-context.js';
@@ -18,7 +19,7 @@ describe('Jobs API', () => {
 
     // Create job queue with the in-memory database
     testJobQueue = new JobQueue(getDatabase(), { concurrency: 1 });
-    registerJobHandlers(testJobQueue);
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
 
     // Create Hono app with error handler
     app = new Hono<AppBindings>();

--- a/packages/server/src/routes/__tests__/sessions.test.ts
+++ b/packages/server/src/routes/__tests__/sessions.test.ts
@@ -12,6 +12,7 @@ import { AgentManager } from '../../services/agent-manager.js';
 import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 import { JobQueue } from '../../jobs/job-queue.js';
 import { registerJobHandlers } from '../../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import { SessionManager } from '../../services/session-manager.js';
 import { JsonSessionRepository } from '../../repositories/index.js';
 
@@ -40,7 +41,7 @@ describe('Sessions API - Pause/Resume', () => {
 
     // Create job queue with the in-memory database
     testJobQueue = new JobQueue(getDatabase(), { concurrency: 1 });
-    registerJobHandlers(testJobQueue);
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
 
     // Reset process mock and mark current process as alive
     resetProcessMock();

--- a/packages/server/src/routes/__tests__/workers.test.ts
+++ b/packages/server/src/routes/__tests__/workers.test.ts
@@ -12,6 +12,7 @@ import { AgentManager } from '../../services/agent-manager.js';
 import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 import { JobQueue } from '../../jobs/job-queue.js';
 import { registerJobHandlers } from '../../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import { SessionManager } from '../../services/session-manager.js';
 import { JsonSessionRepository } from '../../repositories/index.js';
 import { MAX_MESSAGE_FILES, MAX_TOTAL_FILE_SIZE } from '@agent-console/shared';
@@ -36,7 +37,7 @@ describe('Workers API', () => {
     await initializeDatabase(':memory:');
 
     testJobQueue = new JobQueue(getDatabase(), { concurrency: 1 });
-    registerJobHandlers(testJobQueue);
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
 
     resetProcessMock();
     mockProcess.markAlive(process.pid);

--- a/packages/server/src/services/__tests__/session-ownership.test.ts
+++ b/packages/server/src/services/__tests__/session-ownership.test.ts
@@ -18,6 +18,7 @@ import { SqliteSessionRepository } from '../../repositories/sqlite-session-repos
 import { SessionManager } from '../session-manager.js';
 import { JobQueue } from '../../jobs/job-queue.js';
 import { registerJobHandlers } from '../../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 
 const TEST_CONFIG_DIR = '/test/config';
 const ptyFactory = createMockPtyFactory(30000);
@@ -38,7 +39,7 @@ describe('Session Ownership (createdBy)', () => {
 
     const db = getDatabase();
     testJobQueue = new JobQueue(db, { concurrency: 1 });
-    registerJobHandlers(testJobQueue);
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
 
     resetProcessMock();
     mockProcess.markAlive(process.pid);

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -23,6 +23,7 @@ import type { SessionLifecycleCallbacks } from '../session-lifecycle-types.js';
 import { JobQueue } from '../../jobs/index.js';
 import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
 import { AnnotationService } from '../annotation-service.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 
 const TEST_CONFIG_DIR = '/test/config';
 
@@ -101,6 +102,7 @@ describe('WorkerLifecycleManager', () => {
       getSessionLifecycleCallbacks: () => mockCallbacks,
       getPathResolver: () => new SessionDataPathResolver(),
       annotationService: new AnnotationService(),
+      workerOutputFileManager: new WorkerOutputFileManager(),
       ...overrides,
     };
   }
@@ -143,7 +145,7 @@ describe('WorkerLifecycleManager', () => {
     };
 
     const userMode = new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' });
-    workerManager = new WorkerManager(userMode, agentManager);
+    workerManager = new WorkerManager(userMode, agentManager, new WorkerOutputFileManager());
     lifecycleManager = new WorkerLifecycleManager(createDeps());
   });
 
@@ -1070,7 +1072,7 @@ describe('WorkerLifecycleManager', () => {
       const failingUserMode = new SingleUserMode({
         spawn: () => { throw new Error('PTY spawn failed'); },
       } as any, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' });
-      const failingWorkerManager = new WorkerManager(failingUserMode, agentManager);
+      const failingWorkerManager = new WorkerManager(failingUserMode, agentManager, new WorkerOutputFileManager());
       const manager = new WorkerLifecycleManager(createDeps({
         workerManager: failingWorkerManager,
       }));

--- a/packages/server/src/services/__tests__/worker-manager-env.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager-env.test.ts
@@ -9,6 +9,7 @@ import { SingleUserMode } from '../user-mode.js';
 import type { InternalAgentWorker, InternalTerminalWorker } from '../worker-types.js';
 import type { PtySpawnOptions } from '../../lib/pty-provider.js';
 import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 
 /**
  * Tests for AgentConsole context environment variable injection.
@@ -34,7 +35,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
 
     ptyFactory.reset();
     const userMode = new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' });
-    workerManager = new WorkerManager(userMode, agentManager);
+    workerManager = new WorkerManager(userMode, agentManager, new WorkerOutputFileManager());
   });
 
   afterEach(async () => {

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -22,6 +22,7 @@ import type {
 import type { PersistedAgentWorker, PersistedTerminalWorker, PersistedGitDiffWorker } from '../persistence-service.js';
 import { CLAUDE_CODE_AGENT_ID } from '../agent-manager.js';
 import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 
 const TEST_CONFIG_DIR = '/test/config';
 
@@ -43,7 +44,7 @@ describe('WorkerManager', () => {
 
     ptyFactory.reset();
     const userMode = new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' });
-    workerManager = new WorkerManager(userMode, agentManager);
+    workerManager = new WorkerManager(userMode, agentManager, new WorkerOutputFileManager());
   });
 
   afterEach(async () => {

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -50,7 +50,7 @@ import { interSessionMessageService } from './inter-session-message-service.js';
 import { AnnotationService } from './annotation-service.js';
 import { memoService } from './memo-service.js';
 import { createLogger } from '../lib/logger.js';
-import { workerOutputFileManager, type HistoryReadResult } from '../lib/worker-output-file.js';
+import { WorkerOutputFileManager, type HistoryReadResult } from '../lib/worker-output-file.js';
 import { JsonSessionRepository, type SessionRepository } from '../repositories/index.js';
 import type { UserRepository } from '../repositories/user-repository.js';
 import { resolveSpawnUsername } from './resolve-spawn-username.js';
@@ -111,6 +111,8 @@ interface SessionManagerOptions {
   notificationManager?: NotificationManager | null;
   /** In-memory review annotation store. Defaults to a fresh instance if not provided. */
   annotationService?: AnnotationService;
+  /** Worker output file management. Defaults to a fresh instance if not provided. */
+  workerOutputFileManager?: WorkerOutputFileManager;
   /** @deprecated Use userMode instead. Kept for backward compatibility in tests. */
   ptyProvider?: PtyProvider;
 }
@@ -129,6 +131,7 @@ export class SessionManager {
   private userRepository: UserRepository | null = null;
   private jobQueue: JobQueue | null = null;
   private notificationManager: NotificationManager | null = null;
+  private workerOutputFileManager: WorkerOutputFileManager;
   private timerCleanupCallback?: (sessionId: string) => void;
 
   /**
@@ -158,7 +161,9 @@ export class SessionManager {
     const agentManager = options.agentManager;
     this.notificationManager = options?.notificationManager ?? null;
     this.userRepository = options?.userRepository ?? null;
-    this.workerManager = new WorkerManager(userMode, agentManager);
+    const workerOutputFileManager = options.workerOutputFileManager ?? new WorkerOutputFileManager();
+    this.workerOutputFileManager = workerOutputFileManager;
+    this.workerManager = new WorkerManager(userMode, agentManager, workerOutputFileManager);
     this.pathExists = options?.pathExists ?? defaultPathExists;
     this.sessionRepository = options?.sessionRepository ??
       new JsonSessionRepository(path.join(getConfigDir(), 'sessions.json'));
@@ -178,6 +183,7 @@ export class SessionManager {
       resolveSpawnUsername: (createdBy) => resolveSpawnUsername(createdBy, this.userRepository),
       getPathResolver: (session) => this.getPathResolverForSession(session),
       annotationService: options.annotationService ?? new AnnotationService(),
+      workerOutputFileManager,
     });
   }
 
@@ -284,7 +290,7 @@ export class SessionManager {
       const resolver = this.getPathResolverForPersistedSession(orphan);
       // Clean up worker output files
       try {
-        await workerOutputFileManager.deleteSessionOutputs(orphan.id, resolver);
+        await this.workerOutputFileManager.deleteSessionOutputs(orphan.id, resolver);
       } catch (error) {
         logger.error({ sessionId: orphan.id, err: error }, 'Failed to delete worker output files for orphan session');
       }

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -44,7 +44,7 @@ import {
   getCurrentBranch as gitGetCurrentBranch,
   renameBranch as gitRenameBranch,
 } from '../lib/git.js';
-import { workerOutputFileManager, type HistoryReadResult } from '../lib/worker-output-file.js';
+import { type WorkerOutputFileManager, type HistoryReadResult } from '../lib/worker-output-file.js';
 import { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import { createLogger } from '../lib/logger.js';
 
@@ -81,6 +81,8 @@ export interface WorkerLifecycleDeps {
   getPathResolver: (session: InternalSession) => SessionDataPathResolver;
   /** In-memory review annotation store */
   annotationService: AnnotationService;
+  /** Worker output file management (buffering, history, cleanup) */
+  workerOutputFileManager: WorkerOutputFileManager;
 }
 
 /**
@@ -178,7 +180,7 @@ export class WorkerLifecycleManager {
     // Initialize output file immediately for PTY workers (agent/terminal)
     // This prevents race conditions where WebSocket connects before any output is buffered
     if (request.type === 'agent' || request.type === 'terminal') {
-      await workerOutputFileManager.initializeWorkerOutput(sessionId, workerId, resolver);
+      await this.deps.workerOutputFileManager.initializeWorkerOutput(sessionId, workerId, resolver);
     }
 
     await this.deps.persistSession(session);
@@ -376,7 +378,7 @@ export class WorkerLifecycleManager {
 
     // Reset the output file to prevent offset mismatch with client cache.
     const resolver = this.deps.getPathResolver(session);
-    await workerOutputFileManager.resetWorkerOutput(sessionId, workerId, resolver);
+    await this.deps.workerOutputFileManager.resetWorkerOutput(sessionId, workerId, resolver);
 
     // Create new worker with same ID, preserving original createdAt for tab order
     const repositoryEnvVars = await this.deps.getRepositoryEnvVars(sessionId);
@@ -649,10 +651,10 @@ export class WorkerLifecycleManager {
 
     // Use line-limited read for initial connection (fromOffset is 0 or undefined)
     if (maxLines !== undefined && (fromOffset === undefined || fromOffset === 0)) {
-      return workerOutputFileManager.readLastNLines(sessionId, workerId, maxLines, resolver);
+      return this.deps.workerOutputFileManager.readLastNLines(sessionId, workerId, maxLines, resolver);
     }
 
-    return workerOutputFileManager.readHistoryWithOffset(sessionId, workerId, resolver, fromOffset);
+    return this.deps.workerOutputFileManager.readHistoryWithOffset(sessionId, workerId, resolver, fromOffset);
   }
 
   /**
@@ -666,7 +668,7 @@ export class WorkerLifecycleManager {
     if (!worker || worker.type === 'git-diff') return 0;
 
     const resolver = session ? this.deps.getPathResolver(session) : new SessionDataPathResolver();
-    return workerOutputFileManager.getCurrentOffset(sessionId, workerId, resolver);
+    return this.deps.workerOutputFileManager.getCurrentOffset(sessionId, workerId, resolver);
   }
 
   // ========== Private Helpers ==========

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -44,7 +44,7 @@ import type { AgentManager } from './agent-manager.js';
 import { expandTemplate } from '../lib/template.js';
 import { calculateBaseCommit, resolveRef } from './git-diff-service.js';
 import { serverConfig } from '../lib/server-config.js';
-import { workerOutputFileManager } from '../lib/worker-output-file.js';
+import type { WorkerOutputFileManager } from '../lib/worker-output-file.js';
 import { createLogger } from '../lib/logger.js';
 
 const logger = createLogger('worker-manager');
@@ -164,7 +164,7 @@ export class WorkerManager {
   private globalPtyExitCallback?: PtyExitCallback;
   private globalWorkerExitCallback?: GlobalWorkerExitCallback;
 
-  constructor(userMode: UserMode, agentManager: AgentManager) {
+  constructor(userMode: UserMode, agentManager: AgentManager, private workerOutputFileManager: WorkerOutputFileManager) {
     this.userMode = userMode;
     this.agentManager = agentManager;
   }
@@ -428,7 +428,7 @@ export class WorkerManager {
 
       worker.outputOffset += Buffer.byteLength(data, 'utf-8');
 
-      workerOutputFileManager.bufferOutput(sessionId, worker.id, data, resolver);
+      this.workerOutputFileManager.bufferOutput(sessionId, worker.id, data, resolver);
 
       if (worker.type === 'agent' && worker.activityDetector) {
         worker.activityDetector.processOutput(data);

--- a/packages/server/src/websocket/__tests__/routes-notifications.test.ts
+++ b/packages/server/src/websocket/__tests__/routes-notifications.test.ts
@@ -8,6 +8,7 @@ import { resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { JobQueue } from '../../jobs/job-queue.js';
 import { registerJobHandlers } from '../../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import { createSessionRepository } from '../../repositories/index.js';
 import { SqliteRepositoryRepository } from '../../repositories/sqlite-repository-repository.js';
 import { SessionManager } from '../../services/session-manager.js';
@@ -55,7 +56,7 @@ describe('WebSocket routes notifications', () => {
     await initializeDatabase(':memory:');
 
     testJobQueue = new JobQueue(getDatabase());
-    registerJobHandlers(testJobQueue);
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
     const sessionRepository = await createSessionRepository();
     const agentManager = await AgentManager.create(new SqliteAgentRepository(getDatabase()));
     notificationManager = new NotificationManager(new SlackHandler(new RepositorySlackIntegrationService(getDatabase())));

--- a/packages/server/src/websocket/__tests__/routes-worker-error-codes.test.ts
+++ b/packages/server/src/websocket/__tests__/routes-worker-error-codes.test.ts
@@ -9,6 +9,7 @@ import { resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { JobQueue } from '../../jobs/job-queue.js';
 import { registerJobHandlers } from '../../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import { createSessionRepository } from '../../repositories/index.js';
 import { SqliteRepositoryRepository } from '../../repositories/sqlite-repository-repository.js';
 import { SessionManager } from '../../services/session-manager.js';
@@ -85,7 +86,7 @@ describe('Worker WebSocket connection error codes', () => {
     await initializeDatabase(':memory:');
 
     testJobQueue = new JobQueue(getDatabase());
-    registerJobHandlers(testJobQueue);
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
     const sessionRepository = await createSessionRepository();
     const agentManager = await AgentManager.create(new SqliteAgentRepository(getDatabase()));
     const notificationManager = new NotificationManager(new SlackHandler(new RepositorySlackIntegrationService(getDatabase())));
@@ -296,7 +297,7 @@ describe('WebSocket authentication rejection (C4)', () => {
     await initializeDatabase(':memory:');
 
     testJobQueue = new JobQueue(getDatabase());
-    registerJobHandlers(testJobQueue);
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
     const sessionRepository = await createSessionRepository();
     const agentManager = await AgentManager.create(new SqliteAgentRepository(getDatabase()));
     const notificationManager = new NotificationManager(new SlackHandler(new RepositorySlackIntegrationService(getDatabase())));


### PR DESCRIPTION
## Summary
- Remove module-level `workerOutputFileManager` singleton from `worker-output-file.ts`
- Inject `WorkerOutputFileManager` instance via constructor/parameter injection through the service chain: `createAppContext()` → `SessionManager` → `WorkerManager` / `WorkerLifecycleManager`
- Pass instance to `registerJobHandlers()` as a function parameter
- Update all test files to provide the new dependency

Part of #479

## Test plan
- [x] All 1962 server tests pass
- [x] Type check passes
- [x] No singleton import of `workerOutputFileManager` remains in consumer files

🤖 Generated with [Claude Code](https://claude.com/claude-code)