### PR TITLE
docs: sprint retrospective improvements (2026-04-04)

### DIFF
--- a/.claude/skills/frontend-standards/frontend-standards.md
+++ b/.claude/skills/frontend-standards/frontend-standards.md
@@ -326,3 +326,31 @@ See the [TanStack Query](#tanstack-query) section for key factory patterns and i
 
 - Display user-friendly error messages
 - Provide retry mechanisms where appropriate
+
+## Browser Verification (UI changes)
+
+**Mandatory for PRs that change UI components, layout, or styling.**
+
+When a PR modifies visual elements, verify the actual rendered result using Chrome MCP before reporting acceptance.
+
+### Procedure
+1. Find free ports: `lsof -i :<port>` to check availability
+2. Start dev server from the PR's worktree: `CLIENT_PORT=<free> PORT=<free> bun run dev`
+3. Navigate Chrome to the frontend URL (the CLIENT_PORT, not the backend PORT)
+4. Take screenshots at both viewport sizes:
+   - **PC**: 1200x700
+   - **Mobile**: 375x667
+5. Evaluate the UI yourself — do not just confirm "it renders". Check:
+   - Layout and spacing
+   - Information hierarchy (is the most important action prominent?)
+   - Redundancy (duplicate labels, unnecessary descriptions)
+   - Responsiveness (does mobile fallback work?)
+   - Accessibility (buttons reachable, text readable)
+6. Stop dev server after verification
+
+### What to check
+- Component layout changes
+- Styling / Tailwind class changes
+- New UI elements or dialogs
+- Responsive behavior
+- Form interactions (tab through fields, submit button reachable)

--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -36,6 +36,7 @@ You are acting as the Orchestrator of this project. Your job is strategic decisi
   4. `ExitWorktree` with `action: "keep"` (worktree is cleaned up after PR merge)
   This reduces 5-10 minute delegation cycles to ~2 minutes for trivial changes.
 - **Use TaskCreate for multi-step procedures.** When executing enumerated steps from skills (e.g., sprint retrospective, sprint start), create a task checklist via `TaskCreate`/`TaskUpdate` to track progress and prevent step omission. Exception: procedures that have a dedicated script (e.g., `acceptance-check.js`) should use the script instead.
+- **Know your weakness: procedural compliance.** LLMs are good at knowledge-based judgment (evaluating UX, reviewing code, discussing architecture) but structurally bad at following fixed checklists without skipping steps. When a procedure has enumerated steps, always use TaskCreate or an external script — never rely on memory alone. If you notice yourself thinking "I can skip this step", that is the exact moment you must not skip it.
 
 ### DO NOT
 - Write or edit **production code** — always delegate to coding agents. Non-production files (docs/, .claude/skills/**, .claude/agents/**, CLAUDE.md) may be edited by the Orchestrator, but always in a separate worktree (`EnterWorktree`), never in the Orchestrator session itself.

--- a/.claude/skills/orchestrator/core-responsibilities.md
+++ b/.claude/skills/orchestrator/core-responsibilities.md
@@ -32,10 +32,11 @@
 - **Always set `useRemote: true`** when calling `delegate_to_worktree` to branch from `origin/main` instead of the (potentially stale) local main. This prevents worktrees from being based on outdated code.
 - Track active sessions via `list_sessions` and `get_session_status`
 - When delegating, always include: clear scope, relevant Issue URL, branch naming. Only instruct `/review-loop` when the Orchestrator determines it necessary — for large-scale changes or changes affecting security/architecture. You may specify only the reviewers relevant to the change, not all reviewers.
+- **Verify affected components on main before delegating.** The orchestrator's worktree may be behind main. Always check the current state of affected files with `git show main:<path>` or by reading the main worktree. Do not assume your local code is current. (Lesson: #500 — delegated with wrong target component because the orchestrator's worktree was stale.)
 - Before delegating, review and update the Issue's acceptance criteria:
   1. Read the acceptance criteria in the Issue
   2. Evaluate whether they are complete based on your knowledge (design discussions, other PR context, architectural decisions)
-  3. **Impact inventory**: Read the affected files and identify all state-changing operations. Present this list to the owner for review BEFORE delegating.
+  3. **Impact inventory**: Read the affected files on main (`git show main:<path>`) and identify all state-changing operations. Present this list to the owner for review BEFORE delegating.
   4. Update the Issue if criteria need to be added or corrected
   5. You must be able to explain each criterion in your own words before delegating
 - **Generate delegation messages**: Run `node .claude/skills/orchestrator/delegation-prompt.js <Issue number>` to generate a delegation prompt template. The Issue is the source of truth — the prompt references the Issue URL and provides a placeholder for supplementary notes only. Customize the "Key Implementation Notes" section with constraints or context not already in the Issue before sending.


### PR DESCRIPTION
## Summary
Sprint retrospective improvements from 2026-04-04 sprint.

- **Orchestrator self-awareness rule**: LLMs are bad at procedural compliance — always use TaskCreate or external scripts for checklists
- **Verify components on main before delegating**: Prevents stale worktree code from causing wrong delegation targets (#500 incident)
- **Browser Verification for UI changes**: Mandatory Chrome MCP verification procedure added to frontend-standards

## Test plan
- [ ] Verify orchestrator skill loads correctly
- [ ] Verify frontend-standards skill loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)