### PR TITLE
fix: add error handling for fire-and-forget async in InteractiveProcessManager

### DIFF
--- a/packages/server/src/services/__tests__/interactive-process-manager.test.ts
+++ b/packages/server/src/services/__tests__/interactive-process-manager.test.ts
@@ -416,6 +416,60 @@ describe('InteractiveProcessManager', () => {
     });
   });
 
+  describe('error handling for fire-and-forget async patterns', () => {
+    it('should catch errors thrown by onExit callback without unhandled rejection', async () => {
+      const throwingOnExit = mock(() => {
+        throw new Error('onExit callback error');
+      });
+      const errorManager = new InteractiveProcessManager(onOutput, throwingOnExit);
+
+      await errorManager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'echo done',
+      });
+
+      // Wait for the process to exit and the .catch() to handle the error
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline) {
+        if (throwingOnExit.mock.calls.length > 0) break;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      // onExit was called (and threw), but no unhandled rejection occurred
+      expect(throwingOnExit).toHaveBeenCalled();
+
+      errorManager.disposeAll();
+    });
+
+    it('should handle readStream errors gracefully with .catch()', async () => {
+      // readStream internally catches stream read errors, so the outer .catch()
+      // acts as a safety net. Verify that a process with stdout/stderr
+      // completes without unhandled rejections even when the process exits abruptly.
+      await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'echo hello && exit 1',
+      });
+
+      // Wait for exit
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline) {
+        if (onExit.mock.calls.length > 0) break;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      expect(onExit).toHaveBeenCalled();
+      const [exitInfo] = onExit.mock.calls[0];
+      expect(exitInfo.status).toBe('exited');
+      expect(exitInfo.exitCode).toBe(1);
+
+      // stdout output was still captured before the error exit
+      const allOutput = onOutput.mock.calls.map((c: unknown[]) => c[1]).join('');
+      expect(allOutput).toContain('hello');
+    });
+  });
+
   describe('output buffering', () => {
     it('should buffer rapid output and call onOutput once with combined text', async () => {
       // Script outputs 10 lines rapidly with no delay between them.

--- a/packages/server/src/services/interactive-process-manager.ts
+++ b/packages/server/src/services/interactive-process-manager.ts
@@ -90,9 +90,13 @@ export class InteractiveProcessManager {
     this.processes.set(id, stored);
 
     // Read stdout asynchronously
-    this.readStream(id, subprocess.stdout);
+    void this.readStream(id, subprocess.stdout).catch((err) => {
+      logger.warn({ processId: id, err }, 'stdout read stream error');
+    });
     // Also capture stderr and send as output
-    this.readStream(id, subprocess.stderr);
+    void this.readStream(id, subprocess.stderr).catch((err) => {
+      logger.warn({ processId: id, err }, 'stderr read stream error');
+    });
 
     // Monitor process exit
     subprocess.exited.then((exitCode) => {
@@ -103,6 +107,8 @@ export class InteractiveProcessManager {
         logger.info({ processId: id, exitCode }, 'Process exited');
         this.onExit({ ...current.info });
       }
+    }).catch((err) => {
+      logger.error({ processId: id, err }, 'Process exit handler error');
     });
 
     logger.info(


### PR DESCRIPTION
## Summary

- Add `.catch()` to `subprocess.exited.then(...)` to prevent silent unhandled rejections when the exit handler throws
- Add `.catch()` to `readStream()` calls for stdout/stderr as a safety net against stream errors
- Add `void` prefix to `readStream()` calls to satisfy ESLint/TypeScript floating promise rules

Closes #593

## Test plan

- [x] Unit test: `onExit` callback throwing an error is caught by `.catch()` without unhandled rejection
- [x] Unit test: Process with abrupt exit (exit code 1) handles readStream gracefully
- [x] All 30 existing tests pass
- [x] Server typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)