### PR TITLE
refactor: replace github-pr-service module import with DI via AppContext

### DIFF
--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -52,13 +52,9 @@ const mockSuggestSessionMetadata = mock(async () => ({
   title: 'Suggested Title',
 }));
 
-// Mock github-pr-service to avoid spawning real gh processes in tests.
-// findOpenPullRequest returns null (no open PR) by default so deletion proceeds normally.
+// github-pr-service mocks (injected via AppContext)
 const mockFindOpenPullRequest = mock(async () => null as { number: number; title: string } | null);
-mock.module('../services/github-pr-service.js', () => ({
-  findOpenPullRequest: mockFindOpenPullRequest,
-  fetchPullRequestUrl: mock(async () => null),
-}));
+const mockFetchPullRequestUrl = mock(async () => null as string | null);
 
 // =============================================================================
 // Bun.spawn mock for hook command tests (executeHookCommand in worktree-service)
@@ -229,9 +225,11 @@ describe('API Routes Integration', () => {
       title: 'Suggested Title',
     }));
 
-    // Reset github-pr-service mock (default: no open PR)
+    // Reset github-pr-service mocks (default: no open PR, no PR URL)
     mockFindOpenPullRequest.mockReset();
     mockFindOpenPullRequest.mockImplementation(async () => null);
+    mockFetchPullRequestUrl.mockReset();
+    mockFetchPullRequestUrl.mockImplementation(async () => null);
 
     // Reset broadcastToApp mock
     mockBroadcastToApp.mockClear();
@@ -301,6 +299,8 @@ describe('API Routes Integration', () => {
         worktreeService: new WorktreeService({ db: getDatabase() }),
         suggestSessionMetadata: mockSuggestSessionMetadata,
         broadcastToApp: mockBroadcastToApp,
+        findOpenPullRequest: mockFindOpenPullRequest,
+        fetchPullRequestUrl: mockFetchPullRequestUrl,
       }));
       await next();
     });

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -27,6 +27,7 @@ import type { UserMode } from './services/user-mode.js';
 import type { AnnotationService } from './services/annotation-service.js';
 import type { InterSessionMessageService } from './services/inter-session-message-service.js';
 import type { SuggestSessionMetadataFn } from './services/session-metadata-suggester.js';
+import type { OpenPrInfo } from './services/github-pr-service.js';
 import type { InboundIntegrationInstance } from './services/inbound/index.js';
 import { initializeInboundIntegration } from './services/inbound/index.js';
 import { initializeDatabase, createDatabaseForTest, closeDatabase, getGlobalDatabase } from './database/connection.js';
@@ -55,6 +56,7 @@ import { InterSessionMessageService as InterSessionMessageServiceClass } from '.
 import { WorkerOutputFileManager } from './lib/worker-output-file.js';
 import { MemoService } from './services/memo-service.js';
 import { suggestSessionMetadata } from './services/session-metadata-suggester.js';
+import { fetchPullRequestUrl, findOpenPullRequest } from './services/github-pr-service.js';
 
 const logger = createLogger('app-context');
 
@@ -118,6 +120,12 @@ export interface AppContext {
 
   /** Broadcast a message to all connected app WebSocket clients */
   broadcastToApp: (msg: AppServerMessage) => void;
+
+  /** Fetch PR URL for a branch */
+  fetchPullRequestUrl: (branch: string, cwd: string) => Promise<string | null>;
+
+  /** Find open PR for a branch */
+  findOpenPullRequest: (branch: string, cwd: string) => Promise<OpenPrInfo | null>;
 }
 
 /**
@@ -289,6 +297,8 @@ export async function createAppContext(
     timerManager,
     inboundIntegration,
     broadcastToApp: options?.broadcastToApp ?? (() => {}),
+    fetchPullRequestUrl,
+    findOpenPullRequest,
   };
 }
 
@@ -440,6 +450,8 @@ export async function createTestContext(
     timerManager,
     inboundIntegration,
     broadcastToApp: () => {},
+    fetchPullRequestUrl,
+    findOpenPullRequest,
   };
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -138,6 +138,8 @@ const mcpApp = createMcpApp({
   interSessionMessageService: appContext.interSessionMessageService,
   suggestSessionMetadata: appContext.suggestSessionMetadata,
   broadcastToApp: appContext.broadcastToApp,
+  fetchPullRequestUrl: appContext.fetchPullRequestUrl,
+  findOpenPullRequest: appContext.findOpenPullRequest,
 });
 app.route('', mcpApp);
 

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -52,12 +52,9 @@ mock.module('../../services/worktree-creation-service.js', () => ({
   ...require('../../services/worktree-creation-service.js'),
 }));
 
-// Mock github-pr-service
+// github-pr-service mocks (injected via McpDependencies)
 const mockFindOpenPullRequest = mock(async () => null as { number: number; title: string } | null);
-mock.module('../../services/github-pr-service.js', () => ({
-  findOpenPullRequest: mockFindOpenPullRequest,
-  fetchPullRequestUrl: mock(async () => null),
-}));
+const mockFetchPullRequestUrl = mock(async () => null as string | null);
 
 // Import the real deletion service's concurrency guard (for tests that need
 // to pre-populate it). The mock.module above spreads the real module exports,
@@ -179,7 +176,7 @@ describe('MCP Server Tools', () => {
    * the MCP tools see the updated dependencies.
    */
   async function remountMcpApp(): Promise<void> {
-    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService: new InterSessionMessageService(), suggestSessionMetadata: mockSuggestSessionMetadata, broadcastToApp: () => {} });
+    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService: new InterSessionMessageService(), suggestSessionMetadata: mockSuggestSessionMetadata, broadcastToApp: () => {}, findOpenPullRequest: mockFindOpenPullRequest, fetchPullRequestUrl: mockFetchPullRequestUrl });
     app = new Hono();
     app.route('', mcpApp);
     mcpSessionId = await initializeMcp(app);
@@ -224,6 +221,8 @@ describe('MCP Server Tools', () => {
     // Reset github-pr-service mocks
     mockFindOpenPullRequest.mockReset();
     mockFindOpenPullRequest.mockImplementation(async () => null);
+    mockFetchPullRequestUrl.mockReset();
+    mockFetchPullRequestUrl.mockImplementation(async () => null);
 
     // Create session repository
     const sessionRepository = new JsonSessionRepository(`${TEST_CONFIG_DIR}/sessions.json`);

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -21,7 +21,7 @@ import type { AnnotationService } from '../services/annotation-service.js';
 import { sendAnnotationsToClient } from '../websocket/git-diff-handler.js';
 import { deleteWorktree } from '../services/worktree-deletion-service.js';
 import { createWorktreeWithSession } from '../services/worktree-creation-service.js';
-import { findOpenPullRequest } from '../services/github-pr-service.js';
+import type { OpenPrInfo } from '../services/github-pr-service.js';
 import { getCurrentBranch } from '../lib/git.js';
 import { CLAUDE_CODE_AGENT_ID } from '../services/agent-manager.js';
 import type { SuggestSessionMetadataFn } from '../services/session-metadata-suggester.js';
@@ -162,6 +162,8 @@ export interface McpDependencies {
   interSessionMessageService: InterSessionMessageService;
   suggestSessionMetadata: SuggestSessionMetadataFn;
   broadcastToApp: (msg: AppServerMessage) => void;
+  fetchPullRequestUrl: (branch: string, cwd: string) => Promise<string | null>;
+  findOpenPullRequest: (branch: string, cwd: string) => Promise<OpenPrInfo | null>;
 }
 
 // ---------- Factory ----------
@@ -172,7 +174,7 @@ export interface McpDependencies {
  * All MCP tool handlers use the provided dependencies instead of singleton getters.
  */
 export function createMcpApp(deps: McpDependencies): Hono {
-  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService, suggestSessionMetadata, broadcastToApp } = deps;
+  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService, suggestSessionMetadata, broadcastToApp, findOpenPullRequest } = deps;
 
   /**
    * Map a public Session to the worker info format used by MCP tool responses.

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -6,7 +6,6 @@ import {
   UpdateSessionRequestSchema,
 } from '@agent-console/shared';
 import { createSessionValidationService } from '../services/session-validation-service.js';
-import { fetchPullRequestUrl } from '../services/github-pr-service.js';
 import { NotFoundError, ValidationError } from '../lib/errors.js';
 import { vValidator, vQueryValidator } from '../middleware/validation.js';
 import { getOrgRepoFromPath } from '../lib/git.js';
@@ -202,6 +201,7 @@ const sessions = new Hono<AppBindings>()
     const branchName = session.worktreeId;
     const orgRepo = await getOrgRepoFromPath(session.locationPath);
 
+    const { fetchPullRequestUrl } = c.get('appContext');
     const prUrl = await fetchPullRequestUrl(branchName, session.locationPath);
 
     return c.json({

--- a/packages/server/src/routes/worktrees.ts
+++ b/packages/server/src/routes/worktrees.ts
@@ -18,7 +18,6 @@ import {
   deleteWorktree,
 } from '../services/worktree-deletion-service.js';
 import { createWorktreeWithSession } from '../services/worktree-creation-service.js';
-import { findOpenPullRequest } from '../services/github-pr-service.js';
 
 export { _getDeletionsInProgress };
 
@@ -282,7 +281,7 @@ const worktrees = new Hono<AppBindings>()
   // Optionally accepts taskId query parameter for async WebSocket notification
   .delete('/:id/worktrees/*', async (c) => {
     const repoId = c.req.param('id');
-    const { repositoryManager, sessionManager, worktreeService, broadcastToApp } = c.get('appContext');
+    const { repositoryManager, sessionManager, worktreeService, broadcastToApp, findOpenPullRequest } = c.get('appContext');
 
     // Get worktree path from URL (everything after /worktrees/)
     const url = new URL(c.req.url);


### PR DESCRIPTION
## Summary

- Add `fetchPullRequestUrl` and `findOpenPullRequest` to `AppContext` and `McpDependencies` interfaces
- Consumers (`sessions.ts`, `worktrees.ts`, `mcp-server.ts`) now receive these functions via DI instead of direct module import
- Remove `mock.module` usage for `github-pr-service` in `mcp-server.test.ts` and `api.test.ts` — mocks are now passed through DI

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` — all 3430 tests pass
- [x] No changes to `github-pr-service.ts` itself or `worktree-deletion-service.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)