### PR TITLE
refactor: convert acceptance-check wizard to STDIN/STDOUT interactive mode

### DIFF
--- a/.claude/skills/orchestrator/__tests__/acceptance-check.test.js
+++ b/.claude/skills/orchestrator/__tests__/acceptance-check.test.js
@@ -7,7 +7,7 @@ import {
   requiresTestCoverage,
   findTestFiles,
   detectIntegrationTestNeeds,
-  readResponse,
+  createStdinReader,
   getQuestions,
   printQuestion,
   printSummary,
@@ -209,21 +209,22 @@ describe('detectIntegrationTestNeeds', () => {
 
 // --- New tests for STDIN/STDOUT wizard mode ---
 
-describe('readResponse', () => {
+describe('createStdinReader', () => {
   it('reads a single null-byte terminated response', async () => {
     const stdin = createMockStdin(['hello world']);
-    const result = await readResponse(stdin);
+    const readResponse = createStdinReader(stdin);
+    const result = await readResponse();
     expect(result).toBe('hello world');
   });
 
   it('trims whitespace from response', async () => {
     const stdin = createMockStdin(['  answer with spaces  ']);
-    const result = await readResponse(stdin);
+    const readResponse = createStdinReader(stdin);
+    const result = await readResponse();
     expect(result).toBe('answer with spaces');
   });
 
   it('reads multi-chunk response before null byte', async () => {
-    // Simulate data arriving in multiple chunks before the null byte
     let pushCount = 0;
     const stdin = new Readable({
       read() {
@@ -238,25 +239,48 @@ describe('readResponse', () => {
         }
       },
     });
-    const result = await readResponse(stdin);
+    const readResponse = createStdinReader(stdin);
+    const result = await readResponse();
     expect(result).toBe('first part second part');
   });
 
-  it('handles data after null byte (ignores it)', async () => {
-    const stdin = new Readable({
-      read() {
-        this.push(Buffer.from('answer\0extra data'));
-        this.push(null);
-      },
-    });
-    const result = await readResponse(stdin);
-    expect(result).toBe('answer');
+  it('handles data after null byte by buffering for next read', async () => {
+    // Single chunk contains two answers separated by null byte
+    const stdin = createMockStdin(['first answer', 'second answer']);
+    const readResponse = createStdinReader(stdin);
+    const first = await readResponse();
+    const second = await readResponse();
+    expect(first).toBe('first answer');
+    expect(second).toBe('second answer');
   });
 
   it('handles empty response before null byte', async () => {
     const stdin = createMockStdin(['']);
-    const result = await readResponse(stdin);
+    const readResponse = createStdinReader(stdin);
+    const result = await readResponse();
     expect(result).toBe('');
+  });
+
+  it('reads multiple sequential answers from same stream', async () => {
+    const stdin = createMockStdin(['answer1', 'answer2', 'answer3']);
+    const readResponse = createStdinReader(stdin);
+    expect(await readResponse()).toBe('answer1');
+    expect(await readResponse()).toBe('answer2');
+    expect(await readResponse()).toBe('answer3');
+  });
+
+  it('handles multiple answers arriving in a single chunk', async () => {
+    // Simulate all data arriving at once with multiple null bytes
+    const stdin = new Readable({
+      read() {
+        this.push(Buffer.from('a1\0a2\0a3\0'));
+        this.push(null);
+      },
+    });
+    const readResponse = createStdinReader(stdin);
+    expect(await readResponse()).toBe('a1');
+    expect(await readResponse()).toBe('a2');
+    expect(await readResponse()).toBe('a3');
   });
 });
 
@@ -362,6 +386,15 @@ describe('printSummary', () => {
     printSummary(answers, questions);
     const output = logs.join('\n');
     expect(output).toContain('Q1: -- Not answered');
+  });
+
+  it('treats empty string answer as answered (not unanswered)', () => {
+    const questions = [{ key: 'q1' }];
+    const answers = { q1: '' };
+    printSummary(answers, questions);
+    const output = logs.join('\n');
+    expect(output).toContain('Q1: OK');
+    expect(output).not.toContain('Not answered');
   });
 });
 

--- a/.claude/skills/orchestrator/acceptance-check.js
+++ b/.claude/skills/orchestrator/acceptance-check.js
@@ -296,18 +296,31 @@ function getAcceptanceCriteria(issueNumber) {
 
 // --- STDIN reading (null-byte delimited) ---
 
-async function readResponse(stdin = process.stdin) {
-  const chunks = [];
-  for await (const chunk of stdin) {
-    const str = Buffer.from(chunk).toString();
-    const nullIdx = str.indexOf('\0');
-    if (nullIdx !== -1) {
-      chunks.push(str.slice(0, nullIdx));
-      break;
+/**
+ * Creates a reader that reads null-byte delimited responses from a stream.
+ * Uses a raw async iterator (via .next()) instead of for-await-of to avoid
+ * destroying the stream on break — allowing multiple sequential reads.
+ */
+function createStdinReader(stdin = process.stdin) {
+  let buffer = '';
+  const iterator = stdin[Symbol.asyncIterator]();
+
+  return async function readResponse() {
+    while (true) {
+      const nullIdx = buffer.indexOf('\0');
+      if (nullIdx !== -1) {
+        const answer = buffer.slice(0, nullIdx);
+        buffer = buffer.slice(nullIdx + 1);
+        return answer.trim();
+      }
+      const { value, done } = await iterator.next();
+      if (done) break;
+      buffer += Buffer.from(value).toString();
     }
-    chunks.push(str);
-  }
-  return chunks.join('').trim();
+    const answer = buffer;
+    buffer = '';
+    return answer.trim();
+  };
 }
 
 // --- CI status check ---
@@ -601,8 +614,8 @@ function printQuestion(question) {
 function printSummary(answers, questions) {
   console.log('=== Answer Summary ===');
   for (const q of questions) {
-    const answer = answers[q.key];
-    if (answer) {
+    if (q.key in answers) {
+      const answer = answers[q.key];
       const display = answer.length > 100 ? answer.substring(0, 100) + '...' : answer;
       console.log(`${q.key.toUpperCase()}: OK ${display}`);
     } else {
@@ -632,10 +645,11 @@ async function runWizard(prNumber, { stdin = process.stdin } = {}) {
   const hasAcceptanceCriteria = autoDetection.acceptanceCriteria.length > 0;
   const questions = getQuestions(hasAcceptanceCriteria);
   const answers = {};
+  const readResponse = createStdinReader(stdin);
 
   for (const question of questions) {
     printQuestion(question);
-    const answer = await readResponse(stdin);
+    const answer = await readResponse();
     answers[question.key] = answer;
     console.log(`OK ${question.key.toUpperCase()} answered`);
     console.log();
@@ -723,7 +737,7 @@ export {
   detectIntegrationTestNeeds,
   listExistingIntegrationTests,
   INTEGRATION_TRIGGER_PATTERNS,
-  readResponse,
+  createStdinReader,
   runWizard,
   getQuestions,
   printQuestion,


### PR DESCRIPTION
## Summary

- Converted acceptance-check wizard from file-based state persistence (repeated CLI invocations) to a single interactive STDIN/STDOUT process
- Script now outputs each question to STDOUT, blocks on STDIN (null-byte delimited) for answer, then continues to next question
- First real-world consumer of Interactive Process MCP tools (#530)
- `--check-only` mode is completely unchanged

## Changes

- **Removed**: `loadState()`, `saveState()`, `getStateFilePath()`, file-based JSON state persistence
- **Removed**: CLI argument parsing for `q1 "answer"` mode, `printAnswerCommand()`
- **Added**: `readResponse()` — reads STDIN until null-byte (`\0`) delimiter
- **Added**: `runWizard()` — async loop through Q1-Q7 with STDIN/STDOUT interaction
- **Updated**: `printSummary()` — accepts answers + questions directly instead of state object
- **Added**: Unit tests for `readResponse`, `getQuestions`, `printQuestion`, `printSummary`, `printPostAcceptanceWorkflow`

## Test plan

- [x] All 34 existing + new unit tests pass
- [x] `--check-only` mode verified manually
- [x] Server and shared typecheck pass
- [x] Full test suite passes (client: 275, integration: 16, server: 2116 — all 0 fail)

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)