### PR TITLE
fix: stop wiping terminal cache on server restart (closes #648)

### DIFF
--- a/packages/client/src/components/Terminal.tsx
+++ b/packages/client/src/components/Terminal.tsx
@@ -11,7 +11,7 @@ import { useAppWsEvent } from '../hooks/useAppWs';
 import { disconnect, requestHistory } from '../lib/worker-websocket.js';
 import { isScrolledToBottom, stripScrollbackClear as applyScrollbackFilter, stripSystemMessages } from '../lib/terminal-utils.js';
 import { writeFullHistory } from '../lib/terminal-chunk-writer.js';
-import { saveTerminalState, loadTerminalState, clearTerminalState, getCurrentServerPid } from '../lib/terminal-state-cache.js';
+import { saveTerminalState, loadTerminalState, clearTerminalState } from '../lib/terminal-state-cache.js';
 import {
   register as registerSaveManager,
   unregister as unregisterSaveManager,
@@ -196,14 +196,12 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
 
     try {
       const serializedData = serializeAddon.serialize();
-      const serverPid = getCurrentServerPid();
       saveTerminalState(sessionId, workerId, {
         data: serializedData,
         savedAt: Date.now(),
         cols: terminal.cols,
         rows: terminal.rows,
         offset: offsetRef.current,
-        ...(serverPid !== null ? { serverPid } : {}),
       }).catch((e) => logger.warn('[Terminal] Failed to save terminal state after history:', e));
     } catch (e) {
       logger.warn('[Terminal] Failed to serialize terminal state after history:', e);
@@ -542,14 +540,12 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
         return null;
       }
       try {
-        const serverPid = getCurrentServerPid();
         return {
           data: serializeAddonRef.current.serialize(),
           savedAt: Date.now(),
           cols: terminalRef.current.cols,
           rows: terminalRef.current.rows,
           offset: offsetRef.current,
-          ...(serverPid !== null ? { serverPid } : {}),
         };
       } catch {
         return null;

--- a/packages/client/src/components/__tests__/Terminal.test.tsx
+++ b/packages/client/src/components/__tests__/Terminal.test.tsx
@@ -12,6 +12,17 @@ import { isScrolledToBottom, stripSystemMessages, stripScrollbackClear, type Ter
 import { restoreScrollPosition, type ScrollableTerminal } from '../Terminal';
 import { render, screen, cleanup } from '@testing-library/react';
 import { TerminalLoadingBar } from '../ui/TerminalLoadingBar';
+import type { CachedState } from '../../lib/terminal-state-cache';
+import {
+  register as registerSaveManager,
+  unregister as unregisterSaveManager,
+  markDirty as markSaveManagerDirty,
+  setIdleSaveDelay,
+  resetIdleSaveDelay,
+  setSaveFunction,
+  resetSaveFunction,
+  clearRegistry as clearSaveManagerRegistry,
+} from '../../lib/terminal-state-save-manager';
 
 describe('Terminal history handling integration', () => {
   let restoreWebSocket: () => void;
@@ -1307,6 +1318,76 @@ describe('Terminal loading indicator', () => {
   it('should hide loading bar when loadingHistory is false', () => {
     render(<TerminalLoadingBar visible={false} />);
     expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+});
+
+/**
+ * Tests for Terminal cache-save payload contract (#648).
+ *
+ * Terminal.tsx constructs a `CachedState` and hands it to the save-manager
+ * (which eventually calls `saveTerminalState`). Since the server-PID-based
+ * invalidation was removed, the save payload must no longer contain a
+ * `serverPid` field — only the 5 canonical keys: data, savedAt, cols, rows, offset.
+ *
+ * The Terminal component cannot be rendered in unit tests (xterm.js mocking
+ * pollutes global state). This test pins the observable contract by intercepting
+ * the save function via the save-manager's DI hook and asserting the exact
+ * payload shape that Terminal.tsx's registered state-getter would produce.
+ */
+describe('Terminal cache-save payload contract', () => {
+  const TEST_IDLE_DELAY_MS = 20;
+  const capturedSaves: Array<{ sessionId: string; workerId: string; state: CachedState }> = [];
+
+  beforeEach(() => {
+    clearSaveManagerRegistry();
+    capturedSaves.length = 0;
+    setIdleSaveDelay(TEST_IDLE_DELAY_MS);
+    setSaveFunction(async (sessionId, workerId, state) => {
+      capturedSaves.push({ sessionId, workerId, state });
+    });
+  });
+
+  afterEach(() => {
+    clearSaveManagerRegistry();
+    capturedSaves.length = 0;
+    resetIdleSaveDelay();
+    resetSaveFunction();
+  });
+
+  it('should save a payload with exactly the 5 CachedState keys and no serverPid', async () => {
+    // Mirrors the state-getter Terminal.tsx registers with the save manager
+    // (Terminal.tsx ~lines 542-549). The object is typed as CachedState, so
+    // TypeScript would reject any `serverPid` field at compile time. This
+    // runtime assertion pins the same contract so a regression cannot silently
+    // reintroduce the field via a loosely-typed spread.
+    const terminalStateGetter = (): CachedState => ({
+      data: 'serialized-terminal-data',
+      savedAt: 1700000000000,
+      cols: 80,
+      rows: 24,
+      offset: 1234,
+    });
+
+    registerSaveManager('session-1', 'worker-1', terminalStateGetter);
+    markSaveManagerDirty('session-1', 'worker-1');
+
+    // Wait for the idle timer to fire and the save to propagate
+    await new Promise((resolve) => setTimeout(resolve, TEST_IDLE_DELAY_MS + 20));
+    await unregisterSaveManager('session-1', 'worker-1');
+
+    expect(capturedSaves).toHaveLength(1);
+    const [saved] = capturedSaves;
+    expect(saved.sessionId).toBe('session-1');
+    expect(saved.workerId).toBe('worker-1');
+
+    // Exact-key contract: the payload must contain the 5 canonical keys only.
+    // No `serverPid` — the #648 fix removed server-PID-based cache invalidation.
+    // TypeScript enforces this at compile time (CachedState has no serverPid field);
+    // this runtime check pins the same contract so a regression cannot silently
+    // reintroduce the field via a loosely-typed spread.
+    const keys = Object.keys(saved.state).sort();
+    expect(keys).toEqual(['cols', 'data', 'offset', 'rows', 'savedAt']);
+    expect(keys).not.toContain('serverPid');
   });
 });
 

--- a/packages/client/src/lib/__tests__/terminal-state-cache.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-state-cache.test.ts
@@ -71,7 +71,6 @@ import {
   loadTerminalState,
   clearTerminalState,
   cleanupOldStates,
-  clearAllTerminalStates,
   setCurrentServerPid,
   getCurrentServerPid,
   resetCurrentServerPid,
@@ -333,38 +332,6 @@ describe('terminal-state-cache', () => {
     });
   });
 
-  describe('clearAllTerminalStates', () => {
-    it('should clear all terminal entries', async () => {
-      const state1 = createValidState();
-      const state2 = createValidState();
-
-      mockStore.set('terminal:session-1:worker-1', state1);
-      mockStore.set('terminal:session-2:worker-2', state2);
-      mockStore.set('other-key', { foo: 'bar' }); // Non-terminal key
-
-      await clearAllTerminalStates();
-
-      // All terminal entries should be deleted
-      expect(mockStore.get('terminal:session-1:worker-1')).toBeUndefined();
-      expect(mockStore.get('terminal:session-2:worker-2')).toBeUndefined();
-      // Non-terminal key should be untouched
-      expect(mockStore.get('other-key')).toEqual({ foo: 'bar' });
-    });
-
-    it('should handle empty store', async () => {
-      await clearAllTerminalStates();
-
-      // Should complete without error
-      expect(mockStore.keys().length).toBe(0);
-    });
-
-    it('should handle keys() error gracefully', async () => {
-      keysMockThrows = true;
-      // Should not throw
-      await expect(clearAllTerminalStates()).resolves.toBeUndefined();
-    });
-  });
-
   describe('key format', () => {
     it('should handle session and worker IDs with special characters', async () => {
       const state = createValidState();
@@ -392,104 +359,68 @@ describe('terminal-state-cache', () => {
       expect(localStorage.getItem('agent-console:serverPid')).toBe('12345');
     });
 
-    it('should return false when setting PID for the first time', async () => {
-      const result = await setCurrentServerPid(12345);
+    it('should preserve existing cache when setting PID for the first time (no stored PID)', async () => {
+      const state = createValidState();
+      mockStore.set('terminal:session-1:worker-1', state);
 
-      expect(result).toBe(false);
+      await setCurrentServerPid(12345);
+
+      // Cache entry retained
+      expect(mockStore.get('terminal:session-1:worker-1')).toEqual(state);
+      expect(getCurrentServerPid()).toBe(12345);
+      expect(localStorage.getItem('agent-console:serverPid')).toBe('12345');
     });
 
-    it('should return false when PID matches stored value', async () => {
-      localStorage.setItem('agent-console:serverPid', '12345');
-
-      const result = await setCurrentServerPid(12345);
-
-      expect(result).toBe(false);
-    });
-
-    it('should return true and clear cache when PID changes (server restart)', async () => {
-      // Set up initial state
+    it('should preserve cache when PID matches stored value', async () => {
       localStorage.setItem('agent-console:serverPid', '12345');
       const state = createValidState();
       mockStore.set('terminal:session-1:worker-1', state);
 
-      const result = await setCurrentServerPid(67890);
+      await setCurrentServerPid(12345);
 
-      expect(result).toBe(true);
+      expect(mockStore.get('terminal:session-1:worker-1')).toEqual(state);
+    });
+
+    it('should preserve cache when PID changes (no wipe on server restart)', async () => {
+      // Set up initial state with an older PID and a cached entry
+      localStorage.setItem('agent-console:serverPid', '12345');
+      const state = createValidState();
+      mockStore.set('terminal:session-1:worker-1', state);
+
+      await setCurrentServerPid(67890);
+
+      // PID is updated
       expect(localStorage.getItem('agent-console:serverPid')).toBe('67890');
       expect(getCurrentServerPid()).toBe(67890);
-      // Cache should be cleared
-      expect(mockStore.get('terminal:session-1:worker-1')).toBeUndefined();
+      // Cache is retained — server-side truncation detection handles staleness
+      expect(mockStore.get('terminal:session-1:worker-1')).toEqual(state);
     });
 
-    it('should invalidate cache entry with mismatched serverPid during load', async () => {
-      // Set current server PID
+    it('should load cache entry regardless of the current server PID', async () => {
       await setCurrentServerPid(12345);
 
-      // Create a cached state with different serverPid
-      const staleState = createValidState({ serverPid: 99999 });
-      mockStore.set('terminal:session-1:worker-1', staleState);
+      const state = createValidState();
+      mockStore.set('terminal:session-1:worker-1', state);
 
       const result = await loadTerminalState('session-1', 'worker-1');
 
-      expect(result).toBeNull();
-      expect(mockStore.get('terminal:session-1:worker-1')).toBeUndefined();
-    });
-
-    it('should load cache entry with matching serverPid', async () => {
-      // Set current server PID
-      await setCurrentServerPid(12345);
-
-      // Create a cached state with matching serverPid
-      const validState = createValidState({ serverPid: 12345 });
-      mockStore.set('terminal:session-1:worker-1', validState);
-
-      const result = await loadTerminalState('session-1', 'worker-1');
-
-      expect(result).toEqual(validState);
-    });
-
-    it('should invalidate cache entry without serverPid when currentServerPid is known', async () => {
-      // Set current server PID
-      await setCurrentServerPid(12345);
-
-      // Create a cached state without serverPid (legacy format)
-      const legacyState = createValidState();
-      // serverPid is optional, so undefined by default
-      mockStore.set('terminal:session-1:worker-1', legacyState);
-
-      const result = await loadTerminalState('session-1', 'worker-1');
-
-      // Legacy entries without serverPid should be invalidated when currentServerPid is known
-      expect(result).toBeNull();
-      expect(mockStore.get('terminal:session-1:worker-1')).toBeUndefined();
-    });
-
-    it('should load cache entry without serverPid when currentServerPid is not set', async () => {
-      // Don't set current server PID (not yet initialized)
-      const legacyState = createValidState();
-      mockStore.set('terminal:session-1:worker-1', legacyState);
-
-      const result = await loadTerminalState('session-1', 'worker-1');
-
-      // When currentServerPid is null, we can't validate, so allow loading
-      expect(result).toEqual(legacyState);
+      expect(result).toEqual(state);
     });
 
     it('should load cache entry when current serverPid is not set', async () => {
-      // Don't set current server PID (simulates old client version)
-      const stateWithPid = createValidState({ serverPid: 12345 });
-      mockStore.set('terminal:session-1:worker-1', stateWithPid);
+      const state = createValidState();
+      mockStore.set('terminal:session-1:worker-1', state);
 
       const result = await loadTerminalState('session-1', 'worker-1');
 
-      expect(result).toEqual(stateWithPid);
+      expect(result).toEqual(state);
     });
 
-    it('should clear all terminal states when localStorage.setItem throws', async () => {
-      expect(localStorage.getItem('agent-console:serverPid')).toBeNull(); // precondition: no stored PID
+    it('should NOT clear cache when localStorage.setItem throws', async () => {
+      expect(localStorage.getItem('agent-console:serverPid')).toBeNull();
 
       // Pre-populate cache
-      const state = createValidState({ serverPid: 12345 });
+      const state = createValidState();
       mockStore.set('terminal:session-1:worker-1', state);
 
       // Make setItem throw
@@ -501,12 +432,10 @@ describe('terminal-state-cache', () => {
       });
 
       try {
-        const result = await setCurrentServerPid(12345);
-        // Returns false (not a restart detection) and completes despite setItem failure
-        expect(result).toBe(false);
+        await setCurrentServerPid(12345);
         expect(getCurrentServerPid()).toBe(12345);
-        // Cache should be cleared because localStorage persistence failed
-        expect(mockStore.get('terminal:session-1:worker-1')).toBeUndefined();
+        // Cache must remain intact despite the localStorage failure
+        expect(mockStore.get('terminal:session-1:worker-1')).toEqual(state);
       } finally {
         Object.defineProperty(localStorage, 'setItem', {
           value: originalSetItem,
@@ -516,8 +445,7 @@ describe('terminal-state-cache', () => {
       }
     });
 
-    it('should return false and not throw when localStorage.getItem throws', async () => {
-      // Simulate restricted storage environment
+    it('should not throw when localStorage.getItem throws', async () => {
       const originalGetItem = localStorage.getItem.bind(localStorage);
       Object.defineProperty(localStorage, 'getItem', {
         value: () => { throw new Error('Storage access denied'); },
@@ -526,8 +454,7 @@ describe('terminal-state-cache', () => {
       });
 
       try {
-        const result = await setCurrentServerPid(12345);
-        expect(result).toBe(false); // No stored PID known, so no restart detected
+        await setCurrentServerPid(12345);
         expect(getCurrentServerPid()).toBe(12345);
       } finally {
         Object.defineProperty(localStorage, 'getItem', {
@@ -540,36 +467,22 @@ describe('terminal-state-cache', () => {
   });
 
   describe('round-trip integration', () => {
-    it('should load a state that was saved with matching serverPid', async () => {
+    it('should load a state that was saved', async () => {
       await setCurrentServerPid(12345);
 
-      const stateToSave = createValidState({ serverPid: 12345 });
+      const stateToSave = createValidState();
       await saveTerminalState('session-1', 'worker-1', stateToSave);
 
       const result = await loadTerminalState('session-1', 'worker-1');
       expect(result).toEqual(stateToSave);
     });
 
-    it('should reject a state that was saved without serverPid when currentServerPid is known', async () => {
-      await setCurrentServerPid(12345);
-
-      // Legacy-format save: no serverPid field
-      const legacyState = createValidState(); // no serverPid
-      await saveTerminalState('session-1', 'worker-1', legacyState);
+    it('should load a state saved before setCurrentServerPid is called', async () => {
+      const state = createValidState();
+      await saveTerminalState('session-1', 'worker-1', state);
 
       const result = await loadTerminalState('session-1', 'worker-1');
-      expect(result).toBeNull();
-      expect(mockStore.get('terminal:session-1:worker-1')).toBeUndefined();
-    });
-
-    it('should load a state saved without serverPid when currentServerPid is not yet set', async () => {
-      // No setCurrentServerPid called
-
-      const legacyState = createValidState(); // no serverPid
-      await saveTerminalState('session-1', 'worker-1', legacyState);
-
-      const result = await loadTerminalState('session-1', 'worker-1');
-      expect(result).toEqual(legacyState);
+      expect(result).toEqual(state);
     });
   });
 });

--- a/packages/client/src/lib/__tests__/worker-websocket.test.ts
+++ b/packages/client/src/lib/__tests__/worker-websocket.test.ts
@@ -10,6 +10,7 @@ import {
   _reset,
   type TerminalWorkerCallbacks,
 } from '../worker-websocket';
+import * as terminalStateCache from '../terminal-state-cache';
 
 describe('worker-websocket', () => {
   let restoreWebSocket: () => void;
@@ -366,6 +367,25 @@ describe('worker-websocket', () => {
         call.some((arg: unknown) => typeof arg === 'string' && arg.includes('Server restarted notification received'))
       );
       expect(serverRestartLogged).toBe(true);
+    });
+
+    it('should NOT clear terminal state on server-restarted (cache is owned by client; server-side truncation detection handles staleness)', () => {
+      const clearSpy = spyOn(terminalStateCache, 'clearTerminalState');
+
+      const callbacks = createTerminalCallbacks();
+      connect('session-1', 'worker-1', callbacks);
+
+      const ws = MockWebSocket.getLastInstance();
+      ws?.simulateOpen();
+
+      ws?.simulateMessage(JSON.stringify({ type: 'server-restarted', serverPid: 12345 }));
+
+      // clearTerminalState must NOT be called on server-restarted.
+      // Staleness is handled by the server via offset-based truncation
+      // detection (`readHistoryWithOffset`) on reconnect.
+      expect(clearSpy).not.toHaveBeenCalled();
+
+      clearSpy.mockRestore();
     });
   });
 

--- a/packages/client/src/lib/terminal-state-cache.ts
+++ b/packages/client/src/lib/terminal-state-cache.ts
@@ -6,6 +6,19 @@ const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const SERVER_PID_KEY = 'agent-console:serverPid';
 
 /**
+ * Cache entries are owned by the client. Staleness (e.g., server-side file
+ * truncation) is detected by the server via offset comparison in
+ * `readHistoryWithOffset`, which responds with a full-history resync when the
+ * client's offset is beyond the server's current range. The client therefore
+ * does not preemptively invalidate cache on server restart: the next reconnect
+ * self-corrects via the server's truncation-detection protocol.
+ *
+ * Trade-off: a stale cache may be briefly rendered before the server resync
+ * response arrives. This is acceptable — the reconnect is fast and avoids the
+ * previous ~20s full xterm re-render on the first post-restart visit (#648).
+ */
+
+/**
  * Current server PID stored in memory after initialization.
  * Set by setCurrentServerPid() during app initialization.
  */
@@ -29,13 +42,15 @@ export function resetCurrentServerPid(): void {
 }
 
 /**
- * Set the current server PID and handle cache invalidation if server has restarted.
- * Call this during app initialization after fetching config from server.
+ * Record the server PID in memory and localStorage for observability.
+ *
+ * This does NOT invalidate cached terminal states when the PID changes.
+ * Staleness is detected by the server via offset comparison in
+ * `readHistoryWithOffset`, which triggers a full-history resync response.
  *
  * @param serverPid - The server's process ID from /api/config
- * @returns true if cache was invalidated due to server restart
  */
-export async function setCurrentServerPid(serverPid: number): Promise<boolean> {
+export async function setCurrentServerPid(serverPid: number): Promise<void> {
   let storedPidStr: string | null = null;
   try {
     storedPidStr = localStorage.getItem(SERVER_PID_KEY);
@@ -46,24 +61,17 @@ export async function setCurrentServerPid(serverPid: number): Promise<boolean> {
 
   currentServerPid = serverPid;
 
-  // Store the new PID
   try {
     localStorage.setItem(SERVER_PID_KEY, String(serverPid));
   } catch (e) {
     logger.warn('[TerminalCache] Failed to persist serverPid to localStorage:', e);
-    // Cannot detect restarts across page reloads without localStorage; clear all cache to be safe
-    await clearAllTerminalStates();
-    return false;
   }
 
-  // If stored PID exists and differs from current, server has restarted
   if (storedPid !== null && !isNaN(storedPid) && storedPid !== serverPid) {
-    logger.info(`[TerminalCache] Server restart detected (PID changed: ${storedPid} -> ${serverPid}), clearing all cached states`);
-    await clearAllTerminalStates();
-    return true;
+    logger.info(
+      `[TerminalCache] Server PID changed (${storedPid} -> ${serverPid}); cache retained — server-side truncation detection handles staleness`
+    );
   }
-
-  return false;
 }
 
 /**
@@ -80,8 +88,6 @@ export interface CachedState {
   rows: number;
   /** Server-side buffer offset for incremental history requests */
   offset: number;
-  /** Server process ID at time of save. Used to detect server restarts. */
-  serverPid?: number;
 }
 
 /**
@@ -142,9 +148,8 @@ export async function saveTerminalState(
  * - No entry exists for the given session/worker
  * - The entry has expired (older than MAX_AGE_MS)
  * - The entry is malformed
- * - The entry's serverPid doesn't match the current server
  *
- * Expired or stale entries are automatically deleted.
+ * Expired or malformed entries are automatically deleted.
  *
  * @param sessionId - The session ID
  * @param workerId - The worker ID
@@ -175,14 +180,6 @@ export async function loadTerminalState(
     }
 
     if (isExpired(value)) {
-      await del(key);
-      return null;
-    }
-
-    // Invalidate if currentServerPid is known and cached entry doesn't match.
-    // This also invalidates legacy entries without serverPid, since undefined !== currentServerPid.
-    if (currentServerPid !== null && value.serverPid !== currentServerPid) {
-      logger.warn(`[TerminalCache] Cache serverPid mismatch (cached: ${value.serverPid ?? 'none'}, current: ${currentServerPid}), removing:`, key);
       await del(key);
       return null;
     }
@@ -249,28 +246,5 @@ export async function cleanupOldStates(): Promise<void> {
     await Promise.all(deletePromises);
   } catch (error) {
     logger.warn('Failed to cleanup old terminal states:', error);
-  }
-}
-
-/**
- * Clear all terminal state entries from IndexedDB.
- *
- * This is used when a server restart is detected to invalidate all cached states,
- * since the server's in-memory history buffers are lost on restart.
- */
-export async function clearAllTerminalStates(): Promise<void> {
-  try {
-    const allKeys = await keys();
-    const terminalKeys = allKeys.filter(
-      (key): key is string =>
-        typeof key === 'string' && key.startsWith(PREFIX)
-    );
-
-    const deletePromises = terminalKeys.map((key) => del(key));
-    await Promise.all(deletePromises);
-
-    logger.info(`[TerminalCache] Cleared ${terminalKeys.length} cached terminal states`);
-  } catch (error) {
-    logger.warn('Failed to clear all terminal states:', error);
   }
 }

--- a/packages/client/src/lib/worker-websocket.ts
+++ b/packages/client/src/lib/worker-websocket.ts
@@ -290,16 +290,13 @@ function handleTerminalMessage(
     }
     case 'server-restarted':
       // Server restart notification received on an active worker WebSocket.
-      // Update the in-memory PID and invalidate stale caches (setCurrentServerPid
-      // also clears all caches when the PID has changed). Additionally, clear
-      // this specific worker's terminal cache since the server's in-memory
-      // history buffer is lost on restart.
+      // Record the new server PID for observability. Cache is retained —
+      // server-side offset-based truncation detection (`readHistoryWithOffset`)
+      // will trigger a full-history resync on reconnect if the cached offset
+      // is beyond the server's current range.
       logger.debug('[WorkerWS] Server restarted notification received, serverPid:', msg.serverPid);
       setCurrentServerPid(msg.serverPid).catch((err) => {
         logger.error('[WorkerWS] Failed to update server PID on restart:', err);
-      });
-      clearTerminalState(sessionId, workerId).catch((err) => {
-        logger.error('[WorkerWS] Failed to clear terminal state on server restart:', err);
       });
       break;
     default: {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -179,12 +179,11 @@ async function initApp() {
 
     setCapabilities(config.capabilities);
 
-    // Set current server PID and handle cache invalidation if server has restarted
-    // This clears all terminal caches if the server PID has changed
+    // Record the current server PID for observability. Cache retention is
+    // handled by server-side offset-based truncation detection on reconnect.
     await setCurrentServerPid(config.serverPid);
 
-    // Clean up expired terminal states (24 hours old)
-    // This runs after server PID check, so states from previous servers are already cleared
+    // Clean up expired terminal states (older than MAX_AGE_MS).
     cleanupOldStates().catch((e) => {
       logger.warn('Failed to cleanup old terminal states:', e);
     });


### PR DESCRIPTION
## Summary

Closes #648. After #638 unified per-session output files (now up to ~10MB), the first visit to a previously-cached session after a server restart paid a ~20s full xterm render cost. Root cause: `setCurrentServerPid` wiped every IndexedDB cache entry whenever the server PID changed. This was defensive overkill — the server's offset-based truncation detection (`readHistoryWithOffset`) already self-corrects stale caches by responding with a full-history resync when `fromOffset > totalOffset`.

This PR establishes a single, consistent contract: **cache is owned by the client; the server's truncation-detection is the authority for staleness.** All client-side preemptive invalidation paths that contradicted this contract are removed together for consistency.

## Scope notes

Per owner direction during scope review, the following were bundled into one PR rather than split:

1. **Primary fix** — `setCurrentServerPid` no longer calls `clearAllTerminalStates()` on PID change or on `localStorage.setItem` failure. Still records the new PID for observability (info log kept). Signature simplified to `Promise<void>` since no caller read the boolean return.
2. **Per-entry gate removed** — `loadTerminalState` no longer rejects entries whose `serverPid` differs from the current PID.
3. **Narrow clear removed** — `worker-websocket.ts` `server-restarted` handler no longer calls `clearTerminalState(sessionId, workerId)` for the active worker. This was an inconsistent exception to the new contract; removing it means AC #3 ("sub-second cache hit after restart") holds for the active worker too. The `output-truncated` case still clears on an explicit server truncation signal — that path is legitimate and untouched.
4. **`CachedState.serverPid` field removed** — unused after the above gate removals; kept only as cruft otherwise.
5. **`clearAllTerminalStates()` function removed** — no production caller remains; per CLAUDE.md "If something is unused, delete it completely."

## Out of scope (per Issue #648)

- `readLastNLines`, changes to `fileMaxSize` or truncation semantics, Web Worker, xterm.js serialize optimizations, `MAX_AGE_MS` changes, and the optional generation/epoch belt-and-suspenders. The cache fix alone is expected to resolve the 20s pain; generation/epoch to be reconsidered only if observation post-fix shows residual issues.

## Verification

- `bun run typecheck`: all workspaces green.
- `bun run test`: client 1358 pass / 0 fail (2 pre-existing skips), server 2332 pass / 0 fail, shared 288 pass / 0 fail, integration 24 pass / 0 fail.
- New/updated tests in `terminal-state-cache.test.ts` directly pin the AC #2 behavior (cache survives `setCurrentServerPid` with different PID) and the new localStorage-failure retention behavior. New test in `worker-websocket.test.ts` pins the "no clear on `server-restarted`" contract via `spyOn`.
- Manual browser verification skipped — no running backend + Chrome DevTools MCP environment available in this session. The data-flow change is pure behavior subtraction (removing invalidation paths); unit test coverage is direct.

## Test plan

- [x] `bun run typecheck` passes locally
- [x] `bun run test` passes locally
- [x] AC #2 unit test added (cache entries survive PID change)
- [x] Retention test added (first PID set does not wipe existing cache)
- [x] localStorage-failure retention test added
- [x] `server-restarted` no-clear contract test added
- [ ] CI green
- [ ] Manual browser verification (deferred — environment limitation noted above; welcome post-merge owner confirmation on real device per dogfooding rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)