### PR TITLE
feat: add slash command completion to MessagePanel

### DIFF
--- a/packages/client/src/components/sessions/MessagePanel.tsx
+++ b/packages/client/src/components/sessions/MessagePanel.tsx
@@ -5,6 +5,16 @@ import { sendWorkerMessage } from '../../lib/api';
 import { sendInput as sendPtyInput } from '../../lib/worker-websocket';
 import { useDraftMessage } from '../../hooks/useDraftMessage';
 
+export const SLASH_COMMANDS = [
+  { name: '/commit', description: 'Create a git commit' },
+  { name: '/review-loop', description: 'Run automated review loop' },
+  { name: '/code-review', description: 'Review a pull request' },
+  { name: '/simplify', description: 'Review and simplify changed code' },
+  { name: '/orchestrator', description: 'Strategic task orchestration' },
+  { name: '/schedule', description: 'Manage scheduled agents' },
+  { name: '/loop', description: 'Run a command on recurring interval' },
+] as const;
+
 interface MessagePanelProps {
   sessionId: string;
   targetWorkerId: string;
@@ -38,8 +48,21 @@ export const MessagePanel = forwardRef<MessagePanelHandle, MessagePanelProps>(
   const [sending, setSending] = useState(false);
   const [hasUnread, setHasUnread] = useState(false);
   const [files, setFiles] = useState<File[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [completionDismissed, setCompletionDismissed] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Slash command completion - derived state
+  const isSlashPrefix = content.startsWith('/') && !content.includes(' ');
+  const filteredCommands = isSlashPrefix
+    ? SLASH_COMMANDS.filter(cmd => cmd.name.toLowerCase().startsWith(content.toLowerCase()))
+    : [];
+  const showCompletion = isSlashPrefix && filteredCommands.length > 0 && !completionDismissed;
+  // Clamp selectedIndex to valid range
+  const clampedIndex = filteredCommands.length > 0
+    ? Math.min(selectedIndex, filteredCommands.length - 1)
+    : 0;
 
   // Clear non-draft state when target worker changes
   useEffect(() => {
@@ -106,17 +129,49 @@ export const MessagePanel = forwardRef<MessagePanelHandle, MessagePanelProps>(
     }
   }, [sessionId, targetWorkerId, content, files, onError, clearDraft]);
 
+  const selectCommand = useCallback((command: typeof SLASH_COMMANDS[number]) => {
+    setContent(command.name + ' ');
+    setCompletionDismissed(false);
+    textareaRef.current?.focus();
+  }, [setContent]);
+
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Ctrl/Cmd+Enter always sends, even with dropdown visible
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
       e.preventDefault();
       handleSend();
       return;
     }
+
+    // Dropdown-specific key handling
+    if (showCompletion) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelectedIndex(prev => Math.min(prev + 1, filteredCommands.length - 1));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIndex(prev => Math.max(prev - 1, 0));
+        return;
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault();
+        selectCommand(filteredCommands[clampedIndex]);
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setCompletionDismissed(true);
+        return;
+      }
+    }
+
     if (e.key === 'Escape') {
       e.preventDefault();
       sendPtyInput(sessionId, targetWorkerId, '\x1b');
     }
-  }, [handleSend, sessionId, targetWorkerId]);
+  }, [handleSend, sessionId, targetWorkerId, showCompletion, filteredCommands, clampedIndex, selectCommand]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -159,21 +214,49 @@ export const MessagePanel = forwardRef<MessagePanelHandle, MessagePanelProps>(
           <span className="w-2 h-2 bg-blue-500 rounded-full shrink-0" />
         )}
 
-        {/* Message textarea */}
-        <textarea
-          ref={textareaRef}
-          value={content}
-          onChange={e => {
-            setContent(e.target.value);
-            handleResize(e.target);
-          }}
-          onKeyDown={handleKeyDown}
-          onPaste={handlePaste}
-          placeholder="Send message to worker... (Ctrl+Enter to send)"
-          rows={1}
-          className="flex-1 bg-slate-700 text-white text-sm rounded px-2 py-1 border border-slate-600 placeholder-gray-500 resize-none overflow-y-auto"
-          style={{ maxHeight: '120px' }}
-        />
+        {/* Message textarea with completion dropdown */}
+        <div className="flex-1 relative">
+          {showCompletion && (
+            <ul
+              role="listbox"
+              className="absolute bottom-full left-0 mb-1 w-full bg-slate-800 border border-slate-600 rounded shadow-lg max-h-60 overflow-y-auto z-10"
+            >
+              {filteredCommands.map((cmd, index) => (
+                <li
+                  key={cmd.name}
+                  role="option"
+                  aria-selected={index === clampedIndex}
+                  className={`px-3 py-1.5 cursor-pointer text-sm ${
+                    index === clampedIndex ? 'bg-slate-700 text-white' : 'text-gray-300 hover:bg-slate-700'
+                  }`}
+                  onMouseDown={e => {
+                    e.preventDefault(); // prevent textarea blur
+                    selectCommand(cmd);
+                  }}
+                >
+                  <span className="font-medium text-blue-400">{cmd.name}</span>
+                  <span className="ml-2 text-gray-400">{cmd.description}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <textarea
+            ref={textareaRef}
+            value={content}
+            onChange={e => {
+              setContent(e.target.value);
+              setSelectedIndex(0);
+              setCompletionDismissed(false);
+              handleResize(e.target);
+            }}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+            placeholder="Send message to worker... (Ctrl+Enter to send)"
+            rows={1}
+            className="w-full bg-slate-700 text-white text-sm rounded px-2 py-1 border border-slate-600 placeholder-gray-500 resize-none overflow-y-auto"
+            style={{ maxHeight: '120px' }}
+          />
+        </div>
 
         {/* Attach button */}
         <button

--- a/packages/client/src/components/sessions/__tests__/MessagePanel.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/MessagePanel.test.tsx
@@ -23,7 +23,7 @@ mock.module('../../../lib/worker-websocket', () => ({
 
 import { fireEvent, cleanup, act, within } from '@testing-library/react';
 import { renderWithRouter } from '../../../test/renderWithRouter';
-import { MessagePanel, canSend, validateFiles } from '../MessagePanel';
+import { MessagePanel, canSend, validateFiles, SLASH_COMMANDS } from '../MessagePanel';
 import { _getDraftsMap } from '../../../hooks/useDraftMessage';
 
 describe('MessagePanel logic', () => {
@@ -448,6 +448,181 @@ describe('MessagePanel', () => {
     expect((textarea as HTMLTextAreaElement).value).toBe('');
     // Draft should be removed from the map
     expect(_getDraftsMap().has('session-1:agent-1')).toBe(false);
+  });
+
+  describe('slash command completion', () => {
+    it('shows dropdown when typing /', async () => {
+      const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+      const view = within(container);
+
+      const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: '/' } });
+      });
+
+      expect(view.getByRole('listbox')).toBeTruthy();
+    });
+
+    it('shows all commands when typing just /', async () => {
+      const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+      const view = within(container);
+
+      const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: '/' } });
+      });
+
+      const options = view.getAllByRole('option');
+      expect(options.length).toBe(SLASH_COMMANDS.length);
+    });
+
+    it('shows filtered results when typing /re', async () => {
+      const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+      const view = within(container);
+
+      const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: '/re' } });
+      });
+
+      const options = view.getAllByRole('option');
+      expect(options.length).toBe(1);
+      expect(options[0].textContent).toContain('/review-loop');
+    });
+
+    it('does not show dropdown for non-/ prefix', async () => {
+      const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+      const view = within(container);
+
+      const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: 'hello /command' } });
+      });
+
+      expect(view.queryByRole('listbox')).toBeNull();
+    });
+
+    it('does not show dropdown when content has spaces', async () => {
+      const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+      const view = within(container);
+
+      const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: '/commit message' } });
+      });
+
+      expect(view.queryByRole('listbox')).toBeNull();
+    });
+
+    it('navigates items with arrow keys', async () => {
+      const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+      const view = within(container);
+
+      const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: '/' } });
+      });
+
+      // First item should be selected by default
+      const options = view.getAllByRole('option');
+      expect(options[0].getAttribute('aria-selected')).toBe('true');
+
+      // Press ArrowDown to move to second item
+      await act(async () => {
+        fireEvent.keyDown(textarea, { key: 'ArrowDown' });
+      });
+
+      const updatedOptions = view.getAllByRole('option');
+      expect(updatedOptions[0].getAttribute('aria-selected')).toBe('false');
+      expect(updatedOptions[1].getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('selects command with Enter', async () => {
+      const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+      const view = within(container);
+
+      const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)') as HTMLTextAreaElement;
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: '/co' } });
+      });
+
+      // /commit and /code-review match; first is /code-review or /commit depending on order
+      // The filtered list is prefix-matched: /co matches /commit and /code-review
+      await act(async () => {
+        fireEvent.keyDown(textarea, { key: 'Enter' });
+      });
+
+      // First matching command should be selected
+      expect(textarea.value).toBe('/commit ');
+      // Dropdown should be closed (content now has a space)
+      expect(view.queryByRole('listbox')).toBeNull();
+    });
+
+    it('selects command with Tab', async () => {
+      const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+      const view = within(container);
+
+      const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)') as HTMLTextAreaElement;
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: '/sc' } });
+      });
+
+      await act(async () => {
+        fireEvent.keyDown(textarea, { key: 'Tab' });
+      });
+
+      expect(textarea.value).toBe('/schedule ');
+    });
+
+    it('closes dropdown with Escape', async () => {
+      const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+      const view = within(container);
+
+      const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: '/' } });
+      });
+
+      expect(view.getByRole('listbox')).toBeTruthy();
+
+      await act(async () => {
+        fireEvent.keyDown(textarea, { key: 'Escape' });
+      });
+
+      expect(view.queryByRole('listbox')).toBeNull();
+      // Escape should NOT send PTY input when dropdown was visible
+      expect(mockSendInput).not.toHaveBeenCalled();
+    });
+
+    it('selects command on click', async () => {
+      const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+      const view = within(container);
+
+      const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)') as HTMLTextAreaElement;
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: '/' } });
+      });
+
+      const options = view.getAllByRole('option');
+      // Click the second command
+      await act(async () => {
+        fireEvent.mouseDown(options[1]);
+      });
+
+      expect(textarea.value).toBe(SLASH_COMMANDS[1].name + ' ');
+    });
+
+    it('does not show dropdown when no commands match filter', async () => {
+      const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+      const view = within(container);
+
+      const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: '/xyz' } });
+      });
+
+      expect(view.queryByRole('listbox')).toBeNull();
+    });
   });
 
 });


### PR DESCRIPTION
## Summary
- Add `/` prefix autocomplete dropdown to the message panel textarea
- When user types `/` at the start of input, shows a filtered list of available slash commands (commit, review-loop, code-review, simplify, orchestrator, schedule, loop)
- Supports keyboard navigation (Arrow keys, Enter/Tab to select, Escape to dismiss) and mouse click selection
- Dropdown appears above the textarea with consistent dark theme styling

## Test plan
- [x] Dropdown appears when typing `/`
- [x] All commands shown for just `/`, filtered for partial input (e.g., `/re` → `/review-loop`)
- [x] No dropdown for non-`/` prefix or when content has spaces
- [x] Arrow key navigation updates selection
- [x] Enter/Tab selects command and inserts it with trailing space
- [x] Escape closes dropdown without sending PTY escape
- [x] Mouse click selects command
- [x] No dropdown when no commands match filter
- [x] All existing MessagePanel tests pass (1285 client tests, 0 failures)

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)