### PR TITLE
fix: exclude shared/src/types/ from acceptance-check coverage requirements

### DIFF
--- a/.claude/skills/orchestrator/acceptance-check.js
+++ b/.claude/skills/orchestrator/acceptance-check.js
@@ -112,12 +112,18 @@ const COVERAGE_PATTERNS = [
   /^packages\/shared\/src\/.+\.ts$/,
 ];
 
+// Files excluded from coverage requirements (no runtime logic to test)
+const COVERAGE_EXCLUSIONS = [
+  /^packages\/shared\/src\/types\/.+\.ts$/,
+];
+
 function isTestFile(filePath) {
   return filePath.includes('.test.') || filePath.includes('.spec.') || filePath.includes('__tests__/');
 }
 
 function requiresTestCoverage(filePath) {
   if (isTestFile(filePath)) return false;
+  if (COVERAGE_EXCLUSIONS.some(pattern => pattern.test(filePath))) return false;
   return COVERAGE_PATTERNS.some(pattern => pattern.test(filePath));
 }
 


### PR DESCRIPTION
## Summary
- Add `COVERAGE_EXCLUSIONS` array to acceptance-check script
- Exclude `packages/shared/src/types/*.ts` from test coverage requirements
- Pure type definitions have no runtime logic — TypeScript's type checker validates them

Closes #541 (partial — type-only exclusion only, DOM-component heuristic deferred)

## Context
Sprint 2026-04-04c: 3 PRs (#538, #539, #540) all hit false positives where the coverage-check required tests for type definition files, producing meaningless tests that construct TypeScript objects and read properties back.

## Test plan
- [x] Verified `packages/shared/src/types/git-diff.ts` no longer triggers coverage requirement
- [x] Existing coverage requirements for routes, services, hooks, components unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)