### PR TITLE
fix: session status indicator shows stale state

### DIFF
--- a/packages/client/src/components/sessions/__tests__/sessionStatus.test.ts
+++ b/packages/client/src/components/sessions/__tests__/sessionStatus.test.ts
@@ -18,6 +18,14 @@ describe('Session status helpers', () => {
     expect(getConnectionStatusColor('disconnected', 'unknown', 'git-diff')).toBe('bg-gray-500');
   });
 
+  it('returns green for connected agent with known activity state', () => {
+    expect(getConnectionStatusColor('connected', 'idle', 'agent')).toBe('bg-green-500');
+  });
+
+  it('returns Connected text for connected agent with known activity state', () => {
+    expect(getConnectionStatusText('connected', 'idle', null, 'agent')).toBe('Connected');
+  });
+
   it('renders exit details regardless of worker type', () => {
     expect(getConnectionStatusText('exited', 'idle', exitInfo, 'terminal')).toBe('Exited (code: 1)');
   });

--- a/packages/client/src/components/sessions/hooks/__tests__/useSessionPageState.test.ts
+++ b/packages/client/src/components/sessions/hooks/__tests__/useSessionPageState.test.ts
@@ -263,6 +263,95 @@ describe('useSessionPageState', () => {
     })
   })
 
+  describe('session switching', () => {
+    it('should reset activity states when sessionId changes', async () => {
+      // Start with session-1 which has known activity states
+      const session1 = createMockSession({ id: 'session-1', status: 'active' })
+      const session2 = createMockSession({ id: 'session-2', status: 'active' })
+      getSessionResponse = session1
+
+      const rootActivityStates = {
+        'session-1': {
+          'agent-worker-1': 'active' as AgentActivityState,
+        },
+        'session-2': {
+          'agent-worker-1': 'idle' as AgentActivityState,
+        },
+      }
+
+      const refs = createMockRefs()
+      refs.activeTabIdRef.current = 'agent-worker-1'
+
+      // Mount with session-1
+      const { result, rerender } = renderHook(
+        (props: { sessionId: string }) => useSessionPageState({
+          sessionId: props.sessionId,
+          updateTabsFromSessionRef: refs.updateTabsFromSessionRef,
+          activeTabIdRef: refs.activeTabIdRef,
+        }),
+        {
+          wrapper: createContextWrapper(rootActivityStates),
+          initialProps: { sessionId: 'session-1' },
+        },
+      )
+
+      await act(async () => {})
+
+      expect(result.current.activityState).toBe('active')
+
+      // Switch to session-2
+      getSessionResponse = session2
+      await act(async () => {
+        rerender({ sessionId: 'session-2' })
+      })
+
+      // Should show session-2's activity state, not session-1's
+      expect(result.current.activityState).toBe('idle')
+      expect(result.current.workerActivityStates).toEqual({
+        'agent-worker-1': 'idle',
+      })
+    })
+
+    it('should reset to unknown when new session has no activity data', async () => {
+      const session1 = createMockSession({ id: 'session-1', status: 'active' })
+      const session2 = createMockSession({ id: 'session-2', status: 'active' })
+      getSessionResponse = session1
+
+      const rootActivityStates = {
+        'session-1': {
+          'agent-worker-1': 'active' as AgentActivityState,
+        },
+      }
+
+      const refs = createMockRefs()
+      refs.activeTabIdRef.current = 'agent-worker-1'
+
+      const { result, rerender } = renderHook(
+        (props: { sessionId: string }) => useSessionPageState({
+          sessionId: props.sessionId,
+          updateTabsFromSessionRef: refs.updateTabsFromSessionRef,
+          activeTabIdRef: refs.activeTabIdRef,
+        }),
+        {
+          wrapper: createContextWrapper(rootActivityStates),
+          initialProps: { sessionId: 'session-1' },
+        },
+      )
+
+      await act(async () => {})
+      expect(result.current.activityState).toBe('active')
+
+      // Switch to session-2 (no activity data in root context)
+      getSessionResponse = session2
+      await act(async () => {
+        rerender({ sessionId: 'session-2' })
+      })
+
+      expect(result.current.activityState).toBe('unknown')
+      expect(result.current.workerActivityStates).toEqual({})
+    })
+  })
+
   describe('retryLoadSession', () => {
     it('should re-trigger session load on retryLoadSession', async () => {
       getSessionResponse = 'throw-server-unavailable'

--- a/packages/client/src/components/sessions/hooks/useSessionPageState.ts
+++ b/packages/client/src/components/sessions/hooks/useSessionPageState.ts
@@ -76,6 +76,17 @@ export function useSessionPageState({
   const [loadTrigger, setLoadTrigger] = useState(0)
   const syncRequestIdRef = useRef(0)
 
+  // Reset activity states when navigating to a different session.
+  // useState initializers only run on first mount, so we need this effect
+  // to pick up the new session's activity data from the root context.
+  useEffect(() => {
+    const newSessionActivities = rootActivityStates[sessionId] ?? {}
+    setWorkerActivityStates(newSessionActivities)
+    const tabId = activeTabIdRef.current
+    setActivityState(tabId ? (newSessionActivities[tabId] ?? 'unknown') : 'unknown')
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only reset when sessionId changes
+  }, [sessionId])
+
   const handleWorkerActivity = useCallback((eventSessionId: string, workerId: string, newState: AgentActivityState) => {
     if (eventSessionId !== sessionId) return
 

--- a/packages/server/src/websocket/routes.ts
+++ b/packages/server/src/websocket/routes.ts
@@ -619,7 +619,7 @@ export async function setupWebSocketRoutes(
         // Send current activity state on connection (for agent workers)
         if (workerType === 'agent') {
           const activityState = sessionManager.getWorkerActivityState(sessionId, workerId);
-          if (activityState && activityState !== 'unknown') {
+          if (activityState) {
             sender?.send({ type: 'activity', state: activityState });
           }
         }


### PR DESCRIPTION
## Summary
- Server now sends initial activity state on WebSocket connection even when it's `'unknown'`, giving the client a definitive signal instead of silence
- Client resets `activityState` and `workerActivityStates` when `sessionId` changes via navigation, preventing stale state from the previous session
- Added unit tests for status indicator color/text with known activity states and session switching behavior

Closes #576

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (2165 tests, 0 failures)
- [ ] Verify connected agent shows "Connected" (green) instead of "Starting Claude..." (yellow)
- [ ] Verify switching sessions updates the status indicator to reflect the new session

🤖 Generated with [Claude Code](https://claude.com/claude-code)