### PR TITLE
refactor: remove MemoService from AppContext interface

### DIFF
--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -109,9 +109,6 @@ export interface AppContext {
   /** Inter-session message file management */
   interSessionMessageService: InterSessionMessageService;
 
-  /** Memo file management */
-  memoService: MemoService;
-
   /** Suggest session metadata (branch name, title) from user prompt */
   suggestSessionMetadata: SuggestSessionMetadataFn;
 
@@ -291,7 +288,6 @@ export async function createAppContext(
     repositorySlackIntegrationService,
     annotationService,
     interSessionMessageService,
-    memoService,
     suggestSessionMetadata,
     userMode,
     timerManager,
@@ -444,7 +440,6 @@ export async function createTestContext(
     repositorySlackIntegrationService,
     annotationService,
     interSessionMessageService,
-    memoService,
     suggestSessionMetadata,
     userMode,
     timerManager,


### PR DESCRIPTION
## Summary
- Remove `memoService` from `AppContext` interface — it's an internal dependency of `SessionManager`, not a shared service
- MemoService is already DI-injected into SessionManager via constructor; the AppContext exposure was unnecessary

Refs #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)