### PR TITLE
fix: gitignore pattern for routeTree.gen.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ npm-debug.log*
 .env.*.local
 
 # TanStack Router generated files
-src/routeTree.gen.ts
+**/routeTree.gen.ts
 
 # Claude Code local settings
 .claude/settings.local.json


### PR DESCRIPTION
## Summary
- Changed `src/routeTree.gen.ts` to `**/routeTree.gen.ts` in root `.gitignore`
- The file is generated at `packages/client/src/routeTree.gen.ts` which didn't match the previous pattern
- This caused untracked file errors when removing worktrees after running dev server

## Test plan
- [ ] Verify `git status` no longer shows routeTree.gen.ts as untracked after `bun run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)