### PR TITLE
fix: prevent silent form failure when prompt is empty in Create Worktree dialog

### DIFF
--- a/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
+++ b/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
@@ -75,7 +75,7 @@ export function CreateWorktreeForm({
   } = useForm<CreateWorktreeFormData>({
     resolver: valibotResolver(CreateWorktreeFormSchema),
     defaultValues: {
-      branchNameMode: prefillValues?.branchNameMode ?? 'prompt',
+      branchNameMode: prefillValues?.branchNameMode ?? (prefillValues?.initialPrompt?.trim() ? 'prompt' : 'custom'),
       initialPrompt: prefillValues?.initialPrompt ?? '',
       githubIssue: '',
       customBranch: '',
@@ -170,6 +170,22 @@ export function CreateWorktreeForm({
 
   const branchNameMode = watch('branchNameMode');
   const initialPrompt = watch('initialPrompt');
+
+  // Auto-switch branchNameMode based on initialPrompt content
+  // Keeps the radio selection consistent with available options
+  useEffect(() => {
+    const subscription = watch((value, { name }) => {
+      if (name === 'initialPrompt') {
+        const hasPrompt = !!value.initialPrompt?.trim();
+        if (!hasPrompt && value.branchNameMode === 'prompt') {
+          setValue('branchNameMode', 'custom');
+        } else if (hasPrompt && value.branchNameMode === 'custom' && !value.customBranch?.trim()) {
+          setValue('branchNameMode', 'prompt');
+        }
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [watch, setValue]);
 
   // Local state for refreshed default branch (overrides prop when set)
   const [refreshedDefaultBranch, setRefreshedDefaultBranch] = useState<string | null>(null);
@@ -285,7 +301,7 @@ export function CreateWorktreeForm({
             {/* Left column: prompt and title */}
             <div className="flex flex-col gap-2">
               {/* Initial prompt input (available for all modes) */}
-              <FormField label="Initial prompt (optional)" error={errors.initialPrompt}>
+              <FormField label={branchNameMode === 'prompt' ? 'Initial prompt' : 'Initial prompt (optional)'} error={errors.initialPrompt}>
                 <Textarea
                   {...register('initialPrompt')}
                   placeholder="What do you want to work on? (e.g., 'Add a dark mode toggle to the settings page')"

--- a/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
@@ -81,8 +81,8 @@ describe('CreateWorktreeForm', () => {
     mockFetch.mockResolvedValue(createMockResponse(mockAgentsResponse));
   });
 
-  describe('prompt mode (default)', () => {
-    it('should submit successfully with initial prompt', async () => {
+  describe('prompt mode', () => {
+    it('should auto-switch to prompt mode when typing a prompt and submit successfully', async () => {
       const user = userEvent.setup();
       const { props } = renderCreateWorktreeForm();
 
@@ -91,9 +91,19 @@ describe('CreateWorktreeForm', () => {
         expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
       });
 
-      // Fill in initial prompt
+      // Default mode is 'custom' (no prompt yet)
+      const customRadio = screen.getByLabelText(/Custom name \(new branch\)/) as HTMLInputElement;
+      expect(customRadio.checked).toBe(true);
+
+      // Fill in initial prompt - auto-switches to 'prompt' mode since customBranch is empty
       const promptInput = screen.getByPlaceholderText(/What do you want to work on/);
       await user.type(promptInput, 'Add dark mode feature');
+
+      // Auto-generate radio should now be selected
+      await waitFor(() => {
+        const promptRadio = screen.getByLabelText(/Auto-generate/) as HTMLInputElement;
+        expect(promptRadio.checked).toBe(true);
+      });
 
       // Submit form
       const submitButton = screen.getByText('Create & Start Session');
@@ -112,7 +122,7 @@ describe('CreateWorktreeForm', () => {
       });
     });
 
-    it('should show validation error when prompt mode has no initial prompt', async () => {
+    it('should show validation error when submitting empty form in default custom mode', async () => {
       const user = userEvent.setup();
       const { props } = renderCreateWorktreeForm();
 
@@ -121,7 +131,7 @@ describe('CreateWorktreeForm', () => {
         expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
       });
 
-      // Submit without filling anything (prompt mode is default)
+      // Default mode is 'custom' - submit without filling anything
       const submitButton = screen.getByText('Create & Start Session');
       await user.click(submitButton);
 
@@ -130,9 +140,9 @@ describe('CreateWorktreeForm', () => {
         expect(props.onSubmit).not.toHaveBeenCalled();
       });
 
-      // Error should be displayed
+      // Branch name required error should be displayed (custom mode requires branch)
       await waitFor(() => {
-        expect(screen.getByText(/Initial prompt is required/)).toBeTruthy();
+        expect(screen.getByText('Branch name is required')).toBeTruthy();
       });
     });
   });
@@ -428,6 +438,129 @@ describe('CreateWorktreeForm', () => {
       // "Auto-generate" radio should be disabled when no prompt
       const promptRadio = screen.getByLabelText(/Auto-generate/);
       expect((promptRadio as HTMLInputElement).disabled).toBe(true);
+    });
+
+    it('should default to custom mode when no prefill is provided', async () => {
+      renderCreateWorktreeForm();
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      const customRadio = screen.getByLabelText(/Custom name \(new branch\)/) as HTMLInputElement;
+      expect(customRadio.checked).toBe(true);
+
+      // Branch name input should be visible in custom mode
+      expect(screen.getByPlaceholderText('New branch name')).toBeTruthy();
+    });
+
+    it('should show dynamic label based on branchNameMode', async () => {
+      const user = userEvent.setup();
+      renderCreateWorktreeForm();
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      // In custom mode (default), label should say "(optional)"
+      expect(screen.getByText('Initial prompt (optional)')).toBeTruthy();
+
+      // Type a prompt to auto-switch to prompt mode
+      const promptInput = screen.getByPlaceholderText(/What do you want to work on/);
+      await user.type(promptInput, 'Add feature');
+
+      // In prompt mode, label should NOT say "(optional)"
+      await waitFor(() => {
+        expect(screen.getByText('Initial prompt')).toBeTruthy();
+        expect(screen.queryByText('Initial prompt (optional)')).toBeNull();
+      });
+    });
+  });
+
+  describe('branchNameMode auto-switch', () => {
+    it('should switch from prompt to custom when prompt is cleared', async () => {
+      const user = userEvent.setup();
+      renderCreateWorktreeForm();
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      // Type a prompt to switch to prompt mode
+      const promptInput = screen.getByPlaceholderText(/What do you want to work on/);
+      await user.type(promptInput, 'Add feature');
+
+      await waitFor(() => {
+        const promptRadio = screen.getByLabelText(/Auto-generate/) as HTMLInputElement;
+        expect(promptRadio.checked).toBe(true);
+      });
+
+      // Clear the prompt
+      await user.clear(promptInput);
+
+      // Should auto-switch back to custom mode
+      await waitFor(() => {
+        const customRadio = screen.getByLabelText(/Custom name \(new branch\)/) as HTMLInputElement;
+        expect(customRadio.checked).toBe(true);
+      });
+    });
+
+    it('should not auto-switch to prompt when custom branch is already filled', async () => {
+      const user = userEvent.setup();
+      renderCreateWorktreeForm();
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      // Fill in custom branch name first (in default custom mode)
+      const branchInput = screen.getByPlaceholderText('New branch name');
+      await user.type(branchInput, 'feature/my-branch');
+
+      // Now type a prompt - should NOT switch to prompt mode because customBranch is filled
+      const promptInput = screen.getByPlaceholderText(/What do you want to work on/);
+      await user.type(promptInput, 'Add feature');
+
+      // Should stay in custom mode
+      const customRadio = screen.getByLabelText(/Custom name \(new branch\)/) as HTMLInputElement;
+      expect(customRadio.checked).toBe(true);
+    });
+
+    it('should keep prompt mode when prefillValues includes initialPrompt', async () => {
+      renderCreateWorktreeForm({
+        prefillValues: {
+          initialPrompt: 'Fix the bug from issue #123',
+          branchNameMode: 'prompt',
+        },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      // Should be in prompt mode (from prefill)
+      const promptRadio = screen.getByLabelText(/Auto-generate/) as HTMLInputElement;
+      expect(promptRadio.checked).toBe(true);
+
+      // Prompt should be prefilled
+      const promptInput = screen.getByPlaceholderText(/What do you want to work on/) as HTMLTextAreaElement;
+      expect(promptInput.value).toBe('Fix the bug from issue #123');
+    });
+
+    it('should default to prompt mode when prefillValues has initialPrompt without explicit branchNameMode', async () => {
+      renderCreateWorktreeForm({
+        prefillValues: {
+          initialPrompt: 'Fix the bug',
+        },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      // Should be in prompt mode (inferred from non-empty initialPrompt)
+      const promptRadio = screen.getByLabelText(/Auto-generate/) as HTMLInputElement;
+      expect(promptRadio.checked).toBe(true);
     });
   });
 

--- a/packages/client/src/components/worktrees/__tests__/FromIssueTab.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/FromIssueTab.test.tsx
@@ -175,7 +175,7 @@ describe('FromIssueTab', () => {
 
       // Wait for Phase 2: CreateWorktreeForm fields appear
       await waitFor(() => {
-        expect(screen.getByText('Initial prompt (optional)')).toBeTruthy();
+        expect(screen.getByText('Initial prompt')).toBeTruthy();
       });
     }
 
@@ -192,7 +192,7 @@ describe('FromIssueTab', () => {
       await fetchIssue(user);
 
       // CreateWorktreeForm fields should now be visible
-      expect(screen.getByText('Initial prompt (optional)')).toBeTruthy();
+      expect(screen.getByText('Initial prompt')).toBeTruthy();
       expect(screen.getByText('Title (optional)')).toBeTruthy();
       expect(screen.getByText('Branch name:')).toBeTruthy();
 
@@ -318,7 +318,7 @@ describe('FromIssueTab', () => {
 
       // Wait for Phase 2
       await waitFor(() => {
-        expect(screen.getByText('Initial prompt (optional)')).toBeTruthy();
+        expect(screen.getByText('Initial prompt')).toBeTruthy();
       });
 
       // The prompt should be prefilled with ref URL + title (since body is empty)


### PR DESCRIPTION
## Summary
- Auto-switch `branchNameMode` from `'prompt'` to `'custom'` when the initial prompt is cleared, and auto-switch to `'prompt'` when a prompt is typed (if no custom branch is set)
- Default to `'custom'` mode for fresh dialogs so the form is always in a valid, submittable state
- Dynamic label: shows "Initial prompt" (required) in prompt mode, "Initial prompt (optional)" otherwise

Closes #585

## Test plan
- [ ] Open Create Worktree dialog with no prefill → defaults to "Custom name" mode, prompt shows "(optional)"
- [ ] Type a prompt → auto-switches to "Auto-generate" mode, label changes to "Initial prompt"
- [ ] Clear the prompt → auto-switches back to "Custom name" mode
- [ ] Type a custom branch name, then type a prompt → stays in "Custom name" mode (no unwanted auto-switch)
- [ ] FromIssueTab prefill → starts in "Auto-generate" mode with label "Initial prompt"
- [ ] Submit with empty prompt in custom mode without branch name → shows "Branch name is required" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)