### PR TITLE
feat: add interactive sprint retrospective script

### DIFF
--- a/.claude/skills/orchestrator/__tests__/sprint-retro.test.js
+++ b/.claude/skills/orchestrator/__tests__/sprint-retro.test.js
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { Readable } from 'node:stream';
+import {
+  createStdinReader,
+  getSteps,
+  printStepHeader,
+  printSummary,
+  runRetro,
+} from '../sprint-retro.js';
+
+// --- Helper: create a readable stream that emits null-byte terminated data ---
+
+function createMockStdin(answers) {
+  const chunks = answers.map(a => a + '\0');
+  let index = 0;
+  return new Readable({
+    read() {
+      if (index < chunks.length) {
+        this.push(Buffer.from(chunks[index]));
+        index++;
+      } else {
+        this.push(null);
+      }
+    },
+  });
+}
+
+// --- Tests ---
+
+describe('getSteps', () => {
+  it('returns 7 steps', () => {
+    const steps = getSteps();
+    expect(steps).toHaveLength(7);
+  });
+
+  it('returns steps with expected keys in order', () => {
+    const steps = getSteps();
+    const keys = steps.map(s => s.key);
+    expect(keys).toEqual([
+      'triage',
+      'worktree_cleanup',
+      'incident_review',
+      'process_review',
+      'apply_improvements',
+      'memory_writeout',
+      'cross_project',
+    ]);
+  });
+
+  it('each step has title and instructions', () => {
+    const steps = getSteps();
+    for (const step of steps) {
+      expect(step.title).toBeTruthy();
+      expect(step.instructions).toBeInstanceOf(Array);
+      expect(step.instructions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('process_review step lists 4 review perspectives', () => {
+    const steps = getSteps();
+    const processReview = steps.find(s => s.key === 'process_review');
+    const text = processReview.instructions.join('\n');
+    expect(text).toContain('Redundant information');
+    expect(text).toContain('Implicit knowledge');
+    expect(text).toContain('Name-reality mismatches');
+    expect(text).toContain('Owner-dependent discoveries');
+  });
+});
+
+describe('printStepHeader', () => {
+  let logSpy;
+  let logs;
+
+  beforeEach(() => {
+    logs = [];
+    logSpy = spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('prints step title and instructions', () => {
+    const step = {
+      key: 'test',
+      title: 'Step X: Test Step',
+      instructions: ['Do something', 'Do another thing'],
+    };
+    printStepHeader(step);
+    const output = logs.join('\n');
+    expect(output).toContain('--- Step X: Test Step ---');
+    expect(output).toContain('Do something');
+    expect(output).toContain('Do another thing');
+  });
+});
+
+describe('printSummary', () => {
+  let logSpy;
+  let logs;
+
+  beforeEach(() => {
+    logs = [];
+    logSpy = spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('prints all step responses', () => {
+    const steps = [
+      { key: 's1', title: 'Step 1' },
+      { key: 's2', title: 'Step 2' },
+    ];
+    const responses = { s1: 'Response one', s2: 'Response two' };
+    printSummary(responses, steps);
+    const output = logs.join('\n');
+    expect(output).toContain('Sprint Retrospective Summary');
+    expect(output).toContain('[Step 1]');
+    expect(output).toContain('Response one');
+    expect(output).toContain('[Step 2]');
+    expect(output).toContain('Response two');
+  });
+
+  it('truncates long responses to 200 chars', () => {
+    const steps = [{ key: 's1', title: 'Step 1' }];
+    const longResponse = 'x'.repeat(250);
+    const responses = { s1: longResponse };
+    printSummary(responses, steps);
+    const output = logs.join('\n');
+    expect(output).toContain('x'.repeat(200) + '...');
+  });
+
+  it('skips steps without responses', () => {
+    const steps = [
+      { key: 's1', title: 'Step 1' },
+      { key: 's2', title: 'Step 2' },
+    ];
+    const responses = { s1: 'Only this one' };
+    printSummary(responses, steps);
+    const output = logs.join('\n');
+    expect(output).toContain('[Step 1]');
+    expect(output).not.toContain('[Step 2]');
+  });
+});
+
+describe('createStdinReader', () => {
+  it('reads multiple null-byte delimited responses', async () => {
+    const stdin = createMockStdin(['first', 'second', 'third']);
+    const readResponse = createStdinReader(stdin);
+    expect(await readResponse()).toBe('first');
+    expect(await readResponse()).toBe('second');
+    expect(await readResponse()).toBe('third');
+  });
+
+  it('trims whitespace from responses', async () => {
+    const stdin = createMockStdin(['  trimmed  ']);
+    const readResponse = createStdinReader(stdin);
+    expect(await readResponse()).toBe('trimmed');
+  });
+});
+
+describe('runRetro', () => {
+  let logSpy;
+  let logs;
+
+  beforeEach(() => {
+    logs = [];
+    logSpy = spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('runs through all 7 steps and prints summary', async () => {
+    const answers = [
+      'Removed old item from triage',
+      'Cleaned wt-001',
+      'PR #100 went well',
+      'No redundancies found',
+      'Updated CLAUDE.md rule',
+      'Deleted stale memory',
+      'No other sessions',
+    ];
+    const stdin = createMockStdin(answers);
+    await runRetro({ stdin });
+    const output = logs.join('\n');
+
+    // Verify header
+    expect(output).toContain('=== Sprint Retrospective ===');
+
+    // Verify all step titles appear
+    const steps = getSteps();
+    for (const step of steps) {
+      expect(output).toContain(step.title);
+    }
+
+    // Verify all confirmation messages
+    for (const step of steps) {
+      expect(output).toContain(`✓ ${step.title} — recorded`);
+    }
+
+    // Verify summary includes responses
+    expect(output).toContain('Sprint Retrospective Summary');
+    for (const answer of answers) {
+      expect(output).toContain(answer);
+    }
+  });
+
+  it('presents steps in correct order', async () => {
+    const answers = ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7'];
+    const stdin = createMockStdin(answers);
+    await runRetro({ stdin });
+    const output = logs.join('\n');
+
+    const steps = getSteps();
+    let lastIndex = -1;
+    for (const step of steps) {
+      const idx = output.indexOf(`--- ${step.title} ---`);
+      expect(idx).toBeGreaterThan(lastIndex);
+      lastIndex = idx;
+    }
+  });
+
+  it('collects responses and maps them to step keys', async () => {
+    const answers = ['r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7'];
+    const stdin = createMockStdin(answers);
+    await runRetro({ stdin });
+    const output = logs.join('\n');
+
+    // Summary should contain all responses
+    expect(output).toContain('r1');
+    expect(output).toContain('r7');
+  });
+
+  it('handles empty responses gracefully', async () => {
+    const answers = ['', '', '', '', '', '', ''];
+    const stdin = createMockStdin(answers);
+    await runRetro({ stdin });
+    const output = logs.join('\n');
+
+    // Should still complete without errors
+    expect(output).toContain('Sprint Retrospective Summary');
+    const steps = getSteps();
+    for (const step of steps) {
+      expect(output).toContain(`✓ ${step.title} — recorded`);
+    }
+  });
+});

--- a/.claude/skills/orchestrator/sprint-retro.js
+++ b/.claude/skills/orchestrator/sprint-retro.js
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+/**
+ * Sprint Retrospective Interactive Process Script
+ *
+ * Guides the Orchestrator through sprint retrospective steps via STDIN/STDOUT.
+ * Each step displays instructions and waits for a null-byte delimited response.
+ *
+ * Usage:
+ *   Run as interactive process via run_process MCP tool.
+ */
+
+// --- STDIN reading (null-byte delimited) ---
+
+/**
+ * Creates a reader that reads null-byte delimited responses from a stream.
+ * Same pattern as acceptance-check.js.
+ */
+function createStdinReader(stdin = process.stdin) {
+  let buffer = '';
+  const iterator = stdin[Symbol.asyncIterator]();
+
+  return async function readResponse() {
+    while (true) {
+      const nullIdx = buffer.indexOf('\0');
+      if (nullIdx !== -1) {
+        const answer = buffer.slice(0, nullIdx);
+        buffer = buffer.slice(nullIdx + 1);
+        return answer.trim();
+      }
+      const { value, done } = await iterator.next();
+      if (done) break;
+      buffer += Buffer.from(value).toString();
+    }
+    const answer = buffer;
+    buffer = '';
+    return answer.trim();
+  };
+}
+
+// --- Step definitions ---
+
+function getSteps() {
+  return [
+    {
+      key: 'triage',
+      title: 'Step 1: Triage List Update',
+      instructions: [
+        'Review and update the Pending triage list following these rules:',
+        '  - Issue化したら Pending から削除',
+        '  - Resolved した項目は直近2スプリント分のみ保持、それ以前は削除',
+        '  - 新たに発見した課題があれば Pending に追加',
+        '  - memory の project_pending_triage_list.md を更新',
+        '',
+        'Report what you updated (additions, removals, or "no changes").',
+      ],
+    },
+    {
+      key: 'worktree_cleanup',
+      title: 'Step 2: Worktree Cleanup',
+      instructions: [
+        'Clean up worktrees for merged PRs:',
+        '  1. Run list_sessions to see all active sessions/worktrees',
+        '  2. Identify worktrees whose PRs have been merged',
+        '  3. Run remove_worktree for each merged PR worktree',
+        '',
+        'Report which worktrees were removed (or "none to clean up").',
+      ],
+    },
+    {
+      key: 'incident_review',
+      title: 'Step 3a: Per-Incident Review',
+      instructions: [
+        'Review each merged PR from this sprint:',
+        '  1. Present the list of merged PRs',
+        '  2. For each PR, evaluate:',
+        '     - What worked well? (classify: by chance / owner-driven / structural)',
+        '     - What needs improvement?',
+        '     - Improvement proposals (if any)',
+        '',
+        'Report your findings per PR.',
+      ],
+    },
+    {
+      key: 'process_review',
+      title: 'Step 3b: Process-Wide Review',
+      instructions: [
+        'Review the overall development process from these 4 perspectives:',
+        '',
+        '  1. Redundant information: Is there overlap across memory / Issues / skills / rules?',
+        '     (e.g., same guidance in CLAUDE.md and a skill file)',
+        '',
+        '  2. Implicit knowledge: Is there knowledge only the owner knows that should be',
+        '     documented? (e.g., unwritten conventions, tribal knowledge)',
+        '',
+        '  3. Name-reality mismatches: Do any step names, file names, or section titles',
+        '     no longer match what they actually do? (e.g., a file named "cleanup" that',
+        '     also handles initialization)',
+        '',
+        '  4. Owner-dependent discoveries: Were there things this sprint that only the',
+        '     owner noticed or could fix? (e.g., bugs caught by manual review that',
+        '     automation should have caught)',
+        '',
+        'Report findings for each perspective (or "none" if clean).',
+      ],
+    },
+    {
+      key: 'apply_improvements',
+      title: 'Step 4: Apply Process Improvements',
+      instructions: [
+        'Based on findings from Steps 3a and 3b:',
+        '  1. List all agreed improvements',
+        '  2. For each improvement, identify the target file(s) to modify',
+        '     (e.g., CLAUDE.md, skills, rules, agents, memory)',
+        '  3. Apply the changes or create Issues for larger changes',
+        '',
+        'Report what was changed and what was deferred to Issues.',
+      ],
+    },
+    {
+      key: 'memory_writeout',
+      title: 'Step 5: Memory Write-Out',
+      instructions: [
+        'Review memory files against these criteria:',
+        '  - Is the content general knowledge derivable from code? → DELETE',
+        '  - Does it duplicate what is already in skills/rules? → DELETE',
+        '  - Does it have a "why" context that is not obvious? → RETAIN',
+        '  - Is the project status still current? → UPDATE',
+        '',
+        'Actions:',
+        '  1. List deletion candidates with reasoning',
+        '  2. Update sprint status in project_sprint_status.md',
+        '  3. Update any stale memory entries',
+        '',
+        'Report deletions, updates, and rationale.',
+      ],
+    },
+    {
+      key: 'cross_project',
+      title: 'Step 6: Cross-Project Knowledge Sharing',
+      instructions: [
+        'Check for other active orchestrator sessions to share learnings with:',
+        '  1. Run list_sessions to find other orchestrator sessions',
+        '  2. If found, use send_session_message to share relevant sprint learnings',
+        '     (e.g., new patterns, process improvements, tooling changes)',
+        '  3. If no other sessions, skip this step',
+        '',
+        'Report what was shared (or "no other sessions" / "skipped").',
+      ],
+    },
+  ];
+}
+
+// --- Display functions ---
+
+function printStepHeader(step) {
+  console.log(`\n--- ${step.title} ---`);
+  for (const line of step.instructions) {
+    console.log(line);
+  }
+  console.log();
+}
+
+function printSummary(responses, steps) {
+  console.log('\n=== Sprint Retrospective Summary ===\n');
+  for (const step of steps) {
+    const response = responses[step.key];
+    if (response !== undefined) {
+      const display = response.length > 200 ? response.substring(0, 200) + '...' : response;
+      console.log(`[${step.title}]`);
+      console.log(`  ${display}`);
+      console.log();
+    }
+  }
+}
+
+// --- Main flow ---
+
+async function runRetro({ stdin = process.stdin } = {}) {
+  console.log('=== Sprint Retrospective ===');
+
+  const steps = getSteps();
+  const responses = {};
+  const readResponse = createStdinReader(stdin);
+
+  for (const step of steps) {
+    printStepHeader(step);
+    const answer = await readResponse();
+    responses[step.key] = answer;
+    console.log(`✓ ${step.title} — recorded`);
+  }
+
+  printSummary(responses, steps);
+}
+
+// --- Exports for testing ---
+export {
+  createStdinReader,
+  getSteps,
+  printStepHeader,
+  printSummary,
+  runRetro,
+};
+
+// --- Main ---
+
+const isMainModule = import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('sprint-retro.js');
+if (!isMainModule) {
+  // Module is being imported for testing — do not execute main logic
+} else {
+  await runRetro();
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

- Add `.claude/skills/orchestrator/sprint-retro.js` — interactive process script that guides the Orchestrator through 7 sprint retrospective steps via STDIN/STDOUT
- Steps: triage list update, worktree cleanup, per-incident review, process-wide review (4 perspectives), apply improvements, memory write-out, cross-project knowledge sharing
- Uses null-byte delimited STDIN reads compatible with `write_process_response`
- Add 14 unit tests covering step definitions, display functions, full flow, and edge cases

Closes #558

## Test plan

- [x] All 14 new tests pass (`bun test ./.claude/skills/orchestrator/__tests__/sprint-retro.test.js`)
- [x] All 51 orchestrator tests pass (no regression)
- [ ] Manual: run via `run_process` and verify interactive flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)