### PR TITLE
[AI] closed #525 fix: connection indicator incorrectly shows 'Starting Claude...' for unrelated sessions

### DIFF
--- a/packages/client/src/components/sessions/hooks/__tests__/useSessionPageState.test.ts
+++ b/packages/client/src/components/sessions/hooks/__tests__/useSessionPageState.test.ts
@@ -30,6 +30,8 @@ mock.module('../../../../hooks/useAppWs', () => ({
 
 // Must import AFTER mock.module
 import { renderHook, act } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { SessionDataContext, type SessionDataContextValue } from '../../../../contexts/root-contexts'
 import { useSessionPageState, type UseSessionPageStateOptions } from '../useSessionPageState'
 
 // --- Fetch-level mocking ---
@@ -116,12 +118,28 @@ function createDefaultOptions(overrides: Partial<UseSessionPageStateOptions> = {
   }
 }
 
+/** Create a SessionDataContext wrapper for renderHook */
+function createContextWrapper(rootActivityStates: Record<string, Record<string, AgentActivityState>> = {}) {
+  const contextValue: SessionDataContextValue = {
+    sessions: [],
+    wsInitialized: true,
+    workerActivityStates: rootActivityStates,
+  }
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(SessionDataContext.Provider, { value: contextValue }, children)
+  }
+}
+
 /**
  * Mount the hook and wait for initial load to complete.
  * After mounting, capturedCallbacks contains the WS event handlers registered by the hook.
  */
-async function mountHook(options: UseSessionPageStateOptions) {
-  const hookResult = renderHook(() => useSessionPageState(options))
+async function mountHook(
+  options: UseSessionPageStateOptions,
+  rootActivityStates: Record<string, Record<string, AgentActivityState>> = {},
+) {
+  const wrapper = createContextWrapper(rootActivityStates)
+  const hookResult = renderHook(() => useSessionPageState(options), { wrapper })
 
   // Flush initial load fetch
   await act(async () => {})
@@ -191,6 +209,57 @@ describe('useSessionPageState', () => {
       const { result } = await mountHook(createDefaultOptions())
 
       expect(result.current.state.type).toBe('server_unavailable')
+    })
+
+    it('should initialize workerActivityStates from root context', async () => {
+      const session = createMockSession({ status: 'active' })
+      getSessionResponse = session
+
+      const rootActivityStates = {
+        'session-1': {
+          'agent-worker-1': 'active' as AgentActivityState,
+          'terminal-worker-1': 'idle' as AgentActivityState,
+        },
+      }
+
+      const { result } = await mountHook(createDefaultOptions(), rootActivityStates)
+
+      expect(result.current.workerActivityStates).toEqual({
+        'agent-worker-1': 'active',
+        'terminal-worker-1': 'idle',
+      })
+    })
+
+    it('should initialize activityState from root context for active tab', async () => {
+      const session = createMockSession({ status: 'active' })
+      getSessionResponse = session
+
+      const refs = createMockRefs()
+      refs.activeTabIdRef.current = 'agent-worker-1'
+      const options = createDefaultOptions({
+        updateTabsFromSessionRef: refs.updateTabsFromSessionRef,
+        activeTabIdRef: refs.activeTabIdRef,
+      })
+
+      const rootActivityStates = {
+        'session-1': {
+          'agent-worker-1': 'idle' as AgentActivityState,
+        },
+      }
+
+      const { result } = await mountHook(options, rootActivityStates)
+
+      expect(result.current.activityState).toBe('idle')
+    })
+
+    it('should default to unknown when root context has no data for session', async () => {
+      const session = createMockSession({ status: 'active' })
+      getSessionResponse = session
+
+      const { result } = await mountHook(createDefaultOptions(), {})
+
+      expect(result.current.activityState).toBe('unknown')
+      expect(result.current.workerActivityStates).toEqual({})
     })
   })
 
@@ -800,7 +869,6 @@ describe('useSessionPageState', () => {
       })
 
       const { result } = await mountHook(options)
-      expect(result.current.activityState).toBe('unknown')
 
       act(() => {
         capturedCallbacks.onWorkerActivity?.('session-1', 'agent-worker-1', 'asking')

--- a/packages/client/src/components/sessions/hooks/__tests__/useTabManagement.test.ts
+++ b/packages/client/src/components/sessions/hooks/__tests__/useTabManagement.test.ts
@@ -179,6 +179,51 @@ describe('useTabManagement', () => {
       // The initialization effect redirects to the default worker
       expect(navigateToWorker).toHaveBeenCalledWith('agent-1', true);
     });
+
+    it('sets activityState from workerActivityStates when urlWorkerId is valid', () => {
+      const workers = [createAgentWorker('agent-1'), createTerminalWorker('terminal-1')];
+      const setActivityState = mock(() => {});
+      const options = createDefaultOptions({
+        activeSession: { workers },
+        urlWorkerId: 'agent-1',
+        workerActivityStates: { 'agent-1': 'idle' as AgentActivityState },
+        setActivityState,
+      });
+
+      renderHook(() => useTabManagement(options));
+
+      expect(setActivityState).toHaveBeenCalledWith('idle');
+    });
+
+    it('sets activityState from workerActivityStates when redirecting to default tab', () => {
+      const workers = [createAgentWorker('agent-1')];
+      const setActivityState = mock(() => {});
+      const options = createDefaultOptions({
+        activeSession: { workers },
+        urlWorkerId: undefined,
+        workerActivityStates: { 'agent-1': 'active' as AgentActivityState },
+        setActivityState,
+      });
+
+      renderHook(() => useTabManagement(options));
+
+      expect(setActivityState).toHaveBeenCalledWith('active');
+    });
+
+    it('sets activityState to unknown when worker has no known state on init', () => {
+      const workers = [createAgentWorker('agent-1')];
+      const setActivityState = mock(() => {});
+      const options = createDefaultOptions({
+        activeSession: { workers },
+        urlWorkerId: 'agent-1',
+        workerActivityStates: {},
+        setActivityState,
+      });
+
+      renderHook(() => useTabManagement(options));
+
+      expect(setActivityState).toHaveBeenCalledWith('unknown');
+    });
   });
 
   describe('URL sync', () => {

--- a/packages/client/src/components/sessions/hooks/useSessionPageState.ts
+++ b/packages/client/src/components/sessions/hooks/useSessionPageState.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef, type MutableRefObject } from 'react'
 import { getSession, ServerUnavailableError } from '../../../lib/api'
 import { useAppWsEvent } from '../../../hooks/useAppWs'
+import { useSessionDataContext } from '../../../contexts/root-contexts'
 import { resolveResumedState } from '../sessionResumedState'
 import { logger } from '../../../lib/logger'
 import type { Session, AgentActivityState, WorkerActivityInfo, WorkerMessage, Worker } from '@agent-console/shared'
@@ -58,8 +59,18 @@ export function useSessionPageState({
   // must read this ref because React 18 automatic batching defers setState updaters.
   const stateRef = useRef(state)
   stateRef.current = state
-  const [activityState, setActivityState] = useState<AgentActivityState>('unknown')
-  const [workerActivityStates, setWorkerActivityStates] = useState<Record<string, AgentActivityState>>({})
+
+  // Initialize activity states from the root context (which already has synced data
+  // from the app-wide WebSocket). This prevents the "Starting Claude..." flash that
+  // occurs when activityState starts as 'unknown' and the per-worker WS connects
+  // before any worker-activity event arrives.
+  const { workerActivityStates: rootActivityStates } = useSessionDataContext()
+  const initialSessionActivities = rootActivityStates[sessionId] ?? {}
+  const [activityState, setActivityState] = useState<AgentActivityState>(() => {
+    const tabId = activeTabIdRef.current
+    return tabId ? (initialSessionActivities[tabId] ?? 'unknown') : 'unknown'
+  })
+  const [workerActivityStates, setWorkerActivityStates] = useState<Record<string, AgentActivityState>>(initialSessionActivities)
   const [lastMessage, setLastMessage] = useState<WorkerMessage | null>(null)
   const [resumeKey, setResumeKey] = useState(0)
   const [loadTrigger, setLoadTrigger] = useState(0)

--- a/packages/client/src/components/sessions/hooks/useTabManagement.ts
+++ b/packages/client/src/components/sessions/hooks/useTabManagement.ts
@@ -75,13 +75,15 @@ export function useTabManagement({
 
       if (urlWorkerExists) {
         setActiveTabId(urlWorkerId);
+        setActivityState(workerActivityStates[urlWorkerId] ?? 'unknown');
       } else {
         // Calculate default tab
         const defaultTabId = findFirstAgentWorker(workers)?.id ?? newTabs[0]?.id ?? null;
         setActiveTabId(defaultTabId);
 
-        // Redirect to the default worker URL
         if (defaultTabId) {
+          setActivityState(workerActivityStates[defaultTabId] ?? 'unknown');
+          // Redirect to the default worker URL
           navigateToWorker(defaultTabId, true);
         }
       }


### PR DESCRIPTION
## Summary
- Initialize `workerActivityStates` and `activityState` from the root context (`SessionDataContext`) when `useSessionPageState` mounts, instead of starting from empty/unknown
- Set `activityState` during initial tab selection in `useTabManagement`, so the indicator reflects the correct state immediately on session navigation
- Added tests for root context initialization and initial tab activity state sync

## Root Cause
When navigating between sessions, `SessionPage` remounts (via `key={sessionId}`), but `useSessionPageState` initialized `activityState` as `'unknown'` and `workerActivityStates` as `{}`. The root context already had the correct synced data from the app-wide WebSocket, but it was never read during initialization. This caused `getConnectionStatusText()` to return "Starting Claude..." (connected + unknown) until a `worker-activity` WebSocket event arrived.

## Test plan
- [x] All 1252 client tests pass (0 failures)
- [x] Type check passes (no new errors)
- [x] New tests verify initialization from root context
- [x] New tests verify `setActivityState` called during tab initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)