### PR TITLE
chore: add .qa-screenshots to gitignore and improve screenshot display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ npm-debug.log*
 .claude/review-queue/*.jsonl
 .claude/review-queue/fixing.json
 
+# QA screenshots (temporary, uploaded to PR via script)
+.qa-screenshots/
+
 # Orchestrator acceptance check results
 .acceptance-check-*.json

--- a/scripts/upload-qa-screenshots.sh
+++ b/scripts/upload-qa-screenshots.sh
@@ -88,7 +88,7 @@ for file in "$SCREENSHOT_DIR"/*.png; do
   URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${UNIQUE_NAME}"
   # Convert filename to readable description (e.g., "restart-all-button" -> "restart all button")
   DESCRIPTION=$(echo "$BASENAME" | sed 's/[-_]/ /g')
-  UPLOADED_IMAGES+=("### ${DESCRIPTION}"$'\n'"<details>"$'\n'"<summary><img src=\"${URL}\" width=\"400\" alt=\"${DESCRIPTION}\"></summary>"$'\n\n'"<img src=\"${URL}\" alt=\"${DESCRIPTION}\">"$'\n'"</details>")
+  UPLOADED_IMAGES+=("### ${DESCRIPTION}"$'\n'"<img src=\"${URL}\" width=\"400\" alt=\"${DESCRIPTION}\">"$'\n\n'"<details>"$'\n'"<summary>View full size</summary>"$'\n\n'"<img src=\"${URL}\" alt=\"${DESCRIPTION}\">"$'\n'"</details>")
 done
 
 # Build PR comment body


### PR DESCRIPTION
## Summary

- `.qa-screenshots/` を `.gitignore` に追加（一時ファイル、スクリプトで PR にアップロード後は不要）
- スクショ表示形式を改善：サムネイルは静的表示 + 「View full size」で原寸展開

🤖 Generated with [Claude Code](https://claude.com/claude-code)