### PR TITLE
feat: sprint retro stats Phase 1 (closes #642)

### DIFF
--- a/.claude/skills/orchestrator/__tests__/sprint-retro.test.js
+++ b/.claude/skills/orchestrator/__tests__/sprint-retro.test.js
@@ -6,7 +6,24 @@ import {
   printStepHeader,
   printSummary,
   runRetro,
+  runMetricsBlock,
+  isAffirmative,
 } from '../sprint-retro.js';
+import {
+  collectSprintMetrics,
+  collectPrMetrics,
+  computeAggregates,
+  computeFlags,
+  computeTimeToMergeableMin,
+  computeCiStats,
+  computeCodeRabbitCount,
+  formatMetricsReport,
+  findMergedPrNumbers,
+  parseJsonSafe,
+  createCache,
+  DEFAULT_FLAG_MULTIPLIER,
+  MIN_PRS_FOR_DERIVED,
+} from '../sprint-metrics.js';
 
 // --- Helper: create a readable stream that emits null-byte terminated data ---
 
@@ -190,7 +207,7 @@ describe('runRetro', () => {
       'No other sessions',
     ];
     const stdin = createMockStdin(answers);
-    await runRetro({ stdin });
+    await runRetro({ stdin, metricsRunner: async () => ({ proceed: true }) });
     const output = logs.join('\n');
 
     // Verify header and TaskCreate instruction
@@ -218,7 +235,7 @@ describe('runRetro', () => {
   it('presents steps in correct order', async () => {
     const answers = ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7'];
     const stdin = createMockStdin(answers);
-    await runRetro({ stdin });
+    await runRetro({ stdin, metricsRunner: async () => ({ proceed: true }) });
     const output = logs.join('\n');
 
     const steps = getSteps();
@@ -233,7 +250,7 @@ describe('runRetro', () => {
   it('collects responses and maps them to step keys', async () => {
     const answers = ['r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7'];
     const stdin = createMockStdin(answers);
-    await runRetro({ stdin });
+    await runRetro({ stdin, metricsRunner: async () => ({ proceed: true }) });
     const output = logs.join('\n');
 
     // Summary should contain all responses
@@ -244,7 +261,7 @@ describe('runRetro', () => {
   it('handles empty responses gracefully', async () => {
     const answers = ['', '', '', '', '', '', ''];
     const stdin = createMockStdin(answers);
-    await runRetro({ stdin });
+    await runRetro({ stdin, metricsRunner: async () => ({ proceed: true }) });
     const output = logs.join('\n');
 
     // Should still complete without errors
@@ -253,5 +270,508 @@ describe('runRetro', () => {
     for (const step of steps) {
       expect(output).toContain(`✓ ${step.title} — recorded`);
     }
+  });
+
+  it('aborts without running steps if metrics block returns proceed:false', async () => {
+    const answers = ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7'];
+    const stdin = createMockStdin(answers);
+    await runRetro({ stdin, metricsRunner: async () => ({ proceed: false }) });
+    const output = logs.join('\n');
+    expect(output).toContain('Retrospective interrupted by user');
+    expect(output).not.toContain('Sprint Retrospective Summary');
+  });
+});
+
+describe('isAffirmative', () => {
+  it('treats empty string as Y (default)', () => {
+    expect(isAffirmative('')).toBe(true);
+  });
+  it('treats y / yes (any case) as Y', () => {
+    expect(isAffirmative('y')).toBe(true);
+    expect(isAffirmative('Y')).toBe(true);
+    expect(isAffirmative('yes')).toBe(true);
+    expect(isAffirmative('YES')).toBe(true);
+  });
+  it('treats n / no / anything else as not-affirmative', () => {
+    expect(isAffirmative('n')).toBe(false);
+    expect(isAffirmative('no')).toBe(false);
+    expect(isAffirmative('stop')).toBe(false);
+  });
+});
+
+// --- Metrics fixtures ---
+
+const FIXTURE_PRS = {
+  633: {
+    number: 633,
+    title: 'docs: session-data-path design',
+    headRefName: 'docs/pr633',
+    createdAt: '2026-04-17T10:00:00Z',
+    mergedAt: '2026-04-17T10:05:00Z',
+    commits: [{ oid: 'a' }],
+    additions: 100,
+    deletions: 5,
+    reviews: [],
+    author: { login: 'ms2sato' },
+  },
+  635: {
+    number: 635,
+    title: 'docs: architectural-invariants',
+    headRefName: 'docs/pr635',
+    createdAt: '2026-04-17T11:00:00Z',
+    mergedAt: '2026-04-17T11:03:00Z',
+    commits: [{ oid: 'b' }],
+    additions: 200,
+    deletions: 10,
+    reviews: [],
+    author: { login: 'ms2sato' },
+  },
+  638: {
+    number: 638,
+    title: 'feat: session-data-path scope-based impl',
+    headRefName: 'feat/pr638',
+    createdAt: '2026-04-17T12:00:00Z',
+    mergedAt: '2026-04-17T14:20:00Z', // 140 min
+    commits: [{ oid: 'c1' }, { oid: 'c2' }, { oid: 'c3' }, { oid: 'c4' }, { oid: 'c5' }],
+    additions: 500,
+    deletions: 120,
+    reviews: [],
+    author: { login: 'ms2sato' },
+  },
+  639: {
+    number: 639,
+    title: 'feat: structural metrics tooling',
+    headRefName: 'feat/pr639',
+    createdAt: '2026-04-17T15:00:00Z',
+    mergedAt: '2026-04-17T16:20:00Z', // 80 min
+    commits: [{ oid: 'd1' }, { oid: 'd2' }, { oid: 'd3' }, { oid: 'd4' }],
+    additions: 300,
+    deletions: 80,
+    reviews: [],
+    author: { login: 'ms2sato' },
+  },
+};
+
+const FIXTURE_RUNS = {
+  'docs/pr633': [],
+  'docs/pr635': [{ conclusion: 'success' }],
+  'feat/pr638': [
+    { conclusion: 'success' },
+    { conclusion: 'failure' },
+    { conclusion: 'success' },
+  ],
+  'feat/pr639': [
+    { conclusion: 'failure' },
+    { conclusion: 'success' },
+  ],
+};
+
+// coderabbit issue comments per PR
+const FIXTURE_ISSUE_COMMENTS = {
+  633: [],
+  635: [],
+  638: [
+    { user: { login: 'coderabbitai' } },
+    { user: { login: 'coderabbitai[bot]' } },
+    { user: { login: 'coderabbitai' } },
+    { user: { login: 'coderabbitai[bot]' } },
+    { user: { login: 'coderabbitai' } },
+    { user: { login: 'coderabbitai' } },
+    { user: { login: 'ms2sato' } }, // ignored
+  ],
+  639: [
+    { user: { login: 'coderabbitai' } },
+    { user: { login: 'coderabbitai' } },
+    { user: { login: 'coderabbitai' } },
+  ],
+};
+
+const FIXTURE_REVIEW_COMMENTS = {
+  633: [],
+  635: [],
+  638: [],
+  639: [],
+};
+
+function buildFixtureExec(prNumbers, { callLog, fail } = {}) {
+  return (cmd) => {
+    if (callLog) callLog.push(cmd);
+    if (fail && fail.has(cmd)) throw new Error(`simulated failure: ${cmd}`);
+
+    const viewMatch = cmd.match(/^gh pr view (\d+) /);
+    if (viewMatch) {
+      const num = Number(viewMatch[1]);
+      if (!prNumbers.includes(num)) return '';
+      return JSON.stringify(FIXTURE_PRS[num]);
+    }
+    const runMatch = cmd.match(/^gh run list --branch '([^']+)'/);
+    if (runMatch) {
+      const branch = runMatch[1];
+      return JSON.stringify(FIXTURE_RUNS[branch] ?? []);
+    }
+    const issueMatch = cmd.match(/^gh api repos\/[^/]+\/[^/]+\/issues\/(\d+)\/comments/);
+    if (issueMatch) {
+      const num = Number(issueMatch[1]);
+      return JSON.stringify(FIXTURE_ISSUE_COMMENTS[num] ?? []);
+    }
+    const reviewMatch = cmd.match(/^gh api repos\/[^/]+\/[^/]+\/pulls\/(\d+)\/comments/);
+    if (reviewMatch) {
+      const num = Number(reviewMatch[1]);
+      return JSON.stringify(FIXTURE_REVIEW_COMMENTS[num] ?? []);
+    }
+    if (cmd.startsWith('gh pr list')) {
+      return JSON.stringify(prNumbers.map(n => ({ number: n })));
+    }
+    throw new Error(`unexpected command: ${cmd}`);
+  };
+}
+
+describe('boundary validation', () => {
+  it('rejects non-integer PR numbers (shell injection guard)', () => {
+    const exec = () => '[]';
+    const cache = createCache();
+    // Non-integer slips past `collectPrMetrics` → assertSafePrNumber throws
+    expect(() => collectPrMetrics({ exec, cache, prNumber: 'abc; rm -rf /' }))
+      .toThrow(/unsafe PR number/);
+  });
+  it('rejects repo identifiers with suspicious characters', () => {
+    const exec = () => '[]';
+    const cache = createCache();
+    expect(() => collectPrMetrics({ exec, cache, prNumber: 1, repo: 'ms2sato/agent-console; rm -rf /' }))
+      .toThrow(/unsafe repo identifier/);
+  });
+});
+
+describe('parseJsonSafe', () => {
+  it('returns null for empty / null / undefined', () => {
+    expect(parseJsonSafe('')).toBe(null);
+    expect(parseJsonSafe(null)).toBe(null);
+    expect(parseJsonSafe(undefined)).toBe(null);
+  });
+  it('returns null for malformed JSON', () => {
+    expect(parseJsonSafe('not-json')).toBe(null);
+    expect(parseJsonSafe('{')).toBe(null);
+  });
+  it('parses valid JSON', () => {
+    expect(parseJsonSafe('{"a":1}')).toEqual({ a: 1 });
+    expect(parseJsonSafe('[1,2]')).toEqual([1, 2]);
+  });
+});
+
+describe('computeTimeToMergeableMin', () => {
+  it('computes minutes between createdAt and mergedAt', () => {
+    const result = computeTimeToMergeableMin({
+      createdAt: '2026-04-17T10:00:00Z',
+      mergedAt: '2026-04-17T10:45:00Z',
+    });
+    expect(result).toBe(45);
+  });
+  it('returns null if fields missing', () => {
+    expect(computeTimeToMergeableMin({})).toBe(null);
+    expect(computeTimeToMergeableMin({ createdAt: '2026-04-17T10:00:00Z' })).toBe(null);
+  });
+  it('returns null if mergedAt < createdAt (corrupt data)', () => {
+    const result = computeTimeToMergeableMin({
+      createdAt: '2026-04-17T10:00:00Z',
+      mergedAt: '2026-04-17T09:00:00Z',
+    });
+    expect(result).toBe(null);
+  });
+  it('returns null if input is null / __error', () => {
+    expect(computeTimeToMergeableMin(null)).toBe(null);
+    expect(computeTimeToMergeableMin({ __error: 'x' })).toBe(null);
+  });
+});
+
+describe('computeCiStats', () => {
+  it('counts runs and failures', () => {
+    expect(computeCiStats([
+      { conclusion: 'success' },
+      { conclusion: 'failure' },
+      { conclusion: 'cancelled' },
+      { conclusion: 'success' },
+    ])).toEqual({ runCount: 4, failureCount: 2 });
+  });
+  it('returns null counts if input is not an array', () => {
+    expect(computeCiStats(null)).toEqual({ runCount: null, failureCount: null });
+    expect(computeCiStats({ __error: 'x' })).toEqual({ runCount: null, failureCount: null });
+  });
+  it('returns zeros on empty array', () => {
+    expect(computeCiStats([])).toEqual({ runCount: 0, failureCount: 0 });
+  });
+});
+
+describe('computeCodeRabbitCount', () => {
+  it('counts from all three sources', () => {
+    const summary = { reviews: [{ author: { login: 'coderabbitai' } }] };
+    const issueComments = [{ user: { login: 'coderabbitai[bot]' } }, { user: { login: 'ms2sato' } }];
+    const reviewComments = [{ user: { login: 'coderabbitai' } }];
+    expect(computeCodeRabbitCount(summary, issueComments, reviewComments)).toBe(3);
+  });
+  it('returns null if all sources are missing / errored', () => {
+    expect(computeCodeRabbitCount({ __error: 'x' }, null, null)).toBe(null);
+    expect(computeCodeRabbitCount(null, null, null)).toBe(null);
+  });
+  it('returns 0 when at least one source is an empty array', () => {
+    expect(computeCodeRabbitCount(null, [], null)).toBe(0);
+  });
+});
+
+describe('collectPrMetrics + collectSprintMetrics (4-PR fixture)', () => {
+  it('produces the expected numbers from the fixture', () => {
+    const cache = createCache();
+    const exec = buildFixtureExec([633, 635, 638, 639]);
+    const result = collectSprintMetrics({ exec, cache, prNumbers: [633, 635, 638, 639] });
+
+    expect(result.prs).toHaveLength(4);
+
+    const by = {};
+    for (const p of result.prs) by[p.number] = p;
+
+    expect(by[633].commitCount).toBe(1);
+    expect(by[633].ciRunCount).toBe(0);
+    expect(by[633].ciFailureCount).toBe(0);
+    expect(by[633].timeToMergeableMin).toBe(5);
+    expect(by[633].codeRabbitCount).toBe(0);
+    expect(by[633].changeDelta).toBe(105);
+
+    expect(by[635].commitCount).toBe(1);
+    expect(by[635].ciRunCount).toBe(1);
+    expect(by[635].timeToMergeableMin).toBe(3);
+    expect(by[635].codeRabbitCount).toBe(0);
+
+    expect(by[638].commitCount).toBe(5);
+    expect(by[638].ciRunCount).toBe(3);
+    expect(by[638].ciFailureCount).toBe(1);
+    expect(by[638].timeToMergeableMin).toBe(140);
+    expect(by[638].codeRabbitCount).toBe(6);
+
+    expect(by[639].commitCount).toBe(4);
+    expect(by[639].ciRunCount).toBe(2);
+    expect(by[639].ciFailureCount).toBe(1);
+    expect(by[639].timeToMergeableMin).toBe(80);
+    expect(by[639].codeRabbitCount).toBe(3);
+  });
+
+  it('computes aggregates: totals, medians, push-to-fail', () => {
+    const cache = createCache();
+    const exec = buildFixtureExec([633, 635, 638, 639]);
+    const { aggregates } = collectSprintMetrics({ exec, cache, prNumbers: [633, 635, 638, 639] });
+
+    expect(aggregates.prCount).toBe(4);
+    // ttm values [5, 3, 140, 80] sorted → [3, 5, 80, 140], median = (5+80)/2 = 42.5
+    expect(aggregates.medianTimeToMergeableMin).toBe(42.5);
+    expect(aggregates.totalCodeRabbitFindings).toBe(9);
+    expect(aggregates.prsWithCodeRabbitFindings).toBe(2);
+    expect(aggregates.totalCiRuns).toBe(6);
+    expect(aggregates.totalCiFailures).toBe(2);
+    expect(aggregates.pushToFailRatio).toBeCloseTo(2 / 6, 5);
+  });
+
+  it('flags PR #638 for coderabbit-heavy and slow-ttm (>2× median)', () => {
+    const cache = createCache();
+    const exec = buildFixtureExec([633, 635, 638, 639]);
+    const { flags } = collectSprintMetrics({ exec, cache, prNumbers: [633, 635, 638, 639] });
+
+    const pr638Flags = flags.filter(f => f.prNumber === 638);
+    const kinds = pr638Flags.map(f => f.kind).sort();
+    expect(kinds).toEqual(['coderabbit-heavy', 'slow-ttm']);
+
+    // PR #639 should NOT flag: 80 < 2*42.5 = 85; 3 < 2*1.5 = 3 (strict >, equal does not fire)
+    const pr639Flags = flags.filter(f => f.prNumber === 639);
+    expect(pr639Flags).toHaveLength(0);
+  });
+});
+
+describe('computeFlags threshold behavior', () => {
+  it('skips flags entirely when PR count < MIN_PRS_FOR_DERIVED', () => {
+    const prs = [
+      { number: 1, commitCount: 10, timeToMergeableMin: 1000, codeRabbitCount: 10 },
+      { number: 2, commitCount: 1, timeToMergeableMin: 1, codeRabbitCount: 0 },
+    ];
+    const agg = computeAggregates(prs);
+    const flags = computeFlags(prs, agg);
+    expect(flags).toEqual([]);
+    expect(MIN_PRS_FOR_DERIVED).toBe(3);
+  });
+
+  it('respects custom multiplier', () => {
+    const prs = [
+      { number: 1, commitCount: 4, timeToMergeableMin: 40, codeRabbitCount: 2 },
+      { number: 2, commitCount: 2, timeToMergeableMin: 20, codeRabbitCount: 1 },
+      { number: 3, commitCount: 2, timeToMergeableMin: 20, codeRabbitCount: 1 },
+    ];
+    const agg = computeAggregates(prs);
+    // median(ttm) = 20. PR#1 ttm=40 > 1.5*20=30 → flagged
+    const flagsLoose = computeFlags(prs, agg, { multiplier: 1.5 });
+    expect(flagsLoose.some(f => f.prNumber === 1 && f.kind === 'slow-ttm')).toBe(true);
+    // With default multiplier=2, 40 > 2*20=40 is false
+    const flagsStrict = computeFlags(prs, agg, { multiplier: DEFAULT_FLAG_MULTIPLIER });
+    expect(flagsStrict.some(f => f.prNumber === 1 && f.kind === 'slow-ttm')).toBe(false);
+  });
+});
+
+describe('caching', () => {
+  it('calls each gh endpoint only once per PR within one run', () => {
+    const calls = [];
+    const cache = createCache();
+    const exec = buildFixtureExec([638], { callLog: calls });
+    collectSprintMetrics({ exec, cache, prNumbers: [638] });
+
+    // Re-run: cache should short-circuit all fetches
+    const callsBefore = calls.length;
+    collectSprintMetrics({ exec, cache, prNumbers: [638] });
+    expect(calls.length).toBe(callsBefore);
+  });
+
+  it('calls each endpoint once per PR on initial run', () => {
+    const calls = [];
+    const cache = createCache();
+    const exec = buildFixtureExec([638], { callLog: calls });
+    collectSprintMetrics({ exec, cache, prNumbers: [638] });
+    // Expected: pr view, run list, issue comments, review comments = 4 calls
+    expect(calls.length).toBe(4);
+  });
+});
+
+describe('graceful degradation', () => {
+  it('records per-PR error but continues for other PRs', () => {
+    const failCmd = new Set(['gh pr view 635 -R ms2sato/agent-console --json number,title,headRefName,createdAt,mergedAt,commits,additions,deletions,reviews,author']);
+    const exec = buildFixtureExec([633, 635, 638, 639], { fail: failCmd });
+    const cache = createCache();
+    const result = collectSprintMetrics({ exec, cache, prNumbers: [633, 635, 638, 639] });
+
+    expect(result.prs).toHaveLength(4);
+    const pr635 = result.prs.find(p => p.number === 635);
+    expect(pr635.commitCount).toBe(null); // summary failed
+    expect(pr635.errors.length).toBeGreaterThan(0);
+    expect(pr635.errors.some(e => e.source === 'pr-view')).toBe(true);
+
+    // Other PRs still populated
+    const pr633 = result.prs.find(p => p.number === 633);
+    expect(pr633.commitCount).toBe(1);
+
+    // Aggregate captures errors too
+    expect(result.errors.some(e => e.prNumber === 635 && e.source === 'pr-view')).toBe(true);
+  });
+
+  it('never throws even if gh output is malformed JSON', () => {
+    const exec = () => 'this is not json';
+    const cache = createCache();
+    const result = collectSprintMetrics({ exec, cache, prNumbers: [999] });
+    expect(result.prs[0].commitCount).toBe(null);
+    expect(result.prs[0].ciRunCount).toBe(null);
+  });
+});
+
+describe('findMergedPrNumbers', () => {
+  it('returns numbers from gh pr list', () => {
+    const exec = buildFixtureExec([100, 101, 102]);
+    const nums = findMergedPrNumbers({ exec, since: '2026-04-01' });
+    expect(nums).toEqual([100, 101, 102]);
+  });
+  it('returns [] on failure', () => {
+    const exec = () => { throw new Error('boom'); };
+    expect(findMergedPrNumbers({ exec })).toEqual([]);
+  });
+});
+
+describe('formatMetricsReport', () => {
+  it('produces the expected report structure for the 4-PR fixture', () => {
+    const cache = createCache();
+    const exec = buildFixtureExec([633, 635, 638, 639]);
+    const result = collectSprintMetrics({ exec, cache, prNumbers: [633, 635, 638, 639] });
+    const report = formatMetricsReport(result, { sprintLabel: '2026-04-17' });
+
+    expect(report).toContain('Sprint 2026-04-17 Objective Metrics');
+    expect(report).toContain('PRs merged this sprint: 4');
+    expect(report).toContain('PR #638');
+    expect(report).toContain('140min TTM');
+    expect(report).toContain('6 CR');
+    expect(report).toContain('Potential retro topics');
+    expect(report).toContain('PR #638 had 6 CodeRabbit findings');
+    expect(report).toContain('Push-to-fail ratio: 33%');
+  });
+
+  it('skips aggregates block when fewer than MIN_PRS_FOR_DERIVED PRs', () => {
+    const cache = createCache();
+    const exec = buildFixtureExec([633, 635]);
+    const result = collectSprintMetrics({ exec, cache, prNumbers: [633, 635] });
+    const report = formatMetricsReport(result);
+    expect(report).toContain('(skipped — needs 3+ PRs, have 2)');
+    expect(report).not.toContain('Push-to-fail ratio:');
+  });
+
+  it('includes error lines when partial failures occurred', () => {
+    const failCmd = new Set(['gh pr view 635 -R ms2sato/agent-console --json number,title,headRefName,createdAt,mergedAt,commits,additions,deletions,reviews,author']);
+    const exec = buildFixtureExec([633, 635, 638, 639], { fail: failCmd });
+    const cache = createCache();
+    const result = collectSprintMetrics({ exec, cache, prNumbers: [633, 635, 638, 639] });
+    const report = formatMetricsReport(result);
+    expect(report).toContain('Data collection errors');
+    expect(report).toContain('PR #635 pr-view:');
+  });
+});
+
+describe('runMetricsBlock', () => {
+  let logSpy;
+  let logs;
+
+  beforeEach(() => {
+    logs = [];
+    logSpy = spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('skips with a friendly message when no PRs are found', async () => {
+    const readResponse = async () => '';
+    const result = await runMetricsBlock({
+      readResponse,
+      discover: () => [],
+      env: {},
+    });
+    expect(result.proceed).toBe(true);
+    expect(logs.join('\n')).toContain('no merged PRs found');
+  });
+
+  it('uses SPRINT_PR_NUMBERS env override and prints the report', async () => {
+    const readResponse = async () => 'y';
+    const exec = buildFixtureExec([633, 635, 638, 639]);
+    const result = await runMetricsBlock({
+      readResponse,
+      exec,
+      env: { SPRINT_PR_NUMBERS: '633 635 638 639', SPRINT_LABEL: '2026-04-17' },
+    });
+    expect(result.proceed).toBe(true);
+    expect(result.prNumbers).toEqual([633, 635, 638, 639]);
+    expect(logs.join('\n')).toContain('Sprint 2026-04-17 Objective Metrics');
+    expect(logs.join('\n')).toContain('Continue to retro questions? [Y/n]');
+  });
+
+  it('returns proceed:false when user answers n', async () => {
+    const readResponse = async () => 'n';
+    const exec = buildFixtureExec([633, 635, 638, 639]);
+    const result = await runMetricsBlock({
+      readResponse,
+      exec,
+      env: { SPRINT_PR_NUMBERS: '633,635,638,639' },
+    });
+    expect(result.proceed).toBe(false);
+  });
+
+  it('defaults to proceed:true when user answers empty (Y default)', async () => {
+    const readResponse = async () => '';
+    const exec = buildFixtureExec([633, 635, 638, 639]);
+    const result = await runMetricsBlock({
+      readResponse,
+      exec,
+      env: { SPRINT_PR_NUMBERS: '633,635,638,639' },
+    });
+    expect(result.proceed).toBe(true);
   });
 });

--- a/.claude/skills/orchestrator/sprint-lifecycle.md
+++ b/.claude/skills/orchestrator/sprint-lifecycle.md
@@ -54,6 +54,22 @@ run_process({ command: "node .claude/skills/orchestrator/sprint-retro.js" })
 ```
 The script guides you through all retrospective steps interactively via STDIN/STDOUT and instructs you to create a TaskCreate checklist for progress tracking. Do NOT skip the script and attempt the steps manually — the script exists precisely because manual execution leads to step omission.
 
+### Objective metrics block (Phase 1)
+
+Before the first interactive step, the script prints an objective-metrics report for the sprint's merged PRs: commits per PR, CI iterations, time-to-mergeable, CodeRabbit findings, push-to-fail ratio. Flags fire for PRs whose values exceed 2× the sprint median (minimum 3 PRs needed for aggregates). Use the flags as discussion starters for the incident review step — do not treat them as verdicts.
+
+Data sources are live `gh api` / `gh run list` / `gh pr list` calls; no persistent storage yet. If gh fails for a specific PR, that PR's affected fields show `n/a` and the error is listed at the end of the block; the rest of the report still renders.
+
+**Environment overrides** (optional):
+
+| Variable | Effect |
+|---|---|
+| `SPRINT_SINCE` / `SPRINT_UNTIL` | ISO dates (`YYYY-MM-DD`) for the `gh pr list --search "merged:>=..."` query |
+| `SPRINT_PR_NUMBERS` | Space- or comma-separated PR numbers, used verbatim in place of auto-discovery |
+| `SPRINT_LABEL` | Header label for the report (defaults to today's date) |
+
+Answer `Y` (default) at the `Continue to retro questions?` prompt to proceed to the interactive steps. Answer `n` only if the metrics reveal something that warrants re-planning the retrospective itself.
+
 **Process improvement PR convention** (referenced by the script's Step 4):
 - All improvements go into a single PR: branch `docs/sprint-retro-YYYY-MM-DD`, title `docs: sprint retrospective improvements (YYYY-MM-DD)`
 - Use `EnterWorktree` when the first improvement is agreed upon; commit all subsequent improvements to the same worktree

--- a/.claude/skills/orchestrator/sprint-metrics.js
+++ b/.claude/skills/orchestrator/sprint-metrics.js
@@ -1,0 +1,473 @@
+#!/usr/bin/env node
+
+/**
+ * Sprint Metrics — objective numbers for the retrospective.
+ *
+ * Pure-ish module: all shell access goes through an injected `exec`.
+ * Unit tests inject a stub; the interactive script uses `defaultExec`,
+ * which shells out via `child_process.execSync`.
+ *
+ * Phase 1 scope: raw gh/git metrics per PR, simple aggregates,
+ * threshold-based "potential retro topics" flags. No persistence,
+ * no cross-sprint trend analysis.
+ */
+
+import { execSync } from 'node:child_process';
+
+// --- Configuration constants ---
+
+export const DEFAULT_REPO = 'ms2sato/agent-console';
+export const DEFAULT_FLAG_MULTIPLIER = 2; // flag when PR value >= N × sprint median
+export const MIN_PRS_FOR_DERIVED = 3;     // below this, aggregates are too noisy
+export const CODERABBIT_LOGINS = new Set(['coderabbitai', 'coderabbitai[bot]']);
+export const CI_FAILURE_CONCLUSIONS = new Set(['failure', 'timed_out', 'cancelled', 'action_required']);
+
+// --- Default exec (real shell) ---
+
+export function defaultExec(cmd) {
+  return execSync(cmd, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+// --- Safe JSON parsing (I-6: validate at trust boundary) ---
+
+export function parseJsonSafe(raw) {
+  if (raw === undefined || raw === null) return null;
+  const trimmed = String(raw).trim();
+  if (trimmed === '') return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+// --- Cache factory ---
+
+export function createCache() {
+  return new Map();
+}
+
+function cached(cache, key, compute) {
+  if (cache.has(key)) return cache.get(key);
+  const value = compute();
+  cache.set(key, value);
+  return value;
+}
+
+// --- Shell wrappers (all go through injected exec) ---
+
+function runGhJson(exec, args) {
+  const raw = exec(`gh ${args}`);
+  return parseJsonSafe(raw);
+}
+
+// --- Boundary validation (I-6) ---
+// gh arguments we interpolate are expected to come from trusted callers,
+// but since a stray value would become a shell token, we still refuse
+// anything that is not a safe identifier. Fail closed.
+function assertSafePrNumber(n) {
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`unsafe PR number: ${JSON.stringify(n)}`);
+  }
+}
+function assertSafeRepo(r) {
+  if (typeof r !== 'string' || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(r)) {
+    throw new Error(`unsafe repo identifier: ${JSON.stringify(r)}`);
+  }
+}
+
+// --- Per-PR fetchers ---
+
+/**
+ * Fetch PR summary via `gh pr view`. Returns null on error.
+ */
+export function fetchPrSummary({ exec, cache, prNumber, repo = DEFAULT_REPO }) {
+  assertSafePrNumber(prNumber);
+  assertSafeRepo(repo);
+  const key = `pr-view:${repo}:${prNumber}`;
+  return cached(cache, key, () => {
+    try {
+      const fields = 'number,title,headRefName,createdAt,mergedAt,commits,additions,deletions,reviews,author';
+      const data = runGhJson(exec, `pr view ${prNumber} -R ${repo} --json ${fields}`);
+      if (!data || typeof data !== 'object') return null;
+      return data;
+    } catch (err) {
+      return { __error: err?.message ?? String(err) };
+    }
+  });
+}
+
+/**
+ * Fetch CI runs for the PR's head branch. Returns an array of runs or null.
+ * We query by branch so multiple pushes on the same PR are all counted.
+ */
+export function fetchCiRuns({ exec, cache, branch, repo = DEFAULT_REPO, limit = 100 }) {
+  if (!branch) return null;
+  assertSafeRepo(repo);
+  const key = `ci-runs:${repo}:${branch}`;
+  return cached(cache, key, () => {
+    try {
+      const data = runGhJson(
+        exec,
+        `run list --branch ${shellEscape(branch)} -R ${repo} --limit ${limit} --json databaseId,conclusion,status,createdAt,event`
+      );
+      if (!Array.isArray(data)) return null;
+      return data;
+    } catch (err) {
+      return { __error: err?.message ?? String(err) };
+    }
+  });
+}
+
+/**
+ * Fetch issue-level comments (includes coderabbitai summaries). Returns array or null.
+ */
+export function fetchIssueComments({ exec, cache, prNumber, repo = DEFAULT_REPO }) {
+  assertSafePrNumber(prNumber);
+  assertSafeRepo(repo);
+  const key = `issue-comments:${repo}:${prNumber}`;
+  return cached(cache, key, () => {
+    try {
+      const data = runGhJson(exec, `api repos/${repo}/issues/${prNumber}/comments --paginate`);
+      if (!Array.isArray(data)) return null;
+      return data;
+    } catch (err) {
+      return { __error: err?.message ?? String(err) };
+    }
+  });
+}
+
+/**
+ * Fetch line-level review comments. Returns array or null.
+ */
+export function fetchReviewComments({ exec, cache, prNumber, repo = DEFAULT_REPO }) {
+  assertSafePrNumber(prNumber);
+  assertSafeRepo(repo);
+  const key = `review-comments:${repo}:${prNumber}`;
+  return cached(cache, key, () => {
+    try {
+      const data = runGhJson(exec, `api repos/${repo}/pulls/${prNumber}/comments --paginate`);
+      if (!Array.isArray(data)) return null;
+      return data;
+    } catch (err) {
+      return { __error: err?.message ?? String(err) };
+    }
+  });
+}
+
+// --- Derived per-PR metrics ---
+
+export function computeCommitCount(summary) {
+  if (!summary || summary.__error) return null;
+  const commits = summary.commits;
+  if (!Array.isArray(commits)) return null;
+  return commits.length;
+}
+
+export function computeChangeDelta(summary) {
+  if (!summary || summary.__error) return null;
+  const { additions, deletions } = summary;
+  if (typeof additions !== 'number' || typeof deletions !== 'number') return null;
+  return additions + deletions;
+}
+
+export function computeTimeToMergeableMin(summary) {
+  if (!summary || summary.__error) return null;
+  const { createdAt, mergedAt } = summary;
+  if (!createdAt || !mergedAt) return null;
+  const start = Date.parse(createdAt);
+  const end = Date.parse(mergedAt);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return null;
+  return Math.round((end - start) / 60000);
+}
+
+export function computeCiStats(runs) {
+  if (!runs || runs.__error || !Array.isArray(runs)) return { runCount: null, failureCount: null };
+  const runCount = runs.length;
+  let failureCount = 0;
+  for (const run of runs) {
+    if (run && CI_FAILURE_CONCLUSIONS.has(run.conclusion)) failureCount++;
+  }
+  return { runCount, failureCount };
+}
+
+function isCodeRabbitAuthor(entity) {
+  const login = entity?.user?.login ?? entity?.author?.login;
+  if (!login) return false;
+  return CODERABBIT_LOGINS.has(login);
+}
+
+export function computeCodeRabbitCount(summary, issueComments, reviewComments) {
+  let total = 0;
+  let anyDataSeen = false;
+
+  if (summary && !summary.__error && Array.isArray(summary.reviews)) {
+    anyDataSeen = true;
+    total += summary.reviews.filter(isCodeRabbitAuthor).length;
+  }
+  if (Array.isArray(issueComments)) {
+    anyDataSeen = true;
+    total += issueComments.filter(isCodeRabbitAuthor).length;
+  }
+  if (Array.isArray(reviewComments)) {
+    anyDataSeen = true;
+    total += reviewComments.filter(isCodeRabbitAuthor).length;
+  }
+  return anyDataSeen ? total : null;
+}
+
+// --- Per-PR collector ---
+
+/**
+ * Collect all Phase 1 metrics for one PR.
+ *
+ * Returns a PrMetrics record even on partial failure. Each failed data
+ * source is noted in `errors`; other fields are still populated.
+ */
+export function collectPrMetrics({ exec, cache, prNumber, repo = DEFAULT_REPO }) {
+  const errors = [];
+  const summary = fetchPrSummary({ exec, cache, prNumber, repo });
+  if (summary?.__error) errors.push({ source: 'pr-view', message: summary.__error });
+
+  const branch = summary?.headRefName ?? null;
+  const runs = fetchCiRuns({ exec, cache, branch, repo });
+  if (runs?.__error) errors.push({ source: 'ci-runs', message: runs.__error });
+
+  const issueComments = fetchIssueComments({ exec, cache, prNumber, repo });
+  if (issueComments?.__error) errors.push({ source: 'issue-comments', message: issueComments.__error });
+
+  const reviewComments = fetchReviewComments({ exec, cache, prNumber, repo });
+  if (reviewComments?.__error) errors.push({ source: 'review-comments', message: reviewComments.__error });
+
+  const { runCount, failureCount } = computeCiStats(runs);
+
+  return {
+    number: prNumber,
+    title: summary?.title ?? null,
+    commitCount: computeCommitCount(summary),
+    ciRunCount: runCount,
+    ciFailureCount: failureCount,
+    timeToMergeableMin: computeTimeToMergeableMin(summary),
+    codeRabbitCount: computeCodeRabbitCount(summary, issueComments, reviewComments),
+    changeDelta: computeChangeDelta(summary),
+    errors,
+  };
+}
+
+// --- Aggregates & flags ---
+
+function median(values) {
+  const nums = values.filter(v => typeof v === 'number' && Number.isFinite(v));
+  if (nums.length === 0) return null;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+export function computeAggregates(prs) {
+  const ttmValues = prs.map(p => p.timeToMergeableMin);
+  const commitCounts = prs.map(p => p.commitCount);
+  const codeRabbitCounts = prs.map(p => p.codeRabbitCount);
+
+  const totalCiRuns = prs.reduce((s, p) => s + (p.ciRunCount ?? 0), 0);
+  const totalCiFailures = prs.reduce((s, p) => s + (p.ciFailureCount ?? 0), 0);
+  const totalCodeRabbit = codeRabbitCounts.reduce((s, v) => s + (v ?? 0), 0);
+  const prsWithCodeRabbit = codeRabbitCounts.filter(v => typeof v === 'number' && v > 0).length;
+
+  return {
+    prCount: prs.length,
+    medianTimeToMergeableMin: median(ttmValues),
+    medianCommitCount: median(commitCounts),
+    medianCodeRabbitCount: median(codeRabbitCounts),
+    totalCodeRabbitFindings: totalCodeRabbit,
+    prsWithCodeRabbitFindings: prsWithCodeRabbit,
+    totalCiRuns,
+    totalCiFailures,
+    pushToFailRatio: totalCiRuns > 0 ? totalCiFailures / totalCiRuns : null,
+  };
+}
+
+export function computeFlags(prs, aggregates, { multiplier = DEFAULT_FLAG_MULTIPLIER } = {}) {
+  const flags = [];
+  if (prs.length < MIN_PRS_FOR_DERIVED) return flags;
+
+  const { medianTimeToMergeableMin, medianCommitCount, medianCodeRabbitCount } = aggregates;
+
+  for (const pr of prs) {
+    if (
+      typeof pr.codeRabbitCount === 'number' &&
+      typeof medianCodeRabbitCount === 'number' &&
+      medianCodeRabbitCount > 0 &&
+      pr.codeRabbitCount > multiplier * medianCodeRabbitCount
+    ) {
+      flags.push({
+        prNumber: pr.number,
+        kind: 'coderabbit-heavy',
+        value: pr.codeRabbitCount,
+        median: medianCodeRabbitCount,
+        message:
+          `PR #${pr.number} had ${pr.codeRabbitCount} CodeRabbit findings ` +
+          `(>${multiplier}× sprint median ${medianCodeRabbitCount}). ` +
+          `Consider: are catalog additions warranted from the finding patterns?`,
+      });
+    }
+    if (
+      typeof pr.timeToMergeableMin === 'number' &&
+      typeof medianTimeToMergeableMin === 'number' &&
+      medianTimeToMergeableMin > 0 &&
+      pr.timeToMergeableMin > multiplier * medianTimeToMergeableMin
+    ) {
+      flags.push({
+        prNumber: pr.number,
+        kind: 'slow-ttm',
+        value: pr.timeToMergeableMin,
+        median: medianTimeToMergeableMin,
+        message:
+          `PR #${pr.number} time-to-mergeable ${pr.timeToMergeableMin}min ` +
+          `(>${multiplier}× sprint median ${medianTimeToMergeableMin}min). ` +
+          `Consider: Issue acceptance criteria precision, or delegation prompt clarity?`,
+      });
+    }
+    if (
+      typeof pr.commitCount === 'number' &&
+      typeof medianCommitCount === 'number' &&
+      medianCommitCount > 0 &&
+      pr.commitCount > multiplier * medianCommitCount
+    ) {
+      flags.push({
+        prNumber: pr.number,
+        kind: 'rework-hotspot',
+        value: pr.commitCount,
+        median: medianCommitCount,
+        message:
+          `PR #${pr.number} had ${pr.commitCount} commits ` +
+          `(>${multiplier}× sprint median ${medianCommitCount}). ` +
+          `Consider: spec ambiguity or scope creep?`,
+      });
+    }
+  }
+  return flags;
+}
+
+// --- PR discovery ---
+
+/**
+ * Find merged PRs in a date range. Returns array of PR numbers.
+ * Accepts ISO date (YYYY-MM-DD) for both bounds.
+ */
+export function findMergedPrNumbers({ exec, since, until, repo = DEFAULT_REPO, limit = 100 }) {
+  assertSafeRepo(repo);
+  const queryParts = ['is:pr', 'is:merged'];
+  if (since) queryParts.push(`merged:>=${since}`);
+  if (until) queryParts.push(`merged:<=${until}`);
+  const search = queryParts.join(' ');
+  try {
+    const data = runGhJson(
+      exec,
+      `pr list -R ${repo} --state merged --search ${shellEscape(search)} --limit ${limit} --json number`
+    );
+    if (!Array.isArray(data)) return [];
+    return data
+      .map(d => d?.number)
+      .filter(n => typeof n === 'number');
+  } catch {
+    return [];
+  }
+}
+
+// --- Top-level collector ---
+
+export function collectSprintMetrics({ exec = defaultExec, cache = createCache(), prNumbers, repo = DEFAULT_REPO, thresholdMultiplier } = {}) {
+  if (!Array.isArray(prNumbers) || prNumbers.length === 0) {
+    return {
+      prs: [],
+      aggregates: computeAggregates([]),
+      flags: [],
+      errors: [],
+    };
+  }
+  const prs = [];
+  const errors = [];
+  for (const num of prNumbers) {
+    const metrics = collectPrMetrics({ exec, cache, prNumber: num, repo });
+    prs.push(metrics);
+    for (const e of metrics.errors) errors.push({ prNumber: num, ...e });
+  }
+  const aggregates = computeAggregates(prs);
+  const flags = computeFlags(prs, aggregates, { multiplier: thresholdMultiplier ?? DEFAULT_FLAG_MULTIPLIER });
+  return { prs, aggregates, flags, errors };
+}
+
+// --- Formatting ---
+
+function fmtNum(n, suffix = '') {
+  return typeof n === 'number' && Number.isFinite(n) ? `${n}${suffix}` : 'n/a';
+}
+
+function fmtPercent(ratio) {
+  if (typeof ratio !== 'number' || !Number.isFinite(ratio)) return 'n/a';
+  return `${Math.round(ratio * 100)}%`;
+}
+
+function fmtMedian(n, suffix = '') {
+  return typeof n === 'number' && Number.isFinite(n) ? `${Math.round(n)}${suffix}` : 'n/a';
+}
+
+export function formatMetricsReport({ prs, aggregates, flags, errors }, { sprintLabel } = {}) {
+  const lines = [];
+  const header = sprintLabel ? `Sprint ${sprintLabel} Objective Metrics` : 'Sprint Objective Metrics';
+  lines.push(header);
+  lines.push('='.repeat(header.length));
+  lines.push('');
+
+  lines.push(`PRs merged this sprint: ${prs.length}`);
+  for (const pr of prs) {
+    const title = pr.title ?? '(unknown title)';
+    const parts = [
+      `${fmtNum(pr.commitCount)} commit${pr.commitCount === 1 ? '' : 's'}`,
+      `${fmtNum(pr.ciRunCount)} CI iter${pr.ciRunCount === 1 ? '' : 's'}`,
+      `${fmtNum(pr.timeToMergeableMin, 'min')} TTM`,
+      `${fmtNum(pr.codeRabbitCount)} CR`,
+    ];
+    lines.push(`  PR #${pr.number} ${title} — ${parts.join(', ')}`);
+  }
+  lines.push('');
+
+  if (prs.length >= MIN_PRS_FOR_DERIVED) {
+    lines.push('Sprint aggregates:');
+    lines.push(`  Median time-to-mergeable: ${fmtMedian(aggregates.medianTimeToMergeableMin, ' min')}`);
+    lines.push(`  Total CodeRabbit findings: ${aggregates.totalCodeRabbitFindings} (across ${aggregates.prsWithCodeRabbitFindings} PR${aggregates.prsWithCodeRabbitFindings === 1 ? '' : 's'})`);
+    lines.push(
+      `  Push-to-fail ratio: ${fmtPercent(aggregates.pushToFailRatio)}` +
+        (typeof aggregates.pushToFailRatio === 'number'
+          ? ` (${aggregates.totalCiFailures} failed / ${aggregates.totalCiRuns} total CI runs)`
+          : '')
+    );
+    lines.push('');
+  } else if (prs.length > 0) {
+    lines.push(`Sprint aggregates: (skipped — needs ${MIN_PRS_FOR_DERIVED}+ PRs, have ${prs.length})`);
+    lines.push('');
+  }
+
+  if (flags.length > 0) {
+    lines.push('Potential retro topics (flagged by thresholds):');
+    for (const f of flags) lines.push(`  - ${f.message}`);
+    lines.push('');
+  }
+
+  if (errors.length > 0) {
+    lines.push('Data collection errors (metrics may be partial):');
+    for (const e of errors) {
+      lines.push(`  - PR #${e.prNumber} ${e.source}: ${e.message}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// --- helpers ---
+
+function shellEscape(s) {
+  return `'${String(s).replace(/'/g, `'\\''`)}'`;
+}

--- a/.claude/skills/orchestrator/sprint-retro.js
+++ b/.claude/skills/orchestrator/sprint-retro.js
@@ -10,6 +10,14 @@
  *   Run as interactive process via run_process MCP tool.
  */
 
+import {
+  collectSprintMetrics,
+  findMergedPrNumbers,
+  formatMetricsReport,
+  defaultExec,
+  createCache,
+} from './sprint-metrics.js';
+
 // --- STDIN reading (null-byte delimited) ---
 
 /**
@@ -179,9 +187,59 @@ function printSummary(responses, steps) {
   }
 }
 
+// --- Metrics block ---
+
+function isAffirmative(answer) {
+  if (!answer) return true; // default [Y/n] → Y on empty
+  const trimmed = answer.trim().toLowerCase();
+  return trimmed === '' || trimmed === 'y' || trimmed === 'yes';
+}
+
+async function runMetricsBlock({
+  readResponse,
+  exec = defaultExec,
+  cache = createCache(),
+  env = process.env,
+  collect = collectSprintMetrics,
+  discover = findMergedPrNumbers,
+  format = formatMetricsReport,
+} = {}) {
+  const sprintLabel = env.SPRINT_LABEL || new Date().toISOString().slice(0, 10);
+  const since = env.SPRINT_SINCE || null;
+  const until = env.SPRINT_UNTIL || null;
+
+  let prNumbers;
+  if (env.SPRINT_PR_NUMBERS) {
+    prNumbers = env.SPRINT_PR_NUMBERS
+      .split(/[\s,]+/)
+      .map(s => Number.parseInt(s, 10))
+      .filter(n => Number.isFinite(n));
+  } else {
+    try {
+      prNumbers = discover({ exec, since, until });
+    } catch {
+      prNumbers = [];
+    }
+  }
+
+  if (!Array.isArray(prNumbers) || prNumbers.length === 0) {
+    console.log('\n--- Sprint Objective Metrics ---');
+    console.log('(no merged PRs found for this sprint window — skipping metrics)');
+    console.log();
+    return { prNumbers: [], proceed: true };
+  }
+
+  console.log();
+  const result = collect({ exec, cache, prNumbers });
+  console.log(format(result, { sprintLabel }));
+  console.log('Continue to retro questions? [Y/n]');
+  const answer = await readResponse();
+  return { prNumbers, proceed: isAffirmative(answer) };
+}
+
 // --- Main flow ---
 
-async function runRetro({ stdin = process.stdin } = {}) {
+async function runRetro({ stdin = process.stdin, metricsRunner = runMetricsBlock } = {}) {
   console.log('=== Sprint Retrospective ===');
   console.log();
   console.log('Before starting, create a TaskCreate checklist for tracking progress:');
@@ -197,6 +255,12 @@ async function runRetro({ stdin = process.stdin } = {}) {
 
   const responses = {};
   const readResponse = createStdinReader(stdin);
+
+  const { proceed } = await metricsRunner({ readResponse });
+  if (!proceed) {
+    console.log('Retrospective interrupted by user after metrics block.');
+    return;
+  }
 
   for (const step of steps) {
     printStepHeader(step);
@@ -215,6 +279,8 @@ export {
   printStepHeader,
   printSummary,
   runRetro,
+  runMetricsBlock,
+  isAffirmative,
 };
 
 // --- Main ---


### PR DESCRIPTION
## Summary

Adds **Phase 1 objective-metrics gathering** to the sprint retrospective flow. Before the first interactive question, the script now prints per-PR metrics (commits, CI iterations, time-to-mergeable, CodeRabbit findings, change delta), sprint aggregates (medians, push-to-fail ratio, total CR findings), and threshold-based "potential retro topics" flags — giving the retrospective an evidence-based starting point instead of relying on memory alone.

Closes #642.

### What's in the metrics block

- **Per-PR line**: `PR #NNN title — N commits, N CI iters, Nmin TTM, N CR`
- **Sprint aggregates** (when ≥3 PRs): median TTM, total CodeRabbit findings, push-to-fail ratio `(CI failures / CI runs)`
- **Flags** fire when a PR's value is strictly greater than 2× sprint median: `coderabbit-heavy`, `slow-ttm`, `rework-hotspot`
- **Errors block** appears at the end only when a data source failed (graceful degradation — other PRs still rendered)

### Architecture

- `sprint-metrics.js` — pure-ish module with an injected `exec` (defaults to `execSync`). Every `gh` call is wrapped in try/catch; per-PR failures are recorded and other PRs still render.
- `sprint-retro.js` — calls the metrics block before the existing interactive steps, with a `Continue to retro questions? [Y/n]` gate.
- Caching: in-memory `Map` keyed per PR / per endpoint, scoped to one script invocation (no disk cache in v1).
- Boundary validation (I-6): `prNumber` must be a positive integer and `repo` must match `owner/name` before any value is interpolated into a shell command.
- PR discovery: either `SPRINT_PR_NUMBERS` env var (explicit list) or `gh pr list --search "is:merged merged:>=SPRINT_SINCE"`.

### Architectural invariants checklist

- **I-6 (Boundary validation)**: applied. All shell-interpolated inputs (`prNumber`, `repo`) are guarded; `gh` JSON responses go through `parseJsonSafe` (no raw `JSON.parse`). Corrupt / missing fields yield `null` (rendered as `n/a`), never uncaught exceptions.
- **I-2 (Single writer)**: all `gh` invocations funnel through the injected `exec` + `runGhJson` helper — no inline shelling out elsewhere.
- **I-1 / I-3 / I-4 / I-5**: N/A — this change adds no persistent resources and no cross-process state.

## Test Plan

- [x] `bun run test` — 2541+ tests green (49 → 51 new sprint-retro tests: validation + metrics fixtures + flag thresholds + caching + graceful degradation + report formatting)
- [x] `bun run typecheck` — clean across client/server/shared
- [x] `bun run lint` — no-op (no package defines a `lint` script)
- [ ] CI green after push
- [ ] `coderabbit review --agent --base main` — rate-limited at commit time, will run after the 30-min cool-down and address CRITICAL/HIGH/MEDIUM in a follow-up commit if any surface

## Out of Scope (Phase 2)

- Cross-sprint trend analysis (needs persistent storage)
- AI classification of CI failure root causes
- Integration with session activity log (#640)
- Automatic catalog / skill suggestions from observed patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)