### PR TITLE
docs: add mandatory sprint-retro.js invocation to sprint lifecycle

### DIFF
--- a/.claude/skills/orchestrator/sprint-lifecycle.md
+++ b/.claude/skills/orchestrator/sprint-lifecycle.md
@@ -47,12 +47,14 @@ Coding agents send a retrospective report together with the merge notification a
 ## Sprint End (Retrospective)
 The Orchestrator proposes ending the sprint, and when the owner approves, conducts the retrospective. Order matters — memory write-out is done last so retrospective results are captured in memory.
 
-**Step 0: Generate retrospective checklist**
-- Build a dynamic checklist by combining:
-  1. **Core steps** from this skill definition (Steps 1-5 below)
-  2. **Dynamic items** collected from memory (e.g., cross-project knowledge sharing actions, pending follow-ups from previous sprints)
-- Create the checklist via `TaskCreate` to track progress through the retrospective
-- This prevents omission of project-specific actions that are not part of the static skill definition
+**Step 0: Launch the retrospective script**
+- **MUST** run `sprint-retro.js` via `run_process` before proceeding:
+  ```
+  run_process({ command: "node .claude/skills/orchestrator/sprint-retro.js" })
+  ```
+- The script guides you through all retrospective steps (1-6) interactively via STDIN/STDOUT
+- Do NOT skip the script and attempt the steps manually — the script exists precisely because manual execution leads to step omission
+- The steps below document what each step covers for reference, but the script is the authoritative guide during execution
 
 **Step 1: Update pending triage list**
 - Reflect issues discovered during the sprint in `memory/project_pending_triage_list.md`


### PR DESCRIPTION
## Summary

- Update Step 0 of Sprint End (Retrospective) in sprint-lifecycle.md to explicitly require running `sprint-retro.js` via `run_process`
- Replaces the previous TaskCreate-based checklist approach, since the interactive script now handles all step guidance
- Prevents Orchestrator from skipping the script and attempting manual execution

## Context

Owner identified the risk that Orchestrators may forget to call the script. This change makes the invocation a **MUST** in the skill definition, so it's visible every time the retrospective procedure is loaded.

## Test plan

- [x] Documentation-only change, no production code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)