### PR TITLE
fix: stripSystemMessages fails on first-line and non-SGR ANSI sequences

### DIFF
--- a/packages/client/src/lib/__tests__/terminal-utils.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-utils.test.ts
@@ -138,10 +138,9 @@ describe('terminal-utils', () => {
       expect(stripSystemMessages(input)).toBe(input);
     });
 
-    it('should not strip [internal:*] at the very beginning without leading newline', () => {
-      // The regex requires a leading \n, so a line at position 0 is not stripped
+    it('should strip [internal:*] at the very beginning without leading newline', () => {
       const input = '[internal:timer] first line\nnormal line';
-      expect(stripSystemMessages(input)).toBe('[internal:timer] first line\nnormal line');
+      expect(stripSystemMessages(input)).toBe('normal line');
     });
 
     it('should handle empty string', () => {
@@ -186,9 +185,24 @@ describe('terminal-utils', () => {
       expect(stripSystemMessages(input)).toBe('start\nend');
     });
 
-    it('should not strip [Reply Instructions] at position 0 without leading newline', () => {
+    it('should strip [Reply Instructions] at position 0 without leading newline', () => {
       const input = '[Reply Instructions] first line\nnormal line';
-      expect(stripSystemMessages(input)).toBe('[Reply Instructions] first line\nnormal line');
+      expect(stripSystemMessages(input)).toBe('normal line');
+    });
+
+    it('should strip [internal:*] with non-SGR CSI sequences (e.g. \\x1b[2K erase line)', () => {
+      const input = 'before\n\x1b[1m\x1b[33m\x1b[2K[internal:timer]\x1b[0m timestamp=123\nafter';
+      expect(stripSystemMessages(input)).toBe('before\nafter');
+    });
+
+    it('should strip [internal:*] with \\r\\n line endings', () => {
+      const input = 'normal output\r\n[internal:timer] some timer info\r\nmore output';
+      expect(stripSystemMessages(input)).toBe('normal output\r\nmore output');
+    });
+
+    it('should strip [internal:*] at start of chunk with ANSI codes', () => {
+      const input = '\x1b[1m\x1b[33m[internal:message]\x1b[0m incoming from=sess1\nnormal line';
+      expect(stripSystemMessages(input)).toBe('normal line');
     });
   });
 

--- a/packages/client/src/lib/terminal-utils.ts
+++ b/packages/client/src/lib/terminal-utils.ts
@@ -58,15 +58,24 @@ export function isScrolledToBottom(terminal: TerminalScrollInfo): boolean {
  * so the patterns tolerate optional ANSI SGR sequences (`\x1b[...m`) before the bracket.
  */
 
-/** Matches any number of ANSI SGR sequences (e.g. `\x1b[0m`, `\x1b[1;33m`). */
-const ANSI = '(?:\\x1b\\[[0-9;]*m)*';
+/** Matches any number of ANSI CSI sequences (SGR like `\x1b[0m`, and non-SGR like `\x1b[2K`). */
+const ANSI = '(?:\\x1b\\[[0-9;]*[A-Za-z])*';
 
-/** Matches a newline-prefixed `[internal:*]` line, with optional ANSI codes before the bracket. */
-const INTERNAL_RE = new RegExp(`\\n${ANSI}\\[internal:[^\\]]*\\][^\\n]*`, 'g');
+/**
+ * Matches an `[internal:*]` line with optional ANSI codes before the bracket.
+ * Two alternations:
+ *   1. Mid-string: consumes leading \r?\n (removes the line separator before the system line)
+ *   2. Start-of-string: consumes trailing \r?\n (removes the line separator after the system line)
+ * Uses [^\r\n]* to avoid eating \r from \r\n line endings.
+ */
+const INTERNAL_RE = new RegExp(
+  `\\r?\\n${ANSI}\\[internal:[^\\]]*\\][^\\r\\n]*|^${ANSI}\\[internal:[^\\]]*\\][^\\r\\n]*\\r?\\n?`,
+  'g',
+);
 
-/** Matches a newline-prefixed `[Reply Instructions]` block including continuation lines (`- ...`). */
+/** Matches a `[Reply Instructions]` block including continuation lines (`- ...`). */
 const REPLY_INSTRUCTIONS_RE = new RegExp(
-  `\\n${ANSI}\\[Reply Instructions\\][^\\n]*(?:\\n${ANSI}- [^\\n]*)*`,
+  `\\r?\\n${ANSI}\\[Reply Instructions\\][^\\r\\n]*(?:\\r?\\n${ANSI}- [^\\r\\n]*)*|^${ANSI}\\[Reply Instructions\\][^\\r\\n]*(?:\\r?\\n${ANSI}- [^\\r\\n]*)*\\r?\\n?`,
   'g',
 );
 


### PR DESCRIPTION
## Summary

- Broaden ANSI pattern from SGR-only to any CSI sequence, fixing non-SGR codes like `\x1b[2K`
- Add start-of-string matching so first-line `[internal:*]` messages are stripped
- Handle `\r\n` line endings correctly

Closes #578

## Test plan

- [x] 39 terminal-utils tests pass (4 updated, 3 new edge case tests added)
- [x] No regression on existing strip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)