### PR TITLE
docs: add retrospective action items to rules and orchestrator skill

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -73,3 +73,4 @@ Before writing tests, verify:
 - [ ] Mocking at lowest level (fetch, WebSocket, not modules)
 - [ ] Not following existing bad patterns blindly
 - [ ] Not changing production code just for testing without discussion
+- [ ] **Target code is mockable via DI** — check if the code under test imports module-level singletons. If it does, DI refactoring is required before the test can be written safely. Do NOT use `mock.module()` to work around missing DI. See Anti-Pattern #2.

--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -28,7 +28,7 @@ You are acting as the Orchestrator of this project. Your job is strategic decisi
 - Use `write_memo` for all owner-facing communication (status updates, questions, blockers). Terminal output gets buried when the owner monitors multiple sessions. Update the memo on every state change: PR merged, acceptance check completed, new task delegated, task blocked.
 - **Write memos in the user's preferred language.** Follow the Language Policy in CLAUDE.md — adapt to the language the user uses. Technical terms, PR/Issue numbers, and links can remain in English.
 - **Always include links when referencing Issues or PRs in memos.** Use full Markdown links: `[#123](https://github.com/owner/repo/issues/123)` for Issues, `[#123](https://github.com/owner/repo/pull/123)` for PRs. The owner clicks through from the memo — bare numbers are not actionable.
-- Use `create_timer` after delegating tasks to monitor progress. Delete the timer when the agent reports back.
+- Use `create_timer` after delegating tasks to monitor progress. Delete the timer when the agent reports back. **For CI wait timers, use 300+ seconds.** Tests take ~90s, CodeRabbit takes 3-12 minutes — shorter intervals cause excessive polling that clutters the conversation.
 - **Use lightweight worktree flow for trivial changes.** For documentation, skill, or agent definition edits, avoid the full delegate_to_worktree → agent → PR cycle. Instead, use `EnterWorktree` / `ExitWorktree` to create a temporary worktree, edit directly, and push:
   1. `EnterWorktree` (with a descriptive name like `docs/your-change`)
   2. Edit files using the Edit tool
@@ -87,3 +87,5 @@ When proposing priorities, weigh these factors:
 5. **Size**: Prefer smaller, shippable increments over large batches
 
 Present your proposal as a ranked list with one-line justification per item. The owner approves or adjusts.
+
+**Deferral requires justification.** When proposing to defer or split work, provide a concrete reason why doing it now is worse than later. "Incremental is safer" is not sufficient without identifying a specific risk. If the work is mechanical and the pattern is established, batch it rather than splitting into multiple rounds.

--- a/.claude/skills/orchestrator/core-responsibilities.md
+++ b/.claude/skills/orchestrator/core-responsibilities.md
@@ -51,6 +51,7 @@
 - Receive and triage questions from coding agents
 - Answer technical/architectural questions using your knowledge of the codebase and skills
 - Escalate to the owner when: business decisions are needed, scope changes are required, or you are uncertain
+- **Propose root cause fixes, not workarounds.** Before advising an agent, ask: "Does this eliminate the root cause, or just reduce the symptom?" If the root cause is known and a structural fix is feasible, propose that — not a workaround. Explicitly label any suggestion as "workaround" vs "fix" so the agent (and owner) can make an informed choice.
 
 ## 5. Review Dev Agent Work Reports
 - **Agents must report completion only after CI is green.** Do not begin acceptance checks based on "implementation complete" messages — code may change during CodeRabbit or CI feedback. The delegation instructions must explicitly state: "Report completion to the Orchestrator only after CI is fully green on your PR."


### PR DESCRIPTION
## Summary

Codify 4 learnings from the full system review session into durable rules:

1. **testing.md** — Pre-implementation checklist: verify target code is mockable via DI before writing tests
2. **core-responsibilities.md** — First Responder rule: propose root cause fixes, not workarounds
3. **SKILL.md** — Decision Framework: deferral requires concrete justification
4. **SKILL.md** — CI wait timers: 300+ seconds to avoid excessive polling

Documentation-only change.