### PR TITLE
refactor: remove unused persistenceService singleton

### DIFF
--- a/packages/server/src/services/persistence-service.ts
+++ b/packages/server/src/services/persistence-service.ts
@@ -271,6 +271,3 @@ export class PersistenceService {
     return true;
   }
 }
-
-// Singleton instance
-export const persistenceService = new PersistenceService();


### PR DESCRIPTION
## Summary
- Remove the dead code `export const persistenceService = new PersistenceService()` singleton from `persistence-service.ts`
- Verified via grep that this singleton was not imported or used anywhere in production code
- The `PersistenceService` class and its types remain intact as they are used via DI

Part of #479

## Test plan
- [x] `bun run test:only` — all 1962 server tests pass, 0 failures
- [x] Server typecheck passes
- [x] Grep confirmed no remaining references to the singleton

🤖 Generated with [Claude Code](https://claude.com/claude-code)