### PR TITLE
docs: slim CLAUDE.md and rules, eliminate duplication with skills

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -5,121 +5,41 @@ paths:
 
 # Backend Rules
 
-## Tech Stack
+**Delegate to `backend-specialist` subagent** for implementation in this package. Primary agent should not write server code directly.
 
-- **Bun** - JavaScript runtime
-- **Hono** - Web framework
-- **bun-pty** - Pseudo-terminal for spawning processes
-- **Pino** - Structured logging
-- **Valibot** - Schema validation (shared with frontend)
-
-## Directory Structure and Naming
+## Directory Structure
 
 ```
 packages/server/src/
-├── __tests__/      # Unit tests
 ├── lib/            # Utilities (logger, config, error handler)
 ├── middleware/     # Hono middleware
 ├── routes/         # API route handlers
 ├── services/       # Business logic (flat by default, domain dirs when needed)
-│   ├── agents/     # Domain directory (multiple related files)
-│   └── *.ts        # Flat service files
 └── websocket/      # WebSocket handlers
 ```
 
-### Directory Organization Strategy
+Services use **flat-first** approach: start as flat files, move to domain directory when helpers/types grow.
 
-**Services use flat-first approach:**
+## File Naming
 
-| Situation | Organization | Example |
-|-----------|--------------|---------|
-| Single service file | Flat | `services/session-manager.ts` |
-| Service + helpers/types | Domain directory | `services/agents/` |
-| Service grows large | Split into domain directory | - |
-
-### File Naming Conventions
-
-| Type | Convention | Example |
-|------|------------|---------|
-| General | kebab-case | `session-manager.ts` |
-| Service | kebab-case | `persistence-service.ts` |
-| Middleware | kebab-case | `error-handler.ts` |
-| Route handler | kebab-case (plural) | `sessions.ts`, `workers.ts` |
-| Utility | kebab-case | `config.ts`, `logger.ts` |
-| Test | original + `.test` | `session-manager.test.ts` |
-
-- Use **kebab-case** for all directories (exception: `__tests__/`)
-- File name reflects primary export: `session-manager.ts` exports `SessionManager`
-- Use named exports; avoid default exports except for route handlers
+- **kebab-case** for all files and directories (exception: `__tests__/`)
+- Route handlers use **plural** names: `sessions.ts`, `workers.ts`
+- File name reflects primary export: `session-manager.ts` → `SessionManager`
+- Test files: `__tests__/foo-bar.test.ts`
+- Use named exports; avoid default exports
 
 ## Key Principles
 
-- **Server is the source of truth** - Backend manages all session/worker state
-- **Structured logging** - Use Pino with context objects
-- **Resource cleanup** - Always clean up PTY processes and connections
-- **Type safety** - Define types in shared package, validate at boundaries
+- **Server is the source of truth** — backend manages all session/worker state
+- **Structured logging** — Pino with context objects first, message second:
+  ```typescript
+  logger.info({ sessionId, workerId }, 'Worker created');
+  ```
+  Avoid string interpolation in log messages.
 
-## Hono Framework
+## Async Over Sync (Critical)
 
-### Route Organization
-
-```typescript
-const api = new Hono();
-api.route('/sessions', sessions);
-api.route('/agents', agents);
-export { api };
-```
-
-### Request Validation
-
-Use Valibot with Hono's validator (`@hono/valibot-validator`).
-
-### Error Handling
-
-Use centralized error handler via `app.onError(onApiError)`.
-
-## Logging
-
-Use Pino with structured logging:
-
-```typescript
-// Structured data first, message second
-logger.info({ sessionId, workerId }, 'Worker created');
-logger.error({ err: error, context }, 'Operation failed');
-```
-
-- `fatal`: Application crash, unrecoverable errors
-- `error`: Errors that need attention
-- `warn`: Potentially problematic situations
-- `info`: Normal operational messages
-- `debug`: Detailed debugging information
-
-**Avoid string interpolation in log messages.** Use structured data objects.
-
-## Service Design
-
-### Singleton Services
-
-Use module-level singletons for shared services.
-
-### Callback Registration and Detachment
-
-**Always detach callbacks when resources are destroyed** to prevent memory leaks. Every `attachWorkerCallbacks` must have a corresponding `detachWorkerCallbacks` in cleanup/`onClose`.
-
-### Resource Cleanup
-
-Always clean up resources. Cleanup operations should not throw - wrap in try-catch and log warnings.
-
-1. **PTY Processes** - Kill processes when workers are destroyed
-2. **WebSocket Connections** - Close connections on disconnect, handle cleanup in `onClose`
-3. **File Handles** - Close file handles after operations complete
-4. **Event Listeners** - Remove listeners when resources are destroyed
-
-## Performance
-
-### Prefer Async Over Sync
-
-**Always use async functions instead of sync equivalents.** Bun runs on a single-threaded event loop. Sync functions block the entire thread.
+Bun runs on a single-threaded event loop. **Sync functions block the entire thread.**
 
 | Avoid (Sync) | Use (Async) |
 |--------------|-------------|
@@ -128,49 +48,25 @@ Always clean up resources. Cleanup operations should not throw - wrap in try-cat
 | `fs.existsSync()` | `Bun.file().exists()` |
 | `child_process.execSync()` | `Bun.spawn()` |
 
-**Exceptions:** Application startup/initialization and CLI tools.
+Exceptions: Application startup/initialization and CLI tools.
 
-### Async/Await
+**Never use fire-and-forget patterns.** Always await async operations to avoid silent errors and race conditions.
 
-**Always use async/await. Avoid fire-and-forget patterns.** Fire-and-forget causes silent errors, race conditions, and unhandled rejections.
+## Resource Cleanup
 
-### PTY Output Handling
+Always clean up resources. Cleanup operations should not throw — wrap in try-catch and log warnings.
 
-- Buffer output to reduce message frequency
-- Use efficient string concatenation
-- Limit history buffer size
+1. **PTY Processes** — Kill processes when workers are destroyed
+2. **WebSocket Connections** — Close connections on disconnect, handle cleanup in `onClose`
+3. **File Handles** — Close file handles after operations complete
+4. **Event Listeners** — Remove listeners when resources are destroyed
 
-## Dual WebSocket Architecture
+**Always detach callbacks when resources are destroyed** to prevent memory leaks. Every `attachWorkerCallbacks` must have a corresponding `detachWorkerCallbacks`.
 
-1. **App WebSocket (`/ws/app`)**: Single connection for app-wide state sync (session/worker lifecycle events)
-2. **Worker WebSocket (`/ws/session/:id/worker/:id`)**: Per-worker connections (terminal I/O, resize)
+## WebSocket Architecture
 
-### Message Protocol
-
-Server -> Client messages are typed discriminated unions. Client -> Server messages are validated with Valibot schemas.
-
-### Broadcasting
-
-Use broadcast pattern with `Set<WSContext>` for app-wide events.
-
-### Output Buffering
-
-Buffer rapid PTY output before sending to WebSocket to reduce message count.
-
-## Webhook Receiver Patterns
-
-**These patterns apply to webhook receivers only, NOT regular API endpoints.**
-
-- **Always return 200 OK** to the webhook sender, regardless of internal processing results
-- Accept events and process asynchronously (enqueue + return)
-- Verify webhook signatures before enqueuing, but still return 200 on auth failure
-- All failures are handled internally through logging, alerting, and internal retry
-
-| Aspect | Webhook Receiver | API Endpoint |
-|--------|-----------------|--------------|
-| Response codes | Always 200 | Proper HTTP codes |
-| Processing | Async (enqueue + return) | Sync (process + respond) |
-| Error reporting | Internal (logs, alerts) | To caller (error response) |
+1. **App WebSocket (`/ws/app`)** — App-wide state sync (session/worker lifecycle events)
+2. **Worker WebSocket (`/ws/session/:id/worker/:id`)** — Per-worker connections (terminal I/O, resize)
 
 ## Security
 
@@ -179,25 +75,3 @@ Buffer rapid PTY output before sending to WebSocket to reduce message count.
 - Sanitize environment variables before spawning processes
 - Validate paths to prevent directory traversal
 - Use absolute paths
-
-## Configuration
-
-Use typed configuration with environment variables (`lib/server-config.ts`).
-
-## Core Concepts
-
-### Session Manager
-
-Central service managing all sessions and workers (create/delete sessions, spawn/manage workers, track activity states, persist state, broadcast events).
-
-### Workers
-
-- **Agent Worker**: PTY process running AI agent (Claude Code, etc.)
-- **Terminal Worker**: Plain PTY shell
-- **Git-Diff Worker**: Non-PTY worker for real-time diff viewing
-
-### PTY Management
-
-- Use `bun-pty` for spawning interactive processes
-- Workers persist across WebSocket reconnections (tmux-like behavior)
-- Buffer output for history replay on reconnection

--- a/.claude/rules/design-principles.md
+++ b/.claude/rules/design-principles.md
@@ -1,0 +1,19 @@
+# Design Principles
+
+These principles apply to all code changes in this project.
+
+**Purpose over speed.** Do not rush to finish quickly at the expense of losing sight of the original purpose.
+
+**Do not blindly follow existing patterns.** Existing code is not automatically correct. Evaluate whether patterns are appropriate before adopting them.
+
+**Enforce constraints through structure, not convention.** If a constraint can be expressed in the type system, do not enforce it through runtime checks or documentation. `string` where a union type would work, `Record<string, string>` where a typed interface would work — all are type safety gaps. Always choose the path that makes invalid states unrepresentable.
+
+**Define types by what they represent, not where they're used.** A type's home is determined by the scope of the concept it models, not by which module first needs it.
+
+**Think before you act.** First consider the correct approach rather than immediately implementing the easiest solution.
+
+**Speak up about issues.** When you notice something problematic outside the current task scope, mention it as a supplementary note.
+
+**Ask when uncertain.** When uncertain about a design decision, ask the user for confirmation.
+
+**Validate task assumptions before implementing.** Understand WHY the task is needed. If a task assumes existing behavior that seems questionable, verify whether that assumption is correct before implementing.

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -5,17 +5,9 @@ paths:
 
 # Frontend Rules
 
-## Tech Stack
+**Delegate to `frontend-specialist` subagent** for implementation in this package. Primary agent should not write client code directly.
 
-- **React 18** - UI framework
-- **Vite** - Build tool and dev server
-- **TanStack Router** - File-based routing with type safety
-- **TanStack Query** - Server state management
-- **Tailwind CSS** - Utility-first styling
-- **xterm.js** - Terminal emulator
-- **Valibot** - Schema validation
-
-## Directory Structure and Naming
+## Directory Structure
 
 ```
 packages/client/src/
@@ -30,55 +22,28 @@ packages/client/src/
 └── test/           # Test utilities and setup
 ```
 
-### Directory Organization Strategy
-
-**Components use domain-based organization:**
-- Group related components into domain directories (`sessions/`, `workers/`, `agents/`)
-- Shared UI components go in `ui/`
-- Standalone components can remain flat
-
-**Hooks use hybrid approach:**
+## Hook Placement
 
 | Hook Type | Location | Example |
 |-----------|----------|---------|
-| Domain-specific | Inside domain directory | `components/sessions/useSessionState.ts` |
-| Multi-domain | `hooks/` | `hooks/useTerminalWebSocket.ts` |
-| Generic utility | `hooks/` | `hooks/useMounted.ts` |
+| Used by single domain only | Inside domain directory | `components/sessions/hooks/useSessionPageState.ts` |
+| Used by 2+ domains | `hooks/` | `hooks/useAppWs.ts` |
+| Generic utility | `hooks/` | `hooks/useIsMobile.ts` |
 
-Decision criteria:
-1. **Used by single domain only** -> Put in that domain directory
-2. **Used by 2+ domains** -> Put in `hooks/`
-3. **Domain-agnostic utility** -> Put in `hooks/`
-
-### File Naming Conventions
+## File Naming
 
 | Type | Convention | Example |
 |------|------------|---------|
-| React component | PascalCase | `SessionList.tsx`, `WorkerTabs.tsx` |
-| Custom hook | camelCase + `use` prefix | `useTerminal.ts`, `useAppConnection.ts` |
-| Utility/helper | kebab-case | `api-client.ts`, `format-date.ts` |
-| Type definition | kebab-case | `types.ts`, `session-types.ts` |
-| Schema | kebab-case | `session-schema.ts` |
-| Test | original + `.test` | `SessionList.test.tsx`, `useTerminal.test.ts` |
+| React component | PascalCase `.tsx` | `SessionList.tsx` |
+| Custom hook | camelCase `use` prefix `.ts` | `useTerminal.ts` |
+| Utility/helper | kebab-case `.ts` | `api-client.ts` |
+| Test | original + `.test` | `SessionList.test.tsx` |
 
-### Directory Naming
+- **kebab-case** for all directories. Domain directories use plural nouns: `sessions/`, `workers/`
+- Component file name = component name. Use `index.ts` to re-export from directories.
+- Use named exports; avoid default exports.
 
-- Use **kebab-case** for all directories
-- Domain directories use plural nouns: `sessions/`, `workers/`, `agents/`
-
-### Export Conventions
-
-- Component file name = component name: `SessionList.tsx` exports `SessionList`
-- For component directories, use `index.ts` to re-export the main component
-
-## Key React Principles
-
-- **Avoid useEffect** - Use TanStack Query, useSyncExternalStore, or event handlers instead
-- **Prefer Suspense** - For loading states and async boundaries
-- **useSyncExternalStore** - For external state subscriptions (WebSocket, global stores)
-- **Server is the source of truth** - Don't maintain conflicting client state
-
-### useEffect Alternatives
+## Avoid useEffect
 
 | Instead of useEffect for... | Use this |
 |----------------------------|----------|
@@ -86,70 +51,24 @@ Decision criteria:
 | Subscribing to external store | `useSyncExternalStore` |
 | Derived state | Compute during render or `useMemo` |
 | Responding to user events | Event handlers |
-| Syncing with parent component | Lift state up or use context |
 
-**When useEffect is acceptable:**
-- Component-scoped WebSocket connections (tied to component lifecycle)
-- Third-party library integration (xterm.js, etc.)
-- Browser API subscriptions (resize observers, etc.)
+**When useEffect is acceptable:** Component-scoped WebSocket connections, third-party library integration (xterm.js), browser API subscriptions (resize observers).
 
-### State Management Hierarchy
+## State Management Hierarchy
 
 1. **Server state**: TanStack Query (`useQuery`, `useMutation`)
 2. **External state**: `useSyncExternalStore`
 3. **Local UI state**: `useState`, `useReducer`
 4. **Shared client state**: React Context (sparingly)
 
-Avoid prop drilling; prefer composition or context.
-
-### Component Design
-
-- Prefer function components with hooks
-- Keep components focused on single responsibility
-- Extract complex logic into custom hooks
-- Use composition over inheritance
-
-### Icon Components
-
-SVG icons belong in a dedicated `Icons.tsx` file, not inline in View components.
-
-### Async/Await
-
-**Always use async/await. Avoid fire-and-forget patterns.** Fire-and-forget (calling an async function without awaiting) causes silent errors, race conditions, and unhandled promise rejections.
-
-## TanStack Router
-
-- Routes are defined in `src/routes/` directory
-- `__root.tsx` - Root layout, `index.tsx` - Home route, `$param.tsx` - Dynamic segments
-- Route params and search params are automatically typed
-
-## TanStack Query
-
-- Use consistent key factories for related queries
-- Always invalidate related queries after mutations
+**Server is the source of truth** — don't maintain conflicting client state.
 
 ## WebSocket Integration
 
-**Singleton pattern** - For app-wide connections that persist across navigation:
-- Example: `/ws/app` for session/worker lifecycle events
-- Use module-level state with `useSyncExternalStore`
+- **Singleton pattern** (app-wide, persists across navigation): module-level state with `useSyncExternalStore`
+- **Hook-based pattern** (component-scoped): `useEffect` with cleanup, tied to component lifecycle
 
-**Hook-based pattern** - For component-scoped connections:
-- Example: `/ws/session/:id/worker/:id` for terminal I/O
-- Use `useEffect` with cleanup, tied to component lifecycle
-
-### State Synchronization
-
-- Server is the source of truth
-- Update UI based on server messages
-- Don't maintain conflicting client state
-
-## Styling with Tailwind CSS
-
-- Group related utilities: layout -> spacing -> sizing -> colors -> typography
-- Mobile-first approach (`sm:`, `md:`, `lg:` breakpoints)
-
-## Form Handling with Valibot
+## Valibot Form Validation
 
 **Always add minLength before regex:**
 
@@ -162,16 +81,6 @@ const schema = v.pipe(
 )
 ```
 
-## Performance
+## Async/Await
 
-- Memoize expensive computations with `useMemo`
-- Use `useCallback` only when passing to optimized children
-- Avoid inline object/array literals in JSX props
-
-## Error Handling
-
-- Wrap major sections in error boundaries
-- Provide meaningful fallback UI
-- Display user-friendly error messages with retry mechanisms
-
-See also: `ux-design-standards` skill for UX design principles that guide feature-level decisions.
+**Never use fire-and-forget patterns.** Always await async operations to avoid silent errors and race conditions.

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -91,7 +91,11 @@ Design documents (`docs/design/`) are specifications. Code is their implementati
 
 ## Language Policy
 
-**Code and documentation:** Write all code comments, commit messages, and documentation in English.
+**Public artifacts:** Write all code comments, commit messages, issues, pull requests, and documentation in English.
+
+**User-facing artifacts:** Review annotations, memos, and other content visible only to the user should follow the user's preferred language.
+
+**Communication:** Respond in the same language the user uses. Technical terms and code identifiers can remain in English.
 
 ## Claude Code on the Web (Remote Environment)
 

--- a/.claude/skills/code-quality-standards/SKILL.md
+++ b/.claude/skills/code-quality-standards/SKILL.md
@@ -8,7 +8,14 @@ description: Code quality evaluation criteria for reviews. Use when reviewing co
 ## 1. Robustness to Change
 - **Single Responsibility Principle** — Each module/class has only one reason to change. Unrelated concerns are separated.
 - **File Size and Responsibility Checks** — Flag files >500 lines. Look for responsibility clustering (e.g., mixed prefixes like `initializeWorker*` vs `createSession*`). Note: responsibility clustering is the primary signal, not raw line count.
-- **Module Design** — Evaluate cohesion, coupling, and encapsulation. See "Design Review Mindset" in CLAUDE.md for detailed module evaluation criteria.
+- **Module Design** — Evaluate cohesion, coupling, and encapsulation using these perspectives:
+  - Is each module cohesive? (single responsibility, would you name it the same after reading all contents?)
+  - Is coupling minimized? (can change without forcing changes elsewhere?)
+  - Is the interface well-encapsulated? (public API reveals only what callers need?)
+  - Is the dependency direction correct? (high-level modules don't depend on low-level details)
+  - Is the placement appropriate? (module-specific or shared, aligned with scope of responsibility)
+  - Is the interface actually usable? (callers can pass the information they need)
+  - Do default values contradict state? (default makes sense when other fields are unset)
 - **Open-Closed Principle** — New features addable without modifying existing code.
 - **Change Localization** — Single feature change contained within a small area. Watch for Shotgun Surgery.
 - **Dependency Management** — Dependencies injected, loosely coupled, abstracted via interfaces.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,132 +1,8 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+## Project Overview
 
-## Working Principles
-
-**Purpose over speed.** Do not rush to finish quickly at the expense of losing sight of the original purpose. Code that fails to achieve its purpose wastes more time than code written correctly from the start.
-
-**Do not blindly follow existing patterns.** Existing code is not automatically correct. Evaluate whether patterns in the codebase are appropriate before adopting them.
-
-**Enforce constraints through structure, not convention.** If a constraint can be expressed in the type system, do not enforce it through runtime checks, wrapper functions, documentation, or code review. `string` where a union type would work, `Record<string, string>` where a typed interface would work, a runtime guard that re-checks what the compiler could guarantee — all are type safety gaps. Convention can be bypassed; the compiler cannot. Always choose the path that makes invalid states unrepresentable.
-
-**Define types by what they represent, not where they're used.** When creating a type, ask: is this a system-wide concept or a package-internal implementation detail? A type's home is determined by the scope of the concept it models, not by which module first needs it.
-
-**Think before you act.** When facing a problem, first consider the correct approach rather than immediately implementing the easiest solution.
-
-**Speak up about issues.** When you notice something inappropriate or problematic outside the current task scope, mention it as a supplementary note. Do not silently ignore issues just because they are not directly related to the task at hand.
-
-**Ask when uncertain.** When uncertain about a design decision, do not decide arbitrarily. Ask the user for confirmation.
-
-**Validate task assumptions before implementing.** Before implementing any task, understand WHY the task is needed. If a task assumes existing behavior that seems questionable, verify whether that assumption is correct. Do not implement a "fix" for behavior that may not actually need fixing. When in doubt, ask the user to confirm the underlying assumption.
-
-## Design Review Mindset
-
-The following are perspectives to revisit repeatedly during design. This is not a one-way checklist.
-
-- Is the existing pattern truly appropriate?
-  - Are you following it just because other code does so?
-  - When uncertain, ask the user
-
-- Have you considered abstraction? Have you judged whether it is truly necessary after attempting it?
-  - Do not avoid abstraction; judge its necessity after considering it
-
-- Is the module cohesive?
-  - Does each file/class/module have a single, clear responsibility?
-  - If you removed any part, would the rest still make sense as a unit?
-  - Would you name this module the same way after reading all its contents?
-
-- Is coupling minimized?
-  - Can this module change without forcing changes elsewhere?
-  - Does this module depend on implementation details of another?
-  - Would a new team member understand this module without reading its dependencies?
-
-- Is the interface well-encapsulated?
-  - Does the public API reveal only what callers need?
-  - Are implementation details hidden behind stable interfaces?
-  - Can the internal implementation change without affecting callers?
-
-- Is the dependency direction correct?
-  - Do high-level modules depend on low-level details? (They shouldn't)
-  - Are dependencies explicit (imports) rather than implicit (global state, conventions)?
-
-- Is the placement appropriate?
-  - Module-specific or shared?
-  - Does it align with the scope of responsibility?
-
-- Is the interface actually usable?
-  - Is the design such that callers cannot pass the information they need?
-
-- Does the naming cause misunderstanding in context?
-  - Can you predict the value from the name?
-  - Is it consistent with existing naming conventions in the codebase?
-
-- Do default values contradict state?
-  - Does the default value make sense when other fields are unset?
-
-- Is there anything unnecessary? Can it be deleted?
-  - Prioritize deletion over addition
-
-## Subagent and Skill Usage Policy
-
-**Primary agent as coordinator.** The primary agent (first launched) MUST NOT write code directly. Instead:
-1. Understand user requirements
-2. Plan the approach
-3. Delegate implementation to specialist subagents
-4. Evaluate results and coordinate next steps
-
-**MUST delegate code changes to specialists:**
-
-| File Location | Subagent to Use |
-|---------------|-----------------|
-| `packages/client/**` | `frontend-specialist` |
-| `packages/server/**` | `backend-specialist` |
-| `packages/shared/**` | Choose based on primary consumer |
-| Multiple packages | Launch both specialists in parallel |
-
-**Other subagents:**
-
-Built-in:
-- `Explore` - Codebase navigation and understanding
-- `Plan` - Designing complex changes
-
-Project-defined (`.claude/agents/`):
-- `frontend-specialist` - Implementing frontend features and fixes in packages/client
-- `backend-specialist` - Implementing backend features and fixes in packages/server
-- `test-runner` - Running tests and analyzing failures
-- `test-reviewer` - Evaluating test adequacy (use after tests are modified)
-- `code-quality-reviewer` - Evaluating design and maintainability
-- `ux-architecture-reviewer` - Verifying state consistency in client-server interactions
-- `claude-config-specialist` - Analyzing and improving Claude Code configuration (.claude/, CLAUDE.md)
-- `coderabbit-reviewer` - External AI review via CodeRabbit CLI (optional, skips if CLI not installed)
-
-Auto-loaded rules (in `.claude/rules/`):
-- **Frontend rules:** `.claude/rules/frontend.md` - Auto-loaded for `packages/client/**`
-- **Backend rules:** `.claude/rules/backend.md` - Auto-loaded for `packages/server/**`
-- **Testing rules:** `.claude/rules/testing.md` - Auto-loaded for `**/*.test.*`
-- **Verification rules:** `.claude/rules/verification.md` - Always loaded (commands, branching, commits, code quality)
-
-Project-defined skills (in `.claude/skills/`):
-- **Development workflow standards:** `.claude/skills/development-workflow-standards/` - Detailed procedures (conflict assessment, TDD steps)
-- **Code quality standards:** `.claude/skills/code-quality-standards/` - Evaluation criteria for code reviews
-- **Frontend standards:** `.claude/skills/frontend-standards/` - Detailed code examples and patterns
-- **Backend standards:** `.claude/skills/backend-standards/` - Detailed code examples and patterns
-- **Test standards:** `.claude/skills/test-standards/` - Server Bridge Pattern, form testing procedures
-- **UX design standards:** `.claude/skills/ux-design-standards/` - UX design principles for multi-agent management UI
-
-**Parallel execution.** When changes span multiple packages, launch specialists in parallel:
-- Frontend and backend changes → `frontend-specialist` + `backend-specialist` simultaneously
-- After implementation → `test-runner` for verification
-
-**Propose missing subagents or skills.** When you identify a recurring task pattern that would benefit from a specialized subagent or skill but none exists, propose it to the user. Use `/agents` command to create interactively.
-
-## Language Policy
-
-**Public artifacts:** Write all code comments, commit messages, issues, pull requests, and documentation (including files under `docs/`) in English. These are visible to the broader community.
-
-**User-facing artifacts:** Review annotations, memos, and other content visible only to the user should follow the user's preferred language. Adapt to the same language the user uses.
-
-**Communication with Claude:** Respond in the same language the user uses. Technical terms and code identifiers can remain in English.
+A web application for managing multiple AI coding agent instances (Claude Code, etc.) running in different git worktrees. Instead of scattered terminals, users control all instances through a unified browser interface using xterm.js.
 
 ## Project Structure
 
@@ -135,10 +11,6 @@ Monorepo with Bun workspaces:
 - `packages/server` - Bun backend with Hono framework and native WebSocket
 - `packages/shared` - Shared types and utilities
 
-## Project Overview
-
-A web application for managing multiple AI coding agent instances (Claude Code, etc.) running in different git worktrees. Instead of scattered terminals, users control all instances through a unified browser interface using xterm.js.
-
 ## Core Concepts
 
 - **Session**: A working context tied to a worktree or arbitrary directory. Each session can have multiple workers.
@@ -146,6 +18,10 @@ A web application for managing multiple AI coding agent instances (Claude Code, 
   - **Agent Worker**: Runs an AI agent (e.g., Claude Code)
   - **Terminal Worker**: A plain terminal shell
 - **Agent**: Definition of an AI tool (command, activity patterns, etc.). Claude Code is built-in; custom agents can be registered.
+
+## Subagent Policy
+
+**Primary agent MUST NOT write production code directly.** Delegate to specialist subagents defined in `.claude/agents/`. Each package's rule file (auto-loaded by path) specifies which specialist to use.
 
 ## Architecture
 
@@ -158,23 +34,3 @@ See [docs/design/session-worker-design.md](docs/design/session-worker-design.md)
 - WebSocket provides real-time communication (see [docs/design/websocket-protocol.md](docs/design/websocket-protocol.md))
   - `/ws/app` - App-wide state synchronization
   - `/ws/session/:sessionId/worker/:workerId` - Individual worker I/O
-
-## Reference
-
-Details for each domain are defined in rules, skills, and docs. Rules (`.claude/rules/`) are auto-loaded by file path; skills provide detailed procedures and code examples.
-
-| Topic | Rules (auto-loaded) | Skills (explicit) |
-|-------|---------------------|-------------------|
-| Verification, commands, branching, commits | `.claude/rules/verification.md` (always) | `development-workflow-standards` (procedures) |
-| Frontend (React, TanStack, Tailwind, Valibot) | `.claude/rules/frontend.md` (`packages/client/**`) | `frontend-standards` (code examples) |
-| Backend (Hono, Bun, PTY, WebSocket, logging) | `.claude/rules/backend.md` (`packages/server/**`) | `backend-standards` (code examples) |
-| Testing (methodology, anti-patterns) | `.claude/rules/testing.md` (`**/*.test.*`) | `test-standards` (patterns, bridge testing) |
-| Code quality (design principles, evaluation) | — | `code-quality-standards` skill |
-| UX design principles | — | `ux-design-standards` skill |
-
-| Topic | Source |
-|-------|--------|
-| WebSocket protocol specification | [docs/design/websocket-protocol.md](docs/design/websocket-protocol.md) |
-| Terminal state sync design | [docs/design/terminal-state-sync.md](docs/design/terminal-state-sync.md) |
-| Session/Worker data model | [docs/design/session-worker-design.md](docs/design/session-worker-design.md) |
-| Testing guidelines (human reference) | [docs/testing-guidelines.md](docs/testing-guidelines.md) |


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: 180 → 36 lines — project overview and subagent policy only
- **rules/backend.md**: 203 → 77 lines — removed skill-duplicated content, added delegation instruction
- **rules/frontend.md**: 177 → 86 lines — same treatment
- **rules/design-principles.md**: New file with Working Principles (moved from CLAUDE.md)
- **rules/verification.md**: Full Language Policy integrated
- **code-quality-standards/SKILL.md**: Design Review Mindset inlined

Follows official best practices: CLAUDE.md < 200 lines, rules < 100 lines each, no duplication between rules and skills.

## Test plan
- [ ] Verify rules auto-load correctly (path-scoped)
- [ ] Verify delegated agents receive correct specialist instructions
- [ ] No production code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)