### PR TITLE
test: add route-level tests for agents, repositories, validation, resolve-targets

### DIFF
--- a/packages/server/src/middleware/__tests__/validation.test.ts
+++ b/packages/server/src/middleware/__tests__/validation.test.ts
@@ -65,7 +65,7 @@ describe('vValidator middleware', () => {
     expect(body.error).toBeTruthy();
   });
 
-  it('should return 400 for valid input with optional nested object present', async () => {
+  it('should return 200 for valid input with optional nested object present', async () => {
     const app = createApp();
     const res = await postJson(app, { name: 'test', user: { email: 'user@example.com' } });
 

--- a/packages/server/src/routes/__tests__/agents.test.ts
+++ b/packages/server/src/routes/__tests__/agents.test.ts
@@ -97,6 +97,8 @@ describe('Agents API', () => {
 
       const body = (await res.json()) as { success: boolean };
       expect(body.success).toBe(true);
+      expect(agentManager.unregisterAgent).toHaveBeenCalledWith('test');
+      expect(agentManager.unregisterAgent).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -146,8 +146,10 @@ describe('Repositories API', () => {
       // First request starts generation
       const first = app.request('/api/repositories/repo1/generate-description', { method: 'POST' });
 
-      // Wait a tick for the first request to start processing
-      await new Promise((r) => setTimeout(r, 10));
+      // Wait for the first request to reach the generator
+      while (mockGenerateDescription.mock.calls.length === 0) {
+        await new Promise((r) => setTimeout(r, 1));
+      }
 
       // Second request should be blocked
       const second = await app.request('/api/repositories/repo1/generate-description', { method: 'POST' });

--- a/packages/server/src/services/inbound/__tests__/resolve-targets.test.ts
+++ b/packages/server/src/services/inbound/__tests__/resolve-targets.test.ts
@@ -17,7 +17,7 @@ function createEvent(metadata: Partial<InboundSystemEvent['metadata']> = {}): In
   } as InboundSystemEvent;
 }
 
-function createWorktreeSession(overrides: Partial<Session> = {}): Session {
+function createSession(overrides: Partial<Session> = {}): Session {
   return {
     id: 'session-1',
     type: 'worktree',
@@ -35,7 +35,7 @@ const defaultRepository: Repository = {
 
 describe('resolveTargets', () => {
   it('matches repository names case-insensitively', async () => {
-    const session = createWorktreeSession();
+    const session = createSession();
     const deps: TargetResolverDependencies = {
       getSessions: () => [session],
       getRepository: () => defaultRepository,
@@ -48,8 +48,8 @@ describe('resolveTargets', () => {
   });
 
   it('filters by branch when event specifies a branch', async () => {
-    const mainSession = createWorktreeSession({ id: 'session-main', worktreeId: 'main' });
-    const featureSession = createWorktreeSession({ id: 'session-feature', worktreeId: 'feature-branch' });
+    const mainSession = createSession({ id: 'session-main', worktreeId: 'main' });
+    const featureSession = createSession({ id: 'session-feature', worktreeId: 'feature-branch' });
     const deps: TargetResolverDependencies = {
       getSessions: () => [mainSession, featureSession],
       getRepository: () => defaultRepository,
@@ -62,7 +62,7 @@ describe('resolveTargets', () => {
   });
 
   it('skips non-worktree sessions', async () => {
-    const session = createWorktreeSession({ type: 'quick' });
+    const session = createSession({ type: 'quick' });
     const deps: TargetResolverDependencies = {
       getSessions: () => [session],
       getRepository: () => defaultRepository,
@@ -75,8 +75,8 @@ describe('resolveTargets', () => {
   });
 
   it('swallows GitError and continues processing remaining sessions', async () => {
-    const session1 = createWorktreeSession({ id: 'session-1', repositoryId: 'repo-1' });
-    const session2 = createWorktreeSession({ id: 'session-2', repositoryId: 'repo-2' });
+    const session1 = createSession({ id: 'session-1', repositoryId: 'repo-1' });
+    const session2 = createSession({ id: 'session-2', repositoryId: 'repo-2' });
     const repositories: Record<string, Repository> = {
       'repo-1': { id: 'repo-1', path: '/path/to/repo1' } as Repository,
       'repo-2': { id: 'repo-2', path: '/path/to/repo2' } as Repository,
@@ -100,7 +100,7 @@ describe('resolveTargets', () => {
   });
 
   it('returns empty array when repositoryName is missing', async () => {
-    const session = createWorktreeSession();
+    const session = createSession();
     const deps: TargetResolverDependencies = {
       getSessions: () => [session],
       getRepository: () => defaultRepository,


### PR DESCRIPTION
## Summary
- Add missing route-level and service tests for 4 target files (agents.ts, repositories.ts, validation.ts, resolve-targets.ts)
- 23 new tests covering DELETE/PATCH handlers, session conflict checks, concurrent request guards, GitError handling, and Valibot error formatting
- All tests use DI-based mocking (no new mock.module calls for DI-ready services)

Closes #505

## Test plan
- [x] All 4 test files pass individually
- [x] Full test suite passes (`bun run test:only`): shared 271, server 1985, integration 9 — 0 failures
- [x] Server typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)