### PR TITLE
refactor: replace suggestSessionMetadata module import with DI via AppContext

### DIFF
--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -51,9 +51,6 @@ const mockSuggestSessionMetadata = mock(async () => ({
   branch: 'suggested-branch',
   title: 'Suggested Title',
 }));
-mock.module('../services/session-metadata-suggester.js', () => ({
-  suggestSessionMetadata: mockSuggestSessionMetadata,
-}));
 
 // Mock github-pr-service to avoid spawning real gh processes in tests.
 // findOpenPullRequest returns null (no open PR) by default so deletion proceeds normally.
@@ -302,6 +299,7 @@ describe('API Routes Integration', () => {
         systemCapabilities: testSystemCapabilities!,
         agentManager: testAgentManager!,
         worktreeService: new WorktreeService({ db: getDatabase() }),
+        suggestSessionMetadata: mockSuggestSessionMetadata,
         broadcastToApp: mockBroadcastToApp,
       }));
       await next();

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -26,6 +26,7 @@ import type { AuthUser, AppServerMessage } from '@agent-console/shared';
 import type { UserMode } from './services/user-mode.js';
 import type { AnnotationService } from './services/annotation-service.js';
 import type { InterSessionMessageService } from './services/inter-session-message-service.js';
+import type { SuggestSessionMetadataFn } from './services/session-metadata-suggester.js';
 import type { InboundIntegrationInstance } from './services/inbound/index.js';
 import { initializeInboundIntegration } from './services/inbound/index.js';
 import { initializeDatabase, createDatabaseForTest, closeDatabase, getGlobalDatabase } from './database/connection.js';
@@ -53,6 +54,7 @@ import { AnnotationService as AnnotationServiceClass } from './services/annotati
 import { InterSessionMessageService as InterSessionMessageServiceClass } from './services/inter-session-message-service.js';
 import { WorkerOutputFileManager } from './lib/worker-output-file.js';
 import { MemoService } from './services/memo-service.js';
+import { suggestSessionMetadata } from './services/session-metadata-suggester.js';
 
 const logger = createLogger('app-context');
 
@@ -107,6 +109,9 @@ export interface AppContext {
 
   /** Memo file management */
   memoService: MemoService;
+
+  /** Suggest session metadata (branch name, title) from user prompt */
+  suggestSessionMetadata: SuggestSessionMetadataFn;
 
   /** Inbound integration for processing external events (webhooks) */
   inboundIntegration: InboundIntegrationInstance;
@@ -279,6 +284,7 @@ export async function createAppContext(
     annotationService,
     interSessionMessageService,
     memoService,
+    suggestSessionMetadata,
     userMode,
     timerManager,
     inboundIntegration,
@@ -429,6 +435,7 @@ export async function createTestContext(
     annotationService,
     interSessionMessageService,
     memoService,
+    suggestSessionMetadata,
     userMode,
     timerManager,
     inboundIntegration,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -136,6 +136,7 @@ const mcpApp = createMcpApp({
   worktreeService: appContext.worktreeService,
   annotationService: appContext.annotationService,
   interSessionMessageService: appContext.interSessionMessageService,
+  suggestSessionMetadata: appContext.suggestSessionMetadata,
   broadcastToApp: appContext.broadcastToApp,
 });
 app.route('', mcpApp);

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -32,9 +32,6 @@ const mockSuggestSessionMetadata = mock(async () => ({
   branch: 'feat/auto-generated-branch',
   title: 'Auto-Generated Title',
 }));
-mock.module('../../services/session-metadata-suggester.js', () => ({
-  suggestSessionMetadata: mockSuggestSessionMetadata,
-}));
 
 // Mock worktree-deletion-service
 // NOTE: We spread the real module without overriding deleteWorktree.
@@ -182,7 +179,7 @@ describe('MCP Server Tools', () => {
    * the MCP tools see the updated dependencies.
    */
   async function remountMcpApp(): Promise<void> {
-    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService: new InterSessionMessageService(), broadcastToApp: () => {} });
+    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService: new InterSessionMessageService(), suggestSessionMetadata: mockSuggestSessionMetadata, broadcastToApp: () => {} });
     app = new Hono();
     app.route('', mcpApp);
     mcpSessionId = await initializeMcp(app);

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -24,7 +24,7 @@ import { createWorktreeWithSession } from '../services/worktree-creation-service
 import { findOpenPullRequest } from '../services/github-pr-service.js';
 import { getCurrentBranch } from '../lib/git.js';
 import { CLAUDE_CODE_AGENT_ID } from '../services/agent-manager.js';
-import { suggestSessionMetadata } from '../services/session-metadata-suggester.js';
+import type { SuggestSessionMetadataFn } from '../services/session-metadata-suggester.js';
 import type { InterSessionMessageService } from '../services/inter-session-message-service.js';
 import { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import { writePtyNotification } from '../lib/pty-notification.js';
@@ -160,6 +160,7 @@ export interface McpDependencies {
   worktreeService: WorktreeService;
   annotationService: AnnotationService;
   interSessionMessageService: InterSessionMessageService;
+  suggestSessionMetadata: SuggestSessionMetadataFn;
   broadcastToApp: (msg: AppServerMessage) => void;
 }
 
@@ -171,7 +172,7 @@ export interface McpDependencies {
  * All MCP tool handlers use the provided dependencies instead of singleton getters.
  */
 export function createMcpApp(deps: McpDependencies): Hono {
-  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService, broadcastToApp } = deps;
+  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService, suggestSessionMetadata, broadcastToApp } = deps;
 
   /**
    * Map a public Session to the worker info format used by MCP tool responses.

--- a/packages/server/src/routes/worktrees.ts
+++ b/packages/server/src/routes/worktrees.ts
@@ -8,7 +8,6 @@ import { CreateWorktreeRequestSchema, PullWorktreeRequestSchema } from '@agent-c
 import type { AppBindings } from '../app-context.js';
 import { getRepositoriesDir } from '../lib/config.js';
 import { CLAUDE_CODE_AGENT_ID } from '../services/agent-manager.js';
-import { suggestSessionMetadata } from '../services/session-metadata-suggester.js';
 import { NotFoundError, ValidationError } from '../lib/errors.js';
 import { vValidator } from '../middleware/validation.js';
 import { getCurrentBranch, isWorkingDirectoryClean, pullFastForward } from '../lib/git.js';
@@ -50,7 +49,7 @@ const worktrees = new Hono<AppBindings>()
   // Create a worktree (async - returns immediately and broadcasts result via WebSocket)
   .post('/:id/worktrees', vValidator(CreateWorktreeRequestSchema), async (c) => {
     const repoId = c.req.param('id');
-    const { repositoryManager, sessionManager, agentManager, worktreeService, broadcastToApp } = c.get('appContext');
+    const { repositoryManager, sessionManager, agentManager, worktreeService, broadcastToApp, suggestSessionMetadata } = c.get('appContext');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {


### PR DESCRIPTION
## Summary
- Add `suggestSessionMetadata` as `SuggestSessionMetadataFn` to `AppContext` and `McpDependencies` interfaces
- Replace direct module imports in `mcp-server.ts` and `routes/worktrees.ts` with DI
- Remove `mock.module` calls in `api.test.ts` and `mcp-server.test.ts`, passing mock via deps instead

## Test plan
- [x] `bun run test` — all 3428 tests pass
- [x] `bun run typecheck` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)