### PR TITLE
refactor: consolidate test data builders into shared utils

### DIFF
--- a/packages/server/src/__tests__/utils/build-test-data.ts
+++ b/packages/server/src/__tests__/utils/build-test-data.ts
@@ -1,0 +1,266 @@
+/**
+ * Shared test data builders for domain objects.
+ *
+ * Each builder follows the override-spread factory pattern:
+ * - Returns a fully-typed object (no `as` casts needed by callers)
+ * - Accepts optional Partial<T> overrides
+ * - Uses sensible defaults for all required fields
+ *
+ * Naming: `build` prefix + full type name, one function per discriminated union variant.
+ */
+
+import type { AgentDefinition, WorktreeSession, QuickSession } from '@agent-console/shared';
+import type {
+  PersistedWorktreeSession,
+  PersistedQuickSession,
+  PersistedAgentWorker,
+  PersistedTerminalWorker,
+  PersistedGitDiffWorker,
+  PersistedRepository,
+} from '../../services/persistence-service.js';
+import type {
+  InternalWorktreeSession,
+  InternalQuickSession,
+} from '../../services/internal-types.js';
+import type {
+  InternalAgentWorker,
+  InternalTerminalWorker,
+  InternalGitDiffWorker,
+  InternalWorker,
+} from '../../services/worker-types.js';
+
+// ── Persisted Workers ──
+
+export function buildPersistedAgentWorker(
+  overrides?: Partial<PersistedAgentWorker>
+): PersistedAgentWorker {
+  return {
+    id: 'test-agent-worker-id',
+    type: 'agent',
+    name: 'Test Agent',
+    agentId: 'claude-code-builtin',
+    pid: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function buildPersistedTerminalWorker(
+  overrides?: Partial<PersistedTerminalWorker>
+): PersistedTerminalWorker {
+  return {
+    id: 'test-terminal-worker-id',
+    type: 'terminal',
+    name: 'Test Terminal',
+    pid: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function buildPersistedGitDiffWorker(
+  overrides?: Partial<PersistedGitDiffWorker>
+): PersistedGitDiffWorker {
+  return {
+    id: 'test-git-diff-worker-id',
+    type: 'git-diff',
+    name: 'Git Diff',
+    baseCommit: 'abc123def456',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ── Persisted Sessions ──
+
+export function buildPersistedWorktreeSession(
+  overrides?: Partial<PersistedWorktreeSession>
+): PersistedWorktreeSession {
+  return {
+    id: 'test-worktree-session-id',
+    type: 'worktree',
+    locationPath: '/test/worktree',
+    repositoryId: 'repo-1',
+    worktreeId: 'main',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    workers: [],
+    ...overrides,
+  };
+}
+
+export function buildPersistedQuickSession(
+  overrides?: Partial<PersistedQuickSession>
+): PersistedQuickSession {
+  return {
+    id: 'test-quick-session-id',
+    type: 'quick',
+    locationPath: '/test/quick',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    workers: [],
+    ...overrides,
+  };
+}
+
+// ── Persisted Repository ──
+
+export function buildPersistedRepository(
+  overrides?: Partial<PersistedRepository>
+): PersistedRepository {
+  return {
+    id: 'test-repo-id',
+    name: 'test-repo',
+    path: '/test/repo',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ── Internal Workers ──
+
+export function buildInternalAgentWorker(
+  overrides?: Partial<InternalAgentWorker>
+): InternalAgentWorker {
+  return {
+    id: 'w-agent-1',
+    type: 'agent',
+    name: 'Agent',
+    agentId: 'claude-code-builtin',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    pty: null,
+    outputBuffer: '',
+    outputOffset: 0,
+    connectionCallbacks: new Map(),
+    activityState: 'unknown',
+    activityDetector: null,
+    ...overrides,
+  };
+}
+
+export function buildInternalTerminalWorker(
+  overrides?: Partial<InternalTerminalWorker>
+): InternalTerminalWorker {
+  return {
+    id: 'w-term-1',
+    type: 'terminal',
+    name: 'Terminal',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    pty: null,
+    outputBuffer: '',
+    outputOffset: 0,
+    connectionCallbacks: new Map(),
+    ...overrides,
+  };
+}
+
+export function buildInternalGitDiffWorker(
+  overrides?: Partial<InternalGitDiffWorker>
+): InternalGitDiffWorker {
+  return {
+    id: 'w-gitdiff-1',
+    type: 'git-diff',
+    name: 'Git Diff',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    baseCommit: 'abc123',
+    ...overrides,
+  };
+}
+
+// ── Internal Sessions ──
+
+/**
+ * Build an InternalWorktreeSession. Workers can be passed as an array
+ * (converted to Map keyed by worker.id) or as a Map directly via overrides.
+ */
+export function buildInternalWorktreeSession(
+  workers: InternalWorker[] = [],
+  overrides?: Partial<InternalWorktreeSession>
+): InternalWorktreeSession {
+  const workerMap = new Map<string, InternalWorker>();
+  for (const w of workers) workerMap.set(w.id, w);
+  return {
+    id: 'session-1',
+    type: 'worktree',
+    locationPath: '/test/worktree',
+    repositoryId: 'repo-1',
+    worktreeId: 'main',
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    workers: workerMap,
+    ...overrides,
+  };
+}
+
+export function buildInternalQuickSession(
+  workers: InternalWorker[] = [],
+  overrides?: Partial<InternalQuickSession>
+): InternalQuickSession {
+  const workerMap = new Map<string, InternalWorker>();
+  for (const w of workers) workerMap.set(w.id, w);
+  return {
+    id: 'session-2',
+    type: 'quick',
+    locationPath: '/test/quick',
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    workers: workerMap,
+    ...overrides,
+  };
+}
+
+// ── Public API Sessions ──
+// Note: Public Worker types (AgentWorker, TerminalWorker, GitDiffWorker) do NOT get builders
+// because they are always produced by production code.
+
+export function buildWorktreeSession(
+  overrides?: Partial<WorktreeSession>
+): WorktreeSession {
+  return {
+    id: 'session-1',
+    type: 'worktree',
+    locationPath: '/test/worktree',
+    repositoryId: 'repo-1',
+    repositoryName: 'test-repo',
+    worktreeId: 'main',
+    isMainWorktree: false,
+    status: 'active',
+    activationState: 'running',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    workers: [],
+    ...overrides,
+  };
+}
+
+export function buildQuickSession(
+  overrides?: Partial<QuickSession>
+): QuickSession {
+  return {
+    id: 'session-1',
+    type: 'quick',
+    locationPath: '/test/quick',
+    status: 'active',
+    activationState: 'running',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    workers: [],
+    ...overrides,
+  };
+}
+
+// ── Agent Definition ──
+
+export function buildAgentDefinition(
+  overrides?: Partial<AgentDefinition>
+): AgentDefinition {
+  return {
+    id: 'test-agent-id',
+    name: 'Test Agent',
+    commandTemplate: 'agent start --prompt={{prompt}}',
+    isBuiltIn: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    capabilities: {
+      supportsContinue: false,
+      supportsHeadlessMode: false,
+      supportsActivityDetection: false,
+    },
+    ...overrides,
+  };
+}

--- a/packages/server/src/database/__tests__/mappers.test.ts
+++ b/packages/server/src/database/__tests__/mappers.test.ts
@@ -17,26 +17,30 @@ import type {
   PersistedTerminalWorker,
   PersistedGitDiffWorker,
   PersistedWorktreeSession,
-  PersistedQuickSession,
-  PersistedRepository,
 } from '../../services/persistence-service.js';
-import type { AgentDefinition } from '@agent-console/shared';
+import {
+  buildPersistedWorktreeSession,
+  buildPersistedQuickSession,
+  buildPersistedAgentWorker,
+  buildPersistedTerminalWorker,
+  buildPersistedGitDiffWorker,
+  buildPersistedRepository,
+  buildAgentDefinition,
+} from '../../__tests__/utils/build-test-data.js';
 
 describe('mappers', () => {
   describe('toSessionRow', () => {
     it('should convert worktree session with all fields', () => {
-      const session: PersistedWorktreeSession = {
+      const session = buildPersistedWorktreeSession({
         id: 'session-1',
-        type: 'worktree',
         locationPath: '/path/to/worktree',
         repositoryId: 'repo-1',
         worktreeId: 'feature-branch',
         serverPid: 1234,
         createdAt: '2024-01-01T00:00:00.000Z',
-        workers: [],
         initialPrompt: 'Test prompt',
         title: 'Test Session',
-      };
+      });
 
       const row = toSessionRow(session);
 
@@ -51,15 +55,13 @@ describe('mappers', () => {
     });
 
     it('should convert worktree session with optional fields undefined', () => {
-      const session: PersistedWorktreeSession = {
+      const session = buildPersistedWorktreeSession({
         id: 'session-1',
-        type: 'worktree',
         locationPath: '/path/to/worktree',
         repositoryId: 'repo-1',
         worktreeId: 'feature-branch',
         createdAt: '2024-01-01T00:00:00.000Z',
-        workers: [],
-      };
+      });
 
       const row = toSessionRow(session);
 
@@ -69,16 +71,14 @@ describe('mappers', () => {
     });
 
     it('should convert quick session with all fields', () => {
-      const session: PersistedQuickSession = {
+      const session = buildPersistedQuickSession({
         id: 'session-1',
-        type: 'quick',
         locationPath: '/path/to/project',
         serverPid: 5678,
         createdAt: '2024-01-01T00:00:00.000Z',
-        workers: [],
         initialPrompt: 'Quick prompt',
         title: 'Quick Session',
-      };
+      });
 
       const row = toSessionRow(session);
 
@@ -89,14 +89,12 @@ describe('mappers', () => {
     });
 
     it('should map pausedAt to paused_at', () => {
-      const session: PersistedQuickSession = {
+      const session = buildPersistedQuickSession({
         id: 'session-1',
-        type: 'quick',
         locationPath: '/path/to/project',
         createdAt: '2024-01-01T00:00:00.000Z',
-        workers: [],
         pausedAt: '2025-06-15T12:00:00.000Z',
-      };
+      });
 
       const row = toSessionRow(session);
 
@@ -104,13 +102,11 @@ describe('mappers', () => {
     });
 
     it('should map undefined pausedAt to null paused_at', () => {
-      const session: PersistedQuickSession = {
+      const session = buildPersistedQuickSession({
         id: 'session-1',
-        type: 'quick',
         locationPath: '/path/to/project',
         createdAt: '2024-01-01T00:00:00.000Z',
-        workers: [],
-      };
+      });
 
       const row = toSessionRow(session);
 
@@ -120,14 +116,13 @@ describe('mappers', () => {
 
   describe('toWorkerRow', () => {
     it('should convert agent worker with pid', () => {
-      const worker: PersistedAgentWorker = {
+      const worker = buildPersistedAgentWorker({
         id: 'worker-1',
-        type: 'agent',
         name: 'Claude',
         agentId: 'claude-code-builtin',
         pid: 9999,
         createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
 
       const row = toWorkerRow(worker, 'session-1');
 
@@ -140,13 +135,12 @@ describe('mappers', () => {
     });
 
     it('should convert terminal worker', () => {
-      const worker: PersistedTerminalWorker = {
+      const worker = buildPersistedTerminalWorker({
         id: 'worker-1',
-        type: 'terminal',
         name: 'Terminal',
         pid: 8888,
         createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
 
       const row = toWorkerRow(worker, 'session-1');
 
@@ -156,13 +150,12 @@ describe('mappers', () => {
     });
 
     it('should convert git-diff worker', () => {
-      const worker: PersistedGitDiffWorker = {
+      const worker = buildPersistedGitDiffWorker({
         id: 'worker-1',
-        type: 'git-diff',
         name: 'Git Diff',
         baseCommit: 'abc123',
         createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
 
       const row = toWorkerRow(worker, 'session-1');
 
@@ -378,15 +371,14 @@ describe('mappers', () => {
         created_by: null,
       };
 
-      const workers: PersistedAgentWorker[] = [
-        {
+      const workers = [
+        buildPersistedAgentWorker({
           id: 'worker-1',
-          type: 'agent',
           name: 'Claude',
           agentId: 'claude-code-builtin',
           pid: 1234,
           createdAt: '2024-01-01T00:00:00.000Z',
-        },
+        }),
       ];
 
       const session = toPersistedSession(dbSession, workers);
@@ -527,12 +519,12 @@ describe('mappers', () => {
 
   describe('toRepositoryRow', () => {
     it('should convert Repository to database row', () => {
-      const repository: PersistedRepository = {
+      const repository = buildPersistedRepository({
         id: 'repo-1',
         name: 'my-project',
         path: '/home/user/projects/my-project',
         createdAt: '2024-01-15T10:30:00.000Z',
-      };
+      });
 
       const row = toRepositoryRow(repository);
 
@@ -547,13 +539,13 @@ describe('mappers', () => {
     });
 
     it('should map defaultAgentId to default_agent_id', () => {
-      const repository: PersistedRepository = {
+      const repository = buildPersistedRepository({
         id: 'repo-default-agent',
         name: 'default-agent-project',
         path: '/home/user/projects/default-agent-project',
         createdAt: '2024-01-15T10:30:00.000Z',
         defaultAgentId: 'custom-agent-1',
-      };
+      });
 
       const row = toRepositoryRow(repository);
 
@@ -561,13 +553,13 @@ describe('mappers', () => {
     });
 
     it('should map cleanupCommand to cleanup_command', () => {
-      const repository: PersistedRepository = {
+      const repository = buildPersistedRepository({
         id: 'repo-cleanup',
         name: 'cleanup-project',
         path: '/home/user/projects/cleanup-project',
         createdAt: '2024-01-15T10:30:00.000Z',
         cleanupCommand: 'docker compose down',
-      };
+      });
 
       const row = toRepositoryRow(repository);
 
@@ -682,7 +674,7 @@ describe('mappers', () => {
 
   describe('toAgentRow', () => {
     it('should convert AgentDefinition to database row', () => {
-      const agent: AgentDefinition = {
+      const agent = buildAgentDefinition({
         id: 'custom-agent-1',
         name: 'My Custom Agent',
         commandTemplate: 'my-agent --prompt {{prompt}} --dir {{cwd}}',
@@ -696,7 +688,7 @@ describe('mappers', () => {
           supportsHeadlessMode: true,
           supportsActivityDetection: false,
         },
-      };
+      });
 
       const row = toAgentRow(agent);
 
@@ -713,7 +705,7 @@ describe('mappers', () => {
     });
 
     it('should serialize activityPatterns as JSON', () => {
-      const agent: AgentDefinition = {
+      const agent = buildAgentDefinition({
         id: 'agent-with-patterns',
         name: 'Agent With Patterns',
         commandTemplate: 'agent-cmd {{prompt}}',
@@ -727,7 +719,7 @@ describe('mappers', () => {
           supportsHeadlessMode: false,
           supportsActivityDetection: true,
         },
-      };
+      });
 
       const row = toAgentRow(agent);
 
@@ -737,19 +729,18 @@ describe('mappers', () => {
     });
 
     it('should handle null optional fields', () => {
-      const agent: AgentDefinition = {
+      const agent = buildAgentDefinition({
         id: 'minimal-agent',
         name: 'Minimal Agent',
         commandTemplate: 'minimal-cmd {{prompt}}',
         isBuiltIn: false,
         createdAt: '2024-03-10T09:00:00.000Z',
-        // No optional fields
         capabilities: {
           supportsContinue: false,
           supportsHeadlessMode: false,
           supportsActivityDetection: false,
         },
-      };
+      });
 
       const row = toAgentRow(agent);
 

--- a/packages/server/src/repositories/__tests__/json-session-repository.test.ts
+++ b/packages/server/src/repositories/__tests__/json-session-repository.test.ts
@@ -1,59 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
-import type { PersistedSession, PersistedWorker } from '../../services/persistence-service.js';
+import type { PersistedSession } from '../../services/persistence-service.js';
 import { JsonSessionRepository } from '../json-session-repository.js';
 import {
   setupTestConfigDir,
   cleanupTestConfigDir,
 } from '../../__tests__/utils/mock-fs-helper.js';
-
-/**
- * Creates a test quick session with default values.
- */
-function createTestSession(overrides: Partial<PersistedSession> = {}): PersistedSession {
-  return {
-    id: overrides.id ?? 'test-session-id',
-    type: 'quick',
-    locationPath: '/test/path',
-    serverPid: process.pid,
-    createdAt: new Date().toISOString(),
-    workers: [],
-    ...overrides,
-  } as PersistedSession;
-}
-
-/**
- * Creates a test worktree session with default values.
- */
-function createTestWorktreeSession(overrides: Partial<PersistedSession> = {}): PersistedSession {
-  return {
-    id: overrides.id ?? 'test-worktree-session-id',
-    type: 'worktree',
-    locationPath: '/test/worktree/path',
-    repositoryId: 'test-repo-id',
-    worktreeId: 'test-branch',
-    serverPid: process.pid,
-    createdAt: new Date().toISOString(),
-    workers: [],
-    ...overrides,
-  } as PersistedSession;
-}
-
-/**
- * Creates a test worker with default values.
- */
-function createTestWorker(overrides: Partial<PersistedWorker> = {}): PersistedWorker {
-  return {
-    id: 'test-worker-id',
-    type: 'agent',
-    name: 'Test Agent',
-    agentId: 'claude-code-builtin',
-    pid: 12345,
-    createdAt: new Date().toISOString(),
-    ...overrides,
-  } as PersistedWorker;
-}
+import {
+  buildPersistedQuickSession,
+  buildPersistedWorktreeSession,
+  buildPersistedAgentWorker,
+  buildPersistedTerminalWorker,
+} from '../../__tests__/utils/build-test-data.js';
 
 describe('JsonSessionRepository', () => {
   const TEST_CONFIG_DIR = '/test/config';
@@ -85,9 +44,9 @@ describe('JsonSessionRepository', () => {
 
     it('should return all sessions from file', async () => {
       const testSessions = [
-        createTestSession({ id: 'session-1' }),
-        createTestSession({ id: 'session-2' }),
-        createTestWorktreeSession({ id: 'session-3' }),
+        buildPersistedQuickSession({ id: 'session-1' }),
+        buildPersistedQuickSession({ id: 'session-2' }),
+        buildPersistedWorktreeSession({ id: 'session-3' }),
       ];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
 
@@ -100,17 +59,11 @@ describe('JsonSessionRepository', () => {
     });
 
     it('should return sessions with workers', async () => {
-      const testSession = createTestSession({
+      const testSession = buildPersistedQuickSession({
         id: 'session-with-workers',
         workers: [
-          createTestWorker({ id: 'worker-1', name: 'Agent Worker' }),
-          {
-            id: 'worker-2',
-            type: 'terminal',
-            name: 'Terminal',
-            pid: 54321,
-            createdAt: new Date().toISOString(),
-          } as PersistedWorker,
+          buildPersistedAgentWorker({ id: 'worker-1', name: 'Agent Worker' }),
+          buildPersistedTerminalWorker({ id: 'worker-2', name: 'Terminal', pid: 54321 }),
         ],
       });
       fs.writeFileSync(sessionsFilePath, JSON.stringify([testSession], null, 2));
@@ -127,8 +80,8 @@ describe('JsonSessionRepository', () => {
   describe('findById', () => {
     it('should return session if exists', async () => {
       const testSessions = [
-        createTestSession({ id: 'session-1' }),
-        createTestWorktreeSession({ id: 'session-2', repositoryId: 'repo-1' }),
+        buildPersistedQuickSession({ id: 'session-1' }),
+        buildPersistedWorktreeSession({ id: 'session-2', repositoryId: 'repo-1' }),
       ];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
 
@@ -143,7 +96,7 @@ describe('JsonSessionRepository', () => {
     });
 
     it('should return null if session not found', async () => {
-      const testSessions = [createTestSession({ id: 'session-1' })];
+      const testSessions = [buildPersistedQuickSession({ id: 'session-1' })];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
 
       const session = await repository.findById('non-existent');
@@ -161,10 +114,10 @@ describe('JsonSessionRepository', () => {
   describe('findByServerPid', () => {
     it('should return sessions matching the given PID', async () => {
       const testSessions = [
-        createTestSession({ id: 'session-1', serverPid: 1000 }),
-        createTestSession({ id: 'session-2', serverPid: 2000 }),
-        createTestSession({ id: 'session-3', serverPid: 1000 }),
-        createTestWorktreeSession({ id: 'session-4', serverPid: 3000 }),
+        buildPersistedQuickSession({ id: 'session-1', serverPid: 1000 }),
+        buildPersistedQuickSession({ id: 'session-2', serverPid: 2000 }),
+        buildPersistedQuickSession({ id: 'session-3', serverPid: 1000 }),
+        buildPersistedWorktreeSession({ id: 'session-4', serverPid: 3000 }),
       ];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
 
@@ -176,8 +129,8 @@ describe('JsonSessionRepository', () => {
 
     it('should return empty array if no sessions match', async () => {
       const testSessions = [
-        createTestSession({ id: 'session-1', serverPid: 1000 }),
-        createTestSession({ id: 'session-2', serverPid: 2000 }),
+        buildPersistedQuickSession({ id: 'session-1', serverPid: 1000 }),
+        buildPersistedQuickSession({ id: 'session-2', serverPid: 2000 }),
       ];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
 
@@ -196,10 +149,10 @@ describe('JsonSessionRepository', () => {
   describe('findPaused', () => {
     it('should return sessions with null serverPid', async () => {
       const testSessions = [
-        createTestSession({ id: 'session-1', serverPid: 1000 }),
-        createTestSession({ id: 'session-2', serverPid: undefined }),
-        createTestWorktreeSession({ id: 'session-3', serverPid: undefined }),
-        createTestSession({ id: 'session-4', serverPid: 2000 }),
+        buildPersistedQuickSession({ id: 'session-1', serverPid: 1000 }),
+        buildPersistedQuickSession({ id: 'session-2', serverPid: undefined }),
+        buildPersistedWorktreeSession({ id: 'session-3', serverPid: undefined }),
+        buildPersistedQuickSession({ id: 'session-4', serverPid: 2000 }),
       ];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
 
@@ -211,8 +164,8 @@ describe('JsonSessionRepository', () => {
 
     it('should return empty array if no paused sessions', async () => {
       const testSessions = [
-        createTestSession({ id: 'session-1', serverPid: 1000 }),
-        createTestSession({ id: 'session-2', serverPid: 2000 }),
+        buildPersistedQuickSession({ id: 'session-1', serverPid: 1000 }),
+        buildPersistedQuickSession({ id: 'session-2', serverPid: 2000 }),
       ];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
 
@@ -228,11 +181,11 @@ describe('JsonSessionRepository', () => {
     });
 
     it('should include workers in paused sessions', async () => {
-      const testSession = createTestWorktreeSession({
+      const testSession = buildPersistedWorktreeSession({
         id: 'paused-session',
         serverPid: undefined,
         workers: [
-          createTestWorker({ id: 'worker-1', name: 'Agent Worker' }),
+          buildPersistedAgentWorker({ id: 'worker-1', name: 'Agent Worker' }),
         ],
       });
       fs.writeFileSync(sessionsFilePath, JSON.stringify([testSession], null, 2));
@@ -247,7 +200,7 @@ describe('JsonSessionRepository', () => {
 
   describe('save', () => {
     it("should create new session when it doesn't exist", async () => {
-      const newSession = createTestSession({ id: 'new-session' });
+      const newSession = buildPersistedQuickSession({ id: 'new-session' });
 
       await repository.save(newSession);
 
@@ -258,10 +211,10 @@ describe('JsonSessionRepository', () => {
     });
 
     it('should update existing session when it exists', async () => {
-      const initialSession = createTestSession({ id: 'session-1', title: 'Original Title' });
+      const initialSession = buildPersistedQuickSession({ id: 'session-1', title: 'Original Title' });
       fs.writeFileSync(sessionsFilePath, JSON.stringify([initialSession], null, 2));
 
-      const updatedSession = createTestSession({ id: 'session-1', title: 'Updated Title' });
+      const updatedSession = buildPersistedQuickSession({ id: 'session-1', title: 'Updated Title' });
       await repository.save(updatedSession);
 
       const fileContent = fs.readFileSync(sessionsFilePath, 'utf-8');
@@ -272,12 +225,12 @@ describe('JsonSessionRepository', () => {
 
     it('should preserve other sessions when saving', async () => {
       const existingSessions = [
-        createTestSession({ id: 'session-1' }),
-        createTestSession({ id: 'session-2' }),
+        buildPersistedQuickSession({ id: 'session-1' }),
+        buildPersistedQuickSession({ id: 'session-2' }),
       ];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(existingSessions, null, 2));
 
-      const newSession = createTestSession({ id: 'session-3' });
+      const newSession = buildPersistedQuickSession({ id: 'session-3' });
       await repository.save(newSession);
 
       const fileContent = fs.readFileSync(sessionsFilePath, 'utf-8');
@@ -293,7 +246,7 @@ describe('JsonSessionRepository', () => {
     it("should create file if it doesn't exist", async () => {
       expect(fs.existsSync(sessionsFilePath)).toBe(false);
 
-      const newSession = createTestSession({ id: 'first-session' });
+      const newSession = buildPersistedQuickSession({ id: 'first-session' });
       await repository.save(newSession);
 
       expect(fs.existsSync(sessionsFilePath)).toBe(true);
@@ -303,11 +256,11 @@ describe('JsonSessionRepository', () => {
     });
 
     it('should save session with workers', async () => {
-      const sessionWithWorkers = createTestSession({
+      const sessionWithWorkers = buildPersistedQuickSession({
         id: 'session-with-workers',
         workers: [
-          createTestWorker({ id: 'worker-1' }),
-          createTestWorker({ id: 'worker-2', type: 'terminal' }),
+          buildPersistedAgentWorker({ id: 'worker-1' }),
+          buildPersistedTerminalWorker({ id: 'worker-2' }),
         ],
       });
 
@@ -322,15 +275,15 @@ describe('JsonSessionRepository', () => {
   describe('saveAll', () => {
     it('should replace all sessions in file', async () => {
       const initialSessions = [
-        createTestSession({ id: 'old-1' }),
-        createTestSession({ id: 'old-2' }),
+        buildPersistedQuickSession({ id: 'old-1' }),
+        buildPersistedQuickSession({ id: 'old-2' }),
       ];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(initialSessions, null, 2));
 
       const newSessions = [
-        createTestSession({ id: 'new-1' }),
-        createTestWorktreeSession({ id: 'new-2' }),
-        createTestSession({ id: 'new-3' }),
+        buildPersistedQuickSession({ id: 'new-1' }),
+        buildPersistedWorktreeSession({ id: 'new-2' }),
+        buildPersistedQuickSession({ id: 'new-3' }),
       ];
       await repository.saveAll(newSessions);
 
@@ -345,7 +298,7 @@ describe('JsonSessionRepository', () => {
     });
 
     it('should handle empty array', async () => {
-      const initialSessions = [createTestSession({ id: 'session-1' })];
+      const initialSessions = [buildPersistedQuickSession({ id: 'session-1' })];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(initialSessions, null, 2));
 
       await repository.saveAll([]);
@@ -358,7 +311,7 @@ describe('JsonSessionRepository', () => {
     it("should create file if it doesn't exist", async () => {
       expect(fs.existsSync(sessionsFilePath)).toBe(false);
 
-      const sessions = [createTestSession({ id: 'session-1' })];
+      const sessions = [buildPersistedQuickSession({ id: 'session-1' })];
       await repository.saveAll(sessions);
 
       expect(fs.existsSync(sessionsFilePath)).toBe(true);
@@ -371,9 +324,9 @@ describe('JsonSessionRepository', () => {
   describe('delete', () => {
     it('should remove session by id', async () => {
       const testSessions = [
-        createTestSession({ id: 'session-1' }),
-        createTestSession({ id: 'session-2' }),
-        createTestSession({ id: 'session-3' }),
+        buildPersistedQuickSession({ id: 'session-1' }),
+        buildPersistedQuickSession({ id: 'session-2' }),
+        buildPersistedQuickSession({ id: 'session-3' }),
       ];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
 
@@ -390,8 +343,8 @@ describe('JsonSessionRepository', () => {
 
     it('should not affect other sessions', async () => {
       const testSessions = [
-        createTestSession({ id: 'session-1', title: 'First' }),
-        createTestWorktreeSession({ id: 'session-2', repositoryId: 'repo-1' }),
+        buildPersistedQuickSession({ id: 'session-1', title: 'First' }),
+        buildPersistedWorktreeSession({ id: 'session-2', repositoryId: 'repo-1' }),
       ];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
 
@@ -406,7 +359,7 @@ describe('JsonSessionRepository', () => {
     });
 
     it("should not fail if session doesn't exist", async () => {
-      const testSessions = [createTestSession({ id: 'session-1' })];
+      const testSessions = [buildPersistedQuickSession({ id: 'session-1' })];
       fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
 
       // Should not throw
@@ -426,7 +379,7 @@ describe('JsonSessionRepository', () => {
 
   describe('atomic write behavior', () => {
     it('should not leave temp files on successful write', async () => {
-      await repository.save(createTestSession({ id: 'test' }));
+      await repository.save(buildPersistedQuickSession({ id: 'test' }));
 
       const files = fs.readdirSync(TEST_CONFIG_DIR);
       const tempFiles = files.filter((f: string) => f.endsWith('.tmp'));
@@ -434,7 +387,7 @@ describe('JsonSessionRepository', () => {
     });
 
     it('should write formatted JSON', async () => {
-      await repository.save(createTestSession({ id: 'test' }));
+      await repository.save(buildPersistedQuickSession({ id: 'test' }));
 
       const content = fs.readFileSync(sessionsFilePath, 'utf-8');
       // Should be formatted with indentation (2 spaces)

--- a/packages/server/src/repositories/__tests__/sqlite-agent-repository.test.ts
+++ b/packages/server/src/repositories/__tests__/sqlite-agent-repository.test.ts
@@ -4,7 +4,8 @@ import { BunSqliteDialect } from 'kysely-bun-sqlite';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { SqliteAgentRepository } from '../sqlite-agent-repository.js';
 import type { Database } from '../../database/schema.js';
-import type { AgentDefinition, AgentActivityPatterns } from '@agent-console/shared';
+import type { AgentActivityPatterns } from '@agent-console/shared';
+import { buildAgentDefinition } from '../../__tests__/utils/build-test-data.js';
 
 const NOW_ISO8601 = sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`;
 
@@ -46,28 +47,6 @@ describe('SqliteAgentRepository', () => {
     bunDb.close();
   });
 
-  // ========== Helper Functions ==========
-
-  function createAgent(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
-    return {
-      id: overrides.id ?? 'test-agent-id',
-      name: overrides.name ?? 'Test Agent',
-      commandTemplate: overrides.commandTemplate ?? 'agent start --prompt={{prompt}}',
-      continueTemplate: overrides.continueTemplate,
-      headlessTemplate: overrides.headlessTemplate,
-      description: overrides.description,
-      isBuiltIn: overrides.isBuiltIn ?? false,
-      createdAt: overrides.createdAt ?? new Date().toISOString(),
-      activityPatterns: overrides.activityPatterns,
-      baseAgentId: overrides.baseAgentId,
-      capabilities: overrides.capabilities ?? {
-        supportsContinue: false,
-        supportsHeadlessMode: false,
-        supportsActivityDetection: false,
-      },
-    };
-  }
-
   // ========== Test Suites ==========
 
   describe('findAll', () => {
@@ -77,8 +56,8 @@ describe('SqliteAgentRepository', () => {
     });
 
     it('should return all agents', async () => {
-      const agent1 = createAgent({ id: 'agent-1' });
-      const agent2 = createAgent({ id: 'agent-2' });
+      const agent1 = buildAgentDefinition({ id: 'agent-1' });
+      const agent2 = buildAgentDefinition({ id: 'agent-2' });
 
       await repository.save(agent1);
       await repository.save(agent2);
@@ -90,7 +69,7 @@ describe('SqliteAgentRepository', () => {
     });
 
     it('should correctly restore capabilities from templates', async () => {
-      const agent = createAgent({
+      const agent = buildAgentDefinition({
         id: 'capable-agent',
         commandTemplate: 'agent --prompt={{prompt}}',
         continueTemplate: 'agent --continue',
@@ -110,7 +89,7 @@ describe('SqliteAgentRepository', () => {
 
   describe('findById', () => {
     it('should return agent if exists', async () => {
-      const agent = createAgent({ id: 'find-me', name: 'Find Me Agent' });
+      const agent = buildAgentDefinition({ id: 'find-me', name: 'Find Me Agent' });
       await repository.save(agent);
 
       const found = await repository.findById('find-me');
@@ -121,7 +100,7 @@ describe('SqliteAgentRepository', () => {
     });
 
     it('should return null if agent not found', async () => {
-      const agent = createAgent({ id: 'existing' });
+      const agent = buildAgentDefinition({ id: 'existing' });
       await repository.save(agent);
 
       const found = await repository.findById('non-existent');
@@ -137,7 +116,7 @@ describe('SqliteAgentRepository', () => {
 
   describe('save', () => {
     it('should insert new agent', async () => {
-      const agent = createAgent({ id: 'new-agent', name: 'New Agent' });
+      const agent = buildAgentDefinition({ id: 'new-agent', name: 'New Agent' });
 
       await repository.save(agent);
 
@@ -147,10 +126,10 @@ describe('SqliteAgentRepository', () => {
     });
 
     it('should update existing agent', async () => {
-      const agent = createAgent({ id: 'update-agent', name: 'Original' });
+      const agent = buildAgentDefinition({ id: 'update-agent', name: 'Original' });
       await repository.save(agent);
 
-      const updated = createAgent({ id: 'update-agent', name: 'Updated' });
+      const updated = buildAgentDefinition({ id: 'update-agent', name: 'Updated' });
       await repository.save(updated);
 
       const found = await repository.findById('update-agent');
@@ -163,7 +142,7 @@ describe('SqliteAgentRepository', () => {
 
     it('should preserve created_at and update updated_at on update', async () => {
       const originalCreatedAt = '2024-01-01T00:00:00.000Z';
-      const agent = createAgent({
+      const agent = buildAgentDefinition({
         id: 'timestamp-test',
         name: 'Original',
         createdAt: originalCreatedAt,
@@ -184,7 +163,7 @@ describe('SqliteAgentRepository', () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       // Update with a different createdAt (simulating real-world scenario)
-      const updated = createAgent({
+      const updated = buildAgentDefinition({
         id: 'timestamp-test',
         name: 'Updated',
         createdAt: '2024-06-01T00:00:00.000Z', // Different createdAt
@@ -206,7 +185,7 @@ describe('SqliteAgentRepository', () => {
     });
 
     it('should save built-in agents', async () => {
-      const builtInAgent = createAgent({ id: 'built-in', isBuiltIn: true });
+      const builtInAgent = buildAgentDefinition({ id: 'built-in', isBuiltIn: true });
 
       await repository.save(builtInAgent);
 
@@ -221,7 +200,7 @@ describe('SqliteAgentRepository', () => {
 
     it('should preserve all optional fields', async () => {
       const createdAt = '2024-01-15T10:30:00.000Z';
-      const agent = createAgent({
+      const agent = buildAgentDefinition({
         id: 'full-agent',
         name: 'Full Agent',
         commandTemplate: 'agent start --prompt={{prompt}}',
@@ -248,7 +227,7 @@ describe('SqliteAgentRepository', () => {
         askingPatterns: ['do you want to proceed\\?', 'confirm\\?'],
       };
 
-      const agent = createAgent({
+      const agent = buildAgentDefinition({
         id: 'patterns-agent',
         activityPatterns,
       });
@@ -260,7 +239,7 @@ describe('SqliteAgentRepository', () => {
     });
 
     it('should handle undefined optional fields', async () => {
-      const agent = createAgent({
+      const agent = buildAgentDefinition({
         id: 'minimal-agent',
         continueTemplate: undefined,
         headlessTemplate: undefined,
@@ -281,9 +260,9 @@ describe('SqliteAgentRepository', () => {
   describe('delete', () => {
     it('should remove agent by id', async () => {
       const agents = [
-        createAgent({ id: 'agent-1' }),
-        createAgent({ id: 'agent-2' }),
-        createAgent({ id: 'agent-3' }),
+        buildAgentDefinition({ id: 'agent-1' }),
+        buildAgentDefinition({ id: 'agent-2' }),
+        buildAgentDefinition({ id: 'agent-3' }),
       ];
 
       for (const agent of agents) {
@@ -298,7 +277,7 @@ describe('SqliteAgentRepository', () => {
     });
 
     it('should be idempotent for non-existent agent', async () => {
-      await repository.save(createAgent({ id: 'existing' }));
+      await repository.save(buildAgentDefinition({ id: 'existing' }));
 
       // Should not throw for non-existent agent
       await repository.delete('non-existent');
@@ -310,7 +289,7 @@ describe('SqliteAgentRepository', () => {
 
     it('should throw error for built-in agents', async () => {
       // First save a non-built-in agent
-      const customAgent = createAgent({ id: 'custom', isBuiltIn: false });
+      const customAgent = buildAgentDefinition({ id: 'custom', isBuiltIn: false });
       await repository.save(customAgent);
 
       // Then manually insert a built-in agent for testing the delete logic
@@ -344,8 +323,8 @@ describe('SqliteAgentRepository', () => {
     });
 
     it('should not affect other agents', async () => {
-      const agent1 = createAgent({ id: 'agent-1', name: 'Agent One' });
-      const agent2 = createAgent({ id: 'agent-2', name: 'Agent Two' });
+      const agent1 = buildAgentDefinition({ id: 'agent-1', name: 'Agent One' });
+      const agent2 = buildAgentDefinition({ id: 'agent-2', name: 'Agent Two' });
 
       await repository.save(agent1);
       await repository.save(agent2);
@@ -360,7 +339,7 @@ describe('SqliteAgentRepository', () => {
 
   describe('baseAgentId', () => {
     it('should save and retrieve agent with baseAgentId', async () => {
-      const agent = createAgent({ id: 'preset-1', baseAgentId: 'base-agent-id' });
+      const agent = buildAgentDefinition({ id: 'preset-1', baseAgentId: 'base-agent-id' });
       await repository.save(agent);
 
       const found = await repository.findById('preset-1');
@@ -368,10 +347,10 @@ describe('SqliteAgentRepository', () => {
     });
 
     it('should update baseAgentId on save', async () => {
-      const agent = createAgent({ id: 'preset-1', baseAgentId: 'old-base' });
+      const agent = buildAgentDefinition({ id: 'preset-1', baseAgentId: 'old-base' });
       await repository.save(agent);
 
-      const updated = createAgent({ id: 'preset-1', baseAgentId: 'new-base' });
+      const updated = buildAgentDefinition({ id: 'preset-1', baseAgentId: 'new-base' });
       await repository.save(updated);
 
       const found = await repository.findById('preset-1');
@@ -381,7 +360,7 @@ describe('SqliteAgentRepository', () => {
 
   describe('edge cases', () => {
     it('should handle unicode in name and description', async () => {
-      const agent = createAgent({
+      const agent = buildAgentDefinition({
         id: 'unicode-agent',
         name: 'Agent with unicode: Hello World',
         description: 'Description with special chars: @#$%',
@@ -396,7 +375,7 @@ describe('SqliteAgentRepository', () => {
 
     it('should handle long command templates', async () => {
       const longTemplate = 'command '.repeat(1000) + '--prompt={{prompt}}';
-      const agent = createAgent({
+      const agent = buildAgentDefinition({
         id: 'long-template',
         commandTemplate: longTemplate,
       });
@@ -418,7 +397,7 @@ describe('SqliteAgentRepository', () => {
         ],
       };
 
-      const agent = createAgent({
+      const agent = buildAgentDefinition({
         id: 'complex-patterns',
         activityPatterns: complexPatterns,
       });

--- a/packages/server/src/repositories/__tests__/sqlite-session-repository.test.ts
+++ b/packages/server/src/repositories/__tests__/sqlite-session-repository.test.ts
@@ -4,13 +4,13 @@ import { BunSqliteDialect } from 'kysely-bun-sqlite';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { SqliteSessionRepository } from '../sqlite-session-repository.js';
 import type { Database } from '../../database/schema.js';
-import type {
-  PersistedAgentWorker,
-  PersistedTerminalWorker,
-  PersistedGitDiffWorker,
-  PersistedWorktreeSession,
-  PersistedQuickSession,
-} from '../../services/persistence-service.js';
+import {
+  buildPersistedQuickSession,
+  buildPersistedWorktreeSession,
+  buildPersistedAgentWorker,
+  buildPersistedTerminalWorker,
+  buildPersistedGitDiffWorker,
+} from '../../__tests__/utils/build-test-data.js';
 
 const NOW_ISO8601 = sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`;
 
@@ -70,74 +70,6 @@ describe('SqliteSessionRepository', () => {
     bunDb.close();
   });
 
-  // ========== Helper Functions ==========
-
-  function createQuickSession(overrides: Partial<PersistedQuickSession> = {}): PersistedQuickSession {
-    return {
-      id: overrides.id ?? 'test-session-id',
-      type: 'quick',
-      locationPath: '/test/path',
-      serverPid: process.pid,
-      createdAt: new Date().toISOString(),
-      workers: [],
-      ...overrides,
-    };
-  }
-
-  function createWorktreeSession(
-    overrides: Partial<PersistedWorktreeSession> = {}
-  ): PersistedWorktreeSession {
-    return {
-      id: overrides.id ?? 'test-worktree-session-id',
-      type: 'worktree',
-      locationPath: '/test/worktree/path',
-      repositoryId: 'test-repo-id',
-      worktreeId: 'test-branch',
-      serverPid: process.pid,
-      createdAt: new Date().toISOString(),
-      workers: [],
-      ...overrides,
-    };
-  }
-
-  function createAgentWorker(overrides: Partial<PersistedAgentWorker> = {}): PersistedAgentWorker {
-    return {
-      id: overrides.id ?? 'test-agent-worker-id',
-      type: 'agent',
-      name: 'Test Agent',
-      agentId: 'claude-code-builtin',
-      pid: 12345,
-      createdAt: new Date().toISOString(),
-      ...overrides,
-    };
-  }
-
-  function createTerminalWorker(
-    overrides: Partial<PersistedTerminalWorker> = {}
-  ): PersistedTerminalWorker {
-    return {
-      id: overrides.id ?? 'test-terminal-worker-id',
-      type: 'terminal',
-      name: 'Test Terminal',
-      pid: 54321,
-      createdAt: new Date().toISOString(),
-      ...overrides,
-    };
-  }
-
-  function createGitDiffWorker(
-    overrides: Partial<PersistedGitDiffWorker> = {}
-  ): PersistedGitDiffWorker {
-    return {
-      id: overrides.id ?? 'test-git-diff-worker-id',
-      type: 'git-diff',
-      name: 'Git Diff',
-      baseCommit: 'abc123def456',
-      createdAt: new Date().toISOString(),
-      ...overrides,
-    };
-  }
-
   // ========== Test Suites ==========
 
   describe('findAll', () => {
@@ -147,8 +79,8 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should return all sessions with their workers', async () => {
-      const session1 = createQuickSession({ id: 'session-1' });
-      const session2 = createWorktreeSession({ id: 'session-2' });
+      const session1 = buildPersistedQuickSession({ id: 'session-1' });
+      const session2 = buildPersistedWorktreeSession({ id: 'session-2' });
 
       await repository.save(session1);
       await repository.save(session2);
@@ -160,7 +92,7 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should correctly hydrate worktree sessions', async () => {
-      const worktreeSession = createWorktreeSession({
+      const worktreeSession = buildPersistedWorktreeSession({
         id: 'worktree-session',
         repositoryId: 'repo-123',
         worktreeId: 'feature-branch',
@@ -188,7 +120,7 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should correctly hydrate quick sessions', async () => {
-      const quickSession = createQuickSession({
+      const quickSession = buildPersistedQuickSession({
         id: 'quick-session',
         locationPath: '/home/user/project',
         title: 'Quick Task',
@@ -209,11 +141,11 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should return sessions with their workers', async () => {
-      const sessionWithWorkers = createQuickSession({
+      const sessionWithWorkers = buildPersistedQuickSession({
         id: 'session-with-workers',
         workers: [
-          createAgentWorker({ id: 'worker-1' }),
-          createTerminalWorker({ id: 'worker-2' }),
+          buildPersistedAgentWorker({ id: 'worker-1' }),
+          buildPersistedTerminalWorker({ id: 'worker-2' }),
         ],
       });
 
@@ -229,7 +161,7 @@ describe('SqliteSessionRepository', () => {
 
   describe('findById', () => {
     it('should return session if exists', async () => {
-      const session = createWorktreeSession({
+      const session = buildPersistedWorktreeSession({
         id: 'find-me',
         repositoryId: 'repo-1',
         title: 'Find Me',
@@ -248,7 +180,7 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should return null if session not found', async () => {
-      const session = createQuickSession({ id: 'existing-session' });
+      const session = buildPersistedQuickSession({ id: 'existing-session' });
       await repository.save(session);
 
       const found = await repository.findById('non-existent');
@@ -262,11 +194,11 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should include workers in returned session', async () => {
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'session-with-workers',
         workers: [
-          createAgentWorker({ id: 'agent-1', name: 'Claude' }),
-          createTerminalWorker({ id: 'terminal-1', name: 'Shell' }),
+          buildPersistedAgentWorker({ id: 'agent-1', name: 'Claude' }),
+          buildPersistedTerminalWorker({ id: 'terminal-1', name: 'Shell' }),
         ],
       });
 
@@ -284,10 +216,10 @@ describe('SqliteSessionRepository', () => {
   describe('findByServerPid', () => {
     it('should return sessions matching the given PID', async () => {
       const sessions = [
-        createQuickSession({ id: 'session-1', serverPid: 1000 }),
-        createQuickSession({ id: 'session-2', serverPid: 2000 }),
-        createQuickSession({ id: 'session-3', serverPid: 1000 }),
-        createWorktreeSession({ id: 'session-4', serverPid: 3000 }),
+        buildPersistedQuickSession({ id: 'session-1', serverPid: 1000 }),
+        buildPersistedQuickSession({ id: 'session-2', serverPid: 2000 }),
+        buildPersistedQuickSession({ id: 'session-3', serverPid: 1000 }),
+        buildPersistedWorktreeSession({ id: 'session-4', serverPid: 3000 }),
       ];
 
       for (const session of sessions) {
@@ -302,8 +234,8 @@ describe('SqliteSessionRepository', () => {
 
     it('should return empty array if no sessions match', async () => {
       const sessions = [
-        createQuickSession({ id: 'session-1', serverPid: 1000 }),
-        createQuickSession({ id: 'session-2', serverPid: 2000 }),
+        buildPersistedQuickSession({ id: 'session-1', serverPid: 1000 }),
+        buildPersistedQuickSession({ id: 'session-2', serverPid: 2000 }),
       ];
 
       for (const session of sessions) {
@@ -321,10 +253,10 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should include workers for matched sessions', async () => {
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'session-with-workers',
         serverPid: 5000,
-        workers: [createAgentWorker({ id: 'worker-1' })],
+        workers: [buildPersistedAgentWorker({ id: 'worker-1' })],
       });
 
       await repository.save(session);
@@ -340,10 +272,10 @@ describe('SqliteSessionRepository', () => {
   describe('findPaused', () => {
     it('should return sessions with null serverPid', async () => {
       const sessions = [
-        createQuickSession({ id: 'session-1', serverPid: 1000 }),
-        createQuickSession({ id: 'session-2', serverPid: undefined }),
-        createWorktreeSession({ id: 'session-3', serverPid: undefined }),
-        createQuickSession({ id: 'session-4', serverPid: 2000 }),
+        buildPersistedQuickSession({ id: 'session-1', serverPid: 1000 }),
+        buildPersistedQuickSession({ id: 'session-2', serverPid: undefined }),
+        buildPersistedWorktreeSession({ id: 'session-3', serverPid: undefined }),
+        buildPersistedQuickSession({ id: 'session-4', serverPid: 2000 }),
       ];
 
       for (const session of sessions) {
@@ -358,8 +290,8 @@ describe('SqliteSessionRepository', () => {
 
     it('should return empty array if no paused sessions', async () => {
       const sessions = [
-        createQuickSession({ id: 'session-1', serverPid: 1000 }),
-        createQuickSession({ id: 'session-2', serverPid: 2000 }),
+        buildPersistedQuickSession({ id: 'session-1', serverPid: 1000 }),
+        buildPersistedQuickSession({ id: 'session-2', serverPid: 2000 }),
       ];
 
       for (const session of sessions) {
@@ -377,12 +309,12 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should include workers for paused sessions', async () => {
-      const session = createWorktreeSession({
+      const session = buildPersistedWorktreeSession({
         id: 'paused-session',
         serverPid: undefined,
         workers: [
-          createAgentWorker({ id: 'worker-1' }),
-          createTerminalWorker({ id: 'worker-2' }),
+          buildPersistedAgentWorker({ id: 'worker-1' }),
+          buildPersistedTerminalWorker({ id: 'worker-2' }),
         ],
       });
 
@@ -396,7 +328,7 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should correctly hydrate worktree session metadata', async () => {
-      const session = createWorktreeSession({
+      const session = buildPersistedWorktreeSession({
         id: 'paused-worktree',
         serverPid: undefined,
         repositoryId: 'repo-123',
@@ -422,7 +354,7 @@ describe('SqliteSessionRepository', () => {
 
   describe('save', () => {
     it('should insert new session', async () => {
-      const session = createQuickSession({ id: 'new-session', title: 'New Session' });
+      const session = buildPersistedQuickSession({ id: 'new-session', title: 'New Session' });
 
       await repository.save(session);
 
@@ -432,10 +364,10 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should update existing session', async () => {
-      const session = createQuickSession({ id: 'update-session', title: 'Original' });
+      const session = buildPersistedQuickSession({ id: 'update-session', title: 'Original' });
       await repository.save(session);
 
-      const updated = createQuickSession({ id: 'update-session', title: 'Updated' });
+      const updated = buildPersistedQuickSession({ id: 'update-session', title: 'Updated' });
       await repository.save(updated);
 
       const found = await repository.findById('update-session');
@@ -448,7 +380,7 @@ describe('SqliteSessionRepository', () => {
 
     it('should preserve created_at and update updated_at on update', async () => {
       const originalCreatedAt = '2024-01-01T00:00:00.000Z';
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'timestamp-test',
         title: 'Original',
         createdAt: originalCreatedAt,
@@ -470,7 +402,7 @@ describe('SqliteSessionRepository', () => {
 
       // Update with a different createdAt (simulating real-world scenario where
       // the domain object might have different timestamp)
-      const updated = createQuickSession({
+      const updated = buildPersistedQuickSession({
         id: 'timestamp-test',
         title: 'Updated',
         createdAt: '2024-06-01T00:00:00.000Z', // Different createdAt
@@ -493,10 +425,10 @@ describe('SqliteSessionRepository', () => {
 
     it('should preserve worker created_at and update updated_at on session update', async () => {
       const originalWorkerCreatedAt = '2024-01-01T00:00:00.000Z';
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'worker-timestamp-test',
         workers: [
-          createAgentWorker({
+          buildPersistedAgentWorker({
             id: 'worker-1',
             name: 'Original Worker',
             createdAt: originalWorkerCreatedAt,
@@ -520,10 +452,10 @@ describe('SqliteSessionRepository', () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       // Update session with modified worker (same ID, different data)
-      const updated = createQuickSession({
+      const updated = buildPersistedQuickSession({
         id: 'worker-timestamp-test',
         workers: [
-          createAgentWorker({
+          buildPersistedAgentWorker({
             id: 'worker-1', // Same ID
             name: 'Updated Worker',
             createdAt: '2024-06-01T00:00:00.000Z', // Different createdAt (simulates domain object)
@@ -553,10 +485,10 @@ describe('SqliteSessionRepository', () => {
       // This test verifies the upsert strategy by checking that created_at is preserved
       // even when the worker is "updated" through a session save
       const originalCreatedAt = '2024-01-01T00:00:00.000Z';
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'upsert-test',
         workers: [
-          createAgentWorker({
+          buildPersistedAgentWorker({
             id: 'worker-1',
             name: 'Original',
             pid: 1111,
@@ -575,10 +507,10 @@ describe('SqliteSessionRepository', () => {
       expect(originalRow?.created_at).toBe(originalCreatedAt);
 
       // Update session with same worker ID but different data
-      const updated = createQuickSession({
+      const updated = buildPersistedQuickSession({
         id: 'upsert-test',
         workers: [
-          createAgentWorker({
+          buildPersistedAgentWorker({
             id: 'worker-1', // Same ID
             name: 'Updated',
             pid: 9999, // Different PID
@@ -603,11 +535,11 @@ describe('SqliteSessionRepository', () => {
 
     it('should delete all workers when session is updated to have no workers', async () => {
       // Create session with workers
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'delete-all-workers-test',
         workers: [
-          createAgentWorker({ id: 'worker-1' }),
-          createTerminalWorker({ id: 'worker-2' }),
+          buildPersistedAgentWorker({ id: 'worker-1' }),
+          buildPersistedTerminalWorker({ id: 'worker-2' }),
         ],
       });
       await repository.save(session);
@@ -621,7 +553,7 @@ describe('SqliteSessionRepository', () => {
       expect(beforeWorkers.length).toBe(2);
 
       // Update to have no workers
-      const updated = createQuickSession({
+      const updated = buildPersistedQuickSession({
         id: 'delete-all-workers-test',
         workers: [], // Empty
       });
@@ -637,12 +569,12 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should save session with workers', async () => {
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'session-with-workers',
         workers: [
-          createAgentWorker({ id: 'worker-1' }),
-          createTerminalWorker({ id: 'worker-2' }),
-          createGitDiffWorker({ id: 'worker-3' }),
+          buildPersistedAgentWorker({ id: 'worker-1' }),
+          buildPersistedTerminalWorker({ id: 'worker-2' }),
+          buildPersistedGitDiffWorker({ id: 'worker-3' }),
         ],
       });
 
@@ -654,19 +586,19 @@ describe('SqliteSessionRepository', () => {
 
     it('should replace workers on update (not append)', async () => {
       // Initial save with 2 workers
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'worker-replace-test',
         workers: [
-          createAgentWorker({ id: 'worker-1' }),
-          createTerminalWorker({ id: 'worker-2' }),
+          buildPersistedAgentWorker({ id: 'worker-1' }),
+          buildPersistedTerminalWorker({ id: 'worker-2' }),
         ],
       });
       await repository.save(session);
 
       // Update with different workers
-      const updated = createQuickSession({
+      const updated = buildPersistedQuickSession({
         id: 'worker-replace-test',
-        workers: [createGitDiffWorker({ id: 'worker-3' })],
+        workers: [buildPersistedGitDiffWorker({ id: 'worker-3' })],
       });
       await repository.save(updated);
 
@@ -680,9 +612,9 @@ describe('SqliteSessionRepository', () => {
 
     it('should handle transaction atomically', async () => {
       // Save a valid session first
-      const validSession = createQuickSession({
+      const validSession = buildPersistedQuickSession({
         id: 'valid-session',
-        workers: [createAgentWorker({ id: 'valid-worker' })],
+        workers: [buildPersistedAgentWorker({ id: 'valid-worker' })],
       });
       await repository.save(validSession);
 
@@ -692,11 +624,11 @@ describe('SqliteSessionRepository', () => {
       expect(before?.workers[0].id).toBe('valid-worker');
 
       // Now try to update with new workers - should succeed atomically
-      const updateSession = createQuickSession({
+      const updateSession = buildPersistedQuickSession({
         id: 'valid-session',
         workers: [
-          createTerminalWorker({ id: 'terminal-1' }),
-          createGitDiffWorker({ id: 'git-diff-1' }),
+          buildPersistedTerminalWorker({ id: 'terminal-1' }),
+          buildPersistedGitDiffWorker({ id: 'git-diff-1' }),
         ],
       });
       await repository.save(updateSession);
@@ -708,7 +640,7 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should preserve optional fields as undefined when null in database', async () => {
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'minimal-session',
         title: undefined,
         initialPrompt: undefined,
@@ -725,14 +657,14 @@ describe('SqliteSessionRepository', () => {
   describe('saveAll', () => {
     it('should replace all sessions', async () => {
       // Save initial sessions
-      await repository.save(createQuickSession({ id: 'old-1' }));
-      await repository.save(createQuickSession({ id: 'old-2' }));
+      await repository.save(buildPersistedQuickSession({ id: 'old-1' }));
+      await repository.save(buildPersistedQuickSession({ id: 'old-2' }));
 
       // Replace with new sessions
       const newSessions = [
-        createQuickSession({ id: 'new-1' }),
-        createWorktreeSession({ id: 'new-2' }),
-        createQuickSession({ id: 'new-3' }),
+        buildPersistedQuickSession({ id: 'new-1' }),
+        buildPersistedWorktreeSession({ id: 'new-2' }),
+        buildPersistedQuickSession({ id: 'new-3' }),
       ];
 
       await repository.saveAll(newSessions);
@@ -750,8 +682,8 @@ describe('SqliteSessionRepository', () => {
 
     it('should handle empty array', async () => {
       // Save initial sessions
-      await repository.save(createQuickSession({ id: 'session-1' }));
-      await repository.save(createQuickSession({ id: 'session-2' }));
+      await repository.save(buildPersistedQuickSession({ id: 'session-1' }));
+      await repository.save(buildPersistedQuickSession({ id: 'session-2' }));
 
       // Replace with empty array
       await repository.saveAll([]);
@@ -762,10 +694,10 @@ describe('SqliteSessionRepository', () => {
 
     it('should preserve all session types', async () => {
       const sessions = [
-        createQuickSession({ id: 'quick-1' }),
-        createWorktreeSession({ id: 'worktree-1', repositoryId: 'repo-a' }),
-        createQuickSession({ id: 'quick-2' }),
-        createWorktreeSession({ id: 'worktree-2', repositoryId: 'repo-b' }),
+        buildPersistedQuickSession({ id: 'quick-1' }),
+        buildPersistedWorktreeSession({ id: 'worktree-1', repositoryId: 'repo-a' }),
+        buildPersistedQuickSession({ id: 'quick-2' }),
+        buildPersistedWorktreeSession({ id: 'worktree-2', repositoryId: 'repo-b' }),
       ];
 
       await repository.saveAll(sessions);
@@ -782,15 +714,15 @@ describe('SqliteSessionRepository', () => {
 
     it('should save sessions with workers', async () => {
       const sessions = [
-        createQuickSession({
+        buildPersistedQuickSession({
           id: 'session-1',
-          workers: [createAgentWorker({ id: 'worker-1' })],
+          workers: [buildPersistedAgentWorker({ id: 'worker-1' })],
         }),
-        createQuickSession({
+        buildPersistedQuickSession({
           id: 'session-2',
           workers: [
-            createTerminalWorker({ id: 'worker-2' }),
-            createGitDiffWorker({ id: 'worker-3' }),
+            buildPersistedTerminalWorker({ id: 'worker-2' }),
+            buildPersistedGitDiffWorker({ id: 'worker-3' }),
           ],
         }),
       ];
@@ -808,9 +740,9 @@ describe('SqliteSessionRepository', () => {
   describe('delete', () => {
     it('should remove session by id', async () => {
       const sessions = [
-        createQuickSession({ id: 'session-1' }),
-        createQuickSession({ id: 'session-2' }),
-        createQuickSession({ id: 'session-3' }),
+        buildPersistedQuickSession({ id: 'session-1' }),
+        buildPersistedQuickSession({ id: 'session-2' }),
+        buildPersistedQuickSession({ id: 'session-3' }),
       ];
 
       for (const session of sessions) {
@@ -825,11 +757,11 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should cascade delete workers', async () => {
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'session-to-delete',
         workers: [
-          createAgentWorker({ id: 'worker-1' }),
-          createTerminalWorker({ id: 'worker-2' }),
+          buildPersistedAgentWorker({ id: 'worker-1' }),
+          buildPersistedTerminalWorker({ id: 'worker-2' }),
         ],
       });
 
@@ -852,7 +784,7 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should not fail if session does not exist', async () => {
-      await repository.save(createQuickSession({ id: 'existing' }));
+      await repository.save(buildPersistedQuickSession({ id: 'existing' }));
 
       // Should not throw
       await expect(repository.delete('non-existent')).resolves.toBeUndefined();
@@ -863,15 +795,15 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should not affect other sessions', async () => {
-      const session1 = createQuickSession({
+      const session1 = buildPersistedQuickSession({
         id: 'session-1',
         title: 'Session One',
-        workers: [createAgentWorker({ id: 'worker-1' })],
+        workers: [buildPersistedAgentWorker({ id: 'worker-1' })],
       });
-      const session2 = createWorktreeSession({
+      const session2 = buildPersistedWorktreeSession({
         id: 'session-2',
         repositoryId: 'repo-1',
-        workers: [createTerminalWorker({ id: 'worker-2' })],
+        workers: [buildPersistedTerminalWorker({ id: 'worker-2' })],
       });
 
       await repository.save(session1);
@@ -892,14 +824,14 @@ describe('SqliteSessionRepository', () => {
 
   describe('worker types', () => {
     it('should correctly save and retrieve agent workers', async () => {
-      const agentWorker = createAgentWorker({
+      const agentWorker = buildPersistedAgentWorker({
         id: 'agent-worker-test',
         name: 'Claude Agent',
         agentId: 'custom-agent-id',
         pid: 99999,
       });
 
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'agent-worker-session',
         workers: [agentWorker],
       });
@@ -921,13 +853,13 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should correctly save and retrieve terminal workers', async () => {
-      const terminalWorker = createTerminalWorker({
+      const terminalWorker = buildPersistedTerminalWorker({
         id: 'terminal-worker-test',
         name: 'Bash Terminal',
         pid: 88888,
       });
 
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'terminal-worker-session',
         workers: [terminalWorker],
       });
@@ -948,13 +880,13 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should correctly save and retrieve git-diff workers', async () => {
-      const gitDiffWorker = createGitDiffWorker({
+      const gitDiffWorker = buildPersistedGitDiffWorker({
         id: 'git-diff-worker-test',
         name: 'Diff Viewer',
         baseCommit: 'abcdef123456789',
       });
 
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'git-diff-worker-session',
         workers: [gitDiffWorker],
       });
@@ -975,17 +907,17 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should handle workers with null pid', async () => {
-      const agentWithNullPid = createAgentWorker({
+      const agentWithNullPid = buildPersistedAgentWorker({
         id: 'null-pid-agent',
         pid: null,
       });
 
-      const terminalWithNullPid = createTerminalWorker({
+      const terminalWithNullPid = buildPersistedTerminalWorker({
         id: 'null-pid-terminal',
         pid: null,
       });
 
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'null-pid-session',
         workers: [agentWithNullPid, terminalWithNullPid],
       });
@@ -1007,12 +939,12 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should handle mixed worker types in same session', async () => {
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'mixed-workers-session',
         workers: [
-          createAgentWorker({ id: 'agent-1', name: 'Agent' }),
-          createTerminalWorker({ id: 'terminal-1', name: 'Terminal' }),
-          createGitDiffWorker({ id: 'git-diff-1', name: 'Git Diff' }),
+          buildPersistedAgentWorker({ id: 'agent-1', name: 'Agent' }),
+          buildPersistedTerminalWorker({ id: 'terminal-1', name: 'Terminal' }),
+          buildPersistedGitDiffWorker({ id: 'git-diff-1', name: 'Git Diff' }),
         ],
       });
 
@@ -1125,7 +1057,7 @@ describe('SqliteSessionRepository', () => {
 
   describe('update', () => {
     it('should update pausedAt field', async () => {
-      const session = createWorktreeSession({
+      const session = buildPersistedWorktreeSession({
         id: 'update-paused-test',
         serverPid: process.pid,
       });
@@ -1148,7 +1080,7 @@ describe('SqliteSessionRepository', () => {
 
     it('should clear pausedAt when set to null', async () => {
       // Save session with pausedAt set
-      const session = createWorktreeSession({
+      const session = buildPersistedWorktreeSession({
         id: 'clear-paused-test',
         serverPid: undefined,
         pausedAt: '2025-06-15T12:00:00.000Z',
@@ -1185,7 +1117,7 @@ describe('SqliteSessionRepository', () => {
 
   describe('edge cases', () => {
     it('should handle session with empty workers array', async () => {
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'no-workers',
         workers: [],
       });
@@ -1197,7 +1129,7 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should handle sessions with special characters in paths', async () => {
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'special-path-session',
         locationPath: '/path/with spaces/and-dashes/and_underscores',
       });
@@ -1209,7 +1141,7 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should handle sessions with unicode in title', async () => {
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'unicode-session',
         title: 'Session with unicode: Hello World',
       });
@@ -1222,7 +1154,7 @@ describe('SqliteSessionRepository', () => {
 
     it('should handle long initial prompts', async () => {
       const longPrompt = 'A'.repeat(10000);
-      const session = createQuickSession({
+      const session = buildPersistedQuickSession({
         id: 'long-prompt-session',
         initialPrompt: longPrompt,
       });
@@ -1234,7 +1166,7 @@ describe('SqliteSessionRepository', () => {
     });
 
     it('should handle worktree session without optional fields', async () => {
-      const session = createWorktreeSession({
+      const session = buildPersistedWorktreeSession({
         id: 'minimal-worktree',
         title: undefined,
         initialPrompt: undefined,

--- a/packages/server/src/services/__tests__/inbound-handlers.test.ts
+++ b/packages/server/src/services/__tests__/inbound-handlers.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, mock, jest } from 'bun:test';
-import type { InboundSystemEvent, Session, InboundEventSummary } from '@agent-console/shared';
+import type { InboundSystemEvent, InboundEventSummary } from '@agent-console/shared';
 import { createInboundHandlers } from '../inbound/handlers.js';
 import type { InboundHandlerDependencies } from '../inbound/handlers.js';
+import { buildWorktreeSession } from '../../__tests__/utils/build-test-data.js';
 
 function createReviewCommentEvent(): InboundSystemEvent {
   return {
@@ -47,23 +48,15 @@ function createPrCommentEvent(): InboundSystemEvent {
   };
 }
 
-function createMockSession(): Session {
-  return {
-    id: 'session-1',
-    type: 'worktree',
-    repositoryId: 'repo-1',
-    repositoryName: 'repo',
-    worktreeId: 'feature-branch',
-    isMainWorktree: false,
-    locationPath: '/worktrees/repo',
-    status: 'active',
-    activationState: 'running',
-    createdAt: '2024-01-01T00:00:00Z',
-    workers: [
-      { id: 'worker-1', type: 'agent', name: 'Claude', agentId: 'claude-code-builtin', activated: true, createdAt: '2024-01-01T00:00:00Z' },
-    ],
-  };
-}
+const mockSessionOverrides = {
+  repositoryName: 'repo',
+  worktreeId: 'feature-branch',
+  locationPath: '/worktrees/repo',
+  createdAt: '2024-01-01T00:00:00Z',
+  workers: [
+    { id: 'worker-1', type: 'agent' as const, name: 'Claude', agentId: 'claude-code-builtin', activated: true, createdAt: '2024-01-01T00:00:00Z' },
+  ],
+};
 
 function createAgentHandlerWithCapture(): {
   agentHandler: ReturnType<typeof createInboundHandlers>[number];
@@ -71,7 +64,7 @@ function createAgentHandlerWithCapture(): {
 } {
   let capturedMessage = '';
   const mockSessionManager: InboundHandlerDependencies['sessionManager'] = {
-    getSession: mock(() => createMockSession()),
+    getSession: mock(() => buildWorktreeSession(mockSessionOverrides)),
     writeWorkerInput: mock((_sessionId: string, _workerId: string, data: string) => {
       capturedMessage = data;
       return true;
@@ -126,7 +119,7 @@ describe('AgentWorkerHandler', () => {
 
   it('returns false for unrecognized event type', async () => {
     const mockSessionManager: InboundHandlerDependencies['sessionManager'] = {
-      getSession: mock(() => createMockSession()),
+      getSession: mock(() => buildWorktreeSession(mockSessionOverrides)),
       writeWorkerInput: mock(),
     };
 
@@ -157,7 +150,7 @@ describe('AgentWorkerHandler', () => {
     try {
       const writtenData: string[] = [];
       const mockSessionManager: InboundHandlerDependencies['sessionManager'] = {
-        getSession: mock(() => createMockSession()),
+        getSession: mock(() => buildWorktreeSession(mockSessionOverrides)),
         writeWorkerInput: mock((_sessionId: string, _workerId: string, data: string) => {
           writtenData.push(data);
           return true;

--- a/packages/server/src/services/__tests__/inbound-integration.test.ts
+++ b/packages/server/src/services/__tests__/inbound-integration.test.ts
@@ -3,6 +3,7 @@ import { createHmac } from 'node:crypto';
 import type { Repository, Session, InboundSystemEvent } from '@agent-console/shared';
 import { GitHubServiceParser } from '../inbound/github-service-parser.js';
 import { resolveTargets } from '../inbound/resolve-targets.js';
+import { buildWorktreeSession, buildPersistedRepository } from '../../__tests__/utils/build-test-data.js';
 
 describe('GitHubServiceParser', () => {
   const parser = new GitHubServiceParser('secret-token');
@@ -515,24 +516,14 @@ describe('GitHubServiceParser', () => {
 describe('resolveTargets', () => {
   it('matches worktree sessions by repository and branch', async () => {
     const sessions: Session[] = [
-      {
-        id: 'session-1',
-        type: 'worktree',
-        repositoryId: 'repo-1',
+      buildWorktreeSession({
         repositoryName: 'repo',
-        worktreeId: 'main',
-        isMainWorktree: false,
         locationPath: '/worktrees/repo',
-        status: 'active',
-        activationState: 'running',
-        createdAt: '2024-01-01T00:00:00Z',
-        workers: [],
-      },
+      }),
     ];
 
-    const repositories = new Map<string, Repository>([
-      ['repo-1', { id: 'repo-1', name: 'repo', path: '/worktrees/repo', createdAt: '2024-01-01T00:00:00Z' }],
-    ]);
+    const repo = buildPersistedRepository({ id: 'repo-1', name: 'repo', path: '/worktrees/repo' });
+    const repositories = new Map<string, Repository>([[repo.id, repo]]);
 
     const event: InboundSystemEvent = {
       type: 'ci:completed',
@@ -557,24 +548,15 @@ describe('resolveTargets', () => {
 
   it('returns no targets for branch mismatch', async () => {
     const sessions: Session[] = [
-      {
-        id: 'session-1',
-        type: 'worktree',
-        repositoryId: 'repo-1',
+      buildWorktreeSession({
         repositoryName: 'repo',
         worktreeId: 'develop',
-        isMainWorktree: false,
         locationPath: '/worktrees/repo',
-        status: 'active',
-        activationState: 'running',
-        createdAt: '2024-01-01T00:00:00Z',
-        workers: [],
-      },
+      }),
     ];
 
-    const repositories = new Map<string, Repository>([
-      ['repo-1', { id: 'repo-1', name: 'repo', path: '/worktrees/repo', createdAt: '2024-01-01T00:00:00Z' }],
-    ]);
+    const repo = buildPersistedRepository({ id: 'repo-1', name: 'repo', path: '/worktrees/repo' });
+    const repositories = new Map<string, Repository>([[repo.id, repo]]);
 
     const event: InboundSystemEvent = {
       type: 'ci:completed',

--- a/packages/server/src/services/__tests__/session-converter-service.test.ts
+++ b/packages/server/src/services/__tests__/session-converter-service.test.ts
@@ -1,84 +1,21 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
 import type { Worker } from '@agent-console/shared';
-import type { PersistedSession, PersistedWorker } from '../persistence-service.js';
-import type { InternalWorktreeSession, InternalQuickSession } from '../internal-types.js';
-import type { InternalWorker, InternalAgentWorker, InternalTerminalWorker, InternalGitDiffWorker } from '../worker-types.js';
+import type { PersistedWorker } from '../persistence-service.js';
+import type { InternalWorker, InternalAgentWorker } from '../worker-types.js';
 import type { SessionRepositoryCallbacks } from '../session-manager.js';
 import { SessionConverterService, type SessionConverterDeps } from '../session-converter-service.js';
-
-// --- Helpers to build test fixtures ---
-
-function makeAgentWorker(overrides: Partial<InternalAgentWorker> = {}): InternalAgentWorker {
-  return {
-    id: 'w-agent-1',
-    type: 'agent',
-    name: 'Agent',
-    agentId: 'agent-def-1',
-    createdAt: '2026-01-01T00:00:00Z',
-    pty: { pid: 100 } as InternalAgentWorker['pty'],
-    outputBuffer: '',
-    outputOffset: 0,
-    connectionCallbacks: new Map(),
-    activityState: 'idle',
-    activityDetector: null,
-    ...overrides,
-  };
-}
-
-function makeTerminalWorker(overrides: Partial<InternalTerminalWorker> = {}): InternalTerminalWorker {
-  return {
-    id: 'w-term-1',
-    type: 'terminal',
-    name: 'Terminal',
-    createdAt: '2026-01-01T00:01:00Z',
-    pty: { pid: 200 } as InternalTerminalWorker['pty'],
-    outputBuffer: '',
-    outputOffset: 0,
-    connectionCallbacks: new Map(),
-    ...overrides,
-  };
-}
-
-function makeGitDiffWorker(overrides: Partial<InternalGitDiffWorker> = {}): InternalGitDiffWorker {
-  return {
-    id: 'w-gitdiff-1',
-    type: 'git-diff',
-    name: 'Git Diff',
-    createdAt: '2026-01-01T00:02:00Z',
-    baseCommit: 'abc123',
-    ...overrides,
-  };
-}
-
-function makeWorktreeSession(workers: InternalWorker[], overrides: Partial<InternalWorktreeSession> = {}): InternalWorktreeSession {
-  const workerMap = new Map<string, InternalWorker>();
-  for (const w of workers) workerMap.set(w.id, w);
-  return {
-    id: 'session-1',
-    type: 'worktree',
-    locationPath: '/repos/my-repo/wt-001',
-    repositoryId: 'repo-1',
-    worktreeId: 'wt-1',
-    status: 'active',
-    createdAt: '2026-01-01T00:00:00Z',
-    workers: workerMap,
-    ...overrides,
-  };
-}
-
-function makeQuickSession(workers: InternalWorker[], overrides: Partial<InternalQuickSession> = {}): InternalQuickSession {
-  const workerMap = new Map<string, InternalWorker>();
-  for (const w of workers) workerMap.set(w.id, w);
-  return {
-    id: 'session-2',
-    type: 'quick',
-    locationPath: '/tmp/quick',
-    status: 'active',
-    createdAt: '2026-01-01T00:00:00Z',
-    workers: workerMap,
-    ...overrides,
-  };
-}
+import {
+  buildInternalAgentWorker,
+  buildInternalTerminalWorker,
+  buildInternalGitDiffWorker,
+  buildInternalWorktreeSession,
+  buildInternalQuickSession,
+  buildPersistedWorktreeSession,
+  buildPersistedQuickSession,
+  buildPersistedAgentWorker,
+  buildPersistedTerminalWorker,
+  buildPersistedGitDiffWorker,
+} from '../../__tests__/utils/build-test-data.js';
 
 // --- Test suite ---
 
@@ -106,7 +43,6 @@ describe('SessionConverterService', () => {
       toPublicWorker: (w: InternalWorker): Worker => {
         const existing = toPublicWorkerResults.get(w.id);
         if (existing) return existing;
-        // Default conversion for tests
         if (w.type === 'agent') {
           return { id: w.id, type: 'agent', name: w.name, agentId: w.agentId, createdAt: w.createdAt, activated: w.pty !== null };
         } else if (w.type === 'terminal') {
@@ -136,35 +72,35 @@ describe('SessionConverterService', () => {
 
   describe('computeActivationState', () => {
     it('returns running when at least one PTY worker has an active PTY', () => {
-      const session = makeWorktreeSession([
-        makeAgentWorker({ pty: { pid: 100 } as InternalAgentWorker['pty'] }),
-        makeTerminalWorker({ pty: null }),
+      const session = buildInternalWorktreeSession([
+        buildInternalAgentWorker({ pty: { pid: 100 } as InternalAgentWorker['pty'] }),
+        buildInternalTerminalWorker({ pty: null }),
       ]);
       expect(service.computeActivationState(session)).toBe('running');
     });
 
     it('returns hibernated when all PTY workers have null PTY', () => {
-      const session = makeWorktreeSession([
-        makeAgentWorker({ pty: null }),
-        makeTerminalWorker({ pty: null }),
+      const session = buildInternalWorktreeSession([
+        buildInternalAgentWorker({ pty: null }),
+        buildInternalTerminalWorker({ pty: null }),
       ]);
       expect(service.computeActivationState(session)).toBe('hibernated');
     });
 
     it('returns running when there are no PTY workers (only git-diff)', () => {
-      const session = makeWorktreeSession([makeGitDiffWorker()]);
+      const session = buildInternalWorktreeSession([buildInternalGitDiffWorker()]);
       expect(service.computeActivationState(session)).toBe('running');
     });
 
     it('returns running when there are no workers at all', () => {
-      const session = makeWorktreeSession([]);
+      const session = buildInternalWorktreeSession([]);
       expect(service.computeActivationState(session)).toBe('running');
     });
 
     it('returns running when mix of PTY and non-PTY workers with at least one active PTY', () => {
-      const session = makeWorktreeSession([
-        makeAgentWorker({ pty: { pid: 100 } as InternalAgentWorker['pty'] }),
-        makeGitDiffWorker(),
+      const session = buildInternalWorktreeSession([
+        buildInternalAgentWorker({ pty: { pid: 100 } as InternalAgentWorker['pty'] }),
+        buildInternalGitDiffWorker(),
       ]);
       expect(service.computeActivationState(session)).toBe('running');
     });
@@ -174,8 +110,10 @@ describe('SessionConverterService', () => {
 
   describe('toPublicSession', () => {
     it('converts a worktree session with correct fields', () => {
-      const agent = makeAgentWorker();
-      const session = makeWorktreeSession([agent], {
+      const agent = buildInternalAgentWorker({ agentId: 'agent-def-1', pty: { pid: 100 } as InternalAgentWorker['pty'] });
+      const session = buildInternalWorktreeSession([agent], {
+        locationPath: '/repos/my-repo/wt-001',
+        worktreeId: 'wt-1',
         initialPrompt: 'do something',
         title: 'My Session',
         parentSessionId: 'parent-1',
@@ -205,7 +143,7 @@ describe('SessionConverterService', () => {
     });
 
     it('sets isMainWorktree to true when locationPath matches repository path', () => {
-      const session = makeWorktreeSession([], {
+      const session = buildInternalWorktreeSession([], {
         locationPath: '/repos/my-repo', // matches the mock repository path
       });
 
@@ -216,8 +154,8 @@ describe('SessionConverterService', () => {
     });
 
     it('converts a quick session correctly', () => {
-      const terminal = makeTerminalWorker();
-      const session = makeQuickSession([terminal]);
+      const terminal = buildInternalTerminalWorker();
+      const session = buildInternalQuickSession([terminal]);
 
       const result = service.toPublicSession(session);
 
@@ -227,10 +165,10 @@ describe('SessionConverterService', () => {
     });
 
     it('sorts workers by createdAt', () => {
-      const later = makeAgentWorker({ id: 'w-later', createdAt: '2026-01-01T00:10:00Z' });
-      const earlier = makeTerminalWorker({ id: 'w-earlier', createdAt: '2026-01-01T00:01:00Z' });
+      const later = buildInternalAgentWorker({ id: 'w-later', createdAt: '2026-01-01T00:10:00Z' });
+      const earlier = buildInternalTerminalWorker({ id: 'w-earlier', createdAt: '2026-01-01T00:01:00Z' });
       // Insert in reverse order
-      const session = makeQuickSession([later, earlier]);
+      const session = buildInternalQuickSession([later, earlier]);
 
       const result = service.toPublicSession(session);
 
@@ -244,7 +182,7 @@ describe('SessionConverterService', () => {
         isInitialized: () => false,
       };
 
-      const session = makeWorktreeSession([]);
+      const session = buildInternalWorktreeSession([]);
       const result = service.toPublicSession(session);
       if (result.type === 'worktree') {
         expect(result.repositoryName).toBe('Unknown');
@@ -256,21 +194,19 @@ describe('SessionConverterService', () => {
 
   describe('persistedToPublicSession', () => {
     it('converts a persisted worktree session with agent worker', () => {
-      const persisted: PersistedSession = {
+      const persisted = buildPersistedWorktreeSession({
         id: 'ps-1',
-        type: 'worktree',
         locationPath: '/repos/my-repo/wt-001',
-        repositoryId: 'repo-1',
         worktreeId: 'wt-1',
         serverPid: null,
         createdAt: '2026-01-01T00:00:00Z',
         workers: [
-          { id: 'pw-1', type: 'agent', name: 'Agent', agentId: 'agent-1', createdAt: '2026-01-01T00:00:00Z', pid: null },
+          buildPersistedAgentWorker({ id: 'pw-1', agentId: 'agent-1', createdAt: '2026-01-01T00:00:00Z' }),
         ],
         initialPrompt: 'hello',
         title: 'Persisted Session',
         pausedAt: '2026-01-02T00:00:00Z',
-      };
+      });
 
       const result = service.persistedToPublicSession(persisted);
 
@@ -290,16 +226,15 @@ describe('SessionConverterService', () => {
     });
 
     it('converts a persisted quick session with terminal worker', () => {
-      const persisted: PersistedSession = {
+      const persisted = buildPersistedQuickSession({
         id: 'ps-2',
-        type: 'quick',
         locationPath: '/tmp/quick',
         serverPid: null,
         createdAt: '2026-01-01T00:00:00Z',
         workers: [
-          { id: 'pw-2', type: 'terminal', name: 'Terminal', createdAt: '2026-01-01T00:00:00Z', pid: null },
+          buildPersistedTerminalWorker({ id: 'pw-2', createdAt: '2026-01-01T00:00:00Z' }),
         ],
-      };
+      });
 
       const result = service.persistedToPublicSession(persisted);
 
@@ -311,16 +246,15 @@ describe('SessionConverterService', () => {
     });
 
     it('converts a persisted session with git-diff worker', () => {
-      const persisted: PersistedSession = {
+      const persisted = buildPersistedQuickSession({
         id: 'ps-3',
-        type: 'quick',
         locationPath: '/tmp/quick',
         serverPid: null,
         createdAt: '2026-01-01T00:00:00Z',
         workers: [
-          { id: 'pw-3', type: 'git-diff', name: 'Diff', createdAt: '2026-01-01T00:00:00Z', baseCommit: 'abc123' },
+          buildPersistedGitDiffWorker({ id: 'pw-3', name: 'Diff', baseCommit: 'abc123', createdAt: '2026-01-01T00:00:00Z' }),
         ],
-      };
+      });
 
       const result = service.persistedToPublicSession(persisted);
 
@@ -331,17 +265,15 @@ describe('SessionConverterService', () => {
     });
 
     it('includes parentSessionId and parentWorkerId from persisted data', () => {
-      const persisted: PersistedSession = {
+      const persisted = buildPersistedQuickSession({
         id: 'ps-4',
-        type: 'quick',
         locationPath: '/tmp/quick',
         serverPid: null,
         createdAt: '2026-01-01T00:00:00Z',
-        workers: [],
         parentSessionId: 'parent-s',
         parentWorkerId: 'parent-w',
         createdBy: 'user-42',
-      };
+      });
 
       const result = service.persistedToPublicSession(persisted);
 
@@ -355,8 +287,10 @@ describe('SessionConverterService', () => {
 
   describe('toPersistedSession', () => {
     it('converts an internal worktree session to persisted format with current server PID', () => {
-      const agent = makeAgentWorker();
-      const session = makeWorktreeSession([agent], {
+      const agent = buildInternalAgentWorker({ agentId: 'agent-def-1' });
+      const session = buildInternalWorktreeSession([agent], {
+        locationPath: '/repos/my-repo/wt-001',
+        worktreeId: 'wt-1',
         initialPrompt: 'prompt',
         title: 'title',
         parentSessionId: 'ps',
@@ -385,7 +319,7 @@ describe('SessionConverterService', () => {
     });
 
     it('converts an internal quick session to persisted format', () => {
-      const session = makeQuickSession([makeTerminalWorker()]);
+      const session = buildInternalQuickSession([buildInternalTerminalWorker()]);
 
       const result = service.toPersistedSession(session);
 
@@ -396,7 +330,7 @@ describe('SessionConverterService', () => {
 
   describe('toPersistedSessionWithServerPid', () => {
     it('uses the provided serverPid instead of the current one', () => {
-      const session = makeWorktreeSession([]);
+      const session = buildInternalWorktreeSession([]);
 
       const result = service.toPersistedSessionWithServerPid(session, null);
 
@@ -404,10 +338,10 @@ describe('SessionConverterService', () => {
     });
 
     it('maps all workers through toPersistedWorker', () => {
-      const agent = makeAgentWorker();
-      const terminal = makeTerminalWorker();
-      const gitDiff = makeGitDiffWorker();
-      const session = makeQuickSession([agent, terminal, gitDiff]);
+      const agent = buildInternalAgentWorker();
+      const terminal = buildInternalTerminalWorker();
+      const gitDiff = buildInternalGitDiffWorker();
+      const session = buildInternalQuickSession([agent, terminal, gitDiff]);
 
       const result = service.toPersistedSessionWithServerPid(session, 999);
 

--- a/packages/server/src/services/__tests__/session-deletion-service.test.ts
+++ b/packages/server/src/services/__tests__/session-deletion-service.test.ts
@@ -1,55 +1,16 @@
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { SessionDeletionService, type SessionDeletionDeps } from '../session-deletion-service.js';
-import type { InternalSession, InternalWorktreeSession } from '../internal-types.js';
-import type { InternalWorker } from '../worker-types.js';
-import type { PersistedSession } from '../persistence-service.js';
+import type { InternalSession } from '../internal-types.js';
 import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
+import {
+  buildInternalAgentWorker,
+  buildInternalTerminalWorker,
+  buildInternalGitDiffWorker,
+  buildInternalWorktreeSession,
+  buildPersistedWorktreeSession,
+} from '../../__tests__/utils/build-test-data.js';
 
 const mockStopWatching = mock(() => {});
-
-function createMockWorker(overrides: Partial<InternalWorker> & { id: string; type: InternalWorker['type'] }): InternalWorker {
-  const base = {
-    createdAt: new Date().toISOString(),
-    ...overrides,
-  };
-  if (base.type === 'git-diff') {
-    return base as InternalWorker;
-  }
-  return {
-    ...base,
-    pty: null,
-    callbacks: null,
-    exitReason: null,
-  } as unknown as InternalWorker;
-}
-
-function createMockSession(overrides?: Partial<InternalWorktreeSession>): InternalWorktreeSession {
-  return {
-    id: 'session-1',
-    type: 'worktree',
-    locationPath: '/test/worktree',
-    status: 'active',
-    createdAt: new Date().toISOString(),
-    workers: new Map(),
-    repositoryId: 'repo-1',
-    worktreeId: 'wt-1',
-    ...overrides,
-  };
-}
-
-function createMockPersistedSession(overrides?: Partial<PersistedSession>): PersistedSession {
-  return {
-    id: 'session-1',
-    type: 'worktree',
-    locationPath: '/test/worktree',
-    createdAt: new Date().toISOString(),
-    workers: [],
-    repositoryId: 'repo-1',
-    worktreeId: 'wt-1',
-    serverPid: 12345,
-    ...overrides,
-  } as PersistedSession;
-}
 
 function createMockDeps(overrides?: Partial<SessionDeletionDeps>): SessionDeletionDeps {
   const sessions = new Map<string, InternalSession>();
@@ -112,17 +73,13 @@ describe('SessionDeletionService', () => {
     });
 
     it('should kill PTY workers but not git-diff workers', async () => {
-      const agentWorker = createMockWorker({ id: 'w1', type: 'agent' });
-      const terminalWorker = createMockWorker({ id: 'w2', type: 'terminal' });
-      const gitDiffWorker = createMockWorker({ id: 'w3', type: 'git-diff' });
+      const agentWorker = buildInternalAgentWorker({ id: 'w1' });
+      const terminalWorker = buildInternalTerminalWorker({ id: 'w2' });
+      const gitDiffWorker = buildInternalGitDiffWorker({ id: 'w3' });
 
-      const session = createMockSession({
-        workers: new Map([
-          ['w1', agentWorker],
-          ['w2', terminalWorker],
-          ['w3', gitDiffWorker],
-        ]),
-      });
+      const session = buildInternalWorktreeSession(
+        [agentWorker, terminalWorker, gitDiffWorker],
+      );
 
       const deps = createMockDeps({
         getSession: () => session,
@@ -147,11 +104,9 @@ describe('SessionDeletionService', () => {
     });
 
     it('should delete session and clean up all resources', async () => {
-      const session = createMockSession({
-        workers: new Map([
-          ['w1', createMockWorker({ id: 'w1', type: 'agent' })],
-        ]),
-      });
+      const session = buildInternalWorktreeSession(
+        [buildInternalAgentWorker({ id: 'w1' })],
+      );
 
       const onSessionDeleted = mock(() => {});
       const notifySessionDeleted = mock(() => {});
@@ -187,7 +142,7 @@ describe('SessionDeletionService', () => {
     });
 
     it('should throw if jobQueue is not available', async () => {
-      const session = createMockSession();
+      const session = buildInternalWorktreeSession();
 
       const deps = createMockDeps({
         getSession: () => session,
@@ -201,11 +156,9 @@ describe('SessionDeletionService', () => {
     });
 
     it('should restore in-memory session if persistence delete fails', async () => {
-      const session = createMockSession({
-        workers: new Map([
-          ['w1', createMockWorker({ id: 'w1', type: 'agent' })],
-        ]),
-      });
+      const session = buildInternalWorktreeSession(
+        [buildInternalAgentWorker({ id: 'w1' })],
+      );
 
       const setSession = mock(() => {});
 
@@ -230,7 +183,7 @@ describe('SessionDeletionService', () => {
     });
 
     it('should call timer cleanup callback if set', async () => {
-      const session = createMockSession();
+      const session = buildInternalWorktreeSession();
       const timerCleanup = mock(() => {});
 
       const deps = createMockDeps({
@@ -245,10 +198,9 @@ describe('SessionDeletionService', () => {
     });
 
     it('should stop watching git-diff workers during deletion', async () => {
-      const gitDiffWorker = createMockWorker({ id: 'w1', type: 'git-diff' });
-      const session = createMockSession({
-        workers: new Map([['w1', gitDiffWorker]]),
-      });
+      const session = buildInternalWorktreeSession(
+        [buildInternalGitDiffWorker({ id: 'w1' })],
+      );
 
       const deps = createMockDeps({
         getSession: () => session,
@@ -262,7 +214,7 @@ describe('SessionDeletionService', () => {
     });
 
     it('should not fail if inter-session message cleanup throws', async () => {
-      const session = createMockSession();
+      const session = buildInternalWorktreeSession();
 
       const deps = createMockDeps({
         getSession: () => session,
@@ -277,7 +229,7 @@ describe('SessionDeletionService', () => {
     });
 
     it('should not fail if memo cleanup throws', async () => {
-      const session = createMockSession();
+      const session = buildInternalWorktreeSession();
 
       const deps = createMockDeps({
         getSession: () => session,
@@ -294,7 +246,7 @@ describe('SessionDeletionService', () => {
 
   describe('forceDeleteSession', () => {
     it('should delegate to deleteSession for in-memory sessions', async () => {
-      const session = createMockSession();
+      const session = buildInternalWorktreeSession();
 
       const deps = createMockDeps({
         getSession: (id) => id === 'session-1' ? session : undefined,
@@ -308,7 +260,7 @@ describe('SessionDeletionService', () => {
     });
 
     it('should delete from persistence for orphaned sessions', async () => {
-      const persisted = createMockPersistedSession({ id: 'orphan-1' });
+      const persisted = buildPersistedWorktreeSession({ id: 'orphan-1' });
       const onSessionDeleted = mock(() => {});
 
       const deps = createMockDeps({
@@ -345,7 +297,7 @@ describe('SessionDeletionService', () => {
     });
 
     it('should handle orphaned session without jobQueue', async () => {
-      const persisted = createMockPersistedSession({ id: 'orphan-1' });
+      const persisted = buildPersistedWorktreeSession({ id: 'orphan-1' });
 
       const deps = createMockDeps({
         jobQueue: null,
@@ -369,7 +321,7 @@ describe('SessionDeletionService', () => {
     });
 
     it('should not fail if memo cleanup throws for orphaned session', async () => {
-      const persisted = createMockPersistedSession({ id: 'orphan-1' });
+      const persisted = buildPersistedWorktreeSession({ id: 'orphan-1' });
 
       const deps = createMockDeps({
         sessionRepository: {

--- a/packages/server/src/services/__tests__/session-initialization-service.test.ts
+++ b/packages/server/src/services/__tests__/session-initialization-service.test.ts
@@ -6,6 +6,12 @@ import type { JobQueue } from '../../jobs/index.js';
 import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { SessionInitializationService } from '../session-initialization-service.js';
+import {
+  buildPersistedQuickSession,
+  buildPersistedAgentWorker,
+  buildPersistedTerminalWorker,
+  buildPersistedGitDiffWorker,
+} from '../../__tests__/utils/build-test-data.js';
 
 const TEST_SERVER_PID = 99999;
 
@@ -77,14 +83,11 @@ describe('SessionInitializationService', () => {
 
   describe('initializeSessions (via initialize)', () => {
     it('should mark sessions with dead serverPid as paused', async () => {
-      const session: PersistedSession = {
+      const session = buildPersistedQuickSession({
         id: 'session-1',
-        type: 'quick',
         locationPath: '/some/path',
-        workers: [],
         serverPid: 12345,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
       // serverPid 12345 is dead (not marked alive)
 
       const { service, sessionRepository } = createService({ sessions: [session] });
@@ -98,14 +101,11 @@ describe('SessionInitializationService', () => {
     });
 
     it('should preserve sessions owned by live servers', async () => {
-      const session: PersistedSession = {
+      const session = buildPersistedQuickSession({
         id: 'session-1',
-        type: 'quick',
         locationPath: '/some/path',
-        workers: [],
         serverPid: 12345,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
       mockProcess.markAlive(12345);
 
       const { service, sessionRepository } = createService({ sessions: [session] });
@@ -118,15 +118,12 @@ describe('SessionInitializationService', () => {
     });
 
     it('should keep paused sessions (serverPid === null) unchanged', async () => {
-      const session: PersistedSession = {
+      const session = buildPersistedQuickSession({
         id: 'session-1',
-        type: 'quick',
         locationPath: '/some/path',
-        workers: [],
         serverPid: null,
-        createdAt: '2024-01-01T00:00:00.000Z',
         pausedAt: '2024-01-01T01:00:00.000Z',
-      };
+      });
 
       const { service, sessionRepository } = createService({ sessions: [session] });
       await service.initialize();
@@ -138,14 +135,11 @@ describe('SessionInitializationService', () => {
     });
 
     it('should remove sessions whose locationPath no longer exists', async () => {
-      const session: PersistedSession = {
+      const session = buildPersistedQuickSession({
         id: 'orphan-session',
-        type: 'quick',
         locationPath: '/nonexistent/path',
-        workers: [],
         serverPid: 12345,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
       // serverPid 12345 is dead (not marked alive)
 
       const { service, sessionRepository, workerOutputFileManager } = createService({
@@ -163,23 +157,19 @@ describe('SessionInitializationService', () => {
     });
 
     it('should kill orphan worker processes before marking session as paused', async () => {
-      const session: PersistedSession = {
+      const session = buildPersistedQuickSession({
         id: 'session-1',
-        type: 'quick',
         locationPath: '/some/path',
         workers: [
-          {
+          buildPersistedAgentWorker({
             id: 'worker-1',
-            type: 'agent',
             name: 'Claude',
             agentId: 'claude-code',
             pid: 11111,
-            createdAt: '2024-01-01T00:00:00.000Z',
-          },
+          }),
         ],
         serverPid: 12345,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
       mockProcess.markAlive(11111);
       // serverPid 12345 is dead
 
@@ -190,23 +180,19 @@ describe('SessionInitializationService', () => {
     });
 
     it('should skip sessions already in memory', async () => {
-      const session: PersistedSession = {
+      const session = buildPersistedQuickSession({
         id: 'in-memory-session',
-        type: 'quick',
         locationPath: '/some/path',
         workers: [
-          {
+          buildPersistedAgentWorker({
             id: 'worker-1',
-            type: 'agent',
             name: 'Claude',
             agentId: 'claude-code',
             pid: 11111,
-            createdAt: '2024-01-01T00:00:00.000Z',
-          },
+          }),
         ],
         serverPid: 12345,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
       mockProcess.markAlive(11111);
 
       const { service } = createService({
@@ -225,17 +211,15 @@ describe('SessionInitializationService', () => {
       mockProcess.markAlive(1001);
       mockProcess.markAlive(1002);
 
-      const session: PersistedSession = {
+      const session = buildPersistedQuickSession({
         id: 'session-1',
-        type: 'quick',
         locationPath: '/some/path',
         workers: [
-          { id: 'w1', type: 'agent', name: 'Agent', agentId: 'claude-code', pid: 1001, createdAt: '2024-01-01T00:00:00.000Z' },
-          { id: 'w2', type: 'terminal', name: 'Term', pid: 1002, createdAt: '2024-01-01T00:00:00.000Z' },
+          buildPersistedAgentWorker({ id: 'w1', name: 'Agent', agentId: 'claude-code', pid: 1001 }),
+          buildPersistedTerminalWorker({ id: 'w2', name: 'Term', pid: 1002 }),
         ],
         serverPid: 999,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
 
       const count = SessionInitializationService.killOrphanWorkers(session);
       expect(count).toBe(2);
@@ -244,32 +228,28 @@ describe('SessionInitializationService', () => {
     });
 
     it('should skip git-diff workers', () => {
-      const session: PersistedSession = {
+      const session = buildPersistedQuickSession({
         id: 'session-1',
-        type: 'quick',
         locationPath: '/some/path',
         workers: [
-          { id: 'w1', type: 'git-diff', name: 'Diff', baseCommit: 'abc123', createdAt: '2024-01-01T00:00:00.000Z' },
+          buildPersistedGitDiffWorker({ id: 'w1', name: 'Diff', baseCommit: 'abc123' }),
         ],
         serverPid: 999,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
 
       const count = SessionInitializationService.killOrphanWorkers(session);
       expect(count).toBe(0);
     });
 
     it('should skip workers with no pid', () => {
-      const session: PersistedSession = {
+      const session = buildPersistedQuickSession({
         id: 'session-1',
-        type: 'quick',
         locationPath: '/some/path',
         workers: [
-          { id: 'w1', type: 'agent', name: 'Agent', agentId: 'claude-code', pid: null, createdAt: '2024-01-01T00:00:00.000Z' },
+          buildPersistedAgentWorker({ id: 'w1', name: 'Agent', agentId: 'claude-code', pid: null }),
         ],
         serverPid: 999,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
 
       const count = SessionInitializationService.killOrphanWorkers(session);
       expect(count).toBe(0);
@@ -277,16 +257,14 @@ describe('SessionInitializationService', () => {
 
     it('should skip workers whose process is already dead', () => {
       // pid 2001 is not marked alive
-      const session: PersistedSession = {
+      const session = buildPersistedQuickSession({
         id: 'session-1',
-        type: 'quick',
         locationPath: '/some/path',
         workers: [
-          { id: 'w1', type: 'agent', name: 'Agent', agentId: 'claude-code', pid: 2001, createdAt: '2024-01-01T00:00:00.000Z' },
+          buildPersistedAgentWorker({ id: 'w1', name: 'Agent', agentId: 'claude-code', pid: 2001 }),
         ],
         serverPid: 999,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      };
+      });
 
       const count = SessionInitializationService.killOrphanWorkers(session);
       expect(count).toBe(0);

--- a/packages/server/src/services/__tests__/session-manager-cleanup.test.ts
+++ b/packages/server/src/services/__tests__/session-manager-cleanup.test.ts
@@ -4,6 +4,11 @@ import type { PersistedSession } from '../persistence-service.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
+import {
+  buildPersistedQuickSession,
+  buildPersistedWorktreeSession,
+  buildPersistedAgentWorker,
+} from '../../__tests__/utils/build-test-data.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { AgentManager } from '../agent-manager.js';
 import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
@@ -75,23 +80,20 @@ describe('SessionManager cleanup on initialization', () => {
     // Create the location path that the session references
     fs.mkdirSync('/path/to/worktree', { recursive: true });
 
-    const legacySession: PersistedSession = {
+    const legacySession = buildPersistedQuickSession({
       id: 'legacy-session',
-      type: 'quick',
       locationPath: '/path/to/worktree',
       workers: [
-        {
+        buildPersistedAgentWorker({
           id: 'worker-1',
-          type: 'agent',
           name: 'Claude',
           agentId: 'claude-code',
           pid: 11111,
           createdAt: '2024-01-01T00:00:00.000Z',
-        },
+        }),
       ],
-      serverPid: undefined,
       createdAt: '2024-01-01T00:00:00.000Z',
-    };
+    });
     persistSessions([legacySession]);
     persistAgents();
 
@@ -115,25 +117,21 @@ describe('SessionManager cleanup on initialization', () => {
     // Create the location path that the session references
     fs.mkdirSync('/path/to/worktree', { recursive: true });
 
-    const activeSession: PersistedSession = {
+    const activeSession = buildPersistedWorktreeSession({
       id: 'active-session',
-      type: 'worktree',
       locationPath: '/path/to/worktree',
-      repositoryId: 'repo-1',
-      worktreeId: 'main',
       workers: [
-        {
+        buildPersistedAgentWorker({
           id: 'worker-1',
-          type: 'agent',
           name: 'Claude',
           agentId: 'claude-code',
           pid: 22222,
           createdAt: '2024-01-01T00:00:00.000Z',
-        },
+        }),
       ],
       serverPid: 33333, // Parent server PID
       createdAt: '2024-01-01T00:00:00.000Z',
-    };
+    });
     persistSessions([activeSession]);
     persistAgents();
 
@@ -151,23 +149,21 @@ describe('SessionManager cleanup on initialization', () => {
     // Create the location path that the session references
     fs.mkdirSync('/path/to/worktree', { recursive: true });
 
-    const orphanSession: PersistedSession = {
+    const orphanSession = buildPersistedQuickSession({
       id: 'orphan-session',
-      type: 'quick',
       locationPath: '/path/to/worktree',
       workers: [
-        {
+        buildPersistedAgentWorker({
           id: 'worker-1',
-          type: 'agent',
           name: 'Claude',
           agentId: 'claude-code',
           pid: 44444,
           createdAt: '2024-01-01T00:00:00.000Z',
-        },
+        }),
       ],
       serverPid: 55555, // Dead parent server
       createdAt: '2024-01-01T00:00:00.000Z',
-    };
+    });
     persistSessions([orphanSession]);
     persistAgents();
 
@@ -194,59 +190,50 @@ describe('SessionManager cleanup on initialization', () => {
     fs.mkdirSync('/path/3', { recursive: true });
 
     const sessions: PersistedSession[] = [
-      {
+      buildPersistedQuickSession({
         id: 'legacy-session',
-        type: 'quick',
         locationPath: '/path/1',
         workers: [
-          {
+          buildPersistedAgentWorker({
             id: 'worker-1',
-            type: 'agent',
             name: 'Claude',
             agentId: 'claude-code',
             pid: 10001,
             createdAt: '2024-01-01T00:00:00.000Z',
-          },
+          }),
         ],
-        serverPid: undefined,
         createdAt: '2024-01-01T00:00:00.000Z',
-      },
-      {
+      }),
+      buildPersistedWorktreeSession({
         id: 'active-session',
-        type: 'worktree',
         locationPath: '/path/2',
-        repositoryId: 'repo-1',
-        worktreeId: 'main',
         workers: [
-          {
+          buildPersistedAgentWorker({
             id: 'worker-2',
-            type: 'agent',
             name: 'Claude',
             agentId: 'claude-code',
             pid: 10002,
             createdAt: '2024-01-01T00:00:00.000Z',
-          },
+          }),
         ],
         serverPid: 20001, // Alive server
         createdAt: '2024-01-01T00:00:00.000Z',
-      },
-      {
+      }),
+      buildPersistedQuickSession({
         id: 'orphan-session',
-        type: 'quick',
         locationPath: '/path/3',
         workers: [
-          {
+          buildPersistedAgentWorker({
             id: 'worker-3',
-            type: 'agent',
             name: 'Claude',
             agentId: 'claude-code',
             pid: 10003,
             createdAt: '2024-01-01T00:00:00.000Z',
-          },
+          }),
         ],
         serverPid: 20002, // Dead server
         createdAt: '2024-01-01T00:00:00.000Z',
-      },
+      }),
     ];
     persistSessions(sessions);
     persistAgents();

--- a/packages/server/src/services/__tests__/session-metadata-service.test.ts
+++ b/packages/server/src/services/__tests__/session-metadata-service.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
+import {
+  buildInternalWorktreeSession,
+  buildInternalQuickSession,
+  buildPersistedWorktreeSession,
+  buildPersistedQuickSession,
+  buildPersistedAgentWorker,
+  buildPersistedGitDiffWorker,
+} from '../../__tests__/utils/build-test-data.js';
 import { SessionMetadataService, type SessionMetadataDeps } from '../session-metadata-service.js';
-import type { InternalWorktreeSession, InternalQuickSession } from '../internal-types.js';
 import type { InternalSession } from '../internal-types.js';
-import type { PersistedSession, PersistedWorktreeSession, PersistedQuickSession, PersistedGitDiffWorker } from '../persistence-service.js';
+import type { PersistedSession, PersistedWorktreeSession, PersistedGitDiffWorker } from '../persistence-service.js';
 import type { Session } from '@agent-console/shared';
 import type { SessionRepository } from '../../repositories/session-repository.js';
 
@@ -33,45 +40,6 @@ function createMockDeps(overrides?: Partial<SessionMetadataDeps>): SessionMetada
   };
 }
 
-function createActiveWorktreeSession(overrides?: Partial<InternalWorktreeSession>): InternalWorktreeSession {
-  return {
-    id: 'session-1',
-    type: 'worktree',
-    repositoryId: 'repo-1',
-    worktreeId: 'old-branch',
-    locationPath: '/test/path',
-    status: 'active',
-    createdAt: new Date().toISOString(),
-    workers: new Map(),
-    ...overrides,
-  };
-}
-
-function createActiveQuickSession(overrides?: Partial<InternalQuickSession>): InternalQuickSession {
-  return {
-    id: 'session-2',
-    type: 'quick',
-    locationPath: '/test/quick-path',
-    status: 'active',
-    createdAt: new Date().toISOString(),
-    workers: new Map(),
-    ...overrides,
-  };
-}
-
-function createPersistedWorktreeSession(overrides?: Partial<PersistedWorktreeSession>): PersistedWorktreeSession {
-  return {
-    id: 'session-3',
-    type: 'worktree',
-    repositoryId: 'repo-1',
-    worktreeId: 'old-branch',
-    locationPath: '/test/path',
-    createdAt: new Date().toISOString(),
-    workers: [],
-    ...overrides,
-  };
-}
-
 describe('SessionMetadataService', () => {
   let deps: SessionMetadataDeps;
   let service: SessionMetadataService;
@@ -86,7 +54,7 @@ describe('SessionMetadataService', () => {
 
   describe('updateSessionMetadata - active session', () => {
     it('should update title for active session', async () => {
-      const session = createActiveWorktreeSession();
+      const session = buildInternalWorktreeSession([], { worktreeId: 'old-branch', locationPath: '/test/path' });
       const onSessionUpdated = mock(() => {});
       deps = createMockDeps({
         getSession: mock(() => session),
@@ -104,7 +72,7 @@ describe('SessionMetadataService', () => {
     });
 
     it('should rename branch for active worktree session', async () => {
-      const session = createActiveWorktreeSession();
+      const session = buildInternalWorktreeSession([], { worktreeId: 'old-branch', locationPath: '/test/path' });
       deps = createMockDeps({
         getSession: mock(() => session),
       });
@@ -121,7 +89,7 @@ describe('SessionMetadataService', () => {
     });
 
     it('should fail branch rename for quick session', async () => {
-      const session = createActiveQuickSession();
+      const session = buildInternalQuickSession([], { locationPath: '/test/quick-path' });
       deps = createMockDeps({
         getSession: mock(() => session),
       });
@@ -134,7 +102,7 @@ describe('SessionMetadataService', () => {
     });
 
     it('should handle git rename failure for active session', async () => {
-      const session = createActiveWorktreeSession();
+      const session = buildInternalWorktreeSession([], { worktreeId: 'old-branch', locationPath: '/test/path' });
       deps = createMockDeps({
         getSession: mock(() => session),
       });
@@ -148,7 +116,7 @@ describe('SessionMetadataService', () => {
     });
 
     it('should succeed even when git-diff update fails for active session', async () => {
-      const session = createActiveWorktreeSession();
+      const session = buildInternalWorktreeSession([], { worktreeId: 'old-branch', locationPath: '/test/path' });
       deps = createMockDeps({
         getSession: mock(() => session),
         updateGitDiffWorkersAfterBranchRename: mock(() => Promise.reject(new Error('diff error'))),
@@ -162,7 +130,7 @@ describe('SessionMetadataService', () => {
     });
 
     it('should update both title and branch for active session', async () => {
-      const session = createActiveWorktreeSession();
+      const session = buildInternalWorktreeSession([], { worktreeId: 'old-branch', locationPath: '/test/path' });
       deps = createMockDeps({
         getSession: mock(() => session),
       });
@@ -190,7 +158,7 @@ describe('SessionMetadataService', () => {
     });
 
     it('should update title for inactive session', async () => {
-      const persisted = createPersistedWorktreeSession();
+      const persisted = buildPersistedWorktreeSession({ id: 'session-3', worktreeId: 'old-branch', locationPath: '/test/path' });
       const saveMock = mock((_session: PersistedSession) => Promise.resolve());
       deps = createMockDeps({
         sessionRepository: createMockSessionRepository({
@@ -210,7 +178,7 @@ describe('SessionMetadataService', () => {
     });
 
     it('should rename branch for inactive worktree session', async () => {
-      const persisted = createPersistedWorktreeSession();
+      const persisted = buildPersistedWorktreeSession({ id: 'session-3', worktreeId: 'old-branch', locationPath: '/test/path' });
       const saveMock = mock((_session: PersistedSession) => Promise.resolve());
       deps = createMockDeps({
         sessionRepository: createMockSessionRepository({
@@ -230,13 +198,7 @@ describe('SessionMetadataService', () => {
     });
 
     it('should fail branch rename for inactive quick session', async () => {
-      const persisted: PersistedQuickSession = {
-        id: 'session-4',
-        type: 'quick',
-        locationPath: '/test/quick-path',
-        createdAt: new Date().toISOString(),
-        workers: [],
-      };
+      const persisted = buildPersistedQuickSession({ id: 'session-4', locationPath: '/test/quick-path' });
       deps = createMockDeps({
         sessionRepository: createMockSessionRepository({
           findById: mock(() => Promise.resolve(persisted)),
@@ -251,10 +213,13 @@ describe('SessionMetadataService', () => {
     });
 
     it('should update git-diff workers base commit for inactive session', async () => {
-      const persisted = createPersistedWorktreeSession({
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-3',
+        worktreeId: 'old-branch',
+        locationPath: '/test/path',
         workers: [
-          { id: 'w1', type: 'agent', name: 'Claude', agentId: 'claude-code-builtin', pid: null, createdAt: new Date().toISOString() },
-          { id: 'w2', type: 'git-diff', name: 'Diff', baseCommit: 'old-commit', createdAt: new Date().toISOString() },
+          buildPersistedAgentWorker({ id: 'w1', name: 'Claude' }),
+          buildPersistedGitDiffWorker({ id: 'w2', name: 'Diff', baseCommit: 'old-commit' }),
         ],
       });
       const saveMock = mock((_session: PersistedSession) => Promise.resolve());
@@ -279,9 +244,12 @@ describe('SessionMetadataService', () => {
     });
 
     it('should succeed branch rename even when calculateBaseCommit fails for inactive session', async () => {
-      const persisted = createPersistedWorktreeSession({
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-3',
+        worktreeId: 'old-branch',
+        locationPath: '/test/path',
         workers: [
-          { id: 'w1', type: 'git-diff', name: 'Diff', baseCommit: 'old-commit', createdAt: new Date().toISOString() },
+          buildPersistedGitDiffWorker({ id: 'w1', name: 'Diff', baseCommit: 'old-commit' }),
         ],
       });
       const saveMock = mock((_session: PersistedSession) => Promise.resolve());
@@ -305,7 +273,7 @@ describe('SessionMetadataService', () => {
     });
 
     it('should update both title and branch for inactive session in single save', async () => {
-      const persisted = createPersistedWorktreeSession();
+      const persisted = buildPersistedWorktreeSession({ id: 'session-3', worktreeId: 'old-branch', locationPath: '/test/path' });
       const saveMock = mock((_session: PersistedSession) => Promise.resolve());
       deps = createMockDeps({
         sessionRepository: createMockSessionRepository({
@@ -331,9 +299,12 @@ describe('SessionMetadataService', () => {
     });
 
     it('should use HEAD as fallback when calculateBaseCommit returns null', async () => {
-      const persisted = createPersistedWorktreeSession({
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-3',
+        worktreeId: 'old-branch',
+        locationPath: '/test/path',
         workers: [
-          { id: 'w1', type: 'git-diff', name: 'Diff', baseCommit: 'old-commit', createdAt: new Date().toISOString() },
+          buildPersistedGitDiffWorker({ id: 'w1', name: 'Diff', baseCommit: 'old-commit' }),
         ],
       });
       const saveMock = mock((_session: PersistedSession) => Promise.resolve());
@@ -357,7 +328,7 @@ describe('SessionMetadataService', () => {
 
   describe('renameBranch', () => {
     it('should delegate to updateSessionMetadata with branch parameter', async () => {
-      const session = createActiveWorktreeSession();
+      const session = buildInternalWorktreeSession([], { worktreeId: 'old-branch', locationPath: '/test/path' });
       deps = createMockDeps({
         getSession: mock(() => session),
       });
@@ -374,7 +345,7 @@ describe('SessionMetadataService', () => {
   describe('callback broadcasting', () => {
     it('should not broadcast for inactive session updates', async () => {
       const onSessionUpdated = mock(() => {});
-      const persisted = createPersistedWorktreeSession();
+      const persisted = buildPersistedWorktreeSession({ id: 'session-3', worktreeId: 'old-branch', locationPath: '/test/path' });
       deps = createMockDeps({
         sessionRepository: createMockSessionRepository({
           findById: mock(() => Promise.resolve(persisted)),
@@ -389,7 +360,7 @@ describe('SessionMetadataService', () => {
     });
 
     it('should broadcast for active session updates', async () => {
-      const session = createActiveWorktreeSession();
+      const session = buildInternalWorktreeSession([], { worktreeId: 'old-branch', locationPath: '/test/path' });
       const onSessionUpdated = mock(() => {});
       deps = createMockDeps({
         getSession: mock(() => session),
@@ -403,7 +374,7 @@ describe('SessionMetadataService', () => {
     });
 
     it('should handle missing lifecycle callbacks gracefully', async () => {
-      const session = createActiveWorktreeSession();
+      const session = buildInternalWorktreeSession([], { worktreeId: 'old-branch', locationPath: '/test/path' });
       deps = createMockDeps({
         getSession: mock(() => session),
         getSessionLifecycleCallbacks: () => undefined,

--- a/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
+++ b/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
@@ -1,70 +1,20 @@
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { SessionPauseResumeService, type SessionPauseResumeDeps } from '../session-pause-resume-service.js';
-import type { InternalSession, InternalWorktreeSession, InternalQuickSession } from '../internal-types.js';
-import type { InternalWorker } from '../worker-types.js';
+import type { InternalSession } from '../internal-types.js';
 import type { PersistedSession } from '../persistence-service.js';
 import type { Session } from '@agent-console/shared';
+import {
+  buildInternalAgentWorker,
+  buildInternalTerminalWorker,
+  buildInternalGitDiffWorker,
+  buildInternalWorktreeSession,
+  buildInternalQuickSession,
+  buildPersistedWorktreeSession,
+  buildPersistedAgentWorker,
+  buildPersistedTerminalWorker,
+} from '../../__tests__/utils/build-test-data.js';
 
 const mockStopWatching = mock(() => {});
-
-function createMockWorker(overrides: Partial<InternalWorker> & { id: string; type: InternalWorker['type'] }): InternalWorker {
-  const base = {
-    createdAt: new Date().toISOString(),
-    name: overrides.type === 'agent' ? 'Agent' : overrides.type === 'terminal' ? 'Terminal' : 'Diff',
-    ...overrides,
-  };
-  if (base.type === 'git-diff') {
-    return { ...base, baseCommit: 'abc123' } as InternalWorker;
-  }
-  return {
-    ...base,
-    pty: null,
-    callbacks: null,
-    exitReason: null,
-    ...(base.type === 'agent' ? { agentId: 'test-agent' } : {}),
-  } as unknown as InternalWorker;
-}
-
-function createMockWorktreeSession(overrides?: Partial<InternalWorktreeSession>): InternalWorktreeSession {
-  return {
-    id: 'session-1',
-    type: 'worktree',
-    locationPath: '/test/worktree',
-    status: 'active',
-    createdAt: new Date().toISOString(),
-    workers: new Map(),
-    repositoryId: 'repo-1',
-    worktreeId: 'wt-1',
-    ...overrides,
-  };
-}
-
-function createMockQuickSession(overrides?: Partial<InternalQuickSession>): InternalQuickSession {
-  return {
-    id: 'session-2',
-    type: 'quick',
-    locationPath: '/test/quick',
-    status: 'active',
-    createdAt: new Date().toISOString(),
-    workers: new Map(),
-    ...overrides,
-  };
-}
-
-function createMockPersistedSession(overrides?: Partial<PersistedSession>): PersistedSession {
-  return {
-    id: 'session-1',
-    type: 'worktree',
-    locationPath: '/test/worktree',
-    createdAt: new Date().toISOString(),
-    workers: [],
-    repositoryId: 'repo-1',
-    worktreeId: 'wt-1',
-    serverPid: null,
-    pausedAt: '2026-01-01T00:00:00.000Z',
-    ...overrides,
-  } as PersistedSession;
-}
 
 function createMockDeps(overrides?: Partial<SessionPauseResumeDeps>): SessionPauseResumeDeps {
   const sessions = new Map<string, InternalSession>();
@@ -152,7 +102,7 @@ describe('SessionPauseResumeService', () => {
     });
 
     it('should return false for quick sessions', async () => {
-      const session = createMockQuickSession();
+      const session = buildInternalQuickSession();
       const deps = createMockDeps({
         getSession: () => session,
       });
@@ -164,14 +114,9 @@ describe('SessionPauseResumeService', () => {
     });
 
     it('should pause a worktree session successfully', async () => {
-      const agentWorker = createMockWorker({ id: 'w1', type: 'agent' });
-      const gitDiffWorker = createMockWorker({ id: 'w2', type: 'git-diff' });
-      const session = createMockWorktreeSession({
-        workers: new Map([
-          ['w1', agentWorker],
-          ['w2', gitDiffWorker],
-        ]),
-      });
+      const agentWorker = buildInternalAgentWorker({ id: 'w1' });
+      const gitDiffWorker = buildInternalGitDiffWorker({ id: 'w2' });
+      const session = buildInternalWorktreeSession([agentWorker, gitDiffWorker]);
 
       const notifySessionPaused = mock(() => {});
       const onSessionPaused = mock(() => {});
@@ -210,14 +155,9 @@ describe('SessionPauseResumeService', () => {
     });
 
     it('should kill both agent and terminal workers', async () => {
-      const agentWorker = createMockWorker({ id: 'w1', type: 'agent' });
-      const terminalWorker = createMockWorker({ id: 'w2', type: 'terminal' });
-      const session = createMockWorktreeSession({
-        workers: new Map([
-          ['w1', agentWorker],
-          ['w2', terminalWorker],
-        ]),
-      });
+      const agentWorker = buildInternalAgentWorker({ id: 'w1' });
+      const terminalWorker = buildInternalTerminalWorker({ id: 'w2' });
+      const session = buildInternalWorktreeSession([agentWorker, terminalWorker]);
 
       const deps = createMockDeps({
         getSession: () => session,
@@ -232,7 +172,7 @@ describe('SessionPauseResumeService', () => {
 
   describe('resumeSession', () => {
     it('should return existing session if already active', async () => {
-      const session = createMockWorktreeSession();
+      const session = buildInternalWorktreeSession();
       const mockPublicSession = { id: 'session-1' } as unknown as Session;
 
       const deps = createMockDeps({
@@ -258,7 +198,7 @@ describe('SessionPauseResumeService', () => {
     });
 
     it('should return null if path no longer exists', async () => {
-      const persisted = createMockPersistedSession();
+      const persisted = buildPersistedWorktreeSession({ id: 'session-1', serverPid: null, pausedAt: '2026-01-01T00:00:00.000Z' });
       const deps = createMockDeps({
         sessionRepository: {
           ...createMockDeps().sessionRepository,
@@ -274,10 +214,13 @@ describe('SessionPauseResumeService', () => {
     });
 
     it('should resume a paused session successfully', async () => {
-      const agentWorker = createMockWorker({ id: 'w1', type: 'agent' });
+      const agentWorker = buildInternalAgentWorker({ id: 'w1' });
       const restoredWorkers = new Map([['w1', agentWorker]]);
-      const persisted = createMockPersistedSession({
-        workers: [{ id: 'w1', type: 'agent', name: 'Agent', createdAt: new Date().toISOString(), agentId: 'test-agent', pid: null }],
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-1',
+        serverPid: null,
+        pausedAt: '2026-01-01T00:00:00.000Z',
+        workers: [buildPersistedAgentWorker({ id: 'w1', agentId: 'test-agent' })],
       });
 
       const onSessionResumed = mock(() => {});
@@ -320,7 +263,7 @@ describe('SessionPauseResumeService', () => {
     });
 
     it('should prevent concurrent resume attempts for the same session', async () => {
-      const persisted = createMockPersistedSession();
+      const persisted = buildPersistedWorktreeSession({ id: 'session-1', serverPid: null, pausedAt: '2026-01-01T00:00:00.000Z' });
 
       // Create a slow resume that we can control
       let resolveResume: () => void;
@@ -357,9 +300,11 @@ describe('SessionPauseResumeService', () => {
     });
 
     it('should roll back on PTY activation failure', async () => {
-      const agentWorker = createMockWorker({ id: 'w1', type: 'agent' });
+      const agentWorker = buildInternalAgentWorker({ id: 'w1' });
       const restoredWorkers = new Map([['w1', agentWorker]]);
-      const persisted = createMockPersistedSession({
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-1',
+        serverPid: null,
         pausedAt: '2026-01-01T00:00:00.000Z',
       });
 
@@ -391,9 +336,11 @@ describe('SessionPauseResumeService', () => {
     });
 
     it('should roll back on DB persistence failure after successful PTY activation', async () => {
-      const agentWorker = createMockWorker({ id: 'w1', type: 'agent' });
+      const agentWorker = buildInternalAgentWorker({ id: 'w1' });
       const restoredWorkers = new Map([['w1', agentWorker]]);
-      const persisted = createMockPersistedSession({
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-1',
+        serverPid: null,
         pausedAt: '2026-01-01T00:00:00.000Z',
       });
 
@@ -430,10 +377,13 @@ describe('SessionPauseResumeService', () => {
     });
 
     it('should restore terminal workers during resume', async () => {
-      const terminalWorker = createMockWorker({ id: 'w1', type: 'terminal' });
+      const terminalWorker = buildInternalTerminalWorker({ id: 'w1' });
       const restoredWorkers = new Map([['w1', terminalWorker]]);
-      const persisted = createMockPersistedSession({
-        workers: [{ id: 'w1', type: 'terminal', name: 'Terminal', createdAt: new Date().toISOString(), pid: null }],
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-1',
+        serverPid: null,
+        pausedAt: '2026-01-01T00:00:00.000Z',
+        workers: [buildPersistedTerminalWorker({ id: 'w1' })],
       });
 
       const deps = createMockDeps({

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -11,6 +11,7 @@ import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { resetGitMocks, mockGit } from '../../__tests__/utils/mock-git-helper.js';
+import { buildInternalWorktreeSession, buildInternalQuickSession } from '../../__tests__/utils/build-test-data.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { AgentManager, CLAUDE_CODE_AGENT_ID } from '../agent-manager.js';
 import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
@@ -48,30 +49,12 @@ describe('WorkerLifecycleManager', () => {
   let mockOnDiffBaseCommitChanged: ReturnType<typeof mock>;
   let originalAgentConsoleHome: string | undefined;
 
-  function createTestSession(overrides: Partial<InternalSession> = {}): InternalSession {
-    return {
-      id: crypto.randomUUID(),
-      type: 'worktree',
-      locationPath: '/test/project',
-      status: 'active',
-      createdAt: new Date().toISOString(),
-      workers: new Map(),
-      repositoryId: 'repo-1',
-      worktreeId: 'main',
-      ...overrides,
-    } as InternalSession;
+  function createTestSession(overrides?: Parameters<typeof buildInternalWorktreeSession>[1]) {
+    return buildInternalWorktreeSession([], { locationPath: '/test/project', ...overrides });
   }
 
-  function createQuickSession(overrides: Partial<InternalSession> = {}): InternalSession {
-    return {
-      type: 'quick',
-      id: crypto.randomUUID(),
-      locationPath: '/test/project',
-      status: 'active',
-      createdAt: new Date().toISOString(),
-      workers: new Map(),
-      ...overrides,
-    } as InternalSession;
+  function createQuickSession(overrides?: Parameters<typeof buildInternalQuickSession>[1]) {
+    return buildInternalQuickSession([], { locationPath: '/test/project', ...overrides });
   }
 
   function createDeps(overrides: Partial<WorkerLifecycleDeps> = {}): WorkerLifecycleDeps {

--- a/packages/server/src/services/__tests__/worker-manager-env.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager-env.test.ts
@@ -6,10 +6,10 @@ import { AgentManager } from '../agent-manager.js';
 import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
 import { WorkerManager } from '../worker-manager.js';
 import { SingleUserMode } from '../user-mode.js';
-import type { InternalAgentWorker, InternalTerminalWorker } from '../worker-types.js';
 import type { PtySpawnOptions } from '../../lib/pty-provider.js';
 import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
 import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
+import { buildInternalAgentWorker, buildInternalTerminalWorker } from '../../__tests__/utils/build-test-data.js';
 
 /**
  * Tests for AgentConsole context environment variable injection.
@@ -44,41 +44,6 @@ describe('WorkerManager - AgentConsole env var injection', () => {
   });
 
   /**
-   * Create a minimal agent worker for testing (pty: null, ready for activation).
-   */
-  function createTestAgentWorker(id: string = 'worker-1'): InternalAgentWorker {
-    return {
-      id,
-      type: 'agent',
-      name: 'Test Agent',
-      createdAt: new Date().toISOString(),
-      agentId: 'claude-code',
-      pty: null,
-      outputBuffer: '',
-      outputOffset: 0,
-      activityState: 'unknown',
-      activityDetector: null,
-      connectionCallbacks: new Map(),
-    };
-  }
-
-  /**
-   * Create a minimal terminal worker for testing (pty: null, ready for activation).
-   */
-  function createTestTerminalWorker(id: string = 'terminal-1'): InternalTerminalWorker {
-    return {
-      id,
-      type: 'terminal',
-      name: 'Test Terminal',
-      createdAt: new Date().toISOString(),
-      pty: null,
-      outputBuffer: '',
-      outputOffset: 0,
-      connectionCallbacks: new Map(),
-    };
-  }
-
-  /**
    * Extract the env object from the most recent PTY spawn call.
    * The mock spawn is called as spawn(command, args, options).
    */
@@ -90,7 +55,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
 
   describe('agent worker PTY processes', () => {
     it('should include AGENT_CONSOLE_BASE_URL with server port', async () => {
-      const worker = createTestAgentWorker();
+      const worker = buildInternalAgentWorker();
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'session-123',
@@ -109,7 +74,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     });
 
     it('should include AGENT_CONSOLE_SESSION_ID', async () => {
-      const worker = createTestAgentWorker();
+      const worker = buildInternalAgentWorker();
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'session-abc-123',
@@ -126,7 +91,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     });
 
     it('should include AGENT_CONSOLE_WORKER_ID matching the worker id', async () => {
-      const worker = createTestAgentWorker('worker-xyz-789');
+      const worker = buildInternalAgentWorker({ id: 'worker-xyz-789' });
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'session-123',
@@ -143,7 +108,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     });
 
     it('should include AGENT_CONSOLE_REPOSITORY_ID for worktree sessions', async () => {
-      const worker = createTestAgentWorker();
+      const worker = buildInternalAgentWorker();
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'session-123',
@@ -161,7 +126,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     });
 
     it('should NOT include AGENT_CONSOLE_REPOSITORY_ID for quick sessions', async () => {
-      const worker = createTestAgentWorker();
+      const worker = buildInternalAgentWorker();
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'session-123',
@@ -179,7 +144,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     });
 
     it('should include all four env vars for worktree sessions', async () => {
-      const worker = createTestAgentWorker('wkr-all-four');
+      const worker = buildInternalAgentWorker({ id: 'wkr-all-four' });
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'sess-all-four',
@@ -200,7 +165,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     });
 
     it('should use the exact port from serverConfig for AGENT_CONSOLE_BASE_URL', async () => {
-      const worker = createTestAgentWorker();
+      const worker = buildInternalAgentWorker();
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'session-123',
@@ -220,7 +185,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     });
 
     it('should include AGENT_CONSOLE_REPOSITORY_ID when repositoryId contains special characters', async () => {
-      const worker = createTestAgentWorker();
+      const worker = buildInternalAgentWorker();
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'session-123',
@@ -238,7 +203,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     });
 
     it('should not overwrite AGENT_CONSOLE vars with repository env vars', async () => {
-      const worker = createTestAgentWorker('real-worker');
+      const worker = buildInternalAgentWorker({ id: 'real-worker' });
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'real-session',
@@ -265,7 +230,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
 
   describe('parent session env vars for agent workers', () => {
     it('should include AGENT_CONSOLE_PARENT_SESSION_ID when parentSessionId is provided', async () => {
-      const worker = createTestAgentWorker();
+      const worker = buildInternalAgentWorker();
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'session-123',
@@ -283,7 +248,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     });
 
     it('should include AGENT_CONSOLE_PARENT_WORKER_ID when parentWorkerId is provided', async () => {
-      const worker = createTestAgentWorker();
+      const worker = buildInternalAgentWorker();
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'session-123',
@@ -301,7 +266,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     });
 
     it('should NOT include parent env vars when context is not provided', async () => {
-      const worker = createTestAgentWorker();
+      const worker = buildInternalAgentWorker();
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'session-123',
@@ -320,7 +285,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
     });
 
     it('should not allow repository env vars to overwrite parent env vars', async () => {
-      const worker = createTestAgentWorker('secure-worker');
+      const worker = buildInternalAgentWorker({ id: 'secure-worker' });
 
       await workerManager.activateAgentWorkerPty(worker, {
         sessionId: 'secure-session',
@@ -349,7 +314,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
 
   describe('terminal worker PTY processes', () => {
     it('should NOT include any AGENT_CONSOLE env vars', () => {
-      const worker = createTestTerminalWorker();
+      const worker = buildInternalTerminalWorker();
 
       workerManager.activateTerminalWorkerPty(worker, {
         sessionId: 'session-123',

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -9,6 +9,12 @@
 import { describe, it, expect, beforeEach, afterEach, mock, jest } from 'bun:test';
 import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
+import {
+  buildInternalGitDiffWorker,
+  buildPersistedAgentWorker,
+  buildPersistedTerminalWorker,
+  buildPersistedGitDiffWorker,
+} from '../../__tests__/utils/build-test-data.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { AgentManager } from '../agent-manager.js';
 import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
@@ -17,7 +23,6 @@ import { SingleUserMode } from '../user-mode.js';
 import type {
   InternalAgentWorker,
   InternalTerminalWorker,
-  InternalGitDiffWorker,
 } from '../worker-types.js';
 import type { PersistedAgentWorker, PersistedTerminalWorker, PersistedGitDiffWorker } from '../persistence-service.js';
 import { CLAUDE_CODE_AGENT_ID } from '../agent-manager.js';
@@ -478,13 +483,7 @@ describe('WorkerManager', () => {
     });
 
     it('should be safe to call on a git-diff worker (no PTY)', async () => {
-      const worker: InternalGitDiffWorker = {
-        id: 'git-diff-1',
-        type: 'git-diff',
-        name: 'Diff',
-        createdAt: new Date().toISOString(),
-        baseCommit: 'abc123',
-      };
+      const worker = buildInternalGitDiffWorker({ id: 'git-diff-1', name: 'Diff' });
 
       // Should not throw
       await workerManager.killWorker(worker, 'test-session');
@@ -646,13 +645,7 @@ describe('WorkerManager', () => {
     });
 
     it('should convert a git-diff worker', () => {
-      const worker: InternalGitDiffWorker = {
-        id: 'pub-diff',
-        type: 'git-diff',
-        name: 'Diff',
-        createdAt: '2024-01-01T00:00:00Z',
-        baseCommit: 'abc123',
-      };
+      const worker = buildInternalGitDiffWorker({ id: 'pub-diff', name: 'Diff', baseCommit: 'abc123' });
 
       const publicWorker = workerManager.toPublicWorker(worker);
 
@@ -702,13 +695,7 @@ describe('WorkerManager', () => {
     });
 
     it('should persist git-diff worker with baseCommit', () => {
-      const worker: InternalGitDiffWorker = {
-        id: 'diff-1',
-        type: 'git-diff',
-        name: 'Diff',
-        createdAt: '2024-01-01T00:00:00Z',
-        baseCommit: 'def456',
-      };
+      const worker = buildInternalGitDiffWorker({ id: 'diff-1', name: 'Diff', baseCommit: 'def456' });
 
       const persisted = workerManager.toPersistedWorker(worker);
 
@@ -723,14 +710,9 @@ describe('WorkerManager', () => {
 
   describe('restoreWorkersFromPersistence', () => {
     it('should restore agent workers with pty: null', () => {
-      const persistedWorkers: PersistedAgentWorker[] = [{
-        id: 'restored-agent',
-        type: 'agent',
-        name: 'Agent',
-        createdAt: '2024-01-01T00:00:00Z',
-        agentId: 'claude-code',
-        pid: 12345,
-      }];
+      const persistedWorkers: PersistedAgentWorker[] = [
+        buildPersistedAgentWorker({ id: 'restored-agent', name: 'Agent', agentId: 'claude-code', pid: 12345 }),
+      ];
 
       const workers = workerManager.restoreWorkersFromPersistence(persistedWorkers);
 
@@ -746,13 +728,9 @@ describe('WorkerManager', () => {
     });
 
     it('should restore terminal workers with pty: null', () => {
-      const persistedWorkers: PersistedTerminalWorker[] = [{
-        id: 'restored-term',
-        type: 'terminal',
-        name: 'Terminal',
-        createdAt: '2024-01-01T00:00:00Z',
-        pid: null,
-      }];
+      const persistedWorkers: PersistedTerminalWorker[] = [
+        buildPersistedTerminalWorker({ id: 'restored-term', name: 'Terminal' }),
+      ];
 
       const workers = workerManager.restoreWorkersFromPersistence(persistedWorkers);
 
@@ -765,13 +743,9 @@ describe('WorkerManager', () => {
     });
 
     it('should restore git-diff workers fully (no PTY needed)', () => {
-      const persistedWorkers: PersistedGitDiffWorker[] = [{
-        id: 'restored-diff',
-        type: 'git-diff',
-        name: 'Diff',
-        createdAt: '2024-01-01T00:00:00Z',
-        baseCommit: 'xyz789',
-      }];
+      const persistedWorkers: PersistedGitDiffWorker[] = [
+        buildPersistedGitDiffWorker({ id: 'restored-diff', name: 'Diff', baseCommit: 'xyz789' }),
+      ];
 
       const workers = workerManager.restoreWorkersFromPersistence(persistedWorkers);
 
@@ -784,9 +758,9 @@ describe('WorkerManager', () => {
 
     it('should restore multiple workers of different types', () => {
       const persistedWorkers = [
-        { id: 'a1', type: 'agent' as const, name: 'A', createdAt: '2024-01-01T00:00:00Z', agentId: 'claude-code', pid: 100 },
-        { id: 't1', type: 'terminal' as const, name: 'T', createdAt: '2024-01-01T00:00:00Z', pid: null },
-        { id: 'd1', type: 'git-diff' as const, name: 'D', createdAt: '2024-01-01T00:00:00Z', baseCommit: 'head' },
+        buildPersistedAgentWorker({ id: 'a1', name: 'A', agentId: 'claude-code', pid: 100 }),
+        buildPersistedTerminalWorker({ id: 't1', name: 'T' }),
+        buildPersistedGitDiffWorker({ id: 'd1', name: 'D', baseCommit: 'head' }),
       ];
 
       const workers = workerManager.restoreWorkersFromPersistence(persistedWorkers);
@@ -799,8 +773,8 @@ describe('WorkerManager', () => {
 
     it('should give each worker its own connectionCallbacks Map', () => {
       const persistedWorkers = [
-        { id: 'a1', type: 'agent' as const, name: 'A', createdAt: '2024-01-01T00:00:00Z', agentId: 'claude-code', pid: null },
-        { id: 'a2', type: 'agent' as const, name: 'B', createdAt: '2024-01-01T00:00:00Z', agentId: 'claude-code', pid: null },
+        buildPersistedAgentWorker({ id: 'a1', name: 'A', agentId: 'claude-code' }),
+        buildPersistedAgentWorker({ id: 'a2', name: 'B', agentId: 'claude-code' }),
       ];
 
       const workers = workerManager.restoreWorkersFromPersistence(persistedWorkers);

--- a/packages/server/src/services/__tests__/worktree-creation-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-creation-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
-import type { HookCommandResult, Worktree, Session } from '@agent-console/shared';
+import type { HookCommandResult, Worktree } from '@agent-console/shared';
 import type { SessionManager } from '../session-manager.js';
+import { buildWorktreeSession } from '../../__tests__/utils/build-test-data.js';
 // --- Mock worktreeService (now passed as parameter, no mock.module needed) ---
 
 const mockListWorktrees = mock<(repoPath: string, repoId: string) => Promise<Worktree[]>>(() =>
@@ -58,20 +59,13 @@ const WORKTREE: Worktree = {
   index: 2,
 };
 
-const MOCK_SESSION: Session = {
+const MOCK_SESSION = buildWorktreeSession({
   id: 'sess-new',
-  type: 'worktree',
-  repositoryId: 'repo-1',
   repositoryName: 'my-repo',
   worktreeId: 'feature-new',
-  isMainWorktree: false,
   locationPath: CREATED_PATH,
-  status: 'active',
-  activationState: 'running',
-  workers: [],
-  agentId: 'claude',
   createdAt: '2026-01-01T00:00:00Z',
-} as Session;
+});
 
 function createMockSessionManager(): SessionManager & {
   createSession: ReturnType<typeof mock>;

--- a/packages/server/src/services/__tests__/worktree-deletion-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-deletion-service.test.ts
@@ -3,6 +3,7 @@ import type { HookCommandResult, Worktree, Session } from '@agent-console/shared
 import type { SessionManager } from '../session-manager.js';
 import type { DeleteWorktreeDeps } from '../worktree-deletion-service.js';
 import { getRepositoriesDir } from '../../lib/config.js';
+import { buildWorktreeSession } from '../../__tests__/utils/build-test-data.js';
 
 // Use the real repositories directory path to avoid mocking config.js
 // (Bun's mock.module is global and pollutes other test files)
@@ -94,19 +95,12 @@ function createMockDeps(overrides: {
   };
 }
 
-const DEFAULT_WORKTREE_SESSION: Session = {
+const DEFAULT_WORKTREE_SESSION = buildWorktreeSession({
   id: 'sess-1',
-  type: 'worktree',
-  repositoryId: 'repo-1',
   repositoryName: 'my-repo',
   worktreeId: 'feature-1',
-  isMainWorktree: false,
   locationPath: WORKTREE_PATH,
-  status: 'active',
-  activationState: 'running',
-  createdAt: new Date().toISOString(),
-  workers: [],
-};
+});
 
 describe('deleteWorktree', () => {
   beforeEach(() => {
@@ -180,10 +174,13 @@ describe('deleteWorktree', () => {
   // --- Main worktree protection ---
 
   it('returns validation error when session is main worktree', async () => {
-    const mainSession: Session = {
-      ...DEFAULT_WORKTREE_SESSION,
+    const mainSession = buildWorktreeSession({
+      id: 'sess-1',
+      repositoryName: 'my-repo',
+      worktreeId: 'feature-1',
+      locationPath: WORKTREE_PATH,
       isMainWorktree: true,
-    };
+    });
 
     const deps = createMockDeps({ sessions: [mainSession] });
     const result = await deleteWorktree(
@@ -408,10 +405,12 @@ describe('deleteWorktree', () => {
   // --- Multiple sessions ---
 
   it('kills workers and deletes all sessions matching the worktree path', async () => {
-    const session2: Session = {
-      ...DEFAULT_WORKTREE_SESSION,
+    const session2 = buildWorktreeSession({
       id: 'sess-2',
-    };
+      repositoryName: 'my-repo',
+      worktreeId: 'feature-1',
+      locationPath: WORKTREE_PATH,
+    });
 
     const deps = createMockDeps({ sessions: [DEFAULT_WORKTREE_SESSION, session2] });
     const result = await deleteWorktree(
@@ -428,10 +427,12 @@ describe('deleteWorktree', () => {
   });
 
   it('captures errors from multiple session deletions', async () => {
-    const session2: Session = {
-      ...DEFAULT_WORKTREE_SESSION,
+    const session2 = buildWorktreeSession({
       id: 'sess-2',
-    };
+      repositoryName: 'my-repo',
+      worktreeId: 'feature-1',
+      locationPath: WORKTREE_PATH,
+    });
 
     const deps = createMockDeps({ sessions: [DEFAULT_WORKTREE_SESSION, session2] });
     deps.sessionManager.deleteSession.mockImplementation((id: string) => {
@@ -453,11 +454,12 @@ describe('deleteWorktree', () => {
   // --- Session filtering ---
 
   it('only includes sessions matching the worktree path', async () => {
-    const otherSession: Session = {
-      ...DEFAULT_WORKTREE_SESSION,
+    const otherSession = buildWorktreeSession({
       id: 'sess-other',
+      repositoryName: 'my-repo',
+      worktreeId: 'feature-1',
       locationPath: OTHER_WORKTREE_PATH,
-    };
+    });
 
     // getAllSessions returns all sessions, but only matching ones should be processed
     const deps = createMockDeps({ sessions: [DEFAULT_WORKTREE_SESSION, otherSession] });

--- a/packages/server/src/services/inbound/__tests__/resolve-targets.test.ts
+++ b/packages/server/src/services/inbound/__tests__/resolve-targets.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, mock } from 'bun:test';
 import { resolveTargets, type TargetResolverDependencies } from '../resolve-targets.js';
 import { GitError } from '../../../lib/git.js';
-import type { Session, InboundSystemEvent, Repository } from '@agent-console/shared';
+import type { InboundSystemEvent, Repository } from '@agent-console/shared';
+import {
+  buildWorktreeSession,
+  buildQuickSession,
+  buildPersistedRepository,
+} from '../../../__tests__/utils/build-test-data.js';
 
 function createEvent(metadata: Partial<InboundSystemEvent['metadata']> = {}): InboundSystemEvent {
   return {
@@ -17,25 +22,11 @@ function createEvent(metadata: Partial<InboundSystemEvent['metadata']> = {}): In
   } as InboundSystemEvent;
 }
 
-function createSession(overrides: Partial<Session> = {}): Session {
-  return {
-    id: 'session-1',
-    type: 'worktree',
-    repositoryId: 'repo-1',
-    worktreeId: 'main',
-    title: 'Test Session',
-    ...overrides,
-  } as Session;
-}
-
-const defaultRepository: Repository = {
-  id: 'repo-1',
-  path: '/path/to/repo',
-} as Repository;
+const defaultRepository = buildPersistedRepository({ id: 'repo-1', path: '/path/to/repo' });
 
 describe('resolveTargets', () => {
   it('matches repository names case-insensitively', async () => {
-    const session = createSession();
+    const session = buildWorktreeSession({ id: 'session-1', repositoryId: 'repo-1', worktreeId: 'main' });
     const deps: TargetResolverDependencies = {
       getSessions: () => [session],
       getRepository: () => defaultRepository,
@@ -48,8 +39,8 @@ describe('resolveTargets', () => {
   });
 
   it('filters by branch when event specifies a branch', async () => {
-    const mainSession = createSession({ id: 'session-main', worktreeId: 'main' });
-    const featureSession = createSession({ id: 'session-feature', worktreeId: 'feature-branch' });
+    const mainSession = buildWorktreeSession({ id: 'session-main', worktreeId: 'main' });
+    const featureSession = buildWorktreeSession({ id: 'session-feature', worktreeId: 'feature-branch' });
     const deps: TargetResolverDependencies = {
       getSessions: () => [mainSession, featureSession],
       getRepository: () => defaultRepository,
@@ -62,7 +53,7 @@ describe('resolveTargets', () => {
   });
 
   it('skips non-worktree sessions', async () => {
-    const session = createSession({ type: 'quick' });
+    const session = buildQuickSession();
     const deps: TargetResolverDependencies = {
       getSessions: () => [session],
       getRepository: () => defaultRepository,
@@ -75,11 +66,11 @@ describe('resolveTargets', () => {
   });
 
   it('swallows GitError and continues processing remaining sessions', async () => {
-    const session1 = createSession({ id: 'session-1', repositoryId: 'repo-1' });
-    const session2 = createSession({ id: 'session-2', repositoryId: 'repo-2' });
+    const session1 = buildWorktreeSession({ id: 'session-1', repositoryId: 'repo-1' });
+    const session2 = buildWorktreeSession({ id: 'session-2', repositoryId: 'repo-2' });
     const repositories: Record<string, Repository> = {
-      'repo-1': { id: 'repo-1', path: '/path/to/repo1' } as Repository,
-      'repo-2': { id: 'repo-2', path: '/path/to/repo2' } as Repository,
+      'repo-1': buildPersistedRepository({ id: 'repo-1', path: '/path/to/repo1' }),
+      'repo-2': buildPersistedRepository({ id: 'repo-2', path: '/path/to/repo2' }),
     };
     let callCount = 0;
     const deps: TargetResolverDependencies = {
@@ -100,7 +91,7 @@ describe('resolveTargets', () => {
   });
 
   it('returns empty array when repositoryName is missing', async () => {
-    const session = createSession();
+    const session = buildWorktreeSession({ id: 'session-1', repositoryId: 'repo-1' });
     const deps: TargetResolverDependencies = {
       getSessions: () => [session],
       getRepository: () => defaultRepository,

--- a/packages/server/src/websocket/__tests__/app-handler.test.ts
+++ b/packages/server/src/websocket/__tests__/app-handler.test.ts
@@ -8,6 +8,7 @@ import {
   type AppHandlerDependencies,
 } from '../app-handler.js';
 import type { Session, AgentActivityState } from '@agent-console/shared';
+import { buildQuickSession, buildWorktreeSession } from '../../__tests__/utils/build-test-data.js';
 
 describe('App Handler', () => {
   describe('isValidClientMessage', () => {
@@ -58,29 +59,23 @@ describe('App Handler', () => {
 
     it('should build message with sessions and activity states', async () => {
       const sessions: Session[] = [
-        {
+        buildQuickSession({
           id: 'session-1',
-          type: 'quick',
           locationPath: '/path/1',
-          status: 'active',
-          activationState: 'running',
           createdAt: '2024-01-01',
           workers: [
             { id: 'worker-1', type: 'agent', agentId: 'claude', name: 'Agent 1', createdAt: '2024-01-01', activated: true },
             { id: 'worker-2', type: 'terminal', name: 'Terminal 1', createdAt: '2024-01-01', activated: true },
           ],
-        },
-        {
+        }),
+        buildQuickSession({
           id: 'session-2',
-          type: 'quick',
           locationPath: '/path/2',
-          status: 'active',
-          activationState: 'running',
           createdAt: '2024-01-01',
           workers: [
             { id: 'worker-3', type: 'agent', agentId: 'claude', name: 'Agent 2', createdAt: '2024-01-01', activated: true },
           ],
-        },
+        }),
       ];
 
       const deps = {
@@ -112,17 +107,13 @@ describe('App Handler', () => {
 
     it('should skip terminal workers', async () => {
       const sessions: Session[] = [
-        {
-          id: 'session-1',
-          type: 'quick',
+        buildQuickSession({
           locationPath: '/path/1',
-          status: 'active',
-          activationState: 'running',
           createdAt: '2024-01-01',
           workers: [
             { id: 'worker-1', type: 'terminal', name: 'Terminal', createdAt: '2024-01-01', activated: true },
           ],
-        },
+        }),
       ];
 
       const deps = {
@@ -138,17 +129,13 @@ describe('App Handler', () => {
 
     it('should skip workers with undefined activity state', async () => {
       const sessions: Session[] = [
-        {
-          id: 'session-1',
-          type: 'quick',
+        buildQuickSession({
           locationPath: '/path/1',
-          status: 'active',
-          activationState: 'running',
           createdAt: '2024-01-01',
           workers: [
             { id: 'worker-1', type: 'agent', agentId: 'claude', name: 'Agent', createdAt: '2024-01-01', activated: true },
           ],
-        },
+        }),
       ];
 
       const deps = {
@@ -164,35 +151,28 @@ describe('App Handler', () => {
 
     it('should include paused sessions from database', async () => {
       const activeSessions: Session[] = [
-        {
+        buildQuickSession({
           id: 'active-session',
-          type: 'quick',
           locationPath: '/path/active',
-          status: 'active',
-          activationState: 'running',
           createdAt: '2024-01-01',
           workers: [
             { id: 'worker-1', type: 'agent', agentId: 'claude', name: 'Agent', createdAt: '2024-01-01', activated: true },
           ],
-        },
+        }),
       ];
 
       const pausedSessions: Session[] = [
-        {
+        buildWorktreeSession({
           id: 'paused-session',
-          type: 'worktree',
           locationPath: '/path/paused',
-          status: 'active',
           activationState: 'hibernated',
           createdAt: '2024-01-02',
           workers: [
             { id: 'worker-2', type: 'agent', agentId: 'claude', name: 'Agent', createdAt: '2024-01-02', activated: false },
           ],
-          repositoryId: 'repo-1',
           repositoryName: 'Test Repo',
           worktreeId: 'feature-branch',
-          isMainWorktree: false,
-        },
+        }),
       ];
 
       const deps = {
@@ -244,9 +224,9 @@ describe('App Handler', () => {
 
       const deps = {
         getAllSessions: () => [
-          { id: '1', type: 'quick', locationPath: '/', status: 'active', activationState: 'running', createdAt: '', workers: [] },
-          { id: '2', type: 'quick', locationPath: '/', status: 'active', activationState: 'running', createdAt: '', workers: [] },
-        ] as Session[],
+          buildQuickSession({ id: '1', locationPath: '/', createdAt: '' }),
+          buildQuickSession({ id: '2', locationPath: '/', createdAt: '' }),
+        ],
         getAllPausedSessions: async () => [],
         getWorkerActivityState: () => undefined,
         logger: { debug: mockDebug, warn: mock(), error: mock() },
@@ -263,11 +243,11 @@ describe('App Handler', () => {
 
       const deps = {
         getAllSessions: () => [
-          { id: '1', type: 'quick', locationPath: '/', status: 'active', activationState: 'running', createdAt: '', workers: [] },
-        ] as Session[],
+          buildQuickSession({ id: '1', locationPath: '/', createdAt: '' }),
+        ],
         getAllPausedSessions: async () => [
-          { id: '2', type: 'quick', locationPath: '/', status: 'active', activationState: 'hibernated', createdAt: '', workers: [] },
-        ] as Session[],
+          buildQuickSession({ id: '2', locationPath: '/', activationState: 'hibernated', createdAt: '' }),
+        ],
         getWorkerActivityState: () => undefined,
         logger: { debug: mockDebug, warn: mock(), error: mock() },
       };


### PR DESCRIPTION
## Summary
- Create shared test data builder file (`packages/server/src/__tests__/utils/build-test-data.ts`) with 14 builder functions using the override-spread factory pattern
- Migrate 19 test files to use shared builders, replacing inline domain object literals and local factory functions
- Net reduction of 243 lines (-1111/+868) through elimination of duplicated test fixture code

## Builder Functions
`buildPersistedWorktreeSession`, `buildPersistedQuickSession`, `buildPersistedAgentWorker`, `buildPersistedTerminalWorker`, `buildPersistedGitDiffWorker`, `buildPersistedRepository`, `buildInternalWorktreeSession`, `buildInternalQuickSession`, `buildInternalAgentWorker`, `buildInternalTerminalWorker`, `buildInternalGitDiffWorker`, `buildWorktreeSession`, `buildQuickSession`, `buildAgentDefinition`

## Migrated Test Files
- session-manager-cleanup, session-converter-service, session-deletion-service
- session-initialization-service, session-metadata-service, session-pause-resume-service
- worker-lifecycle-manager, worker-manager, worker-manager-env
- worktree-creation-service, worktree-deletion-service, inbound-handlers
- inbound-integration, resolve-targets, sqlite-session-repository
- json-session-repository, sqlite-agent-repository, mappers, app-handler

## Design Decisions
- Public Worker types (AgentWorker, TerminalWorker, GitDiffWorker) intentionally have no builders per Issue requirements
- Raw database row literals (snake_case fields) in mapper tests kept as-is since they test the DB layer
- CreateSessionRequest/CreateWorkerParams (API request DTOs) kept as inline since they test the API boundary
- Factory functions calling production code (e.g., `workerManager.initializeAgentWorker()`) kept as-is

## Test plan
- [x] `bun run typecheck` passes (server + shared clean; client errors are pre-existing routeTree.gen)
- [x] All 2135 server tests pass with 0 failures
- [x] All 275 shared tests pass
- [x] No production code changes
- [x] Grep verified no remaining inline domain constructions in migrated files

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)