### PR TITLE
feat: dynamic branch tracking via fs.watch for worktree sessions

### DIFF
--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -31,6 +31,7 @@ import type { MessageTemplateRepository } from './repositories/message-template-
 import type { SuggestSessionMetadataFn } from './services/session-metadata-suggester.js';
 import type { OpenPrInfo } from './services/github-pr-service.js';
 import type { GenerateRepositoryDescriptionFn } from './services/repository-description-generator.js';
+import type { BranchWatcherService as BranchWatcherServiceType } from './services/branch-watcher-service.js';
 import type { InboundIntegrationInstance } from './services/inbound/index.js';
 import { initializeInboundIntegration } from './services/inbound/index.js';
 import { initializeDatabase, createDatabaseForTest, closeDatabase, getGlobalDatabase } from './database/connection.js';
@@ -60,6 +61,7 @@ import { AnnotationService as AnnotationServiceClass } from './services/annotati
 import { InterSessionMessageService as InterSessionMessageServiceClass } from './services/inter-session-message-service.js';
 import { WorkerOutputFileManager } from './lib/worker-output-file.js';
 import { MemoService } from './services/memo-service.js';
+import { BranchWatcherService } from './services/branch-watcher-service.js';
 import { suggestSessionMetadata } from './services/session-metadata-suggester.js';
 import { fetchPullRequestUrl, findOpenPullRequest } from './services/github-pr-service.js';
 import { generateRepositoryDescription } from './services/repository-description-generator.js';
@@ -139,6 +141,9 @@ export interface AppContext {
 
   /** Message template CRUD repository */
   messageTemplateRepository: MessageTemplateRepository;
+
+  /** Branch watcher service for dynamic branch tracking */
+  branchWatcherService: BranchWatcherServiceType;
 }
 
 /**
@@ -331,6 +336,16 @@ export async function createAppContext(
     interactiveProcessManager.deleteProcessesBySession(sessionId);
   });
 
+  // 6.9. Create branch watcher service and wire into session lifecycle
+  const branchWatcherService = new BranchWatcherService(async (sessionId, newBranch) => {
+    await sessionManager.syncBranchFromGit(sessionId, newBranch);
+  });
+  sessionManager.setBranchWatcherCallbacks({
+    startWatching: (sessionId, locationPath, currentBranch) =>
+      branchWatcherService.startWatching(sessionId, locationPath, currentBranch),
+    stopWatching: (sessionId) => branchWatcherService.stopWatching(sessionId),
+  });
+
   // 7. Wire cross-dependencies between managers
   repositoryManager.setDependencyCallbacks({
     getSessionsUsingRepository: (repoId) =>
@@ -380,6 +395,7 @@ export async function createAppContext(
     findOpenPullRequest,
     generateRepositoryDescription,
     messageTemplateRepository,
+    branchWatcherService,
   };
 }
 
@@ -550,6 +566,7 @@ export async function createTestContext(
     findOpenPullRequest,
     generateRepositoryDescription,
     messageTemplateRepository,
+    branchWatcherService: new BranchWatcherService(async () => {}),
   };
 }
 
@@ -563,9 +580,10 @@ export async function createTestContext(
 export async function shutdownAppContext(
   context: AppContext,
 ): Promise<void> {
-  // Dispose timer manager and interactive process manager
+  // Dispose timer manager, interactive process manager, and branch watcher
   context.timerManager.disposeAll();
   context.interactiveProcessManager.disposeAll();
+  context.branchWatcherService.stopAll();
 
   // Stop job queue
   await context.jobQueue.stop();

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -340,7 +340,7 @@ export async function createAppContext(
   const branchWatcherService = new BranchWatcherService(async (sessionId, newBranch) => {
     await sessionManager.syncBranchFromGit(sessionId, newBranch);
   });
-  sessionManager.setBranchWatcherCallbacks({
+  await sessionManager.setBranchWatcherCallbacks({
     startWatching: (sessionId, locationPath, currentBranch) =>
       branchWatcherService.startWatching(sessionId, locationPath, currentBranch),
     stopWatching: (sessionId) => branchWatcherService.stopWatching(sessionId),

--- a/packages/server/src/services/__tests__/branch-watcher-service.test.ts
+++ b/packages/server/src/services/__tests__/branch-watcher-service.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { type FSWatcher } from 'node:fs';
+import { EventEmitter } from 'node:events';
+import { parseBranchFromHead, resolveHeadFilePath, BranchWatcherService } from '../branch-watcher-service.js';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+// Use Bun APIs and shell commands for file operations to avoid memfs
+// mock contamination from mock-fs-helper.ts (which globally mocks node:fs)
+async function createTempDir(prefix: string): Promise<string> {
+  const tmpDir = path.join(os.tmpdir(), `${prefix}${crypto.randomUUID().slice(0, 8)}`);
+  await Bun.spawn(['mkdir', '-p', tmpDir]).exited;
+  return tmpDir;
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+  await Bun.spawn(['rm', '-rf', dir]).exited;
+}
+
+async function createDir(dir: string): Promise<void> {
+  await Bun.spawn(['mkdir', '-p', dir]).exited;
+}
+
+describe('parseBranchFromHead', () => {
+  it('should parse branch name from ref format', () => {
+    expect(parseBranchFromHead('ref: refs/heads/main\n')).toBe('main');
+    expect(parseBranchFromHead('ref: refs/heads/feat/dynamic-branch-tracking')).toBe('feat/dynamic-branch-tracking');
+    expect(parseBranchFromHead('ref: refs/heads/fix-123')).toBe('fix-123');
+  });
+
+  it('should return (detached) for raw commit hash', () => {
+    expect(parseBranchFromHead('abc123def456\n')).toBe('(detached)');
+    expect(parseBranchFromHead('4b825dc642cb6eb9a060e54bf899d69f82563773')).toBe('(detached)');
+  });
+
+  it('should return (detached) for empty content', () => {
+    expect(parseBranchFromHead('')).toBe('(detached)');
+    expect(parseBranchFromHead('  \n')).toBe('(detached)');
+  });
+
+  it('should handle trailing whitespace', () => {
+    expect(parseBranchFromHead('ref: refs/heads/main  \n')).toBe('main');
+  });
+});
+
+describe('resolveHeadFilePath', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTempDir('branch-watcher-test-');
+  });
+
+  afterEach(async () => {
+    await removeTempDir(tmpDir);
+  });
+
+  it('should resolve HEAD for main repository (.git directory)', async () => {
+    const gitDir = path.join(tmpDir, '.git');
+    await createDir(gitDir);
+    await Bun.write(path.join(gitDir, 'HEAD'), 'ref: refs/heads/main\n');
+
+    const result = await resolveHeadFilePath(tmpDir);
+    expect(result).toBe(path.join(gitDir, 'HEAD'));
+  });
+
+  it('should resolve HEAD for worktree (.git file with gitdir)', async () => {
+    const mainRepoGitDir = path.join(tmpDir, 'main-repo', '.git');
+    const worktreeGitDir = path.join(mainRepoGitDir, 'worktrees', 'wt-001');
+    await createDir(worktreeGitDir);
+    await Bun.write(path.join(worktreeGitDir, 'HEAD'), 'ref: refs/heads/feature-branch\n');
+
+    const worktreeDir = path.join(tmpDir, 'wt-001');
+    await createDir(worktreeDir);
+    await Bun.write(path.join(worktreeDir, '.git'), `gitdir: ${worktreeGitDir}\n`);
+
+    const result = await resolveHeadFilePath(worktreeDir);
+    expect(result).toBe(path.join(worktreeGitDir, 'HEAD'));
+  });
+
+  it('should resolve HEAD for worktree with relative gitdir path', async () => {
+    const mainRepoDir = path.join(tmpDir, 'main-repo');
+    const gitDir = path.join(mainRepoDir, '.git');
+    const worktreeGitDir = path.join(gitDir, 'worktrees', 'wt-001');
+    await createDir(worktreeGitDir);
+    await Bun.write(path.join(worktreeGitDir, 'HEAD'), 'ref: refs/heads/feature\n');
+
+    const worktreeDir = path.join(tmpDir, 'wt-001');
+    await createDir(worktreeDir);
+    const relativeGitdir = path.relative(worktreeDir, worktreeGitDir);
+    await Bun.write(path.join(worktreeDir, '.git'), `gitdir: ${relativeGitdir}\n`);
+
+    const result = await resolveHeadFilePath(worktreeDir);
+    expect(result).toBe(path.join(worktreeGitDir, 'HEAD'));
+  });
+
+  it('should return null when .git does not exist', async () => {
+    const result = await resolveHeadFilePath(tmpDir);
+    expect(result).toBeNull();
+  });
+});
+
+describe('BranchWatcherService', () => {
+  // Create a mock FSWatcher that exposes the callback for manual triggering.
+  // This avoids depending on real fs.watch which is mocked by memfs in the full test suite.
+  let mockWatchCallbacks: Map<string, (eventType: string, filename: string | null) => void>;
+  let mockWatchCloseFns: Map<string, ReturnType<typeof mock>>;
+
+  function createMockWatch() {
+    mockWatchCallbacks = new Map();
+    mockWatchCloseFns = new Map();
+
+    return ((filePath: string, callback: (eventType: string, filename: string | null) => void) => {
+      const key = filePath;
+      mockWatchCallbacks.set(key, callback);
+      const closeFn = mock(() => { mockWatchCallbacks.delete(key); });
+      mockWatchCloseFns.set(key, closeFn);
+      const emitter = new EventEmitter() as EventEmitter & { close: typeof closeFn };
+      emitter.close = closeFn;
+      return emitter as unknown as FSWatcher;
+    }) as unknown as typeof import('node:fs').watch;
+  }
+
+  it('should start and stop watching', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      await Bun.write(path.join(gitDir, 'HEAD'), 'ref: refs/heads/main\n');
+
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(async () => {}, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'main');
+      expect(service.isWatching('session-1')).toBe(true);
+
+      service.stopWatching('session-1');
+      expect(service.isWatching('session-1')).toBe(false);
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should detect branch change when HEAD file changes', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      const headPath = path.join(gitDir, 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/main\n');
+
+      const onBranchChanged = mock(async () => {});
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(onBranchChanged, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      // Simulate file change: write new content then trigger watcher
+      await Bun.write(headPath, 'ref: refs/heads/feature-branch\n');
+      const callback = mockWatchCallbacks.get(headPath);
+      callback?.('change', 'HEAD');
+
+      // Wait for debounce
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      expect(onBranchChanged).toHaveBeenCalledWith('session-1', 'feature-branch');
+
+      service.stopAll();
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should not fire callback when branch has not changed', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      const headPath = path.join(gitDir, 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/main\n');
+
+      const onBranchChanged = mock(async () => {});
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(onBranchChanged, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      // Trigger watcher without changing content
+      const callback = mockWatchCallbacks.get(headPath);
+      callback?.('change', 'HEAD');
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      expect(onBranchChanged).not.toHaveBeenCalled();
+
+      service.stopAll();
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should handle detached HEAD state', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      const headPath = path.join(gitDir, 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/main\n');
+
+      const onBranchChanged = mock(async () => {});
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(onBranchChanged, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      // Simulate detached HEAD
+      await Bun.write(headPath, '4b825dc642cb6eb9a060e54bf899d69f82563773\n');
+      mockWatchCallbacks.get(headPath)?.('change', 'HEAD');
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      expect(onBranchChanged).toHaveBeenCalledWith('session-1', '(detached)');
+
+      service.stopAll();
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should debounce rapid changes', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      const headPath = path.join(gitDir, 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/main\n');
+
+      const onBranchChanged = mock(async () => {});
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(onBranchChanged, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      const callback = mockWatchCallbacks.get(headPath)!;
+
+      // Rapid triggers — only the last write should be read
+      await Bun.write(headPath, 'ref: refs/heads/branch-a\n');
+      callback('change', 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/branch-b\n');
+      callback('change', 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/branch-c\n');
+      callback('change', 'HEAD');
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      // Debounce should mean only one call with the final content
+      expect(onBranchChanged).toHaveBeenCalledTimes(1);
+      expect(onBranchChanged).toHaveBeenCalledWith('session-1', 'branch-c');
+
+      service.stopAll();
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should stop all watchers on stopAll', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      await Bun.write(path.join(gitDir, 'HEAD'), 'ref: refs/heads/main\n');
+
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(async () => {}, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'main');
+      expect(service.isWatching('session-1')).toBe(true);
+
+      service.stopAll();
+      expect(service.isWatching('session-1')).toBe(false);
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should replace existing watcher when startWatching is called again', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      await Bun.write(path.join(gitDir, 'HEAD'), 'ref: refs/heads/branch-a\n');
+
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(async () => {}, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'branch-a');
+
+      // Start again — should close old watcher and create new one
+      await service.startWatching('session-1', tmpDir, 'branch-b');
+      expect(service.isWatching('session-1')).toBe(true);
+
+      service.stopAll();
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should not start watcher when HEAD file does not exist', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(async () => {}, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      expect(service.isWatching('session-1')).toBe(false);
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('stopWatching should be no-op for unknown session', () => {
+    const service = new BranchWatcherService(async () => {});
+    service.stopWatching('unknown-session');
+    expect(service.isWatching('unknown-session')).toBe(false);
+  });
+});

--- a/packages/server/src/services/__tests__/branch-watcher-service.test.ts
+++ b/packages/server/src/services/__tests__/branch-watcher-service.test.ts
@@ -315,4 +315,91 @@ describe('BranchWatcherService', () => {
     service.stopWatching('unknown-session');
     expect(service.isWatching('unknown-session')).toBe(false);
   });
+
+  it('should reconcile stale branch on startWatching', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      // HEAD says 'feature-branch' but caller passes 'stale-branch'
+      await Bun.write(path.join(gitDir, 'HEAD'), 'ref: refs/heads/feature-branch\n');
+
+      const onBranchChanged = mock(async (_sid: string, _branch: string) => {});
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(onBranchChanged, mockWatch);
+
+      await service.startWatching('session-1', tmpDir, 'stale-branch');
+
+      // Should have immediately called onBranchChanged to reconcile
+      expect(onBranchChanged).toHaveBeenCalledWith('session-1', 'feature-branch');
+      expect(service.isWatching('session-1')).toBe(true);
+
+      service.stopAll();
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should not reconcile when actual HEAD matches stored branch', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      await Bun.write(path.join(gitDir, 'HEAD'), 'ref: refs/heads/main\n');
+
+      const onBranchChanged = mock(async (_sid: string, _branch: string) => {});
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(onBranchChanged, mockWatch);
+
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      // No reconciliation needed
+      expect(onBranchChanged).not.toHaveBeenCalled();
+
+      service.stopAll();
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should only update currentBranch after successful sync', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      const headPath = path.join(gitDir, 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/main\n');
+
+      // First call succeeds, second call fails
+      let callCount = 0;
+      const onBranchChanged = mock(async (_sid: string, _branch: string) => {
+        callCount++;
+        if (callCount === 2) throw new Error('sync failed');
+      });
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(onBranchChanged, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      // First change: succeeds
+      await Bun.write(headPath, 'ref: refs/heads/branch-a\n');
+      mockWatchCallbacks.get(headPath)?.('change', 'HEAD');
+      await new Promise(resolve => setTimeout(resolve, 300));
+      expect(onBranchChanged).toHaveBeenCalledWith('session-1', 'branch-a');
+
+      // Second change: fails — currentBranch should NOT advance
+      await Bun.write(headPath, 'ref: refs/heads/branch-b\n');
+      mockWatchCallbacks.get(headPath)?.('change', 'HEAD');
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      // Third change: should still detect from branch-a (not branch-b)
+      await Bun.write(headPath, 'ref: refs/heads/branch-c\n');
+      mockWatchCallbacks.get(headPath)?.('change', 'HEAD');
+      await new Promise(resolve => setTimeout(resolve, 300));
+      expect(onBranchChanged).toHaveBeenCalledWith('session-1', 'branch-c');
+
+      service.stopAll();
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
 });

--- a/packages/server/src/services/__tests__/session-deletion-service.test.ts
+++ b/packages/server/src/services/__tests__/session-deletion-service.test.ts
@@ -55,6 +55,7 @@ function createMockDeps(overrides?: Partial<SessionDeletionDeps>): SessionDeleti
     getTimerCleanupCallback: () => undefined,
     getProcessCleanupCallback: () => undefined,
     stopWatching: mockStopWatching,
+    stopBranchWatching: () => {},
     ...overrides,
   };
 }

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -2679,7 +2679,7 @@ describe('SessionManager', () => {
       const manager = await getSessionManager();
       const startWatching = mock(async (_sid: string, _path: string, _branch: string) => {});
       const stopWatching = mock((_sid: string) => {});
-      manager.setBranchWatcherCallbacks({ startWatching, stopWatching });
+      await manager.setBranchWatcherCallbacks({ startWatching, stopWatching });
 
       await manager.createSession({
         type: 'worktree',
@@ -2698,7 +2698,7 @@ describe('SessionManager', () => {
       const manager = await getSessionManager();
       const startWatching = mock(async (_sid: string, _path: string, _branch: string) => {});
       const stopWatching = mock((_sid: string) => {});
-      manager.setBranchWatcherCallbacks({ startWatching, stopWatching });
+      await manager.setBranchWatcherCallbacks({ startWatching, stopWatching });
 
       await manager.createSession({
         type: 'quick',

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -2622,6 +2622,94 @@ describe('SessionManager', () => {
     });
   });
 
+  describe('syncBranchFromGit', () => {
+    it('should update worktreeId without calling gitRenameBranch', async () => {
+      const manager = await getSessionManager();
+
+      const session = await manager.createSession({
+        type: 'worktree',
+        locationPath: '/test/path',
+        repositoryId: 'repo-1',
+        worktreeId: 'old-branch',
+        agentId: 'claude-code',
+      });
+
+      mockGit.renameBranch.mockReset();
+
+      const result = await manager.syncBranchFromGit(session.id, 'new-branch');
+
+      expect(result.success).toBe(true);
+      expect(result.branch).toBe('new-branch');
+
+      // Verify worktreeId was updated
+      const updated = manager.getSession(session.id);
+      expect(updated).toBeDefined();
+      if (updated?.type === 'worktree') {
+        expect(updated.worktreeId).toBe('new-branch');
+      }
+
+      // gitRenameBranch should NOT have been called
+      expect(mockGit.renameBranch).not.toHaveBeenCalled();
+    });
+
+    it('should broadcast session update via lifecycle callback', async () => {
+      const manager = await getSessionManager();
+      const onSessionUpdated = mock(() => {});
+      manager.setSessionLifecycleCallbacks({ onSessionUpdated });
+
+      const session = await manager.createSession({
+        type: 'worktree',
+        locationPath: '/test/path',
+        repositoryId: 'repo-1',
+        worktreeId: 'old-branch',
+        agentId: 'claude-code',
+      });
+
+      // Reset to only count the syncBranchFromGit call
+      onSessionUpdated.mockReset();
+
+      await manager.syncBranchFromGit(session.id, 'new-branch');
+
+      expect(onSessionUpdated).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setBranchWatcherCallbacks', () => {
+    it('should call startWatching when worktree session is created', async () => {
+      const manager = await getSessionManager();
+      const startWatching = mock(async () => {});
+      const stopWatching = mock(() => {});
+      manager.setBranchWatcherCallbacks({ startWatching, stopWatching });
+
+      await manager.createSession({
+        type: 'worktree',
+        locationPath: '/test/path',
+        repositoryId: 'repo-1',
+        worktreeId: 'main',
+        agentId: 'claude-code',
+      });
+
+      expect(startWatching).toHaveBeenCalledTimes(1);
+      expect(startWatching.mock.calls[0][1]).toBe('/test/path');
+      expect(startWatching.mock.calls[0][2]).toBe('main');
+    });
+
+    it('should not call startWatching for quick sessions', async () => {
+      const manager = await getSessionManager();
+      const startWatching = mock(async () => {});
+      const stopWatching = mock(() => {});
+      manager.setBranchWatcherCallbacks({ startWatching, stopWatching });
+
+      await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+
+      expect(startWatching).not.toHaveBeenCalled();
+    });
+  });
+
   describe('pauseSession', () => {
     it('should call notifySessionPaused before killing PTY workers', async () => {
       const manager = await getSessionManager();

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -2677,8 +2677,8 @@ describe('SessionManager', () => {
   describe('setBranchWatcherCallbacks', () => {
     it('should call startWatching when worktree session is created', async () => {
       const manager = await getSessionManager();
-      const startWatching = mock(async () => {});
-      const stopWatching = mock(() => {});
+      const startWatching = mock(async (_sid: string, _path: string, _branch: string) => {});
+      const stopWatching = mock((_sid: string) => {});
       manager.setBranchWatcherCallbacks({ startWatching, stopWatching });
 
       await manager.createSession({
@@ -2696,8 +2696,8 @@ describe('SessionManager', () => {
 
     it('should not call startWatching for quick sessions', async () => {
       const manager = await getSessionManager();
-      const startWatching = mock(async () => {});
-      const stopWatching = mock(() => {});
+      const startWatching = mock(async (_sid: string, _path: string, _branch: string) => {});
+      const stopWatching = mock((_sid: string) => {});
       manager.setBranchWatcherCallbacks({ startWatching, stopWatching });
 
       await manager.createSession({

--- a/packages/server/src/services/__tests__/session-metadata-service.test.ts
+++ b/packages/server/src/services/__tests__/session-metadata-service.test.ts
@@ -386,4 +386,112 @@ describe('SessionMetadataService', () => {
       expect(result.success).toBe(true);
     });
   });
+
+  describe('syncBranchFromGit', () => {
+    it('should update worktreeId without calling gitRenameBranch for active session', async () => {
+      const session = buildInternalWorktreeSession([], { worktreeId: 'old-branch', locationPath: '/test/path' });
+      const onSessionUpdated = mock(() => {});
+      deps = createMockDeps({
+        getSession: mock(() => session),
+        getSessionLifecycleCallbacks: () => ({ onSessionUpdated }),
+      });
+      service = new SessionMetadataService(deps);
+
+      const result = await service.syncBranchFromGit('session-1', 'new-branch');
+
+      expect(result.success).toBe(true);
+      expect(result.branch).toBe('new-branch');
+      expect(session.worktreeId).toBe('new-branch');
+      expect(deps.persistSession).toHaveBeenCalledWith(session);
+      expect(onSessionUpdated).toHaveBeenCalledTimes(1);
+      // gitRenameBranch should NOT have been called (it's in the git mock)
+      expect(mockGit.renameBranch).not.toHaveBeenCalled();
+    });
+
+    it('should skip update when branch has not changed', async () => {
+      const session = buildInternalWorktreeSession([], { worktreeId: 'same-branch' });
+      deps = createMockDeps({
+        getSession: mock(() => session),
+      });
+      service = new SessionMetadataService(deps);
+
+      const result = await service.syncBranchFromGit('session-1', 'same-branch');
+
+      expect(result.success).toBe(true);
+      expect(result.branch).toBe('same-branch');
+      expect(deps.persistSession).not.toHaveBeenCalled();
+    });
+
+    it('should return error for non-worktree session', async () => {
+      const session = buildInternalQuickSession();
+      deps = createMockDeps({
+        getSession: mock(() => session),
+      });
+      service = new SessionMetadataService(deps);
+
+      const result = await service.syncBranchFromGit('session-1', 'new-branch');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('worktree');
+    });
+
+    it('should update inactive session in persistence without git rename', async () => {
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-3',
+        worktreeId: 'old-branch',
+        locationPath: '/test/path',
+        workers: [
+          buildPersistedGitDiffWorker({ id: 'w1', name: 'Diff', baseCommit: 'old-commit' }),
+        ],
+      });
+      const saveMock = mock((_session: PersistedSession) => Promise.resolve());
+      deps = createMockDeps({
+        sessionRepository: createMockSessionRepository({
+          findById: mock(() => Promise.resolve(persisted)),
+          save: saveMock,
+        }),
+      });
+      service = new SessionMetadataService(deps);
+
+      const result = await service.syncBranchFromGit('session-3', 'new-branch');
+
+      expect(result.success).toBe(true);
+      expect(result.branch).toBe('new-branch');
+      expect(saveMock).toHaveBeenCalledTimes(1);
+      const savedSession = saveMock.mock.calls[0][0] as PersistedWorktreeSession;
+      expect(savedSession.worktreeId).toBe('new-branch');
+      // gitRenameBranch should NOT have been called
+      expect(mockGit.renameBranch).not.toHaveBeenCalled();
+    });
+
+    it('should handle detached HEAD state', async () => {
+      const session = buildInternalWorktreeSession([], { worktreeId: 'main' });
+      const onSessionUpdated = mock(() => {});
+      deps = createMockDeps({
+        getSession: mock(() => session),
+        getSessionLifecycleCallbacks: () => ({ onSessionUpdated }),
+      });
+      service = new SessionMetadataService(deps);
+
+      const result = await service.syncBranchFromGit('session-1', '(detached)');
+
+      expect(result.success).toBe(true);
+      expect(session.worktreeId).toBe('(detached)');
+      expect(onSessionUpdated).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return error when session not found', async () => {
+      deps = createMockDeps({
+        sessionRepository: createMockSessionRepository({
+          findById: mock(() => Promise.resolve(null)),
+        }),
+      });
+      service = new SessionMetadataService(deps);
+
+      const result = await service.syncBranchFromGit('nonexistent', 'new-branch');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('session_not_found');
+    });
+  });
 });

--- a/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
+++ b/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
@@ -83,6 +83,8 @@ function createMockDeps(overrides?: Partial<SessionPauseResumeDeps>): SessionPau
     userRepository: null,
     resolveSpawnUsername: mock(async () => 'testuser'),
     stopWatching: mockStopWatching,
+    startBranchWatching: async () => {},
+    stopBranchWatching: () => {},
     getServerPid: () => 99999,
     ...overrides,
   };

--- a/packages/server/src/services/branch-watcher-service.ts
+++ b/packages/server/src/services/branch-watcher-service.ts
@@ -1,0 +1,198 @@
+/**
+ * BranchWatcherService - Monitors git HEAD files to detect branch changes.
+ *
+ * Watches the HEAD file for each worktree session via fs.watch.
+ * When a branch change is detected, updates worktreeId in memory,
+ * persists to database, and broadcasts to connected clients.
+ *
+ * HEAD file locations:
+ * - Main repository: <locationPath>/.git/HEAD
+ * - Git worktree: <main-repo>/.git/worktrees/<basename>/HEAD
+ */
+
+import { watch, type FSWatcher } from 'node:fs';
+import * as path from 'node:path';
+import { createLogger } from '../lib/logger.js';
+
+const logger = createLogger('branch-watcher');
+
+const DEBOUNCE_DELAY = 200;
+
+/** Parse branch name from HEAD file content. */
+export function parseBranchFromHead(content: string): string {
+  const trimmed = content.trim();
+  const refPrefix = 'ref: refs/heads/';
+  if (trimmed.startsWith(refPrefix)) {
+    return trimmed.slice(refPrefix.length);
+  }
+  // Detached HEAD (raw commit hash or other)
+  return '(detached)';
+}
+
+/**
+ * Resolve the path to the HEAD file for a given locationPath.
+ *
+ * For git worktrees, the .git entry is a file containing "gitdir: <path>".
+ * We read that to find the actual git directory, which contains the HEAD file.
+ *
+ * For main repositories, .git is a directory and HEAD is at .git/HEAD.
+ */
+export async function resolveHeadFilePath(locationPath: string): Promise<string | null> {
+  const dotGitPath = path.join(locationPath, '.git');
+
+  // Try reading .git as a file (worktree case: contains "gitdir: <path>")
+  // Uses Bun.file() to avoid node:fs/promises mock contamination in tests
+  try {
+    const content = await Bun.file(dotGitPath).text();
+    if (content.startsWith('gitdir: ')) {
+      const gitdir = content.slice('gitdir: '.length).trim();
+      const resolvedGitdir = path.isAbsolute(gitdir)
+        ? gitdir
+        : path.resolve(locationPath, gitdir);
+      return path.join(resolvedGitdir, 'HEAD');
+    }
+  } catch {
+    // Not a readable file — may be a directory or not exist
+  }
+
+  // Main repository: HEAD is at .git/HEAD
+  const headPath = path.join(dotGitPath, 'HEAD');
+  if (await Bun.file(headPath).exists()) {
+    return headPath;
+  }
+
+  return null;
+}
+
+interface WatcherEntry {
+  watcher: FSWatcher;
+  debounceTimer: ReturnType<typeof setTimeout> | null;
+  currentBranch: string;
+}
+
+export interface BranchChangeCallback {
+  (sessionId: string, newBranch: string): Promise<void>;
+}
+
+type WatchFn = typeof watch;
+
+export class BranchWatcherService {
+  private watchers = new Map<string, WatcherEntry>();
+  private watchFn: WatchFn;
+
+  constructor(
+    private readonly onBranchChanged: BranchChangeCallback,
+    watchFn?: WatchFn,
+  ) {
+    this.watchFn = watchFn ?? watch;
+  }
+
+  /**
+   * Start watching the HEAD file for a session.
+   * If already watching this session, stops the previous watcher first.
+   */
+  async startWatching(sessionId: string, locationPath: string, currentBranch: string): Promise<void> {
+    // Stop any existing watcher for this session
+    this.stopWatching(sessionId);
+
+    const headFilePath = await resolveHeadFilePath(locationPath);
+    if (!headFilePath) {
+      logger.warn({ sessionId, locationPath }, 'Could not resolve HEAD file path, skipping branch watch');
+      return;
+    }
+
+    // Verify the HEAD file exists before watching
+    const headFile = Bun.file(headFilePath);
+    if (!await headFile.exists()) {
+      logger.warn({ sessionId, headFilePath }, 'HEAD file does not exist, skipping branch watch');
+      return;
+    }
+
+    const entry: WatcherEntry = {
+      watcher: null as unknown as FSWatcher,
+      debounceTimer: null,
+      currentBranch,
+    };
+
+    try {
+      const fsWatcher = this.watchFn(headFilePath, (_eventType) => {
+        // Debounce: git may write HEAD multiple times during a single operation
+        if (entry.debounceTimer) {
+          clearTimeout(entry.debounceTimer);
+        }
+        entry.debounceTimer = setTimeout(() => {
+          entry.debounceTimer = null;
+          this.handleHeadChange(sessionId, headFilePath, entry);
+        }, DEBOUNCE_DELAY);
+      });
+
+      fsWatcher.on('error', (error) => {
+        logger.error({ sessionId, headFilePath, err: error }, 'HEAD file watcher error');
+      });
+
+      entry.watcher = fsWatcher;
+      this.watchers.set(sessionId, entry);
+
+      logger.info({ sessionId, headFilePath, currentBranch }, 'Started watching HEAD file');
+    } catch (error) {
+      logger.error({ sessionId, headFilePath, err: error }, 'Failed to start HEAD file watcher');
+    }
+  }
+
+  /**
+   * Stop watching the HEAD file for a session.
+   */
+  stopWatching(sessionId: string): void {
+    const entry = this.watchers.get(sessionId);
+    if (!entry) return;
+
+    if (entry.debounceTimer) {
+      clearTimeout(entry.debounceTimer);
+    }
+    entry.watcher.close();
+    this.watchers.delete(sessionId);
+
+    logger.info({ sessionId }, 'Stopped watching HEAD file');
+  }
+
+  /**
+   * Stop all watchers. Called on server shutdown.
+   */
+  stopAll(): void {
+    for (const [sessionId, entry] of this.watchers) {
+      if (entry.debounceTimer) {
+        clearTimeout(entry.debounceTimer);
+      }
+      entry.watcher.close();
+      logger.debug({ sessionId }, 'Stopped HEAD watcher (shutdown)');
+    }
+    this.watchers.clear();
+  }
+
+  /**
+   * Check if a session is being watched.
+   */
+  isWatching(sessionId: string): boolean {
+    return this.watchers.has(sessionId);
+  }
+
+  private async handleHeadChange(sessionId: string, headFilePath: string, entry: WatcherEntry): Promise<void> {
+    try {
+      const content = await Bun.file(headFilePath).text();
+      const newBranch = parseBranchFromHead(content);
+
+      if (newBranch === entry.currentBranch) {
+        return; // No change
+      }
+
+      const oldBranch = entry.currentBranch;
+      entry.currentBranch = newBranch;
+
+      logger.info({ sessionId, oldBranch, newBranch }, 'Branch change detected');
+
+      await this.onBranchChanged(sessionId, newBranch);
+    } catch (error) {
+      logger.error({ sessionId, headFilePath, err: error }, 'Failed to handle HEAD change');
+    }
+  }
+}

--- a/packages/server/src/services/branch-watcher-service.ts
+++ b/packages/server/src/services/branch-watcher-service.ts
@@ -64,10 +64,26 @@ export async function resolveHeadFilePath(locationPath: string): Promise<string 
   return null;
 }
 
+/**
+ * Read the current branch from a HEAD file path.
+ */
+async function readBranchFromHeadFile(headFilePath: string): Promise<string | null> {
+  try {
+    const content = await Bun.file(headFilePath).text();
+    return parseBranchFromHead(content);
+  } catch {
+    return null;
+  }
+}
+
 interface WatcherEntry {
   watcher: FSWatcher;
   debounceTimer: ReturnType<typeof setTimeout> | null;
   currentBranch: string;
+  /** Serialization lock: when set, a sync is in progress. Next change waits. */
+  syncInProgress: boolean;
+  /** Whether another change arrived during an in-progress sync. */
+  pendingRecheck: boolean;
 }
 
 export interface BranchChangeCallback {
@@ -90,6 +106,9 @@ export class BranchWatcherService {
   /**
    * Start watching the HEAD file for a session.
    * If already watching this session, stops the previous watcher first.
+   *
+   * Reads the actual HEAD file to seed the watcher with the real current branch,
+   * and triggers onBranchChanged if it differs from the provided currentBranch.
    */
   async startWatching(sessionId: string, locationPath: string, currentBranch: string): Promise<void> {
     // Stop any existing watcher for this session
@@ -101,17 +120,29 @@ export class BranchWatcherService {
       return;
     }
 
-    // Verify the HEAD file exists before watching
-    const headFile = Bun.file(headFilePath);
-    if (!await headFile.exists()) {
-      logger.warn({ sessionId, headFilePath }, 'HEAD file does not exist, skipping branch watch');
+    // Read actual HEAD to seed the watcher from reality, not stale metadata
+    const actualBranch = await readBranchFromHeadFile(headFilePath);
+    if (actualBranch === null) {
+      logger.warn({ sessionId, headFilePath }, 'HEAD file not readable, skipping branch watch');
       return;
+    }
+
+    // If stored branch differs from actual HEAD, reconcile immediately
+    if (actualBranch !== currentBranch) {
+      logger.info({ sessionId, storedBranch: currentBranch, actualBranch }, 'Reconciling stale branch on watcher start');
+      try {
+        await this.onBranchChanged(sessionId, actualBranch);
+      } catch (error) {
+        logger.error({ sessionId, err: error }, 'Failed to reconcile stale branch');
+      }
     }
 
     const entry: WatcherEntry = {
       watcher: null as unknown as FSWatcher,
       debounceTimer: null,
-      currentBranch,
+      currentBranch: actualBranch,
+      syncInProgress: false,
+      pendingRecheck: false,
     };
 
     try {
@@ -122,7 +153,7 @@ export class BranchWatcherService {
         }
         entry.debounceTimer = setTimeout(() => {
           entry.debounceTimer = null;
-          this.handleHeadChange(sessionId, headFilePath, entry);
+          this.serializedHeadChange(sessionId, headFilePath, entry);
         }, DEBOUNCE_DELAY);
       });
 
@@ -133,7 +164,7 @@ export class BranchWatcherService {
       entry.watcher = fsWatcher;
       this.watchers.set(sessionId, entry);
 
-      logger.info({ sessionId, headFilePath, currentBranch }, 'Started watching HEAD file');
+      logger.info({ sessionId, headFilePath, currentBranch: actualBranch }, 'Started watching HEAD file');
     } catch (error) {
       logger.error({ sessionId, headFilePath, err: error }, 'Failed to start HEAD file watcher');
     }
@@ -176,6 +207,29 @@ export class BranchWatcherService {
     return this.watchers.has(sessionId);
   }
 
+  /**
+   * Serialize sync operations per entry to prevent parallel handleHeadChange runs.
+   */
+  private async serializedHeadChange(sessionId: string, headFilePath: string, entry: WatcherEntry): Promise<void> {
+    if (entry.syncInProgress) {
+      entry.pendingRecheck = true;
+      return;
+    }
+
+    entry.syncInProgress = true;
+    try {
+      await this.handleHeadChange(sessionId, headFilePath, entry);
+    } finally {
+      entry.syncInProgress = false;
+
+      // If another change arrived during sync, process it
+      if (entry.pendingRecheck) {
+        entry.pendingRecheck = false;
+        await this.serializedHeadChange(sessionId, headFilePath, entry);
+      }
+    }
+  }
+
   private async handleHeadChange(sessionId: string, headFilePath: string, entry: WatcherEntry): Promise<void> {
     try {
       const content = await Bun.file(headFilePath).text();
@@ -186,11 +240,12 @@ export class BranchWatcherService {
       }
 
       const oldBranch = entry.currentBranch;
-      entry.currentBranch = newBranch;
 
       logger.info({ sessionId, oldBranch, newBranch }, 'Branch change detected');
 
+      // Call onBranchChanged first; only update currentBranch on success
       await this.onBranchChanged(sessionId, newBranch);
+      entry.currentBranch = newBranch;
     } catch (error) {
       logger.error({ sessionId, headFilePath, err: error }, 'Failed to handle HEAD change');
     }

--- a/packages/server/src/services/session-deletion-service.ts
+++ b/packages/server/src/services/session-deletion-service.ts
@@ -51,8 +51,9 @@ export class SessionDeletionService {
     const session = this.deps.getSession(id);
     if (!session) return;
 
-    // Stop branch watcher
-    this.deps.stopBranchWatching(id);
+    // NOTE: Do NOT stop branch watching here. This method keeps the session
+    // recoverable — branch tracking should continue for surviving sessions.
+    // stopBranchWatching is called in deleteSession() which is the final teardown.
 
     const killPromises: Promise<void>[] = [];
     for (const worker of session.workers.values()) {

--- a/packages/server/src/services/session-deletion-service.ts
+++ b/packages/server/src/services/session-deletion-service.ts
@@ -36,6 +36,7 @@ export interface SessionDeletionDeps {
   getTimerCleanupCallback: () => ((sessionId: string) => void) | undefined;
   getProcessCleanupCallback: () => ((sessionId: string) => void) | undefined;
   stopWatching: (locationPath: string) => void;
+  stopBranchWatching: (sessionId: string) => void;
 }
 
 export class SessionDeletionService {
@@ -49,6 +50,9 @@ export class SessionDeletionService {
   async killSessionWorkers(id: string): Promise<void> {
     const session = this.deps.getSession(id);
     if (!session) return;
+
+    // Stop branch watcher
+    this.deps.stopBranchWatching(id);
 
     const killPromises: Promise<void>[] = [];
     for (const worker of session.workers.values()) {
@@ -73,6 +77,9 @@ export class SessionDeletionService {
     // Notify all active Worker WebSocket connections that session is being deleted
     // This must happen BEFORE killing workers so clients receive the notification
     this.deps.getWebSocketCallbacks()?.notifySessionDeleted(id);
+
+    // Stop branch watcher
+    this.deps.stopBranchWatching(id);
 
     // Kill all workers first (before removing from memory)
     const killPromises: Promise<void>[] = [];

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -448,12 +448,22 @@ export class SessionManager {
    * Set callbacks for branch watcher lifecycle.
    * Wired in app-context to connect SessionManager with BranchWatcherService
    * without creating a direct dependency.
+   *
+   * Backfills watchers for any worktree sessions that were already restored
+   * by initialize() before this setter was called.
    */
-  setBranchWatcherCallbacks(callbacks: {
+  async setBranchWatcherCallbacks(callbacks: {
     startWatching: (sessionId: string, locationPath: string, currentBranch: string) => Promise<void>;
     stopWatching: (sessionId: string) => void;
-  }): void {
+  }): Promise<void> {
     this.branchWatcherCallbacks = callbacks;
+
+    // Backfill watchers for already-live worktree sessions (auto-resumed during initialize)
+    for (const [sessionId, session] of this.sessions) {
+      if (session.type === 'worktree') {
+        await callbacks.startWatching(sessionId, session.locationPath, session.worktreeId);
+      }
+    }
   }
 
   // ========== Session Lifecycle ==========

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -150,6 +150,10 @@ export class SessionManager {
   private sessionConverterService: SessionConverterService;
   private timerCleanupCallback?: (sessionId: string) => void;
   private processCleanupCallback?: (sessionId: string) => void;
+  private branchWatcherCallbacks?: {
+    startWatching: (sessionId: string, locationPath: string, currentBranch: string) => Promise<void>;
+    stopWatching: (sessionId: string) => void;
+  };
 
   /**
    * Create a SessionManager instance with async initialization.
@@ -274,6 +278,7 @@ export class SessionManager {
       getTimerCleanupCallback: () => this.timerCleanupCallback,
       getProcessCleanupCallback: () => this.processCleanupCallback,
       stopWatching,
+      stopBranchWatching: (sessionId) => this.branchWatcherCallbacks?.stopWatching(sessionId),
     });
 
     this.sessionPauseResumeService = new SessionPauseResumeService({
@@ -296,6 +301,9 @@ export class SessionManager {
       userRepository: this.userRepository,
       resolveSpawnUsername,
       stopWatching,
+      startBranchWatching: (sessionId, locationPath, currentBranch) =>
+        this.branchWatcherCallbacks?.startWatching(sessionId, locationPath, currentBranch) ?? Promise.resolve(),
+      stopBranchWatching: (sessionId) => this.branchWatcherCallbacks?.stopWatching(sessionId),
       getServerPid,
     });
   }
@@ -436,6 +444,18 @@ export class SessionManager {
     this.processCleanupCallback = callback;
   }
 
+  /**
+   * Set callbacks for branch watcher lifecycle.
+   * Wired in app-context to connect SessionManager with BranchWatcherService
+   * without creating a direct dependency.
+   */
+  setBranchWatcherCallbacks(callbacks: {
+    startWatching: (sessionId: string, locationPath: string, currentBranch: string) => Promise<void>;
+    stopWatching: (sessionId: string) => void;
+  }): void {
+    this.branchWatcherCallbacks = callbacks;
+  }
+
   // ========== Session Lifecycle ==========
 
   async createSession(request: CreateSessionRequest, context?: SessionCreationContext): Promise<Session> {
@@ -512,6 +532,11 @@ export class SessionManager {
     ]);
 
     logger.info({ sessionId: id, type: internalSession.type }, 'Session created');
+
+    // Start branch watcher for worktree sessions
+    if (internalSession.type === 'worktree') {
+      await this.branchWatcherCallbacks?.startWatching(id, internalSession.locationPath, internalSession.worktreeId);
+    }
 
     const publicSession = this.toPublicSession(internalSession);
     this.sessionLifecycleCallbacks?.onSessionCreated?.(publicSession);
@@ -808,6 +833,17 @@ export class SessionManager {
     newBranch: string
   ): Promise<{ success: boolean; branch?: string; error?: string }> {
     return this.sessionMetadataService.renameBranch(sessionId, newBranch);
+  }
+
+  /**
+   * Sync worktreeId after an external branch change detected by fs.watch.
+   * Unlike updateSessionMetadata, this does NOT rename the git branch.
+   */
+  async syncBranchFromGit(
+    sessionId: string,
+    newBranch: string
+  ): Promise<{ success: boolean; branch?: string; error?: string }> {
+    return this.sessionMetadataService.syncBranchFromGit(sessionId, newBranch);
   }
 
   /**

--- a/packages/server/src/services/session-metadata-service.ts
+++ b/packages/server/src/services/session-metadata-service.ts
@@ -79,6 +79,100 @@ export class SessionMetadataService {
     return this.updateSessionMetadata(sessionId, { branch: newBranch });
   }
 
+  /**
+   * Update worktreeId after an external branch change (e.g., detected by fs.watch).
+   *
+   * Unlike updateSessionMetadata, this does NOT call gitRenameBranch because
+   * the branch has already changed in git. It only updates in-memory state,
+   * persists, and broadcasts.
+   */
+  async syncBranchFromGit(
+    sessionId: string,
+    newBranch: string
+  ): Promise<SessionMetadataUpdateResult> {
+    const session = this.deps.getSession(sessionId);
+
+    if (!session) {
+      // For inactive sessions, update persistence directly
+      return this.syncBranchForInactiveSession(sessionId, newBranch);
+    }
+
+    if (session.type !== 'worktree') {
+      return { success: false, error: 'Can only sync branch for worktree sessions' };
+    }
+
+    if (session.worktreeId === newBranch) {
+      return { success: true, branch: newBranch };
+    }
+
+    session.worktreeId = newBranch;
+
+    // Update git-diff workers' base commit for the new branch
+    try {
+      await this.deps.updateGitDiffWorkersAfterBranchRename(sessionId);
+    } catch (diffUpdateError) {
+      logger.error(
+        { sessionId, err: diffUpdateError },
+        'Failed to update git-diff workers after branch sync'
+      );
+    }
+
+    await this.deps.persistSession(session);
+
+    // Broadcast session update via WebSocket
+    this.deps.getSessionLifecycleCallbacks()?.onSessionUpdated?.(this.deps.toPublicSession(session));
+
+    logger.info({ sessionId, newBranch }, 'Branch synced from git');
+
+    return { success: true, branch: newBranch };
+  }
+
+  private async syncBranchForInactiveSession(
+    sessionId: string,
+    newBranch: string
+  ): Promise<SessionMetadataUpdateResult> {
+    const metadata = await this.deps.sessionRepository.findById(sessionId);
+    if (!metadata) {
+      return { success: false, error: 'session_not_found' };
+    }
+
+    if (metadata.type !== 'worktree') {
+      return { success: false, error: 'Can only sync branch for worktree sessions' };
+    }
+
+    if (metadata.worktreeId === newBranch) {
+      return { success: true, branch: newBranch };
+    }
+
+    // Update base commit for git-diff workers
+    let updatedWorkers: typeof metadata.workers | undefined;
+    try {
+      const newBaseCommit = await calculateBaseCommit(metadata.locationPath);
+      const resolvedBaseCommit = newBaseCommit ?? 'HEAD';
+      updatedWorkers = metadata.workers.map(w => {
+        if (w.type === 'git-diff') {
+          return { ...w, baseCommit: resolvedBaseCommit };
+        }
+        return w;
+      });
+    } catch (diffUpdateError) {
+      logger.error(
+        { sessionId, err: diffUpdateError },
+        'Failed to update git-diff workers after branch sync for inactive session'
+      );
+    }
+
+    const toSave = { ...metadata, worktreeId: newBranch };
+    if (updatedWorkers !== undefined) {
+      toSave.workers = updatedWorkers;
+    }
+    await this.deps.sessionRepository.save(toSave);
+
+    logger.info({ sessionId, newBranch }, 'Branch synced from git (inactive session)');
+
+    return { success: true, branch: newBranch };
+  }
+
   private async updateInactiveSession(
     sessionId: string,
     updates: { title?: string; branch?: string }

--- a/packages/server/src/services/session-pause-resume-service.ts
+++ b/packages/server/src/services/session-pause-resume-service.ts
@@ -54,6 +54,8 @@ export interface SessionPauseResumeDeps {
   userRepository: UserRepository | null;
   resolveSpawnUsername: (createdBy: string | undefined, userRepo: UserRepository | null) => Promise<string>;
   stopWatching: (locationPath: string) => void;
+  startBranchWatching: (sessionId: string, locationPath: string, currentBranch: string) => Promise<void>;
+  stopBranchWatching: (sessionId: string) => void;
   getServerPid: () => number;
 }
 
@@ -81,6 +83,9 @@ export class SessionPauseResumeService {
       logger.warn({ sessionId: id }, 'Cannot pause quick session: use delete instead');
       return false;
     }
+
+    // Stop branch watcher before pausing
+    this.deps.stopBranchWatching(id);
 
     // Notify all active Worker WebSocket connections that session is being paused
     // This must happen BEFORE killing workers so clients receive the notification
@@ -310,6 +315,11 @@ export class SessionPauseResumeService {
     }
 
     logger.info({ sessionId: id }, 'Session resumed');
+
+    // Start branch watcher for worktree sessions
+    if (internalSession.type === 'worktree') {
+      await this.deps.startBranchWatching(id, internalSession.locationPath, internalSession.worktreeId);
+    }
 
     const publicSession = this.deps.toPublicSession(internalSession);
 


### PR DESCRIPTION
## Summary
- Add `BranchWatcherService` that monitors git HEAD files via `fs.watch` to detect branch changes
- Add `syncBranchFromGit` method to `SessionMetadataService` for lightweight worktreeId updates (skips git branch rename)
- Integrate watcher start/stop into session lifecycle (create, resume, pause, delete)
- Handle both main repositories (`.git/HEAD`) and git worktrees (`.git/worktrees/<name>/HEAD`)
- Handle detached HEAD state gracefully (`(detached)`)

Closes #624

## Test plan
- [x] Unit tests for `parseBranchFromHead` (ref format, detached HEAD, empty)
- [x] Unit tests for `resolveHeadFilePath` (main repo, worktree, relative gitdir, missing .git)
- [x] Unit tests for `BranchWatcherService` (start/stop, branch change detection, debounce, no-change, detached HEAD)
- [x] Unit tests for `syncBranchFromGit` (active session, inactive session, no-change, non-worktree, not found)
- [x] Existing tests updated for new deps (`stopBranchWatching`, `startBranchWatching`)
- [x] All 2252 tests pass, server typecheck clean
- [ ] Manual verification: change branch in worktree and confirm UI updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)