### PR TITLE
refactor: replace memoService singleton with DI via constructor injection

### DIFF
--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -52,6 +52,7 @@ import { RepositorySlackIntegrationService as RepositorySlackIntegrationServiceC
 import { AnnotationService as AnnotationServiceClass } from './services/annotation-service.js';
 import { InterSessionMessageService as InterSessionMessageServiceClass } from './services/inter-session-message-service.js';
 import { WorkerOutputFileManager } from './lib/worker-output-file.js';
+import { MemoService } from './services/memo-service.js';
 
 const logger = createLogger('app-context');
 
@@ -103,6 +104,9 @@ export interface AppContext {
 
   /** Inter-session message file management */
   interSessionMessageService: InterSessionMessageService;
+
+  /** Memo file management */
+  memoService: MemoService;
 
   /** Inbound integration for processing external events (webhooks) */
   inboundIntegration: InboundIntegrationInstance;
@@ -160,6 +164,7 @@ export async function createAppContext(
   const worktreeService = new WorktreeServiceClass({ db });
   const annotationService = new AnnotationServiceClass();
   const interSessionMessageService = new InterSessionMessageServiceClass();
+  const memoService = new MemoService();
 
   // 4. Create agent manager (needed by SessionManager)
   const agentRepository = new SqliteAgentRepository(db);
@@ -188,6 +193,7 @@ export async function createAppContext(
     annotationService,
     workerOutputFileManager,
     interSessionMessageService,
+    memoService,
   });
 
   const repositoryManager = await RepositoryManagerClass.create({
@@ -269,6 +275,7 @@ export async function createAppContext(
     repositorySlackIntegrationService,
     annotationService,
     interSessionMessageService,
+    memoService,
     userMode,
     timerManager,
     inboundIntegration,
@@ -322,6 +329,7 @@ export async function createTestContext(
   const worktreeService = new WorktreeServiceClass({ db });
   const annotationService = new AnnotationServiceClass();
   const interSessionMessageService = new InterSessionMessageServiceClass();
+  const memoService = new MemoService();
 
   // Create agent manager (needed by SessionManager)
   const agentRepository = new SqliteAgentRepository(db);
@@ -353,6 +361,7 @@ export async function createTestContext(
     annotationService,
     workerOutputFileManager,
     interSessionMessageService,
+    memoService,
   });
 
   const repositoryManager = await RepositoryManagerClass.create({
@@ -415,6 +424,7 @@ export async function createTestContext(
     repositorySlackIntegrationService,
     annotationService,
     interSessionMessageService,
+    memoService,
     userMode,
     timerManager,
     inboundIntegration,

--- a/packages/server/src/services/memo-service.ts
+++ b/packages/server/src/services/memo-service.ts
@@ -83,5 +83,3 @@ export class MemoService {
     logger.debug({ sessionId }, 'Memo deleted');
   }
 }
-
-export const memoService = new MemoService();

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -48,7 +48,7 @@ import type { SessionLifecycleCallbacks } from './session-lifecycle-types.js';
 import { MessageService } from './message-service.js';
 import { InterSessionMessageService } from './inter-session-message-service.js';
 import { AnnotationService } from './annotation-service.js';
-import { memoService } from './memo-service.js';
+import { MemoService } from './memo-service.js';
 import { createLogger } from '../lib/logger.js';
 import { WorkerOutputFileManager, type HistoryReadResult } from '../lib/worker-output-file.js';
 import { JsonSessionRepository, type SessionRepository } from '../repositories/index.js';
@@ -115,6 +115,8 @@ interface SessionManagerOptions {
   workerOutputFileManager?: WorkerOutputFileManager;
   /** Inter-session message file management. Defaults to a fresh instance if not provided. */
   interSessionMessageService?: InterSessionMessageService;
+  /** Memo file management. Defaults to a fresh instance if not provided. */
+  memoService?: MemoService;
   /** @deprecated Use userMode instead. Kept for backward compatibility in tests. */
   ptyProvider?: PtyProvider;
 }
@@ -135,6 +137,7 @@ export class SessionManager {
   private notificationManager: NotificationManager | null = null;
   private workerOutputFileManager: WorkerOutputFileManager;
   private interSessionMessageService: InterSessionMessageService;
+  private memoService: MemoService;
   private timerCleanupCallback?: (sessionId: string) => void;
 
   /**
@@ -167,6 +170,7 @@ export class SessionManager {
     const workerOutputFileManager = options.workerOutputFileManager ?? new WorkerOutputFileManager();
     this.workerOutputFileManager = workerOutputFileManager;
     this.interSessionMessageService = options.interSessionMessageService ?? new InterSessionMessageService();
+    this.memoService = options.memoService ?? new MemoService();
     this.workerManager = new WorkerManager(userMode, agentManager, workerOutputFileManager);
     this.pathExists = options?.pathExists ?? defaultPathExists;
     this.sessionRepository = options?.sessionRepository ??
@@ -692,7 +696,7 @@ export class SessionManager {
 
       // 2d. Clean up memo file
       try {
-        await memoService.deleteMemo(id, resolver);
+        await this.memoService.deleteMemo(id, resolver);
       } catch (err) {
         logger.warn({ sessionId: id, err }, 'Failed to clean memo file');
       }
@@ -1092,7 +1096,7 @@ export class SessionManager {
       await this.sessionRepository.delete(id);
       // Clean up memo file
       try {
-        await memoService.deleteMemo(id, resolver);
+        await this.memoService.deleteMemo(id, resolver);
       } catch (err) {
         logger.warn({ sessionId: id, err }, 'Failed to clean memo file');
       }
@@ -1259,10 +1263,10 @@ export class SessionManager {
       throw new Error(`Session not found: ${sessionId}`);
     }
     const resolver = this.getPathResolverForSession(session);
-    const filePath = await memoService.writeMemo(sessionId, content, resolver);
+    const filePath = await this.memoService.writeMemo(sessionId, content, resolver);
     // Re-check after async write: session may have been deleted during the write
     if (!this.sessions.has(sessionId)) {
-      await memoService.deleteMemo(sessionId, resolver).catch(() => {});
+      await this.memoService.deleteMemo(sessionId, resolver).catch(() => {});
       throw new Error(`Session deleted during memo write: ${sessionId}`);
     }
     this.sessionLifecycleCallbacks?.onMemoUpdated?.(sessionId, content);
@@ -1280,7 +1284,7 @@ export class SessionManager {
       throw new Error(`Session not found: ${sessionId}`);
     }
     const resolver = this.getPathResolverForSession(session);
-    return memoService.readMemo(sessionId, resolver);
+    return this.memoService.readMemo(sessionId, resolver);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Remove module-level singleton export from `memo-service.ts`
- Inject `MemoService` through `SessionManagerOptions` and `AppContext`, following the same pattern as `interSessionMessageService` and `workerOutputFileManager`
- Create instances in both `createAppContext()` and `createTestContext()`
- Replace all 5 direct singleton references in `session-manager.ts` with `this.memoService`

This is the **last singleton** in the DI series.

Part of #479

## Test plan
- [x] Server typecheck passes (`bun run --filter @agent-console/server typecheck`)
- [x] All 1962 server tests pass (`bun run test:only`)
- [x] All 271 shared tests pass
- [x] All 9 integration tests pass
- [x] Existing memo-service tests unchanged (already used `new MemoService()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)