### PR TITLE
refactor: inject generateRepositoryDescription via AppContext DI

### DIFF
--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -28,6 +28,7 @@ import type { AnnotationService } from './services/annotation-service.js';
 import type { InterSessionMessageService } from './services/inter-session-message-service.js';
 import type { SuggestSessionMetadataFn } from './services/session-metadata-suggester.js';
 import type { OpenPrInfo } from './services/github-pr-service.js';
+import type { GenerateRepositoryDescriptionFn } from './services/repository-description-generator.js';
 import type { InboundIntegrationInstance } from './services/inbound/index.js';
 import { initializeInboundIntegration } from './services/inbound/index.js';
 import { initializeDatabase, createDatabaseForTest, closeDatabase, getGlobalDatabase } from './database/connection.js';
@@ -57,6 +58,7 @@ import { WorkerOutputFileManager } from './lib/worker-output-file.js';
 import { MemoService } from './services/memo-service.js';
 import { suggestSessionMetadata } from './services/session-metadata-suggester.js';
 import { fetchPullRequestUrl, findOpenPullRequest } from './services/github-pr-service.js';
+import { generateRepositoryDescription } from './services/repository-description-generator.js';
 
 const logger = createLogger('app-context');
 
@@ -123,6 +125,9 @@ export interface AppContext {
 
   /** Find open PR for a branch */
   findOpenPullRequest: (branch: string, cwd: string) => Promise<OpenPrInfo | null>;
+
+  /** Generate AI-powered repository description */
+  generateRepositoryDescription: GenerateRepositoryDescriptionFn;
 }
 
 /**
@@ -295,6 +300,7 @@ export async function createAppContext(
     broadcastToApp: options?.broadcastToApp ?? (() => {}),
     fetchPullRequestUrl,
     findOpenPullRequest,
+    generateRepositoryDescription,
   };
 }
 
@@ -447,6 +453,7 @@ export async function createTestContext(
     broadcastToApp: () => {},
     fetchPullRequestUrl,
     findOpenPullRequest,
+    generateRepositoryDescription,
   };
 }
 

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 
-// Mock the description generator BEFORE importing test-utils to ensure proper mock ordering
 const mockGenerateDescription = mock(() => Promise.resolve({ description: 'test' }));
-mock.module('../../services/repository-description-generator.js', () => ({
-  generateRepositoryDescription: mockGenerateDescription,
-}));
 
 import type { Hono } from 'hono';
 import type { AppBindings } from '../../app-context.js';
@@ -73,6 +69,7 @@ describe('Repositories API', () => {
       sessionManager: sessionManager as any,
       repositorySlackIntegrationService: repositorySlackIntegrationService as any,
       agentManager: agentManager as any,
+      generateRepositoryDescription: mockGenerateDescription as any,
     });
   });
 

--- a/packages/server/src/routes/repositories.ts
+++ b/packages/server/src/routes/repositories.ts
@@ -9,7 +9,6 @@ import {
   RepositorySlackIntegrationInputSchema,
 } from '@agent-console/shared';
 import { CLAUDE_CODE_AGENT_ID } from '../services/agent-manager.js';
-import { generateRepositoryDescription } from '../services/repository-description-generator.js';
 import { fetchGitHubIssue } from '../services/github-issue-service.js';
 import { ConflictError, NotFoundError, ValidationError } from '../lib/errors.js';
 import { vValidator } from '../middleware/validation.js';
@@ -158,7 +157,7 @@ const repositories = new Hono<AppBindings>()
   // Generate a repository description using AI
   .post('/:id/generate-description', async (c) => {
     const repoId = c.req.param('id');
-    const { repositoryManager, agentManager } = c.get('appContext');
+    const { repositoryManager, agentManager, generateRepositoryDescription } = c.get('appContext');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {


### PR DESCRIPTION
## Summary
- Add `generateRepositoryDescription` to `AppContext` interface for DI injection
- Remove direct module import from `routes/repositories.ts`; use `c.get('appContext')` instead
- Remove `mock.module()` from `repositories.test.ts`; pass mock via `createTestApp()` DI

Refs #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)