### PR TITLE
refactor: deduplicate orphan cleanup logic in SessionManager

### DIFF
--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -629,6 +629,34 @@ describe('SessionManager', () => {
       expect(injectCalls[0].sessionId).toBe(session.id);
       expect(injectCalls[0].workerId).toBe(agentWorker.id);
     });
+
+    it('should return null when injected PtyMessageInjectionService returns false', async () => {
+      const mockInjectionService = new PtyMessageInjectionService(
+        () => true,
+        () => true,
+      );
+      // Override injectMessage to always fail
+      mockInjectionService.injectMessage = () => false;
+
+      const module = await import(`../session-manager.js?v=${++importCounter}`);
+      const manager = await module.SessionManager.create({
+        ptyProvider: ptyFactory.provider,
+        pathExists: mockPathExists,
+        jobQueue: testJobQueue,
+        agentManager,
+        ptyMessageInjectionService: mockInjectionService,
+      });
+
+      const session = await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      const agentWorker = session.workers.find((w: Worker) => w.type === 'agent')!;
+
+      const message = manager.sendMessage(session.id, null, agentWorker.id, 'should fail');
+      expect(message).toBeNull();
+    });
   });
 
   describe('resizeWorker', () => {

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -274,29 +274,7 @@ export class SessionManager {
       }
 
       // Kill any orphan worker processes first
-      for (const worker of session.workers) {
-        // Skip git-diff workers (no process) and workers with no pid (not yet activated)
-        if (worker.type === 'git-diff' || worker.pid === null) continue;
-
-        if (isProcessAlive(worker.pid)) {
-          try {
-            processKill(worker.pid, 'SIGTERM');
-            logger.info({ pid: worker.pid, workerId: worker.id, sessionId: session.id }, 'Killed orphan worker process');
-            killedWorkerCount++;
-          } catch (error) {
-            logger.error({ pid: worker.pid, workerId: worker.id, sessionId: session.id, err: error }, 'Failed to kill orphan worker with SIGTERM');
-            // Try SIGKILL as fallback for stubborn processes
-            try {
-              processKill(worker.pid, 'SIGKILL');
-              logger.info({ pid: worker.pid, workerId: worker.id, sessionId: session.id }, 'Killed orphan worker with SIGKILL');
-              killedWorkerCount++;
-            } catch {
-              // Process may have exited between checks, log but continue
-              logger.warn({ pid: worker.pid, workerId: worker.id, sessionId: session.id }, 'Failed to kill orphan worker (process may have already exited)');
-            }
-          }
-        }
-      }
+      killedWorkerCount += SessionManager.killOrphanWorkers(session);
 
       // Mark as paused in DB (not loaded into memory) - user can resume later
       sessionsToSave.push({
@@ -474,28 +452,7 @@ export class SessionManager {
       orphanSessions.push(session);
 
       // Kill all workers in this session (only PTY workers have pid)
-      for (const worker of session.workers) {
-        // Skip git-diff workers (no process) and workers with no pid (not yet activated)
-        if (worker.type === 'git-diff' || worker.pid === null) continue;
-
-        if (isProcessAlive(worker.pid)) {
-          try {
-            processKill(worker.pid, 'SIGTERM');
-            logger.info({ pid: worker.pid, workerId: worker.id, sessionId: session.id }, 'Killed orphan worker process');
-            killedCount++;
-          } catch (error) {
-            logger.error({ pid: worker.pid, workerId: worker.id, sessionId: session.id, err: error }, 'Failed to kill orphan worker with SIGTERM');
-            // Try SIGKILL as fallback
-            try {
-              processKill(worker.pid, 'SIGKILL');
-              logger.info({ pid: worker.pid, workerId: worker.id, sessionId: session.id }, 'Killed orphan worker with SIGKILL');
-              killedCount++;
-            } catch {
-              logger.warn({ pid: worker.pid, workerId: worker.id, sessionId: session.id }, 'Failed to kill orphan worker (process may have already exited)');
-            }
-          }
-        }
-      }
+      killedCount += SessionManager.killOrphanWorkers(session);
     }
 
     // Remove orphan sessions from persistence and delete output files
@@ -519,6 +476,38 @@ export class SessionManager {
       preservedSessions: preservedCount,
       serverPid: currentServerPid,
     }, 'Orphan cleanup completed');
+  }
+
+  /**
+   * Kill orphan worker processes for a session.
+   * Returns the number of workers successfully killed.
+   */
+  private static killOrphanWorkers(session: PersistedSession): number {
+    let killedCount = 0;
+    for (const worker of session.workers) {
+      // Skip git-diff workers (no process) and workers with no pid (not yet activated)
+      if (worker.type === 'git-diff' || worker.pid === null) continue;
+
+      if (isProcessAlive(worker.pid)) {
+        try {
+          processKill(worker.pid, 'SIGTERM');
+          logger.info({ pid: worker.pid, workerId: worker.id, sessionId: session.id }, 'Killed orphan worker process');
+          killedCount++;
+        } catch (error) {
+          logger.error({ pid: worker.pid, workerId: worker.id, sessionId: session.id, err: error }, 'Failed to kill orphan worker with SIGTERM');
+          // Try SIGKILL as fallback for stubborn processes
+          try {
+            processKill(worker.pid, 'SIGKILL');
+            logger.info({ pid: worker.pid, workerId: worker.id, sessionId: session.id }, 'Killed orphan worker with SIGKILL');
+            killedCount++;
+          } catch {
+            // Process may have exited between checks, log but continue
+            logger.warn({ pid: worker.pid, workerId: worker.id, sessionId: session.id }, 'Failed to kill orphan worker (process may have already exited)');
+          }
+        }
+      }
+    }
+    return killedCount;
   }
 
   // ========== Session Lifecycle ==========


### PR DESCRIPTION
## Summary
- Extract shared process-killing logic from `initializeSessions()` and `cleanupOrphanProcesses()` into a `private static killOrphanWorkers()` helper method
- Both methods now call the shared helper instead of duplicating the SIGTERM/SIGKILL fallback loop
- Add missing test for `sendMessage` returning `null` when `PtyMessageInjectionService.injectMessage` returns `false`

Refs #503

## Test plan
- [x] All existing tests pass (3464 tests, 0 failures)
- [x] New sendMessage null-return test added and passing
- [x] No behavior changes — pure refactoring + test addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)