### PR TITLE
fix: interactive process does not exit after script completes

### DIFF
--- a/.claude/skills/orchestrator/acceptance-check.js
+++ b/.claude/skills/orchestrator/acceptance-check.js
@@ -771,5 +771,6 @@ if (!prNumber || !/^\d+$/.test(prNumber)) {
 
 // Interactive wizard mode: outputs questions to STDOUT, reads answers from STDIN
 await runWizard(prNumber);
+process.exit(0);
 
 } // end isMainModule guard

--- a/packages/server/src/services/__tests__/interactive-process-manager.test.ts
+++ b/packages/server/src/services/__tests__/interactive-process-manager.test.ts
@@ -101,6 +101,40 @@ describe('InteractiveProcessManager', () => {
       expect(exitInfo.status).toBe('exited');
       expect(exitInfo.exitCode).toBe(0);
     });
+
+    it('should detect exit when a stdin-reading script calls process.exit(0)', async () => {
+      // Simulates the fix for #546: a script that reads from stdin via async iterator
+      // must call process.exit(0) after completing work, otherwise stdin keeps it alive.
+      const script = `
+        const iter = process.stdin[Symbol.asyncIterator]();
+        const { value } = await iter.next();
+        const input = Buffer.from(value).toString().replace('\\0', '').trim();
+        console.log('received: ' + input);
+        process.exit(0);
+      `;
+      const processInfo = await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: `bun -e "${script.replace(/"/g, '\\"')}"`,
+      });
+
+      // Send input to unblock the script
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      await manager.writeResponse(processInfo.id, 'test-input');
+
+      // Wait for exit
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline) {
+        if (onExit.mock.calls.length > 0) break;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      expect(onExit).toHaveBeenCalled();
+      const [exitInfo] = onExit.mock.calls[0];
+      expect(exitInfo.status).toBe('exited');
+      expect(exitInfo.exitCode).toBe(0);
+    });
+
   });
 
   describe('killProcess', () => {


### PR DESCRIPTION
## Summary

- Add `process.exit(0)` after `runWizard()` in acceptance-check.js to prevent the open STDIN async iterator from keeping the Node.js event loop alive
- Add test verifying that a stdin-reading script with `process.exit(0)` properly exits and is detected by InteractiveProcessManager

Fixes #546

## Root Cause

The `createStdinReader()` function creates an async iterator on `process.stdin`. Even after `runWizard()` completes and all output is done, the open STDIN stream prevents the process from exiting. The fix is simply calling `process.exit(0)` after the wizard finishes.

## Server-side consideration

Considered closing STDIN from the server side after output streams end, but this doesn't help because `sh -c` wrapping means stdout/stderr stay open until the entire shell process exits — creating a circular dependency (stdout waits for process exit, which waits for stdin close). The script-side `process.exit(0)` is the correct and sufficient fix.

## Test plan

- [x] Added test: stdin-reading script with `process.exit(0)` exits cleanly and InteractiveProcessManager detects exit
- [x] All existing tests pass (`bun run test`)
- [x] Typecheck passes (`bun run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)