### PR TITLE
refactor: replace broadcastToApp module import with DI via AppContext

### DIFF
--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -13,7 +13,6 @@ import { setupMemfs, cleanupMemfs, createMockGitRepoFiles } from './utils/mock-f
 import { mockProcess, resetProcessMock } from './utils/mock-process-helper.js';
 import { MockPty } from './utils/mock-pty.js';
 import { mockGit, GitError } from './utils/mock-git-helper.js';
-import * as wsRoutes from '../websocket/routes.js';
 
 // Set up test config directory BEFORE any service imports to ensure
 // services use the test config path when their modules are loaded
@@ -161,6 +160,9 @@ branch refs/heads/main
   mockGit.pullFastForward.mockImplementation(() => Promise.resolve(0));
 }
 
+// Mock broadcastToApp for capturing broadcast calls from route handlers
+const mockBroadcastToApp = mock((_msg: Record<string, unknown>) => {});
+
 // Test JobQueue instance (created fresh for each test)
 let testJobQueue: JobQueue | null = null;
 
@@ -234,8 +236,8 @@ describe('API Routes Integration', () => {
     mockFindOpenPullRequest.mockReset();
     mockFindOpenPullRequest.mockImplementation(async () => null);
 
-    // Spy on broadcastToApp to capture calls from async route handlers
-    spyOn(wsRoutes, 'broadcastToApp');
+    // Reset broadcastToApp mock
+    mockBroadcastToApp.mockClear();
 
     // Setup default git command responses
     setupDefaultGitMocks();
@@ -300,6 +302,7 @@ describe('API Routes Integration', () => {
         systemCapabilities: testSystemCapabilities!,
         agentManager: testAgentManager!,
         worktreeService: new WorktreeService({ db: getDatabase() }),
+        broadcastToApp: mockBroadcastToApp,
       }));
       await next();
     });
@@ -1984,7 +1987,7 @@ describe('API Routes Integration', () => {
           expect(bunSpawnCalls[0].args[2]).toBe('docker compose down');
 
           // No sessions exist for this worktree, so no broadcast should occur
-          const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+          const broadcastSpy = mockBroadcastToApp;
           const completedCalls = broadcastSpy.mock.calls.filter(
             (call: unknown[]) => (call[0] as { type: string }).type === 'worktree-deletion-completed'
           );
@@ -2209,7 +2212,7 @@ describe('API Routes Integration', () => {
         expect(deleteSpy).not.toHaveBeenCalled();
 
         // broadcastToApp was called with worktree-deletion-failed
-        const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+        const broadcastSpy = mockBroadcastToApp;
         const failedCall = broadcastSpy.mock.calls.find(
           (call: unknown[]) => {
             const message = call[0] as { type: string; taskId?: string };
@@ -2269,7 +2272,7 @@ describe('API Routes Integration', () => {
         await new Promise((resolve) => setTimeout(resolve, 200));
 
         // Verify broadcastToApp was called with worktree-deletion-completed for EACH session ID
-        const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+        const broadcastSpy = mockBroadcastToApp;
         const completedCalls = broadcastSpy.mock.calls.filter(
           (call: unknown[]) => {
             const message = call[0] as { type: string; taskId?: string };
@@ -2304,7 +2307,7 @@ describe('API Routes Integration', () => {
         await new Promise((resolve) => setTimeout(resolve, 200));
 
         // Verify broadcastToApp was NOT called with worktree-deletion-completed for this taskId
-        const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+        const broadcastSpy = mockBroadcastToApp;
         const completedCalls = broadcastSpy.mock.calls.filter(
           (call: unknown[]) => {
             const message = call[0] as { type: string; taskId?: string };
@@ -2364,7 +2367,7 @@ describe('API Routes Integration', () => {
         await new Promise((resolve) => setTimeout(resolve, 200));
 
         // Verify broadcastToApp was called with worktree-deletion-failed for EACH session ID
-        const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+        const broadcastSpy = mockBroadcastToApp;
         const failedCalls = broadcastSpy.mock.calls.filter(
           (call: unknown[]) => {
             const message = call[0] as { type: string; taskId?: string };
@@ -2547,7 +2550,7 @@ describe('API Routes Integration', () => {
         // Wait for background operation
         await new Promise((resolve) => setTimeout(resolve, 200));
 
-        const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+        const broadcastSpy = mockBroadcastToApp;
         const completedCall = broadcastSpy.mock.calls.find(
           (call: unknown[]) => {
             const m = call[0] as { type: string; taskId?: string };
@@ -2603,7 +2606,7 @@ describe('API Routes Integration', () => {
         // Wait for background operation
         await new Promise((resolve) => setTimeout(resolve, 200));
 
-        const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+        const broadcastSpy = mockBroadcastToApp;
         const completedCall = broadcastSpy.mock.calls.find(
           (call: unknown[]) => {
             const m = call[0] as { type: string; taskId?: string };
@@ -2640,7 +2643,7 @@ describe('API Routes Integration', () => {
         // Wait for background operation
         await new Promise((resolve) => setTimeout(resolve, 200));
 
-        const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+        const broadcastSpy = mockBroadcastToApp;
         const failedCall = broadcastSpy.mock.calls.find(
           (call: unknown[]) => {
             const m = call[0] as { type: string; taskId?: string };
@@ -2680,7 +2683,7 @@ describe('API Routes Integration', () => {
         // Wait for background operation
         await new Promise((resolve) => setTimeout(resolve, 200));
 
-        const broadcastSpy = wsRoutes.broadcastToApp as ReturnType<typeof spyOn>;
+        const broadcastSpy = mockBroadcastToApp;
         const failedCall = broadcastSpy.mock.calls.find(
           (call: unknown[]) => {
             const m = call[0] as { type: string; taskId?: string };

--- a/packages/server/src/__tests__/test-utils.ts
+++ b/packages/server/src/__tests__/test-utils.ts
@@ -155,6 +155,7 @@ export const TEST_AUTH_USER = {
 export function asAppContext(partial: Partial<AppContext>): AppContext {
   return {
     userMode: new SingleUserMode(bunPtyProvider, TEST_AUTH_USER),
+    broadcastToApp: () => {},
     ...partial,
   } as AppContext;
 }

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -22,11 +22,11 @@ import type { TimerManager } from './services/timer-manager.js';
 import type { SystemCapabilitiesService } from './services/system-capabilities-service.js';
 import type { WorktreeService } from './services/worktree-service.js';
 import type { RepositorySlackIntegrationService } from './services/notifications/repository-slack-integration-service.js';
-import type { AuthUser } from '@agent-console/shared';
+import type { AuthUser, AppServerMessage } from '@agent-console/shared';
 import type { UserMode } from './services/user-mode.js';
 import type { AnnotationService } from './services/annotation-service.js';
 import type { InterSessionMessageService } from './services/inter-session-message-service.js';
-import type { InboundIntegrationInstance, InboundIntegrationOptions } from './services/inbound/index.js';
+import type { InboundIntegrationInstance } from './services/inbound/index.js';
 import { initializeInboundIntegration } from './services/inbound/index.js';
 import { initializeDatabase, createDatabaseForTest, closeDatabase, getGlobalDatabase } from './database/connection.js';
 import { JobQueue as JobQueueClass } from './jobs/job-queue.js';
@@ -110,6 +110,9 @@ export interface AppContext {
 
   /** Inbound integration for processing external events (webhooks) */
   inboundIntegration: InboundIntegrationInstance;
+
+  /** Broadcast a message to all connected app WebSocket clients */
+  broadcastToApp: (msg: AppServerMessage) => void;
 }
 
 /**
@@ -121,7 +124,7 @@ export interface CreateAppContextOptions {
   /** Job queue concurrency (default: 4) */
   jobConcurrency?: number;
   /** Callback to broadcast messages to app WebSocket clients */
-  broadcastToApp?: InboundIntegrationOptions['broadcastToApp'];
+  broadcastToApp?: (msg: AppServerMessage) => void;
 }
 
 /**
@@ -279,6 +282,7 @@ export async function createAppContext(
     userMode,
     timerManager,
     inboundIntegration,
+    broadcastToApp: options?.broadcastToApp ?? (() => {}),
   };
 }
 
@@ -428,6 +432,7 @@ export async function createTestContext(
     userMode,
     timerManager,
     inboundIntegration,
+    broadcastToApp: () => {},
   };
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -136,6 +136,7 @@ const mcpApp = createMcpApp({
   worktreeService: appContext.worktreeService,
   annotationService: appContext.annotationService,
   interSessionMessageService: appContext.interSessionMessageService,
+  broadcastToApp: appContext.broadcastToApp,
 });
 app.route('', mcpApp);
 

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -182,7 +182,7 @@ describe('MCP Server Tools', () => {
    * the MCP tools see the updated dependencies.
    */
   async function remountMcpApp(): Promise<void> {
-    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService: new InterSessionMessageService() });
+    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService: new InterSessionMessageService(), broadcastToApp: () => {} });
     app = new Hono();
     app.route('', mcpApp);
     mcpSessionId = await initializeMcp(app);

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -19,7 +19,6 @@ import type { TimerManager } from '../services/timer-manager.js';
 import type { WorktreeService } from '../services/worktree-service.js';
 import type { AnnotationService } from '../services/annotation-service.js';
 import { sendAnnotationsToClient } from '../websocket/git-diff-handler.js';
-import { broadcastToApp } from '../websocket/routes.js';
 import { deleteWorktree } from '../services/worktree-deletion-service.js';
 import { createWorktreeWithSession } from '../services/worktree-creation-service.js';
 import { findOpenPullRequest } from '../services/github-pr-service.js';
@@ -31,7 +30,7 @@ import { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import { writePtyNotification } from '../lib/pty-notification.js';
 import { getRemoteUrl, GitError } from '../lib/git.js';
 import { createLogger } from '../lib/logger.js';
-import type { Session, AgentActivityState } from '@agent-console/shared';
+import type { Session, AgentActivityState, AppServerMessage } from '@agent-console/shared';
 
 const logger = createLogger('mcp');
 
@@ -161,6 +160,7 @@ export interface McpDependencies {
   worktreeService: WorktreeService;
   annotationService: AnnotationService;
   interSessionMessageService: InterSessionMessageService;
+  broadcastToApp: (msg: AppServerMessage) => void;
 }
 
 // ---------- Factory ----------
@@ -171,7 +171,7 @@ export interface McpDependencies {
  * All MCP tool handlers use the provided dependencies instead of singleton getters.
  */
 export function createMcpApp(deps: McpDependencies): Hono {
-  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService } = deps;
+  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService, broadcastToApp } = deps;
 
   /**
    * Map a public Session to the worker info format used by MCP tool responses.

--- a/packages/server/src/routes/__tests__/review-queue.test.ts
+++ b/packages/server/src/routes/__tests__/review-queue.test.ts
@@ -4,16 +4,10 @@ import type { AppBindings } from '../../app-context.js';
 import { onApiError } from '../../lib/error-handler.js';
 import { asAppContext } from '../../__tests__/test-utils.js';
 import { AnnotationService } from '../../services/annotation-service.js';
+import { reviewQueue } from '../review-queue.js';
 import type { ReviewAnnotationInput, ReviewComment, ReviewQueueGroup } from '@agent-console/shared';
 
-// Mock broadcastToApp to prevent WebSocket side effects in tests
 const mockBroadcastToApp = mock(() => {});
-mock.module('../../websocket/routes.js', () => ({
-  broadcastToApp: mockBroadcastToApp,
-}));
-
-// Dynamically import the route after mocking
-const { reviewQueue } = await import('../review-queue.js');
 
 function validInput(): ReviewAnnotationInput {
   return {
@@ -62,7 +56,7 @@ describe('Review Queue API', () => {
 
     app = new Hono<AppBindings>();
     app.use('*', async (c, next) => {
-      c.set('appContext', asAppContext({ sessionManager: mockSessionManager as never, annotationService }));
+      c.set('appContext', asAppContext({ sessionManager: mockSessionManager as never, annotationService, broadcastToApp: mockBroadcastToApp }));
       await next();
     });
     app.onError(onApiError);

--- a/packages/server/src/routes/review-queue.ts
+++ b/packages/server/src/routes/review-queue.ts
@@ -4,7 +4,6 @@ import type { ReviewQueueGroup } from '@agent-console/shared';
 import type { AppBindings } from '../app-context.js';
 import { NotFoundError, ValidationError } from '../lib/errors.js';
 import { vValidator } from '../middleware/validation.js';
-import { broadcastToApp } from '../websocket/routes.js';
 import { createLogger } from '../lib/logger.js';
 import { writePtyNotification } from '../lib/pty-notification.js';
 
@@ -47,7 +46,7 @@ export const reviewQueue = new Hono<AppBindings>()
   })
   .post('/:workerId/comments', vValidator(AddCommentSchema), async (c) => {
     const workerId = c.req.param('workerId');
-    const { sessionManager, annotationService } = c.get('appContext');
+    const { sessionManager, annotationService, broadcastToApp } = c.get('appContext');
     const { file, line, body } = c.req.valid('json');
 
     const annotationSet = annotationService.getAnnotations(workerId);
@@ -96,7 +95,7 @@ export const reviewQueue = new Hono<AppBindings>()
   })
   .patch('/:workerId/status', vValidator(UpdateStatusSchema), (c) => {
     const workerId = c.req.param('workerId');
-    const { sessionManager, annotationService } = c.get('appContext');
+    const { sessionManager, annotationService, broadcastToApp } = c.get('appContext');
     const { status } = c.req.valid('json');
 
     const annotationSet = annotationService.getAnnotations(workerId);

--- a/packages/server/src/routes/worktrees.ts
+++ b/packages/server/src/routes/worktrees.ts
@@ -13,7 +13,6 @@ import { NotFoundError, ValidationError } from '../lib/errors.js';
 import { vValidator } from '../middleware/validation.js';
 import { getCurrentBranch, isWorkingDirectoryClean, pullFastForward } from '../lib/git.js';
 import { createLogger } from '../lib/logger.js';
-import { broadcastToApp } from '../websocket/routes.js';
 import {
   _getDeletionsInProgress,
   isDeletionInProgress,
@@ -51,7 +50,7 @@ const worktrees = new Hono<AppBindings>()
   // Create a worktree (async - returns immediately and broadcasts result via WebSocket)
   .post('/:id/worktrees', vValidator(CreateWorktreeRequestSchema), async (c) => {
     const repoId = c.req.param('id');
-    const { repositoryManager, sessionManager, agentManager, worktreeService } = c.get('appContext');
+    const { repositoryManager, sessionManager, agentManager, worktreeService, broadcastToApp } = c.get('appContext');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {
@@ -173,7 +172,7 @@ const worktrees = new Hono<AppBindings>()
   // Pull a worktree (git pull --ff-only, async)
   .post('/:id/worktrees/pull', vValidator(PullWorktreeRequestSchema), async (c) => {
     const repoId = c.req.param('id');
-    const { repositoryManager, worktreeService } = c.get('appContext');
+    const { repositoryManager, worktreeService, broadcastToApp } = c.get('appContext');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {
@@ -284,7 +283,7 @@ const worktrees = new Hono<AppBindings>()
   // Optionally accepts taskId query parameter for async WebSocket notification
   .delete('/:id/worktrees/*', async (c) => {
     const repoId = c.req.param('id');
-    const { repositoryManager, sessionManager, worktreeService } = c.get('appContext');
+    const { repositoryManager, sessionManager, worktreeService, broadcastToApp } = c.get('appContext');
 
     // Get worktree path from URL (everything after /worktrees/)
     const url = new URL(c.req.url);


### PR DESCRIPTION
## Summary
- Added `broadcastToApp` to `AppContext` interface so consumers access it through DI instead of importing directly from `websocket/routes.ts`
- Updated `worktrees.ts`, `review-queue.ts`, and `mcp-server.ts` to get `broadcastToApp` from AppContext
- Replaced `mock.module()` and `spyOn()` in tests with DI-based mocking through AppContext

## Test plan
- [x] All 1962 tests pass (`bun run test`)
- [x] `review-queue.test.ts` no longer uses `mock.module` for broadcastToApp
- [x] `api.test.ts` no longer uses `spyOn(wsRoutes, 'broadcastToApp')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)