### PR TITLE
fix: upload-qa-screenshots.sh BSD sed compatibility

### DIFF
--- a/scripts/upload-qa-screenshots.sh
+++ b/scripts/upload-qa-screenshots.sh
@@ -31,7 +31,7 @@ else
     exit 1
   fi
   # Extract owner/repo from SSH or HTTPS URL
-  REPO=$(echo "$REMOTE_URL" | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
+  REPO=$(echo "$REMOTE_URL" | sed -E 's#.*[:/]([^/]+/[^/]+)$#\1#' | sed 's/\.git$//')
 fi
 
 RELEASE_TAG="qa-screenshots"


### PR DESCRIPTION
## Summary

- BSD sed (macOS) で非貪欲量指定子 `+?` が使えない問題を修正
- `sed -E 's#...+?...#'` → 2段階 `sed` に分割（extract + strip .git）

## Context

PR #607 でマージした `upload-qa-screenshots.sh` を実際に使ったところ、macOS の BSD sed でリポジトリ名に `.git` が残る問題が発覚。

🤖 Generated with [Claude Code](https://claude.com/claude-code)