### PR TITLE
[AI] closed #496 feat: forward ESC key from message panel to terminal for agent interruption

### DIFF
--- a/packages/client/src/components/sessions/MessagePanel.tsx
+++ b/packages/client/src/components/sessions/MessagePanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, forwardRef, useImperativeHand
 import type { WorkerMessage } from '@agent-console/shared';
 import { MAX_MESSAGE_FILES, MAX_TOTAL_FILE_SIZE } from '@agent-console/shared';
 import { sendWorkerMessage } from '../../lib/api';
+import { sendInput as sendPtyInput } from '../../lib/worker-websocket';
 import { useDraftMessage } from '../../hooks/useDraftMessage';
 
 interface MessagePanelProps {
@@ -109,8 +110,13 @@ export const MessagePanel = forwardRef<MessagePanelHandle, MessagePanelProps>(
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
       e.preventDefault();
       handleSend();
+      return;
     }
-  }, [handleSend]);
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      sendPtyInput(sessionId, targetWorkerId, '\x1b');
+    }
+  }, [handleSend, sessionId, targetWorkerId]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();

--- a/packages/client/src/components/sessions/__tests__/MessagePanel.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/MessagePanel.test.tsx
@@ -16,6 +16,11 @@ mock.module('../../../lib/api', () => ({
   sendWorkerMessage: mockSendWorkerMessage,
 }));
 
+const mockSendInput = mock(() => true);
+mock.module('../../../lib/worker-websocket', () => ({
+  sendInput: mockSendInput,
+}));
+
 import { fireEvent, cleanup, act, within } from '@testing-library/react';
 import { renderWithRouter } from '../../../test/renderWithRouter';
 import { MessagePanel, canSend, validateFiles } from '../MessagePanel';
@@ -114,6 +119,7 @@ describe('MessagePanel', () => {
   afterEach(() => {
     cleanup();
     mockSendWorkerMessage.mockClear();
+    mockSendInput.mockClear();
   });
 
   it('renders send form with textarea and send button', async () => {
@@ -336,6 +342,49 @@ describe('MessagePanel', () => {
     });
     const textarea3 = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
     expect((textarea3 as HTMLTextAreaElement).value).toBe('draft for agent-1');
+  });
+
+  it('ESC key sends escape character to PTY via WebSocket', async () => {
+    const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+    const view = within(container);
+
+    const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'Escape' });
+    });
+
+    expect(mockSendInput).toHaveBeenCalledWith('session-1', 'agent-1', '\x1b');
+  });
+
+  it('ESC key preserves draft content in textarea', async () => {
+    const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+    const view = within(container);
+
+    const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'my draft' } });
+    });
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'Escape' });
+    });
+
+    expect((textarea as HTMLTextAreaElement).value).toBe('my draft');
+    expect(mockSendInput).toHaveBeenCalledWith('session-1', 'agent-1', '\x1b');
+  });
+
+  it('ESC key does not trigger HTTP message send', async () => {
+    const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+    const view = within(container);
+
+    const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'hello' } });
+    });
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'Escape' });
+    });
+
+    expect(mockSendWorkerMessage).not.toHaveBeenCalled();
   });
 
   it('clears draft on successful send', async () => {


### PR DESCRIPTION
## Summary
- When the message panel textarea is focused, pressing ESC now sends `\x1b` to the active worker's PTY via WebSocket `sendInput()`
- Draft content in the textarea is preserved after ESC
- Textarea retains focus after ESC
- ESC does not trigger the HTTP message send API

## Changes
- `MessagePanel.tsx`: Import `sendInput` from `worker-websocket.ts` and handle ESC keydown in the existing `handleKeyDown` callback
- `MessagePanel.test.tsx`: Add 3 tests verifying ESC forwards to PTY, preserves draft, and doesn't trigger HTTP send

## Test plan
- [x] All 2010 tests pass (0 fail)
- [x] New ESC key tests verify correct behavior
- [x] Typecheck passes (pre-existing TanStack Router type errors only)

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)