### PR TITLE
fix: add typecheck to delegation prompt and CI check to acceptance check

### DIFF
--- a/.claude/skills/orchestrator/acceptance-check.js
+++ b/.claude/skills/orchestrator/acceptance-check.js
@@ -250,6 +250,22 @@ function saveState(state) {
   writeFileSync(path, JSON.stringify(state, null, 2) + '\n', 'utf-8');
 }
 
+// --- CI status check ---
+
+function getCiStatus(prNumber) {
+  const result = exec(`gh pr checks ${prNumber} --json name,state,conclusion 2>/dev/null`);
+  if (!result) return null;
+  try {
+    const checks = JSON.parse(result);
+    const failed = checks.filter(c => c.conclusion === 'FAILURE' || c.conclusion === 'failure');
+    const pending = checks.filter(c => c.state === 'PENDING' || c.state === 'pending' || c.state === 'IN_PROGRESS');
+    const passed = checks.filter(c => c.conclusion === 'SUCCESS' || c.conclusion === 'success');
+    return { checks, failed, pending, passed, allGreen: failed.length === 0 && pending.length === 0 };
+  } catch {
+    return null;
+  }
+}
+
 // --- Auto-detection ---
 
 function runAutoDetection(prNumber) {
@@ -257,6 +273,7 @@ function runAutoDetection(prNumber) {
   const categories = categorizeFiles(changedFiles);
   const { testFiles, productionFiles, testCoverage } = findTestFiles(changedFiles);
   const boundaries = analyzePackageBoundaries(categories);
+  const ciStatus = getCiStatus(prNumber);
 
   const linkedIssue = getLinkedIssueNumber(prNumber);
   let acceptanceCriteria = [];
@@ -273,13 +290,38 @@ function runAutoDetection(prNumber) {
     boundaries,
     linkedIssue,
     acceptanceCriteria,
+    ciStatus,
   };
 }
 
 // --- Display functions ---
 
 function printAutoDetection(autoDetection) {
-  const { categories, testFiles, testCoverage, boundaries, linkedIssue, acceptanceCriteria } = autoDetection;
+  const { categories, testFiles, testCoverage, boundaries, linkedIssue, acceptanceCriteria, ciStatus } = autoDetection;
+
+  // CI status (must be green before acceptance)
+  console.log('[CI Status]');
+  if (!ciStatus) {
+    console.log('  ⚠ Could not retrieve CI status');
+  } else if (ciStatus.allGreen) {
+    console.log(`  ✅ All checks passed (${ciStatus.passed.length} checks)`);
+  } else {
+    if (ciStatus.failed.length > 0) {
+      console.log(`  ❌ FAILED checks (${ciStatus.failed.length}):`);
+      for (const c of ciStatus.failed) {
+        console.log(`    - ${c.name}`);
+      }
+      console.log('  ⛔ CI must be green before acceptance. Do NOT proceed until all checks pass.');
+    }
+    if (ciStatus.pending.length > 0) {
+      console.log(`  ⏳ Pending checks (${ciStatus.pending.length}):`);
+      for (const c of ciStatus.pending) {
+        console.log(`    - ${c.name}`);
+      }
+      console.log('  ⏳ Wait for all checks to complete before proceeding.');
+    }
+  }
+  console.log();
 
   // File categorization
   console.log('[File Categorization]');

--- a/.claude/skills/orchestrator/delegation-prompt.js
+++ b/.claude/skills/orchestrator/delegation-prompt.js
@@ -100,10 +100,12 @@ Read the Issue carefully — it contains the full design, acceptance criteria, a
 
 ## Completion Steps
 1. Run the FULL test suite (\`bun run test\`) and confirm ALL tests pass — not just your new tests. If any pre-existing test fails, investigate whether your changes caused it.
-2. Run CodeRabbit CLI self-review: \`coderabbit review --agent --base main\`. Fix any CRITICAL/HIGH/MEDIUM issues before creating the PR. If CLI is not installed, skip this step.
-3. Create PR: \`[AI] closed #${issueNumber} ${issue.title.replace(/^\[AI\]\s*/, '')}\`
-4. Wait for CI green, fix any issues.
-5. Report completion with PR URL and retrospective to Orchestrator.
+2. Run typecheck and confirm no errors. For client changes: \`cd packages/client && bunx tsc --noEmit\`. For server changes: \`cd packages/server && bunx tsc --noEmit\`. Skip this step for documentation-only changes.
+3. Do NOT push until both step 1 and step 2 pass.
+4. Run CodeRabbit CLI self-review: \`coderabbit review --agent --base main\`. Fix any CRITICAL/HIGH/MEDIUM issues before creating the PR. If CLI is not installed, skip this step.
+5. Create PR: \`[AI] closed #${issueNumber} ${issue.title.replace(/^\[AI\]\s*/, '')}\`
+6. Wait for CI green, fix any issues.
+7. Report completion with PR URL and retrospective to Orchestrator.
 `;
 
 console.log(output);


### PR DESCRIPTION
## Summary
- **delegation-prompt.js**: Add typecheck step (`bunx tsc --noEmit`) as step 2, with explicit "do not push until both pass" gate. Documentation-only changes can skip typecheck.
- **acceptance-check.js**: Add CI status check to auto-detection output. Shows pass/fail/pending status and blocks acceptance if CI is not green.

## Why
PR #513 had 3 rounds of CI failures (unused import, mock.module pollution, fetch mock type) that could have been caught locally. These changes enforce verification at both delegation (agent side) and acceptance (orchestrator side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)