### PR TITLE
refactor: replace interSessionMessageService singleton with DI via constructor injection

### DIFF
--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -25,6 +25,7 @@ import type { RepositorySlackIntegrationService } from './services/notifications
 import type { AuthUser } from '@agent-console/shared';
 import type { UserMode } from './services/user-mode.js';
 import type { AnnotationService } from './services/annotation-service.js';
+import type { InterSessionMessageService } from './services/inter-session-message-service.js';
 import type { InboundIntegrationInstance, InboundIntegrationOptions } from './services/inbound/index.js';
 import { initializeInboundIntegration } from './services/inbound/index.js';
 import { initializeDatabase, createDatabaseForTest, closeDatabase, getGlobalDatabase } from './database/connection.js';
@@ -49,6 +50,7 @@ import { writePtyNotification } from './lib/pty-notification.js';
 import { WorktreeService as WorktreeServiceClass } from './services/worktree-service.js';
 import { RepositorySlackIntegrationService as RepositorySlackIntegrationServiceClass } from './services/notifications/repository-slack-integration-service.js';
 import { AnnotationService as AnnotationServiceClass } from './services/annotation-service.js';
+import { InterSessionMessageService as InterSessionMessageServiceClass } from './services/inter-session-message-service.js';
 import { WorkerOutputFileManager } from './lib/worker-output-file.js';
 
 const logger = createLogger('app-context');
@@ -98,6 +100,9 @@ export interface AppContext {
 
   /** In-memory review annotation store */
   annotationService: AnnotationService;
+
+  /** Inter-session message file management */
+  interSessionMessageService: InterSessionMessageService;
 
   /** Inbound integration for processing external events (webhooks) */
   inboundIntegration: InboundIntegrationInstance;
@@ -154,6 +159,7 @@ export async function createAppContext(
   const repositoryRepository = new SqliteRepositoryRepository(db);
   const worktreeService = new WorktreeServiceClass({ db });
   const annotationService = new AnnotationServiceClass();
+  const interSessionMessageService = new InterSessionMessageServiceClass();
 
   // 4. Create agent manager (needed by SessionManager)
   const agentRepository = new SqliteAgentRepository(db);
@@ -181,6 +187,7 @@ export async function createAppContext(
     notificationManager,
     annotationService,
     workerOutputFileManager,
+    interSessionMessageService,
   });
 
   const repositoryManager = await RepositoryManagerClass.create({
@@ -261,6 +268,7 @@ export async function createAppContext(
     worktreeService,
     repositorySlackIntegrationService,
     annotationService,
+    interSessionMessageService,
     userMode,
     timerManager,
     inboundIntegration,
@@ -313,6 +321,7 @@ export async function createTestContext(
   const repositoryRepository = new SqliteRepositoryRepository(db);
   const worktreeService = new WorktreeServiceClass({ db });
   const annotationService = new AnnotationServiceClass();
+  const interSessionMessageService = new InterSessionMessageServiceClass();
 
   // Create agent manager (needed by SessionManager)
   const agentRepository = new SqliteAgentRepository(db);
@@ -343,6 +352,7 @@ export async function createTestContext(
     notificationManager,
     annotationService,
     workerOutputFileManager,
+    interSessionMessageService,
   });
 
   const repositoryManager = await RepositoryManagerClass.create({
@@ -404,6 +414,7 @@ export async function createTestContext(
     worktreeService,
     repositorySlackIntegrationService,
     annotationService,
+    interSessionMessageService,
     userMode,
     timerManager,
     inboundIntegration,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -135,6 +135,7 @@ const mcpApp = createMcpApp({
   timerManager: appContext.timerManager,
   worktreeService: appContext.worktreeService,
   annotationService: appContext.annotationService,
+  interSessionMessageService: appContext.interSessionMessageService,
 });
 app.route('', mcpApp);
 

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -24,6 +24,7 @@ import { WorktreeService } from '../../services/worktree-service.js';
 import type { PtySpawnOptions } from '../../lib/pty-provider.js';
 import { TimerManager } from '../../services/timer-manager.js';
 import { AnnotationService } from '../../services/annotation-service.js';
+import { InterSessionMessageService } from '../../services/inter-session-message-service.js';
 import { createMcpApp } from '../mcp-server.js';
 
 // Mock session-metadata-suggester to avoid spawning real agent processes.
@@ -181,7 +182,7 @@ describe('MCP Server Tools', () => {
    * the MCP tools see the updated dependencies.
    */
   async function remountMcpApp(): Promise<void> {
-    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService });
+    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService: new InterSessionMessageService() });
     app = new Hono();
     app.route('', mcpApp);
     mcpSessionId = await initializeMcp(app);

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -26,7 +26,7 @@ import { findOpenPullRequest } from '../services/github-pr-service.js';
 import { getCurrentBranch } from '../lib/git.js';
 import { CLAUDE_CODE_AGENT_ID } from '../services/agent-manager.js';
 import { suggestSessionMetadata } from '../services/session-metadata-suggester.js';
-import { interSessionMessageService } from '../services/inter-session-message-service.js';
+import type { InterSessionMessageService } from '../services/inter-session-message-service.js';
 import { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import { writePtyNotification } from '../lib/pty-notification.js';
 import { getRemoteUrl, GitError } from '../lib/git.js';
@@ -160,6 +160,7 @@ export interface McpDependencies {
   timerManager: TimerManager;
   worktreeService: WorktreeService;
   annotationService: AnnotationService;
+  interSessionMessageService: InterSessionMessageService;
 }
 
 // ---------- Factory ----------
@@ -170,7 +171,7 @@ export interface McpDependencies {
  * All MCP tool handlers use the provided dependencies instead of singleton getters.
  */
 export function createMcpApp(deps: McpDependencies): Hono {
-  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService } = deps;
+  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService } = deps;
 
   /**
    * Map a public Session to the worker info format used by MCP tool responses.

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -23,6 +23,7 @@ import type { SessionLifecycleCallbacks } from '../session-lifecycle-types.js';
 import { JobQueue } from '../../jobs/index.js';
 import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
 import { AnnotationService } from '../annotation-service.js';
+import { InterSessionMessageService } from '../inter-session-message-service.js';
 import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 
 const TEST_CONFIG_DIR = '/test/config';
@@ -103,6 +104,7 @@ describe('WorkerLifecycleManager', () => {
       getPathResolver: () => new SessionDataPathResolver(),
       annotationService: new AnnotationService(),
       workerOutputFileManager: new WorkerOutputFileManager(),
+      interSessionMessageService: new InterSessionMessageService(),
       ...overrides,
     };
   }

--- a/packages/server/src/services/inter-session-message-service.ts
+++ b/packages/server/src/services/inter-session-message-service.ts
@@ -141,5 +141,3 @@ export class InterSessionMessageService {
     logger.debug({ sessionId, workerId }, 'Worker message directory removed');
   }
 }
-
-export const interSessionMessageService = new InterSessionMessageService();

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -46,7 +46,7 @@ import {
 import { stopWatching, calculateBaseCommit } from './git-diff-service.js';
 import type { SessionLifecycleCallbacks } from './session-lifecycle-types.js';
 import { MessageService } from './message-service.js';
-import { interSessionMessageService } from './inter-session-message-service.js';
+import { InterSessionMessageService } from './inter-session-message-service.js';
 import { AnnotationService } from './annotation-service.js';
 import { memoService } from './memo-service.js';
 import { createLogger } from '../lib/logger.js';
@@ -113,6 +113,8 @@ interface SessionManagerOptions {
   annotationService?: AnnotationService;
   /** Worker output file management. Defaults to a fresh instance if not provided. */
   workerOutputFileManager?: WorkerOutputFileManager;
+  /** Inter-session message file management. Defaults to a fresh instance if not provided. */
+  interSessionMessageService?: InterSessionMessageService;
   /** @deprecated Use userMode instead. Kept for backward compatibility in tests. */
   ptyProvider?: PtyProvider;
 }
@@ -132,6 +134,7 @@ export class SessionManager {
   private jobQueue: JobQueue | null = null;
   private notificationManager: NotificationManager | null = null;
   private workerOutputFileManager: WorkerOutputFileManager;
+  private interSessionMessageService: InterSessionMessageService;
   private timerCleanupCallback?: (sessionId: string) => void;
 
   /**
@@ -163,6 +166,7 @@ export class SessionManager {
     this.userRepository = options?.userRepository ?? null;
     const workerOutputFileManager = options.workerOutputFileManager ?? new WorkerOutputFileManager();
     this.workerOutputFileManager = workerOutputFileManager;
+    this.interSessionMessageService = options.interSessionMessageService ?? new InterSessionMessageService();
     this.workerManager = new WorkerManager(userMode, agentManager, workerOutputFileManager);
     this.pathExists = options?.pathExists ?? defaultPathExists;
     this.sessionRepository = options?.sessionRepository ??
@@ -184,6 +188,7 @@ export class SessionManager {
       getPathResolver: (session) => this.getPathResolverForSession(session),
       annotationService: options.annotationService ?? new AnnotationService(),
       workerOutputFileManager,
+      interSessionMessageService: this.interSessionMessageService,
     });
   }
 
@@ -680,7 +685,7 @@ export class SessionManager {
 
       // 2c. Clean up inter-session message files
       try {
-        await interSessionMessageService.deleteSessionMessages(id, resolver);
+        await this.interSessionMessageService.deleteSessionMessages(id, resolver);
       } catch (err) {
         logger.warn({ sessionId: id, err }, 'Failed to clean inter-session message files');
       }

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -37,7 +37,7 @@ import { JOB_TYPES } from '../jobs/index.js';
 import { CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
 import type { AgentManager } from './agent-manager.js';
 import type { NotificationManager } from './notifications/notification-manager.js';
-import { interSessionMessageService } from './inter-session-message-service.js';
+import type { InterSessionMessageService } from './inter-session-message-service.js';
 import type { AnnotationService } from './annotation-service.js';
 import { stopWatching, calculateBaseCommit } from './git-diff-service.js';
 import {
@@ -83,6 +83,8 @@ export interface WorkerLifecycleDeps {
   annotationService: AnnotationService;
   /** Worker output file management (buffering, history, cleanup) */
   workerOutputFileManager: WorkerOutputFileManager;
+  /** Inter-session message file management */
+  interSessionMessageService: InterSessionMessageService;
 }
 
 /**
@@ -292,7 +294,7 @@ export class WorkerLifecycleManager {
 
     // Clean up inter-session message files for this worker
     try {
-      await interSessionMessageService.deleteWorkerMessages(sessionId, workerId, resolver);
+      await this.deps.interSessionMessageService.deleteWorkerMessages(sessionId, workerId, resolver);
     } catch (err) {
       logger.warn(
         { sessionId, workerId, err },


### PR DESCRIPTION
## Summary
- Remove module-level singleton `export const interSessionMessageService` from `inter-session-message-service.ts`
- Create `InterSessionMessageService` instance in `createAppContext()` and `createTestContext()`
- Inject through `SessionManager` → `WorkerLifecycleManager` via constructor options/deps
- Inject into `McpDependencies` for MCP tool handlers
- Update tests to pass DI instances

Part of #479

## Test plan
- [x] All existing tests pass (`bun run test` — 1962 server, 271 shared, 9 integration)
- [x] No type errors (`bun run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)