### PR TITLE
chore: add .claude/worktrees/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ npm-debug.log*
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/worktrees/
 .claude/review-queue/*.jsonl
 .claude/review-queue/fixing.json
 


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` to `.gitignore`
- These are temporary working directories created by Claude Code's `EnterWorktree` and should not be tracked

## Test plan
- [ ] Configuration only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)