### PR TITLE
refactor: replace worktree service mock.module with DI in mcp-server

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,8 @@ import { pinoLogger } from 'hono-pino';
 import { api } from './routes/api.js';
 import { webhooks } from './routes/webhooks.js';
 import { createMcpApp } from './mcp/mcp-server.js';
+import { createWorktreeWithSession } from './services/worktree-creation-service.js';
+import { deleteWorktree } from './services/worktree-deletion-service.js';
 import { setupWebSocketRoutes, broadcastToApp } from './websocket/routes.js';
 import { onApiError } from './lib/error-handler.js';
 import { serverConfig } from './lib/server-config.js';
@@ -137,6 +139,8 @@ const mcpApp = createMcpApp({
   annotationService: appContext.annotationService,
   interSessionMessageService: appContext.interSessionMessageService,
   suggestSessionMetadata: appContext.suggestSessionMetadata,
+  createWorktreeWithSession,
+  deleteWorktree,
   broadcastToApp: appContext.broadcastToApp,
   fetchPullRequestUrl: appContext.fetchPullRequestUrl,
   findOpenPullRequest: appContext.findOpenPullRequest,

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -26,6 +26,8 @@ import { TimerManager } from '../../services/timer-manager.js';
 import { AnnotationService } from '../../services/annotation-service.js';
 import { InterSessionMessageService } from '../../services/inter-session-message-service.js';
 import { createMcpApp } from '../mcp-server.js';
+import { createWorktreeWithSession } from '../../services/worktree-creation-service.js';
+import { deleteWorktree, _getDeletionsInProgress } from '../../services/worktree-deletion-service.js';
 
 // Mock session-metadata-suggester to avoid spawning real agent processes.
 const mockSuggestSessionMetadata = mock(async () => ({
@@ -33,33 +35,9 @@ const mockSuggestSessionMetadata = mock(async () => ({
   title: 'Auto-Generated Title',
 }));
 
-// Mock worktree-deletion-service
-// NOTE: We spread the real module without overriding deleteWorktree.
-// Bun's mock.module is process-global, so overriding deleteWorktree here
-// would break service-level tests (worktree-deletion-orchestration.test.ts).
-// Instead, deleteWorktree runs the real implementation with mocked git operations
-// (via mock-git-helper) and mocked github-pr-service. Tests that need specific
-// validation behavior set up proper DB state and paths.
-mock.module('../../services/worktree-deletion-service.js', () => ({
-  ...require('../../services/worktree-deletion-service.js'),
-}));
-
-// Mock worktree-creation-service
-// Like worktree-deletion-service above, we spread the real module to preserve
-// the real createWorktreeWithSession for tests. This prevents mock.module
-// interference with worktree-creation-orchestration.test.ts.
-mock.module('../../services/worktree-creation-service.js', () => ({
-  ...require('../../services/worktree-creation-service.js'),
-}));
-
 // github-pr-service mocks (injected via McpDependencies)
 const mockFindOpenPullRequest = mock(async () => null as { number: number; title: string } | null);
 const mockFetchPullRequestUrl = mock(async () => null as string | null);
-
-// Import the real deletion service's concurrency guard (for tests that need
-// to pre-populate it). The mock.module above spreads the real module exports,
-// so this import returns the real _getDeletionsInProgress function.
-const { _getDeletionsInProgress } = await import('../../services/worktree-deletion-service.js');
 
 // Test config directory
 const TEST_CONFIG_DIR = '/test/config';
@@ -176,7 +154,7 @@ describe('MCP Server Tools', () => {
    * the MCP tools see the updated dependencies.
    */
   async function remountMcpApp(): Promise<void> {
-    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService: new InterSessionMessageService(), suggestSessionMetadata: mockSuggestSessionMetadata, broadcastToApp: () => {}, findOpenPullRequest: mockFindOpenPullRequest, fetchPullRequestUrl: mockFetchPullRequestUrl });
+    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService: new InterSessionMessageService(), suggestSessionMetadata: mockSuggestSessionMetadata, createWorktreeWithSession, deleteWorktree, broadcastToApp: () => {}, findOpenPullRequest: mockFindOpenPullRequest, fetchPullRequestUrl: mockFetchPullRequestUrl });
     app = new Hono();
     app.route('', mcpApp);
     mcpSessionId = await initializeMcp(app);

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -19,8 +19,8 @@ import type { TimerManager } from '../services/timer-manager.js';
 import type { WorktreeService } from '../services/worktree-service.js';
 import type { AnnotationService } from '../services/annotation-service.js';
 import { sendAnnotationsToClient } from '../websocket/git-diff-handler.js';
-import { deleteWorktree } from '../services/worktree-deletion-service.js';
-import { createWorktreeWithSession } from '../services/worktree-creation-service.js';
+import type { DeleteWorktreeFn } from '../services/worktree-deletion-service.js';
+import type { CreateWorktreeWithSessionFn } from '../services/worktree-creation-service.js';
 import type { OpenPrInfo } from '../services/github-pr-service.js';
 import { getCurrentBranch } from '../lib/git.js';
 import { CLAUDE_CODE_AGENT_ID } from '../services/agent-manager.js';
@@ -161,6 +161,8 @@ export interface McpDependencies {
   annotationService: AnnotationService;
   interSessionMessageService: InterSessionMessageService;
   suggestSessionMetadata: SuggestSessionMetadataFn;
+  createWorktreeWithSession: CreateWorktreeWithSessionFn;
+  deleteWorktree: DeleteWorktreeFn;
   broadcastToApp: (msg: AppServerMessage) => void;
   fetchPullRequestUrl: (branch: string, cwd: string) => Promise<string | null>;
   findOpenPullRequest: (branch: string, cwd: string) => Promise<OpenPrInfo | null>;
@@ -174,7 +176,7 @@ export interface McpDependencies {
  * All MCP tool handlers use the provided dependencies instead of singleton getters.
  */
 export function createMcpApp(deps: McpDependencies): Hono {
-  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService, suggestSessionMetadata, broadcastToApp, findOpenPullRequest } = deps;
+  const { sessionManager, repositoryManager, agentManager, timerManager, worktreeService, annotationService, interSessionMessageService, suggestSessionMetadata, createWorktreeWithSession, deleteWorktree, broadcastToApp, findOpenPullRequest } = deps;
 
   /**
    * Map a public Session to the worker info format used by MCP tool responses.

--- a/packages/server/src/services/worktree-creation-service.ts
+++ b/packages/server/src/services/worktree-creation-service.ts
@@ -59,6 +59,8 @@ export interface CreateWorktreeResult {
  *
  * On failure after worktree creation, rolls back by force-removing the created worktree.
  */
+export type CreateWorktreeWithSessionFn = typeof createWorktreeWithSession;
+
 export async function createWorktreeWithSession(
   params: CreateWorktreeParams,
   sessionManager: SessionManager,

--- a/packages/server/src/services/worktree-deletion-service.ts
+++ b/packages/server/src/services/worktree-deletion-service.ts
@@ -142,6 +142,8 @@ export interface DeleteWorktreeParams {
  * 5. Acquire concurrency guard
  * 6. Execute cleanup command, kill workers, remove worktree, delete sessions
  */
+export type DeleteWorktreeFn = typeof deleteWorktree;
+
 export async function deleteWorktree(
   params: DeleteWorktreeParams,
   deps: DeleteWorktreeDeps,


### PR DESCRIPTION
## Summary

- Add `createWorktreeWithSession` and `deleteWorktree` to `McpDependencies` interface, replacing direct module imports in `mcp-server.ts`
- Remove two `mock.module` calls in `mcp-server.test.ts` that were spreading real modules to prevent process-global interference
- Export `CreateWorktreeWithSessionFn` and `DeleteWorktreeFn` type aliases from their respective service files

This completes the mock.module elimination effort for worktree services. The remaining mock.module calls in the codebase are for low-level infrastructure (git, logger, pty-provider, open) which are acceptable.

## Test plan

- [x] `bun run test` — all 1962 server tests and 9 shared tests pass
- [x] Type check passes
- [x] No mock.module calls remain for worktree-creation-service or worktree-deletion-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)