### PR TITLE
fix: stripSystemMessages regex handles ANSI codes and Reply Instructions blocks

### DIFF
--- a/packages/client/src/lib/__tests__/terminal-utils.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-utils.test.ts
@@ -152,6 +152,44 @@ describe('terminal-utils', () => {
       const input = 'output\n[internal:reviewed] review done\n[internal:review-comment] comment here\nmore';
       expect(stripSystemMessages(input)).toBe('output\nmore');
     });
+
+    it('should strip [internal:*] with ANSI codes before the bracket', () => {
+      const input = 'normal\n\x1b[1m\x1b[33m[internal:timer]\x1b[0m timestamp=123 intent=inform\nmore';
+      expect(stripSystemMessages(input)).toBe('normal\nmore');
+    });
+
+    it('should strip [internal:*] wrapped entirely in ANSI codes', () => {
+      const input = 'normal\n\x1b[90m[internal:timer] timestamp=123 intent=inform\x1b[0m\nmore';
+      expect(stripSystemMessages(input)).toBe('normal\nmore');
+    });
+
+    it('should strip [internal:*] with complex ANSI SGR sequences', () => {
+      const input = 'before\n\x1b[1;33m[internal:process]\x1b[0m process started pid=42\nafter';
+      expect(stripSystemMessages(input)).toBe('before\nafter');
+    });
+
+    it('should strip [Reply Instructions] block (plain text)', () => {
+      const input =
+        'output\n[Reply Instructions] To reply, use the send_session_message MCP tool with:\n- toSessionId: "abc"\n- fromSessionId: Use your AGENT_CONSOLE_SESSION_ID environment variable\nmore';
+      expect(stripSystemMessages(input)).toBe('output\nmore');
+    });
+
+    it('should strip [Reply Instructions] block with ANSI codes', () => {
+      const input =
+        'output\n\x1b[90m[Reply Instructions] To reply, use the send_session_message MCP tool with:\x1b[0m\n\x1b[90m- toSessionId: "abc"\x1b[0m\n\x1b[90m- fromSessionId: Use your AGENT_CONSOLE_SESSION_ID environment variable\x1b[0m\nmore';
+      expect(stripSystemMessages(input)).toBe('output\nmore');
+    });
+
+    it('should strip combined [internal:*] and [Reply Instructions] block', () => {
+      const input =
+        'start\n\x1b[33m[internal:message]\x1b[0m incoming from=sess1\n\x1b[90m[Reply Instructions] To reply:\x1b[0m\n\x1b[90m- toSessionId: "sess1"\x1b[0m\n\x1b[90m- fromSessionId: Use your AGENT_CONSOLE_SESSION_ID environment variable\x1b[0m\nend';
+      expect(stripSystemMessages(input)).toBe('start\nend');
+    });
+
+    it('should not strip [Reply Instructions] at position 0 without leading newline', () => {
+      const input = '[Reply Instructions] first line\nnormal line';
+      expect(stripSystemMessages(input)).toBe('[Reply Instructions] first line\nnormal line');
+    });
   });
 
   describe('stripScrollbackClear', () => {

--- a/packages/client/src/lib/terminal-utils.ts
+++ b/packages/client/src/lib/terminal-utils.ts
@@ -47,15 +47,31 @@ export function isScrolledToBottom(terminal: TerminalScrollInfo): boolean {
  * than honoring scrollback-clear requests.
  */
 /**
- * Strip system messages (`[internal:*]`) from terminal output.
+ * Strip system messages from terminal output.
  *
- * These messages are intended for the AI agent, not the human viewer.
- * The pattern matches newline-prefixed `[internal:...]` followed by any
- * content until the next newline, so they are removed from xterm.js display
- * while remaining available to the agent via PTY.
+ * Removes two kinds of messages that are intended for the AI agent, not the human viewer:
+ *
+ * 1. `[internal:*]` lines — e.g. `[internal:timer] timestamp=... intent=inform`
+ * 2. `[Reply Instructions]` blocks — multi-line blocks with `- toSessionId:` / `- fromSessionId:` continuation lines
+ *
+ * Claude Code renders these with ANSI escape codes (e.g. `\x1b[1m\x1b[33m[internal:timer]\x1b[0m ...`),
+ * so the patterns tolerate optional ANSI SGR sequences (`\x1b[...m`) before the bracket.
  */
+
+/** Matches any number of ANSI SGR sequences (e.g. `\x1b[0m`, `\x1b[1;33m`). */
+const ANSI = '(?:\\x1b\\[[0-9;]*m)*';
+
+/** Matches a newline-prefixed `[internal:*]` line, with optional ANSI codes before the bracket. */
+const INTERNAL_RE = new RegExp(`\\n${ANSI}\\[internal:[^\\]]*\\][^\\n]*`, 'g');
+
+/** Matches a newline-prefixed `[Reply Instructions]` block including continuation lines (`- ...`). */
+const REPLY_INSTRUCTIONS_RE = new RegExp(
+  `\\n${ANSI}\\[Reply Instructions\\][^\\n]*(?:\\n${ANSI}- [^\\n]*)*`,
+  'g',
+);
+
 export function stripSystemMessages(data: string): string {
-  return data.replace(/\n\[internal:[^\]]*\][^\n]*/g, '');
+  return data.replace(INTERNAL_RE, '').replace(REPLY_INSTRUCTIONS_RE, '');
 }
 
 export function stripScrollbackClear(data: string): string {


### PR DESCRIPTION
## Summary
- Fix `stripSystemMessages` regex to tolerate ANSI SGR escape sequences (`\x1b[...m`) that Claude Code inserts before `[internal:*]` brackets
- Add stripping of `[Reply Instructions]` multi-line blocks (also with ANSI code tolerance)
- Compile regex patterns as module-level constants for performance

Closes #565

## Test plan
- [x] All existing `stripSystemMessages` tests still pass (plain text cases)
- [x] New tests: ANSI codes before bracket, wrapping entire line, complex SGR sequences
- [x] New tests: `[Reply Instructions]` block (plain text and ANSI-wrapped)
- [x] New tests: Combined `[internal:*]` + `[Reply Instructions]` stripping
- [x] `bun run test` passes (2428 tests across all packages)
- [x] `bun run typecheck` passes (client route-tree errors are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)