### PR TITLE
fix: use details/summary for QA screenshot thumbnails

### DIFF
--- a/scripts/upload-qa-screenshots.sh
+++ b/scripts/upload-qa-screenshots.sh
@@ -88,7 +88,7 @@ for file in "$SCREENSHOT_DIR"/*.png; do
   URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${UNIQUE_NAME}"
   # Convert filename to readable description (e.g., "restart-all-button" -> "restart all button")
   DESCRIPTION=$(echo "$BASENAME" | sed 's/[-_]/ /g')
-  UPLOADED_IMAGES+=("### ${DESCRIPTION}"$'\n'"<a href=\"${URL}\"><img src=\"${URL}\" width=\"400\" alt=\"${DESCRIPTION}\"></a>")
+  UPLOADED_IMAGES+=("### ${DESCRIPTION}"$'\n'"<details>"$'\n'"<summary><img src=\"${URL}\" width=\"400\" alt=\"${DESCRIPTION}\"></summary>"$'\n\n'"<img src=\"${URL}\" alt=\"${DESCRIPTION}\">"$'\n'"</details>")
 done
 
 # Build PR comment body


### PR DESCRIPTION
## Summary

スクショのサムネイルクリック時に GitHub Release のダウンロードが走る問題を修正。

`<a href><img></a>` → `<details><summary><img></summary><img></details>` に変更。
- サムネイル（width=400）は常時表示
- クリックで原寸画像が展開（ダウンロードにならない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)