### PR TITLE
docs: sprint retrospective improvements (2026-04-07)

### DIFF
--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -51,6 +51,7 @@ Follow GitHub-Flow. The `main` branch is always kept GREEN.
 
 - **Testing with code changes:** Always update or add tests. Code without tests is incomplete.
 - **TDD for bug fixes:** Write a failing test first, then implement the fix.
+- **Real-device verification for bug fixes:** When fixing bugs reported from real usage (dogfooding, production), verify the fix on the actual environment before considering it complete. The verification sequence is: reproduce on real device → identify code path via browser console/logs → implement fix → verify fix on real device. Do not rely solely on unit tests for bugs that were discovered through real usage. (Lesson: Sprint 2026-04-07 — two #627 fixes passed all tests but had no effect on the actual bug because the diagnosed code path was wrong.)
 
 ## Commit Standards
 

--- a/.claude/skills/orchestrator/core-responsibilities.md
+++ b/.claude/skills/orchestrator/core-responsibilities.md
@@ -58,6 +58,7 @@
 - Answer technical/architectural questions using your knowledge of the codebase and skills
 - Escalate to the owner when: business decisions are needed, scope changes are required, or you are uncertain
 - **Propose root cause fixes, not workarounds.** Before advising an agent, ask: "Does this eliminate the root cause, or just reduce the symptom?" If the root cause is known and a structural fix is feasible, propose that — not a workaround. Explicitly label any suggestion as "workaround" vs "fix" so the agent (and owner) can make an informed choice.
+- **Verify external reviewer edge cases before dismissing.** When an external reviewer (Codex, CodeRabbit, etc.) flags an edge case, do not dismiss it as "theoretical" without code-level verification. Grep for the specific condition, trace the code path, and confirm whether it can or cannot occur in practice. If it can occur, address it. (Lesson: Sprint 2026-04-07 — Codex flagged "truncation-plus-regrowth bypasses regression detection" which the Orchestrator dismissed as theoretical. It turned out to be the true root cause of #627.)
 
 ## 5. Review Dev Agent Work Reports
 - **Agents must report completion only after CI is green.** Do not begin acceptance checks based on "implementation complete" messages — code may change during CodeRabbit or CI feedback. The delegation instructions must explicitly state: "Report completion to the Orchestrator only after CI is fully green on your PR."


### PR DESCRIPTION
## Summary
- Add real-device verification requirement for bug fixes discovered through real usage
- Add rule to verify external reviewer edge cases before dismissing

## Changes

### verification.md
Bug fixes discovered through real usage (dogfooding, production) must follow: reproduce on real device → identify code path via console logs → fix → verify on real device. Unit tests alone are insufficient for bugs found in practice.

Lesson: Sprint 2026-04-07 — two #627 fixes passed all tests but had no effect because the diagnosed code path was wrong.

### core-responsibilities.md
When an external reviewer (Codex, CodeRabbit, etc.) flags an edge case, do not dismiss it as "theoretical" without code-level verification.

Lesson: Sprint 2026-04-07 — Codex flagged "truncation-plus-regrowth bypasses regression detection" which the Orchestrator dismissed. It was the true root cause of #627.

## Test plan
- [ ] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)