### PR TITLE
docs: audit and resolve skill/rule duplication (closes #651)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,62 @@
+# `.claude/` Structure
+
+This directory holds Claude Code configuration, rules, and skills for the agent-console project.
+
+## Two-tier content model
+
+- **Rules** (`rules/*.md`): declarative, auto-loaded by path pattern. Short, command-form, always-on in the matching scope. States *what* to do, *when*, and *why* — tersely. Example: `rules/backend.md` auto-loads whenever Claude works on files under `packages/server/**`.
+- **Skills** (`skills/<name>/SKILL.md` + sub-files): procedural detail, loaded on-demand when the skill is invoked. Elaborates *how* via step-by-step procedures, code examples, decision tables, and worked scenarios. Example: `skills/backend-standards/` uses `SKILL.md` as a router that links to `backend-standards.md`, `websocket-patterns.md`, and `webhook-receiver-patterns.md`.
+
+This split follows the Claude Code docs recommendation: "Use rules to keep CLAUDE.md focused. Rules only load when Claude works with matching files, saving context." Lengthy or optional reference material belongs in a skill; always-on guidance belongs in a rule.
+
+## Invariant: no verbatim duplication
+
+Rule prose must not appear verbatim in any skill file. When a topic is covered by both, the rule is the canonical declarative form and the skill supplies only what the rule cannot: code examples, procedural steps, tables with more columns than fit in a rule, worked scenarios.
+
+**Rationale.** When the same guidance lives in two files, they drift. Each edit only touches one copy, and over time the two versions disagree without any error surfacing. A real drift between `rules/verification.md` and `skills/development-workflow-standards/development-workflow-standards.md` was the motivating case for this cleanup — both claimed to list the pre-push verification checklist, but they enumerated different steps.
+
+## Cross-references
+
+- **Skills may link to rules.** Include a pointer at the top of each skill sub-file: `> See [rules/backend.md](../../rules/backend.md) for the declarative rules.` This tells the reader where the short form lives.
+- **Rules do not link to skills.** Rules are auto-loaded and must stand alone in the context they reach. A rule that says "see skill X" forces the reader to fetch more context to understand the rule, which defeats the point of a declarative auto-loaded file.
+
+## Verification
+
+Run `node .claude/skills/orchestrator/rule-skill-duplication-check.js` to detect rule paragraphs that have leaked into skill files. The check is also wired into `preflight-check.js`, so CI flags future regressions on every PR.
+
+## Skill structure recommendation
+
+Per the official Claude Code skill documentation, a skill may use `SKILL.md` as a **router** and place additional content in sibling `.md` files. Each supporting file should be referenced from `SKILL.md` with a one-line description of when to load it. This project follows that pattern for `backend-standards/`, `frontend-standards/`, and others with multi-file content.
+
+When a single skill has multiple sub-files, each sub-file should have a distinct, non-overlapping topic. For example, `frontend-standards/` splits into `frontend-standards.md` (agent-console-specific patterns like TanStack Router/Query, xterm.js, Browser QA) and `react-patterns.md` (generic React patterns with code examples). The boundary between the two is explicit and does not repeat content.
+
+## Directory layout
+
+```
+.claude/
+├── README.md                # this file
+├── rules/                   # declarative, auto-loaded by path pattern
+│   ├── backend.md           # packages/server/**
+│   ├── frontend.md          # packages/client/**
+│   ├── testing.md           # **/*.test.* and **/__tests__/**
+│   ├── verification.md      # always (workflow invariants)
+│   ├── design-principles.md # always (design invariants)
+│   └── test-trigger.md      # production file patterns requiring tests
+├── skills/                  # on-demand; SKILL.md as router
+│   ├── backend-standards/
+│   ├── frontend-standards/
+│   ├── test-standards/
+│   ├── development-workflow-standards/
+│   ├── orchestrator/
+│   ├── architectural-invariants/
+│   ├── code-quality-standards/
+│   ├── browser-qa/
+│   └── ux-design-standards/
+├── agents/                  # subagent definitions
+├── commands/                # slash commands
+├── hooks/                   # event hooks
+├── settings.json
+└── settings.local.json
+```
+
+The project-wide `CLAUDE.md` lives at the repository root, not in `.claude/`. It is always auto-loaded by Claude Code.

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -6,15 +6,17 @@ These rules apply to all code changes in this project.
 
 Before completing any code changes, always verify:
 
-1. **Run tests:** Execute `bun run test` and ensure all tests pass
+1. **Run the full test suite:** Execute `bun run test` and ensure ALL tests pass — not just the tests you added or modified. The full suite must be green before every push.
 2. **Run type check:** Execute `bun run typecheck` and ensure no type errors
-3. **Review test quality:** When tests are added or modified, evaluate adequacy and coverage
-4. **Manual verification (UI changes only):** When modifying UI components and Chrome DevTools MCP is available, perform manual testing through the browser
-5. **Duplication check:** When adding or modifying logic, grep the repository for the core processing part (method chains, regex patterns, transformation expressions) with variable names removed. For example, search for `.replace(/\r?\n/g, '\r')` rather than `content.replace(...)`. If hits are found, review whether they represent the same concern and should be consolidated into a shared function.
-
-6. **Shell script execution test:** When adding or modifying shell scripts (`scripts/*.sh`), execute them locally on macOS before committing. CI does not cover shell scripts. Watch for BSD/GNU incompatibilities (e.g., `sed -E` with non-greedy `+?` is not portable). (Lesson: Sprint 2026-04-05c — `upload-qa-screenshots.sh` had 2 bugs only caught at runtime.)
+3. **Run CodeRabbit CLI review:** Execute `coderabbit review --agent --base main` and fix any CRITICAL, HIGH, or MEDIUM severity issues before creating a PR. If the CodeRabbit CLI is not installed locally, skip this step and recommend installation: `curl -fsSL https://cli.coderabbit.ai/install.sh | sh`.
+4. **Review test quality:** When tests are added or modified, evaluate adequacy and coverage
+5. **Manual verification (UI changes only):** When modifying UI components and Chrome DevTools MCP is available, perform manual testing through the browser
+6. **Duplication check:** When adding or modifying logic, grep the repository for the core processing part (method chains, regex patterns, transformation expressions) with variable names removed. For example, search for `.replace(/\r?\n/g, '\r')` rather than `content.replace(...)`. If hits are found, review whether they represent the same concern and should be consolidated into a shared function.
+7. **Shell script execution test:** When adding or modifying shell scripts (`scripts/*.sh`), execute them locally on macOS before committing. CI does not cover shell scripts. Watch for BSD/GNU incompatibilities (e.g., `sed -E` with non-greedy `+?` is not portable). (Lesson: Sprint 2026-04-05c — `upload-qa-screenshots.sh` had 2 bugs only caught at runtime.)
 
 **CRITICAL: Verify BEFORE pushing.** Do NOT push code to the remote until `bun run typecheck` and `bun run test` both pass locally. Pushing unverified code wastes CI cycles and blocks other developers. If pre-existing errors exist that are unrelated to your changes, note them explicitly in your commit message or report.
+
+**Hard rule for production code changes.** When any file outside of `docs/`, `.claude/skills/`, or `.claude/agents/` is modified, you MUST run `bun run test` (full suite) and confirm zero failures before pushing. Do not report task completion without full test verification. Running only the tests you touched is insufficient.
 
 **Important:** The main branch is always kept GREEN (all tests and type checks pass). If any verification fails, assume it is caused by your changes on the current branch and fix it before proceeding.
 

--- a/.claude/skills/backend-standards/SKILL.md
+++ b/.claude/skills/backend-standards/SKILL.md
@@ -9,6 +9,6 @@ description: Detailed backend patterns and code examples for server implementati
 
 ## Detailed Documentation
 
-- [backend-standards.md](backend-standards.md) - Full code examples for Hono routes, Valibot validation, logging patterns, service singletons, callback lifecycle, resource cleanup, async patterns
-- [websocket-patterns.md](websocket-patterns.md) - WebSocket implementation details: dual architecture setup, message protocol types, broadcast implementation, output buffering code
-- [webhook-receiver-patterns.md](webhook-receiver-patterns.md) - Webhook receiver implementation: always-200 pattern, async processing, signature verification, error handling strategy
+- [backend-standards.md](backend-standards.md) — procedural detail and code patterns beyond the rule: Dependency Injection Policy, Hono framework patterns (routes, Valibot validation, error handling), structured logging examples, async patterns (route handlers, callbacks, process-level), callback lifecycle, resource cleanup worked example, PTY output buffering, async-over-sync exceptions and examples, WebSocket message typing.
+- [websocket-patterns.md](websocket-patterns.md) — WebSocket implementation details: dual architecture setup, message protocol types, broadcast implementation, output buffering.
+- [webhook-receiver-patterns.md](webhook-receiver-patterns.md) — webhook receiver implementation: always-200 pattern, async processing, signature verification, error handling strategy.

--- a/.claude/skills/backend-standards/backend-standards.md
+++ b/.claude/skills/backend-standards/backend-standards.md
@@ -1,71 +1,18 @@
-# Backend Standards
+# Backend Standards (Procedural Detail)
 
-This document defines backend-specific knowledge and patterns for the agent-console project.
+> See [rules/backend.md](../../rules/backend.md) for the declarative rules (directory structure, file naming, async-over-sync requirement, resource cleanup checklist, security basics, structured logging). This document covers procedural detail, code patterns, and decision frameworks.
 
 ## Tech Stack
 
-- **Bun** - JavaScript runtime
-- **Hono** - Web framework
-- **bun-pty** - Pseudo-terminal for spawning processes
-- **Pino** - Structured logging
-- **Valibot** - Schema validation (shared with frontend)
-
-## Directory Structure and Naming
-
-```
-packages/server/src/
-├── __tests__/      # Unit tests
-├── lib/            # Utilities (logger, config, error handler)
-├── middleware/     # Hono middleware
-├── routes/         # API route handlers
-├── services/       # Business logic (flat by default, domain dirs when needed)
-│   ├── agents/     # Domain directory (multiple related files)
-│   └── *.ts        # Flat service files
-└── websocket/      # WebSocket handlers
-```
-
-### Directory Organization Strategy
-
-**Services use flat-first approach:**
-- Keep services as flat files by default
-- Create domain directory when a service needs multiple related files
-
-| Situation | Organization | Example |
-|-----------|--------------|---------|
-| Single service file | Flat | `services/session-manager.ts` |
-| Service + helpers/types | Domain directory | `services/agents/` |
-| Service grows large | Split into domain directory | - |
-
-Decision criteria:
-1. **Single file sufficient** → Keep flat
-2. **2+ closely related files** → Create domain directory
-3. **Splitting for readability** → Create domain directory
-
-### File Naming Conventions
-
-| Type | Convention | Example |
-|------|------------|---------|
-| General | kebab-case | `session-manager.ts` |
-| Service | kebab-case | `persistence-service.ts` |
-| Middleware | kebab-case | `error-handler.ts` |
-| Route handler | kebab-case (plural) | `sessions.ts`, `workers.ts` |
-| Utility | kebab-case | `config.ts`, `logger.ts` |
-| Test | original + `.test` | `session-manager.test.ts` |
-
-### Directory Naming
-
-- Use **kebab-case** for all directories
-- Exception: `__tests__/` follows Node.js convention with underscores
-
-### Export Conventions
-
-- File name reflects the primary export: `session-manager.ts` exports `SessionManager`
-- Use named exports for multiple related items
-- Avoid default exports except for route handlers
+- **Bun** — JavaScript runtime
+- **Hono** — web framework
+- **bun-pty** — pseudo-terminal for spawning processes
+- **Pino** — structured logging
+- **Valibot** — schema validation (shared with frontend)
 
 ## Dependency Injection Policy
 
-**Rule: No module-level singleton exports.** Services with state or external dependencies (DB, file system) must be instantiated in `createAppContext()` and injected where needed.
+**Rule: no module-level singleton exports.** Services with state or external dependencies (DB, file system) must be instantiated in `createAppContext()` and injected where needed.
 
 ### Service Classification
 
@@ -126,7 +73,7 @@ private get repository() {
 import { worktreeService } from '../services/worktree-service.js';
 ```
 
-### When Creating a New Service
+### Decision Flow for a New Service
 
 1. Does a route handler or MCP tool use it? → **Add to AppContext** (first-class)
 2. Is it only used by other services? → **Accept as parameter** (internal)
@@ -143,12 +90,11 @@ Central service managing all sessions and workers. Responsibilities:
 - Persist session state
 - Broadcast lifecycle events
 
-### Workers
+### Worker Types
 
-Three types of workers:
-- **Agent Worker**: PTY process running AI agent (Claude Code, etc.)
-- **Terminal Worker**: Plain PTY shell
-- **Git-Diff Worker**: Non-PTY worker for real-time diff viewing
+- **Agent Worker** — PTY process running an AI agent (Claude Code, etc.)
+- **Terminal Worker** — plain PTY shell
+- **Git-Diff Worker** — non-PTY worker for real-time diff viewing
 
 ### PTY Management
 
@@ -171,9 +117,7 @@ export { api };
 app.route('/api', api);
 ```
 
-### Request Validation
-
-Use Valibot with Hono's validator:
+### Request Validation (Valibot)
 
 ```typescript
 import * as v from 'valibot';
@@ -193,9 +137,7 @@ app.post('/items', vValidator('json', schema), (c) => {
 });
 ```
 
-### Error Handling
-
-Use centralized error handler:
+### Centralized Error Handling
 
 ```typescript
 // lib/error-handler.ts
@@ -207,200 +149,48 @@ export function onApiError(err: Error, c: Context): Response {
 app.onError(onApiError);
 ```
 
-## Logging
+## Structured Logging — Code Patterns
 
-Use Pino with structured logging:
+The rule states the requirement (Pino, context object first). This is the idiomatic pattern with good/bad examples:
 
 ```typescript
 import { createLogger } from './lib/logger.js';
 
 const logger = createLogger('service-name');
 
-// Structured data first, message second
+// ❌ String interpolation — loses structure
+logger.info(`Worker ${workerId} created for session ${sessionId}`);
+
+// ✅ Structured data first, message second
 logger.info({ sessionId, workerId }, 'Worker created');
-logger.error({ err: error, context }, 'Operation failed');
+
+// ❌ Logging an Error object directly — breaks serialization
+logger.error(error, 'Operation failed');
+
+// ✅ Wrap the error in an `err` key
+logger.error({ err: error, sessionId }, 'Operation failed');
 ```
 
 ### Log Levels
 
-- `fatal`: Application crash, unrecoverable errors
-- `error`: Errors that need attention
-- `warn`: Potentially problematic situations
-- `info`: Normal operational messages
-- `debug`: Detailed debugging information
+- `fatal`: application crash, unrecoverable errors
+- `error`: errors that need attention
+- `warn`: potentially problematic situations
+- `info`: normal operational messages
+- `debug`: detailed debugging information
 
-## Service Design
+## Async Patterns — Route Handlers
 
-### Singleton Services
-
-Use module-level singletons for shared services:
+The rule bans fire-and-forget. This shows the common mistakes and the fix:
 
 ```typescript
-// services/session-manager.ts
-class SessionManager {
-  // ...implementation
-}
-
-export const sessionManager = new SessionManager();
-```
-
-### Callback Patterns
-
-For async notifications, use callback registration:
-
-```typescript
-class SessionManager {
-  private activityCallback?: (sessionId: string, workerId: string, state: AgentActivityState) => void;
-
-  setGlobalActivityCallback(callback: typeof this.activityCallback) {
-    this.activityCallback = callback;
-  }
-}
-```
-
-### Resource Cleanup
-
-Always clean up resources:
-
-```typescript
-// Process termination handlers
-process.on('SIGTERM', () => cleanup());
-process.on('SIGINT', () => cleanup());
-
-// Worker cleanup
-onClose() {
-  sessionManager.detachWorkerCallbacks(sessionId, workerId);
-}
-```
-
-## Configuration
-
-Use typed configuration with environment variables:
-
-```typescript
-// lib/server-config.ts
-export const serverConfig = {
-  PORT: process.env.PORT || '3001',
-  NODE_ENV: process.env.NODE_ENV || 'development',
-  AGENT_CONSOLE_HOME: process.env.AGENT_CONSOLE_HOME || path.join(homedir(), '.agent-console'),
-};
-```
-
-## Testing
-
-### Unit Tests
-
-- Place tests in `__tests__/` directories
-- Use Vitest
-- Mock external dependencies (file system, processes)
-
-### Integration Tests
-
-- Test API endpoints with real HTTP requests
-- Test WebSocket connections
-
-### Test Patterns
-
-```typescript
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-
-describe('ServiceName', () => {
-  beforeEach(() => {
-    // Setup
-  });
-
-  afterEach(() => {
-    // Cleanup
-  });
-
-  it('should do something', () => {
-    // Test
-  });
-});
-```
-
-## Security
-
-### Input Validation
-
-- Validate all API inputs at boundaries
-- Use Valibot schemas
-- Never trust client-provided data
-
-External service payloads (webhook payloads, etc.) MUST be parsed using Valibot schemas. Do not manually extract fields with helper functions like `getString`/`getRecord`. Define a schema that declares the expected payload structure and use `safeParse` for type-safe validation.
-
-### Process Spawning
-
-- Sanitize environment variables before spawning
-- Don't expose sensitive env vars to child processes
-
-### File System Access
-
-- Validate paths to prevent directory traversal
-- Use absolute paths
-- Check file existence before operations
-
-## Performance
-
-### Prefer Async Over Sync
-
-**Always use async functions instead of sync equivalents.**
-
-Bun runs on a single-threaded event loop. Sync functions block the entire thread, preventing all other requests from being processed until the operation completes. This directly impacts server responsiveness and throughput.
-
-| Avoid (Sync) | Use (Async) |
-|--------------|-------------|
-| `fs.readFileSync()` | `fs.promises.readFile()` or `Bun.file().text()` |
-| `fs.writeFileSync()` | `fs.promises.writeFile()` or `Bun.write()` |
-| `fs.existsSync()` | `fs.promises.access()` or `Bun.file().exists()` |
-| `fs.mkdirSync()` | `fs.promises.mkdir()` |
-| `fs.readdirSync()` | `fs.promises.readdir()` |
-| `fs.statSync()` | `fs.promises.stat()` |
-| `fs.rmSync()` | `fs.promises.rm()` |
-| `child_process.execSync()` | `child_process.exec()` with promisify or `Bun.spawn()` |
-| `child_process.spawnSync()` | `Bun.spawn()` |
-
-**Exceptions:**
-- **Application startup/initialization**: Sync operations during server bootstrap (before accepting requests) are acceptable since no requests are blocked
-- **CLI tools**: Command-line scripts that run to completion may use sync operations
-
-**Example:**
-
-```typescript
-// ❌ Blocks the event loop - all other requests wait
-const config = fs.readFileSync('config.json', 'utf-8');
-const data = JSON.parse(config);
-
-// ✅ Non-blocking - other requests continue processing
-const file = Bun.file('config.json');
-const data = await file.json();
-
-// ✅ Alternative with fs.promises
-import { readFile } from 'fs/promises';
-const config = await readFile('config.json', 'utf-8');
-const data = JSON.parse(config);
-```
-
-### Async/Await and Fire-and-Forget
-
-**Always use async/await. Avoid fire-and-forget patterns.**
-
-Fire-and-forget (calling an async function without awaiting) is problematic because:
-- **Silent errors:** Errors are never caught, making debugging extremely difficult
-- **Race conditions:** Operations complete in unpredictable order
-- **Difficult tracing:** Stack traces are lost when promises are not awaited
-- **Unhandled rejections:** Can crash the process or leave it in an inconsistent state
-
-#### Route Handlers
-
-```typescript
-// ❌ Fire-and-forget - error silently ignored
+// ❌ Fire-and-forget — error silently ignored
 app.post('/sessions', (c) => {
   sessionManager.createSession(data);  // Promise ignored
   return c.json({ success: true });
 });
 
-// ❌ async handler without await - same problem
+// ❌ async handler without await — same problem
 app.post('/sessions', async (c) => {
   sessionManager.createSession(data);  // Still fire-and-forget
   return c.json({ success: true });
@@ -413,12 +203,12 @@ app.post('/sessions', async (c) => {
     return c.json(session);
   } catch (error) {
     logger.error({ err: error }, 'Failed to create session');
-    throw error;  // Let error handler respond appropriately
+    throw error;  // Let the centralized handler respond
   }
 });
 ```
 
-#### Callbacks and Event Handlers
+## Async Patterns — Callbacks and Event Handlers
 
 ```typescript
 // ❌ Fire-and-forget in callback
@@ -426,7 +216,7 @@ worker.onData((data) => {
   persistToFile(data);  // Promise ignored
 });
 
-// ✅ Proper async callback with error handling
+// ✅ Async callback with error handling
 worker.onData(async (data) => {
   try {
     await persistToFile(data);
@@ -436,9 +226,9 @@ worker.onData(async (data) => {
 });
 ```
 
-#### Process-Level Error Handling
+## Process-Level Error Handling
 
-Add process-level handlers as a safety net for unhandled rejections:
+Safety net for unhandled rejections, not a substitute for proper await/catch:
 
 ```typescript
 // lib/error-handler.ts
@@ -453,60 +243,9 @@ process.on('uncaughtException', (error) => {
 });
 ```
 
-**Note:** Process-level handlers are a safety net, not a substitute for proper await/catch patterns.
+## Callback Registration and Detachment
 
-### PTY Output Handling
-
-- Buffer output to reduce message frequency
-- Use efficient string concatenation
-- Limit history buffer size
-
-### Connection Management
-
-- Clean up dead WebSocket connections
-- Use timeouts for operations
-- Handle reconnection gracefully
-
-## Backend Best Practices
-
-### Resource Cleanup Checklist
-
-When creating resources that need cleanup:
-
-1. **PTY Processes** - Kill processes when workers are destroyed
-2. **WebSocket Connections** - Close connections on disconnect, handle cleanup in `onClose`
-3. **File Handles** - Close file handles after operations complete
-4. **Event Listeners** - Remove listeners when resources are destroyed
-
-```typescript
-// ✅ Proper cleanup pattern with error handling
-class Worker {
-  private pty: Pty;
-  private callbacks: Map<string, () => void> = new Map();
-
-  destroy() {
-    // 1. Kill PTY process (handle failures gracefully)
-    try {
-      this.pty.kill();
-    } catch (error) {
-      logger.warn({ err: error }, 'Error killing PTY during cleanup');
-    }
-
-    // 2. Detach all callbacks to prevent memory leaks
-    this.callbacks.forEach((unsubscribe) => unsubscribe());
-    this.callbacks.clear();
-
-    // 3. Close any open file handles
-    // ...
-  }
-}
-```
-
-**Note**: Cleanup operations should not throw. Wrap potentially failing operations in try-catch and log warnings instead of propagating errors.
-
-### Callback Registration and Detachment
-
-**Always detach callbacks when resources are destroyed** to prevent memory leaks:
+The rule says "always detach callbacks when resources are destroyed." This is the pattern:
 
 ```typescript
 // ❌ Memory leak: callbacks never detached
@@ -534,7 +273,34 @@ onClose() {
 }
 ```
 
-### WebSocket Message Types
+## Resource Cleanup — Full Pattern
+
+The rule lists the 4 resource categories (PTY processes, WebSocket connections, file handles, event listeners) and says cleanup should not throw. This is the worked pattern:
+
+```typescript
+class Worker {
+  private pty: Pty;
+  private callbacks: Map<string, () => void> = new Map();
+
+  destroy() {
+    // 1. Kill PTY process (handle failures gracefully)
+    try {
+      this.pty.kill();
+    } catch (error) {
+      logger.warn({ err: error }, 'Error killing PTY during cleanup');
+    }
+
+    // 2. Detach all callbacks to prevent memory leaks
+    this.callbacks.forEach((unsubscribe) => unsubscribe());
+    this.callbacks.clear();
+
+    // 3. Close any open file handles
+    // ...
+  }
+}
+```
+
+## WebSocket Message Typing
 
 Define and validate message types explicitly for both directions:
 
@@ -559,12 +325,12 @@ const AppClientMessageSchema = v.variant('type', [
 ]);
 ```
 
-### PTY Output Buffering
+## PTY Output Buffering
 
 Buffer rapid PTY output before sending to WebSocket to reduce message frequency:
 
 ```typescript
-// ❌ Sends every byte immediately - high message frequency
+// ❌ Sends every byte immediately — high message frequency
 pty.onData((data) => {
   ws.send(data);
 });
@@ -591,18 +357,55 @@ class OutputBuffer {
 }
 ```
 
-### Structured Logging Best Practices
+## Async-Over-Sync — Exceptions and Examples
+
+The rule's table covers the common replacements. Two narrow exceptions to the async-only default:
+
+- **Application startup/initialization**: sync operations during server bootstrap (before accepting requests) are acceptable since no requests are blocked.
+- **CLI tools**: command-line scripts that run to completion may use sync operations.
+
+Worked example of the cost of ignoring the rule:
 
 ```typescript
-// ❌ Avoid: string interpolation
-logger.info(`Worker ${workerId} created for session ${sessionId}`);
+// ❌ Blocks the event loop — all other requests wait
+const config = fs.readFileSync('config.json', 'utf-8');
+const data = JSON.parse(config);
 
-// ✅ Prefer: structured data first, message second
-logger.info({ sessionId, workerId }, 'Worker created');
+// ✅ Non-blocking — other requests continue processing
+const file = Bun.file('config.json');
+const data = await file.json();
 
-// ❌ Avoid: logging objects directly
-logger.error(error, 'Operation failed');
-
-// ✅ Prefer: wrap error in `err` key for proper serialization
-logger.error({ err: error, sessionId }, 'Operation failed');
+// ✅ Alternative with fs.promises
+import { readFile } from 'fs/promises';
+const config = await readFile('config.json', 'utf-8');
+const data = JSON.parse(config);
 ```
+
+## Configuration
+
+Typed configuration with environment variables:
+
+```typescript
+// lib/server-config.ts
+export const serverConfig = {
+  PORT: process.env.PORT || '3001',
+  NODE_ENV: process.env.NODE_ENV || 'development',
+  AGENT_CONSOLE_HOME: process.env.AGENT_CONSOLE_HOME || path.join(homedir(), '.agent-console'),
+};
+```
+
+## Testing (brief)
+
+- Place tests in `__tests__/` directories at the same level as the production file
+- Use Vitest
+- Mock external dependencies (file system, processes) via injection — see the Dependency Injection Policy above
+
+For detailed test patterns, see the [test-standards skill](../test-standards/SKILL.md).
+
+## Connection Management
+
+- Clean up dead WebSocket connections
+- Use timeouts for operations
+- Handle reconnection gracefully
+
+See [websocket-patterns.md](websocket-patterns.md) for the dual-architecture implementation and broadcast patterns, and [webhook-receiver-patterns.md](webhook-receiver-patterns.md) for webhook receiver specifics.

--- a/.claude/skills/development-workflow-standards/development-workflow-standards.md
+++ b/.claude/skills/development-workflow-standards/development-workflow-standards.md
@@ -1,35 +1,10 @@
-# Development Workflow Standards
+# Development Workflow Standards (Procedural Detail)
 
-This document defines the development process rules that all implementation work must follow.
+> See [rules/verification.md](../../rules/verification.md) for the declarative rules (verification checklist, branching strategy, testing requirements, commit standards, code quality, language policy, Claude Code on the Web essentials). This document covers procedural detail and decision frameworks that are too long for an auto-loaded rule.
 
-See [CLAUDE.md](/CLAUDE.md#working-principles) for working principles that apply to all work.
+## Conflict Assessment Before PR
 
-## Branching Strategy (GitHub-Flow)
-
-Follow GitHub-Flow. The `main` branch is always kept GREEN (all tests and type checks pass).
-
-### Starting Work (Branch Creation)
-
-Before creating a feature branch, **always fetch and sync with the latest main**:
-
-```bash
-# 1. Fetch the latest changes from remote
-git fetch origin
-
-# 2. Create a new branch from the latest origin/main
-git checkout -b feature/your-feature origin/main
-```
-
-**Important:** Never branch from a stale local main. Always use `origin/main` after fetching.
-
-### During Development
-
-1. Make changes with descriptive commits
-2. Run verification checklist before considering work complete
-
-### Before Completing Work (Conflict Assessment)
-
-Before opening a pull request, **always check for conflicts with the latest main**:
+Before opening a pull request, check for conflicts with the latest main:
 
 ```bash
 # 1. Fetch latest changes
@@ -42,7 +17,7 @@ git diff origin/main...HEAD --stat
 git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD
 ```
 
-**Conflict Assessment Criteria:**
+### Conflict Assessment Criteria
 
 | Conflict Level | Criteria | Action |
 |----------------|----------|--------|
@@ -50,14 +25,14 @@ git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD
 | **Moderate** | Conflicts in 3-5 files, but changes are isolated | Attempt rebase, resolve carefully |
 | **Severe** | Conflicts in core files you modified, or structural changes to same components | **Propose re-implementation** |
 
-**When to propose re-implementation:**
+### When to Propose Re-Implementation
 
 - The main branch has significant changes to files you heavily modified
 - The architectural approach in main has diverged from your implementation
 - Resolving conflicts would require understanding and integrating unfamiliar changes
 - The merge resolution effort approaches or exceeds the original implementation effort
 
-**Re-implementation proposal format:**
+### Re-Implementation Proposal Format
 
 > ⚠️ **Conflict Assessment Result**
 >
@@ -70,22 +45,8 @@ git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD
 > - No risk of regression from incorrect merge resolution
 > - Opportunity to leverage any new patterns introduced in main
 
-### Pull Request
+## TDD for Bug Fixes — Worked Example
 
-1. Open pull requests for review
-2. **Merging is the user's responsibility** - Never merge PRs automatically. Always leave the merge decision to the user.
-3. **Write in English** - PR titles, descriptions, and comments must be written in English (per Language Policy).
-
-## Testing Requirements
-
-**Testing with code changes.** When modifying code, always update or add corresponding tests. Code changes without test coverage are incomplete.
-
-**TDD for bug fixes.** When fixing bugs, apply Test-Driven Development where feasible:
-1. Write a failing test that reproduces the bug
-2. Implement the fix
-3. Verify the test passes
-
-Example:
 ```typescript
 // 1. Write failing test that reproduces the bug
 it('should handle session with no workers without crashing', () => {
@@ -100,112 +61,26 @@ it('should handle session with no workers without crashing', () => {
 // 4. Run test - it passes (confirms bug is fixed)
 ```
 
-## Verification Checklist
+The value of step 1 is not just "write a test" — it is *proving that the test catches the bug before you touch production code*. A green test after the fix does not guarantee coverage of the original bug; a failing test before the fix does.
 
-Before completing any code changes, always verify:
+## Claude Code on the Web — Full Setup
 
-1. **Run the FULL test suite:** Execute `bun run test` and ensure **ALL** tests pass — not just the tests you added or modified. Running only new tests is not sufficient. The full suite must be green before every push.
-2. **Run type check:** Execute `bun run typecheck` and ensure no type errors
-3. **Run CodeRabbit CLI review:** Execute `coderabbit review --agent --base main` and fix any CRITICAL, HIGH, or MEDIUM severity issues before creating a PR. If CodeRabbit CLI is not installed, skip this step and recommend installation: `curl -fsSL https://cli.coderabbit.ai/install.sh | sh`
-4. **Review test quality:** When tests are added or modified, evaluate adequacy and coverage
-5. **Manual verification (UI changes only):** When modifying UI components and Chrome DevTools MCP is available, perform manual testing through the browser to verify the changes work as expected.
+The declarative summary is in the rule. This is the full operational setup.
 
-**Hard rule for production code changes:** When any file outside of `docs/`, `.claude/skills/`, or `.claude/agents/` is modified, you MUST run `bun run test` (full suite) and confirm zero failures before pushing. Do not report task completion without full test verification. Violations waste review cycles and block other developers.
+Required custom-environment configuration:
 
-**Important:** The main branch is always kept GREEN (all tests and type checks pass). If any verification fails, assume it is caused by your changes on the current branch and fix it before proceeding.
+- **`GH_TOKEN`**: set in the custom environment variables. The `gh` CLI recognizes this automatically; no additional login step.
+- **Network access**: if using custom network mode, add `release-assets.githubusercontent.com` to the allowlist so `gh` can download release artifacts.
 
-## Commands
+The `gh` CLI is installed automatically by the `SessionStart` hook at `.claude/hooks/gh-setup.sh` on each web session.
 
-```bash
-bun run dev        # Start development servers (uses AGENT_CONSOLE_HOME=$HOME/.agent-console-dev)
-bun run build      # Build all packages
-bun run test       # Run typecheck then tests
-bun run test:only  # Run tests only (skip typecheck)
-bun run typecheck  # Type check all packages
-bun run lint       # Lint all packages
-```
-
-### Environment Configuration
-
-**Before starting `bun run dev`:** Check `.env` for port configuration. Each worktree may use different ports to avoid conflicts:
-
-```bash
-cat .env  # Check PORT and CLIENT_PORT values
-```
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PORT` | 3457 | Backend server port |
-| `CLIENT_PORT` | 5173 | Frontend dev server port |
-| `AGENT_CONSOLE_HOME` | ~/.agent-console-dev | Data directory |
-
-## Claude Code on the Web (Remote Environment)
-
-When running in Claude Code on the Web, `gh` CLI is automatically installed via a SessionStart hook (`.claude/hooks/gh-setup.sh`). The following setup is required in the Claude Code Web custom environment:
-
-- **GH_TOKEN**: Set in the custom environment variables (gh CLI recognizes this automatically)
-- **Network access**: If using custom network mode, add `release-assets.githubusercontent.com` to the allowlist
-
-**Important:** Due to the sandbox proxy, `gh` commands require the `-R owner/repo` flag explicitly. For this repository, always use `-R ms2sato/agent-console`:
+Due to the sandbox proxy, `gh` commands always require the `-R owner/repo` flag explicitly. For this repository:
 
 ```bash
 gh issue list -R ms2sato/agent-console
 gh pr list -R ms2sato/agent-console
 gh pr view 123 -R ms2sato/agent-console
+gh pr diff 123 -R ms2sato/agent-console
 ```
 
-## Design Documents as Specification
-
-Design documents (`docs/design/`) are specifications. Code is their implementation. When adding new features or changing behavior, update the design document FIRST as the spec, then implement code to match. When code changes affect the spec, update the design document as well. The spec and implementation must never silently diverge.
-
-## Commit Standards
-
-Use conventional commit format: `type: description`
-
-- `feat:` new feature
-- `fix:` bug fix
-- `refactor:` code change without feature/fix
-- `test:` adding or updating tests
-- `docs:` documentation changes
-
-### Skipping CI with `[skip ci]`
-
-Use `[skip ci]` in the commit message for commits that **only** change non-production files:
-
-- `docs/**` — documentation
-- `.claude/skills/**` — skill definitions
-- `.claude/agents/**` — agent definitions
-- `CLAUDE.md` — project instructions
-
-These files do not affect production code, so running the full CI pipeline is unnecessary.
-
-Example: `docs: update orchestrator skill [skip ci]`
-
-**Do not use `[skip ci]`** if the commit includes any production code or test changes alongside documentation.
-
-## Code Quality
-
-**Avoid over-engineering.** Only make changes that are directly requested or clearly necessary. Keep solutions simple and focused.
-
-- Don't add features, refactor code, or make "improvements" beyond what was asked
-- A bug fix doesn't need surrounding code cleaned up
-- A simple feature doesn't need extra configurability
-- Don't add docstrings, comments, or type annotations to code you didn't change
-- Only add comments where the logic isn't self-evident
-
-**Avoid unnecessary complexity.**
-
-- Don't add error handling, fallbacks, or validation for scenarios that can't happen
-- Trust internal code and framework guarantees
-- Only validate at system boundaries (user input, external APIs)
-- Don't create helpers, utilities, or abstractions for one-time operations
-- Don't design for hypothetical future requirements
-
-**Clean up properly.**
-
-- Avoid backwards-compatibility hacks like renaming unused `_vars`, re-exporting types, adding `// removed` comments
-- If something is unused, delete it completely
-
-## Language Policy
-
-**Code and documentation:** Write all code comments, commit messages, and documentation in English.
+Omitting `-R` yields an opaque proxy error, not the usual "not a git repository" message. If a `gh` command fails in an unexpected way in the web environment, the first thing to check is whether `-R` was supplied.

--- a/.claude/skills/frontend-standards/SKILL.md
+++ b/.claude/skills/frontend-standards/SKILL.md
@@ -9,7 +9,9 @@ description: Detailed React patterns and code examples for frontend implementati
 
 ## Detailed Documentation
 
-- [react-patterns.md](react-patterns.md) - React patterns with code examples (useEffect alternatives, Suspense, async/await, state management)
-- [frontend-standards.md](frontend-standards.md) - Full code examples for TanStack Router/Query, WebSocket integration, xterm.js, Valibot forms, testing, performance
+- [frontend-standards.md](frontend-standards.md) — agent-console-specific frontend patterns: TanStack Router/Query usage, xterm.js integration, Tailwind conventions, Valibot form pitfalls, Browser Verification procedure for UI changes.
+- [react-patterns.md](react-patterns.md) — generic React patterns with full code examples: `useSyncExternalStore` for external stores, Suspense for async, async/await in event handlers, async useEffect with cleanup flag, icon component extraction.
+
+The two files are non-overlapping. When a topic is generic React, it lives in `react-patterns.md`; when it is specific to agent-console's stack, it lives in `frontend-standards.md`.
 
 See also: `ux-design-standards` skill for UX design principles that guide feature-level decisions.

--- a/.claude/skills/frontend-standards/frontend-standards.md
+++ b/.claude/skills/frontend-standards/frontend-standards.md
@@ -1,83 +1,27 @@
-# Frontend Standards
+# Frontend Standards (agent-console-specific)
 
-This document defines frontend-specific knowledge and patterns for the agent-console project.
+> See [rules/frontend.md](../../rules/frontend.md) for the declarative rules (directory structure, hook placement, naming, useEffect alternatives, state management hierarchy, WebSocket patterns). This document covers agent-console-specific patterns. For generic React patterns (useSyncExternalStore, Suspense, useEffect cleanup, etc.), see [react-patterns.md](react-patterns.md).
 
 ## Tech Stack
 
-- **React 18** - UI framework
-- **Vite** - Build tool and dev server
-- **TanStack Router** - File-based routing with type safety
-- **TanStack Query** - Server state management
-- **Tailwind CSS** - Utility-first styling
-- **xterm.js** - Terminal emulator
-- **Valibot** - Schema validation
-
-## Directory Structure and Naming
-
-```
-packages/client/src/
-├── components/     # React components (domain-organized)
-│   ├── sessions/   # Session-related components and hooks
-│   ├── workers/    # Worker-related components and hooks
-│   └── ui/         # Shared UI components
-├── hooks/          # Shared/generic hooks only
-├── lib/            # Utilities and API clients
-├── routes/         # TanStack Router file-based routes
-├── schemas/        # Valibot validation schemas
-└── test/           # Test utilities and setup
-```
-
-### Directory Organization Strategy
-
-**Components use domain-based organization:**
-- Group related components into domain directories (`sessions/`, `workers/`, `agents/`)
-- Shared UI components go in `ui/`
-- Standalone components can remain flat
-
-**Hooks use hybrid approach:**
-
-| Hook Type | Location | Example |
-|-----------|----------|---------|
-| Domain-specific | Inside domain directory | `components/sessions/useSessionState.ts` |
-| Multi-domain | `hooks/` | `hooks/useTerminalWebSocket.ts` |
-| Generic utility | `hooks/` | `hooks/useMounted.ts` |
-
-Decision criteria:
-1. **Used by single domain only** → Put in that domain directory
-2. **Used by 2+ domains** → Put in `hooks/`
-3. **Domain-agnostic utility** → Put in `hooks/`
-
-### File Naming Conventions
-
-| Type | Convention | Example |
-|------|------------|---------|
-| React component | PascalCase | `SessionList.tsx`, `WorkerTabs.tsx` |
-| Custom hook | camelCase + `use` prefix | `useTerminal.ts`, `useAppConnection.ts` |
-| Utility/helper | kebab-case | `api-client.ts`, `format-date.ts` |
-| Type definition | kebab-case | `types.ts`, `session-types.ts` |
-| Schema | kebab-case | `session-schema.ts` |
-| Test | original + `.test` | `SessionList.test.tsx`, `useTerminal.test.ts` |
-
-### Directory Naming
-
-- Use **kebab-case** for all directories
-- Domain directories use plural nouns: `sessions/`, `workers/`, `agents/`
-
-### Export Conventions
-
-- Component file name = component name: `SessionList.tsx` exports `SessionList`
-- For component directories, use `index.ts` to re-export the main component
+- **React 18** — UI framework
+- **Vite** — build tool and dev server
+- **TanStack Router** — file-based routing with type safety
+- **TanStack Query** — server state management
+- **Tailwind CSS** — utility-first styling
+- **xterm.js** — terminal emulator
+- **Valibot** — schema validation
 
 ## TanStack Router
 
 ### File-Based Routing
 
-- Routes are defined in `src/routes/` directory
-- `__root.tsx` - Root layout
-- `index.tsx` - Home route (`/`)
-- `$param.tsx` - Dynamic segments
+Routes live in `src/routes/`. Conventions:
+- `__root.tsx` — root layout
+- `index.tsx` — home route (`/`)
+- `$param.tsx` — dynamic segments
 
-### Route Types
+### Route Types and Navigation
 
 ```typescript
 // Route params are automatically typed
@@ -85,12 +29,8 @@ const { sessionId } = Route.useParams()
 
 // Search params with validation
 const { tab } = Route.useSearch()
-```
 
-### Navigation
-
-```typescript
-// Use Link component for navigation
+// Link component for navigation
 <Link to="/sessions/$sessionId" params={{ sessionId }}>
 
 // Programmatic navigation
@@ -100,7 +40,7 @@ navigate({ to: '/sessions/$sessionId', params: { sessionId } })
 
 ## TanStack Query
 
-### Query Keys
+### Query Key Factories
 
 Use consistent key factories for related queries:
 
@@ -111,7 +51,7 @@ const sessionKeys = {
 }
 ```
 
-### Mutations
+### Mutations with Invalidation
 
 Always invalidate related queries after mutations:
 
@@ -124,53 +64,25 @@ const mutation = useMutation({
 })
 ```
 
-## WebSocket Integration
-
-### Choose the Right Pattern
-
-**Singleton pattern** - For app-wide connections that persist across navigation:
-- Example: `/ws/app` for session/worker lifecycle events
-- Use module-level state with `useSyncExternalStore`
-
-**Hook-based pattern** - For component-scoped connections:
-- Example: `/ws/session/:id/worker/:id` for terminal I/O
-- Use `useEffect` with cleanup, tied to component lifecycle
-
-### State Synchronization
-
-- Server is the source of truth
-- Update UI based on server messages
-- Don't maintain conflicting client state
-
 ## xterm.js Integration
-
-### Terminal Setup
 
 - Initialize with appropriate options (font, theme, scrollback)
 - Attach fit addon for responsive sizing
 - Handle resize events
-
-### Input/Output
-
 - Send user input via WebSocket
 - Write received output to terminal
 - Handle special keys appropriately
 
-## Styling with Tailwind CSS
+xterm.js is one of the narrow cases where `useEffect` is acceptable — the terminal instance's lifecycle is tied to the component.
 
-### Class Organization
+## Tailwind CSS
 
-Group related utilities: layout → spacing → sizing → colors → typography
+- **Class organization**: layout → spacing → sizing → colors → typography
+- **Responsive design**: mobile-first (`sm:`, `md:`, `lg:` breakpoints)
 
-### Responsive Design
+## Valibot Form Validation
 
-Mobile-first approach (`sm:`, `md:`, `lg:` breakpoints)
-
-## Form Handling with Valibot
-
-### Validation Patterns
-
-**Always add minLength before regex:**
+**Always place `minLength` before `regex`:**
 
 ```typescript
 const schema = v.pipe(
@@ -181,133 +93,13 @@ const schema = v.pipe(
 )
 ```
 
-## React Best Practices
-
-### Suspense Usage
-
-- Prefer Suspense for async operations and loading states over manual `isLoading` flags
-- Use Suspense boundaries for code splitting and data fetching
-- Pair ErrorBoundary with Suspense for error handling
-
-```typescript
-// ❌ Avoid: manual loading state
-function UserProfile({ userId }: { userId: string }) {
-  const { data, isLoading, error } = useQuery(...);
-  if (isLoading) return <Spinner />;
-  if (error) return <ErrorMessage />;
-  return <Profile user={data} />;
-}
-
-// ✅ Prefer: Suspense boundary
-function UserProfile({ userId }: { userId: string }) {
-  const { data } = useSuspenseQuery(...);
-  return <Profile user={data} />;
-}
-// Wrapped with <Suspense fallback={<Spinner />}> at parent level
-```
-
-### useEffect Discipline
-
-Challenge every useEffect - could it be:
-- A derived value (computed from props/state)?
-- An event handler?
-- `useMemo` or `useCallback`?
-
-```typescript
-// ❌ Avoid: useEffect for derived state
-const [fullName, setFullName] = useState('');
-useEffect(() => {
-  setFullName(`${firstName} ${lastName}`);
-}, [firstName, lastName]);
-
-// ✅ Prefer: derived value
-const fullName = `${firstName} ${lastName}`;
-
-// ❌ Avoid: useEffect for event response
-useEffect(() => {
-  if (submitted) {
-    navigate('/success');
-  }
-}, [submitted]);
-
-// ✅ Prefer: event handler
-const handleSubmit = async () => {
-  await submitForm();
-  navigate('/success');
-};
-```
-
-### Icon Components
-
-SVG icons should be in a dedicated `Icons.tsx` file, not inline in View components:
-
-```typescript
-// ❌ Avoid: inline SVG in component
-function DeleteButton() {
-  return (
-    <button>
-      <svg viewBox="0 0 24 24">...</svg>
-    </button>
-  );
-}
-
-// ✅ Prefer: extracted icon component
-// In Icons.tsx
-export function TrashIcon(props: IconProps) {
-  return <svg viewBox="0 0 24 24" {...props}>...</svg>;
-}
-
-// In component
-function DeleteButton() {
-  return (
-    <button>
-      <TrashIcon className="w-4 h-4" />
-    </button>
-  );
-}
-```
-
-### External State (useSyncExternalStore)
-
-Use `useSyncExternalStore` for singleton/global state subscriptions, not useEffect:
-
-```typescript
-// ❌ Avoid: useEffect with manual subscription
-function useConnectionStatus() {
-  const [status, setStatus] = useState(connectionStore.getStatus());
-  useEffect(() => {
-    const unsubscribe = connectionStore.subscribe(setStatus);
-    return unsubscribe;
-  }, []);
-  return status;
-}
-
-// ✅ Prefer: useSyncExternalStore
-function useConnectionStatus() {
-  return useSyncExternalStore(
-    connectionStore.subscribe,
-    connectionStore.getStatus,
-    connectionStore.getServerStatus // optional: for SSR
-  );
-}
-```
-
-### Query Key Management
-
-See the [TanStack Query](#tanstack-query) section for key factory patterns and invalidation best practices.
+Reason: without `minLength(1)`, the `regex` check on an empty string produces the regex error message ("Invalid format") instead of the more helpful "required" message. User-facing message quality depends on the order.
 
 ## Testing
 
-### Component Testing
-
 - Use `@testing-library/react`
 - Test user interactions, not implementation
-- Mock API calls appropriately
-
-### Hook Testing
-
-- Test all state transitions
-- Mock dependencies appropriately
+- Mock API calls at the fetch level — see [test-standards skill](../test-standards/SKILL.md)
 
 ## Performance
 
@@ -327,16 +119,18 @@ See the [TanStack Query](#tanstack-query) section for key factory patterns and i
 - Display user-friendly error messages
 - Provide retry mechanisms where appropriate
 
-## Browser Verification (UI changes)
+## Browser Verification for UI Changes
 
-**Mandatory for PRs that change UI components, layout, or styling.**
-
-When a PR modifies visual elements, verify the actual rendered result using Chrome MCP before reporting acceptance.
+**Mandatory** for PRs that change UI components, layout, or styling. When a PR modifies visual elements, verify the actual rendered result using Chrome DevTools MCP before reporting acceptance.
 
 ### Procedure
+
 1. Find free ports: `lsof -i :<port>` to check availability
-2. Start dev server from the PR's worktree: `CLIENT_PORT=<free> PORT=<free> bun run dev`
-3. Navigate Chrome to the frontend URL (the CLIENT_PORT, not the backend PORT)
+2. Start the dev server from the PR's worktree:
+   ```bash
+   CLIENT_PORT=<free> PORT=<free> bun run dev
+   ```
+3. Navigate Chrome to the frontend URL (the `CLIENT_PORT`, not the backend `PORT`)
 4. Take screenshots at both viewport sizes:
    - **PC**: 1200x700
    - **Mobile**: 375x667
@@ -346,9 +140,10 @@ When a PR modifies visual elements, verify the actual rendered result using Chro
    - Redundancy (duplicate labels, unnecessary descriptions)
    - Responsiveness (does mobile fallback work?)
    - Accessibility (buttons reachable, text readable)
-6. Stop dev server after verification
+6. Stop the dev server after verification
 
-### What to check
+### What to Check
+
 - Component layout changes
 - Styling / Tailwind class changes
 - New UI elements or dialogs

--- a/.claude/skills/frontend-standards/react-patterns.md
+++ b/.claude/skills/frontend-standards/react-patterns.md
@@ -1,30 +1,13 @@
-# React Patterns
+# React Patterns (generic, code-example detail)
 
-This document defines React patterns to follow in the agent-console project.
-
-## Avoid useEffect - Use Alternatives
-
-**useEffect should be a last resort.** Most use cases have better alternatives:
-
-| Instead of useEffect for... | Use this |
-|----------------------------|----------|
-| Fetching data | TanStack Query (`useQuery`) |
-| Subscribing to external store | `useSyncExternalStore` |
-| Derived state | Compute during render or `useMemo` |
-| Responding to user events | Event handlers |
-| Syncing with parent component | Lift state up or use context |
-
-**When useEffect is acceptable:**
-- Component-scoped WebSocket connections (tied to component lifecycle)
-- Third-party library integration (xterm.js, etc.)
-- Browser API subscriptions (resize observers, etc.)
+> See [rules/frontend.md](../../rules/frontend.md) for the declarative rules (useEffect alternatives table, state management hierarchy, async/await requirement). This file covers generic React patterns with the full code-example detail those rules imply. For agent-console-specific frontend standards (TanStack stack, xterm.js, Browser QA), see [frontend-standards.md](frontend-standards.md).
 
 ## useSyncExternalStore for External State
 
 When subscribing to external state (global stores, singletons), use `useSyncExternalStore`:
 
 ```typescript
-// lib/app-websocket.ts - External store with subscribe/getState pattern
+// lib/app-websocket.ts — external store with subscribe/getState
 export function subscribeState(listener: () => void): () => void {
   stateListeners.add(listener);
   return () => stateListeners.delete(listener);
@@ -34,21 +17,44 @@ export function getState(): AppWebSocketState {
   return state;
 }
 
-// hooks/useAppWs.ts - Hook using useSyncExternalStore
+// hooks/useAppWs.ts — hook using useSyncExternalStore
 export function useAppWsState<T>(selector: (state: AppWebSocketState) => T): T {
   return useSyncExternalStore(subscribeState, () => selector(getState()));
 }
 ```
 
-**Why this pattern:**
+Why this pattern:
 - React-safe synchronization with external state
 - Automatic subscription cleanup
 - Works with concurrent rendering
-- No stale closure issues
+- No stale-closure issues
+
+Contrast with the useEffect-based approach the rule tells you to avoid:
+
+```typescript
+// ❌ useEffect with manual subscription — stale closures, cleanup bugs
+function useConnectionStatus() {
+  const [status, setStatus] = useState(connectionStore.getStatus());
+  useEffect(() => {
+    const unsubscribe = connectionStore.subscribe(setStatus);
+    return unsubscribe;
+  }, []);
+  return status;
+}
+
+// ✅ useSyncExternalStore
+function useConnectionStatus() {
+  return useSyncExternalStore(
+    connectionStore.subscribe,
+    connectionStore.getStatus,
+    connectionStore.getServerStatus  // optional: for SSR
+  );
+}
+```
 
 ## Suspense for Async Operations
 
-**Prefer Suspense** for handling loading states:
+**Prefer Suspense** over manual `isLoading` flags:
 
 ```typescript
 // Route-level Suspense with TanStack Router
@@ -63,29 +69,39 @@ export const Route = createFileRoute('/sessions/$sessionId')({
 </Suspense>
 ```
 
-**Benefits:**
-- Cleaner component code (no loading state management)
-- Better UX with coordinated loading states
+Benefits:
+- Cleaner component code (no loading-state management)
+- Coordinated loading states at a boundary
 - Enables streaming and progressive rendering
 
-## Async/Await and Fire-and-Forget
+```typescript
+// ❌ Manual loading state
+function UserProfile({ userId }: { userId: string }) {
+  const { data, isLoading, error } = useQuery(...);
+  if (isLoading) return <Spinner />;
+  if (error) return <ErrorMessage />;
+  return <Profile user={data} />;
+}
 
-**Always use async/await. Avoid fire-and-forget patterns.**
+// ✅ Suspense boundary
+function UserProfile({ userId }: { userId: string }) {
+  const { data } = useSuspenseQuery(...);
+  return <Profile user={data} />;
+}
+// Wrapped with <Suspense fallback={<Spinner />}> at parent level
+```
 
-Fire-and-forget (calling an async function without awaiting) causes:
-- Silent errors that are difficult to debug
-- Race conditions and unpredictable behavior
-- Unhandled promise rejections
+## Async/Await in Event Handlers
 
-### Event Handlers
+The rule bans fire-and-forget. This is the mechanical pattern:
 
 ```typescript
-// ❌ Fire-and-forget - errors are silently swallowed
+// ❌ Fire-and-forget — errors are silently swallowed
 const handleClick = () => {
   submitForm(data);  // Promise ignored
 };
 
-// ❌ async without await - same problem
+// ❌ async without await — same problem
 const handleClick = async () => {
   submitForm(data);  // Still fire-and-forget
 };
@@ -100,7 +116,9 @@ const handleClick = async () => {
 };
 ```
 
-### useEffect with Async Operations
+## Async useEffect with Cleanup
+
+useEffect callbacks cannot be async directly. The canonical pattern:
 
 ```typescript
 // ❌ Fire-and-forget in useEffect
@@ -113,7 +131,7 @@ useEffect(async () => {  // TypeScript error
   await fetchData();
 }, []);
 
-// ✅ Proper pattern with cleanup
+// ✅ Proper pattern with cleanup flag
 useEffect(() => {
   let cancelled = false;
 
@@ -138,14 +156,16 @@ useEffect(() => {
 }, []);
 ```
 
-### Intentional Background Work
+The `cancelled` flag prevents state updates on an unmounted component (React will warn, and stale state can overwrite fresh state in the common remount-then-settle case).
+
+## Intentional Background Work
 
 When you genuinely need fire-and-forget (rare), make it explicit:
 
 ```typescript
-// ✅ Explicit fire-and-forget with error handling
+// ✅ Explicit fire-and-forget with local error handling
 const handleClick = async () => {
-  // Intentionally not awaiting - fire-and-forget for analytics
+  // Intentionally not awaiting — fire-and-forget for analytics
   trackAnalytics('button_clicked').catch((error) => {
     console.error('Analytics failed:', error);
   });
@@ -155,20 +175,47 @@ const handleClick = async () => {
 };
 ```
 
-**Note:** For data fetching, prefer TanStack Query over manual useEffect patterns.
+The `.catch()` is what makes this safe. A bare `trackAnalytics(...)` with no `.catch()` would silently swallow an unhandled rejection.
+
+**Prefer TanStack Query** over manual data-fetch useEffects. Query handles the cleanup, cancellation, caching, and retries for you. Manual useEffect is only appropriate for non-request-shaped async work (subscriptions, timers, third-party library integration).
 
 ## Component Design
 
 - Prefer function components with hooks
-- Keep components focused on single responsibility
+- Keep components focused on a single responsibility
 - Extract complex logic into custom hooks
 - Use composition over inheritance
 
-## State Management Hierarchy
-
-1. **Server state**: TanStack Query (`useQuery`, `useMutation`)
-2. **External state**: `useSyncExternalStore`
-3. **Local UI state**: `useState`, `useReducer`
-4. **Shared client state**: React Context (sparingly)
-
 Avoid prop drilling; prefer composition or context.
+
+## Icon Components
+
+SVG icons belong in a dedicated `Icons.tsx` file, not inline in view components:
+
+```typescript
+// ❌ Inline SVG in component
+function DeleteButton() {
+  return (
+    <button>
+      <svg viewBox="0 0 24 24">...</svg>
+    </button>
+  );
+}
+
+// ✅ Extracted icon component
+// In Icons.tsx
+export function TrashIcon(props: IconProps) {
+  return <svg viewBox="0 0 24 24" {...props}>...</svg>;
+}
+
+// In the button
+function DeleteButton() {
+  return (
+    <button>
+      <TrashIcon className="w-4 h-4" />
+    </button>
+  );
+}
+```
+
+Benefits: markup stays readable, icons are reusable, and accessibility attributes are set in one place.

--- a/.claude/skills/orchestrator/core-responsibilities.md
+++ b/.claude/skills/orchestrator/core-responsibilities.md
@@ -111,7 +111,7 @@
 - **CodeRabbit review**: CodeRabbit auto-reviews PRs on push. No manual re-review requests needed — if rate-limited, it resolves naturally.
 - **Important**: Run acceptance checks in parallel when multiple PRs are ready
 - **MANDATORY: Every PR must go through both checks.**
-  - **Preflight check** (mechanical): `node .claude/skills/orchestrator/preflight-check.js <PR>` — test coverage validation. CI runs this automatically.
+  - **Preflight check** (mechanical): `node .claude/skills/orchestrator/preflight-check.js <PR>` — test coverage validation and rule/skill duplication invariant check. CI runs this automatically.
   - **Acceptance check** (human judgment): `node .claude/skills/orchestrator/acceptance-check.js <PR>` via `run_process` — full Q1-Q7 interactive review. **Always required for production code changes.** Never skip this — even when the diff looks trivial. (Lesson: Sprint 2026-04-05c — skipping the full acceptance check caused a UI requirement to be missed on #599.)
 
 ## 7. Post-Merge Flow

--- a/.claude/skills/orchestrator/preflight-check.js
+++ b/.claude/skills/orchestrator/preflight-check.js
@@ -23,6 +23,7 @@ import {
   isTestFile,
   detectIntegrationTestNeeds,
 } from './check-utils.js';
+import { run as runDuplicationCheck } from './rule-skill-duplication-check.js';
 
 // --- Display ---
 
@@ -59,42 +60,48 @@ function run(changedFiles) {
   if (filesNeedingCoverage.length === 0 && !integrationTestNeeds) {
     console.log('## Test Coverage Check\n');
     console.log('No production files matching coverage patterns were changed.\n');
-    process.exit(0);
-  }
-
-  const gaps = filesNeedingCoverage.filter(tc => !tc.hasTest);
-  const covered = filesNeedingCoverage.filter(tc => tc.hasTest);
-
-  console.log('## Test Coverage Check\n');
-
-  if (covered.length > 0) {
-    console.log(`### Covered (${covered.length})\n`);
-    for (const { file } of covered) {
-      console.log(`- ✅ \`${file}\``);
-    }
-    console.log();
-  }
-
-  if (gaps.length > 0) {
-    console.log(`### Missing Tests (${gaps.length})\n`);
-    for (const { file, expectedTestPath } of gaps) {
-      console.log(`- ❌ \`${file}\` — expected: \`${expectedTestPath}\``);
-    }
-    console.log();
-  }
-
-  printIntegrationTestCoverage(integrationTestNeeds);
-
-  if (hasUnitGaps) {
-    console.log(`**${gaps.length} production file(s) missing test coverage.**`);
-    process.exit(1);
-  } else if (hasIntegrationGap) {
-    console.log('**Integration test gap detected — review recommended.** ⚠');
-    process.exit(0);
   } else {
-    console.log('**All production files have corresponding tests.** ✅');
-    process.exit(0);
+    const gaps = filesNeedingCoverage.filter(tc => !tc.hasTest);
+    const covered = filesNeedingCoverage.filter(tc => tc.hasTest);
+
+    console.log('## Test Coverage Check\n');
+
+    if (covered.length > 0) {
+      console.log(`### Covered (${covered.length})\n`);
+      for (const { file } of covered) {
+        console.log(`- ✅ \`${file}\``);
+      }
+      console.log();
+    }
+
+    if (gaps.length > 0) {
+      console.log(`### Missing Tests (${gaps.length})\n`);
+      for (const { file, expectedTestPath } of gaps) {
+        console.log(`- ❌ \`${file}\` — expected: \`${expectedTestPath}\``);
+      }
+      console.log();
+    }
+
+    printIntegrationTestCoverage(integrationTestNeeds);
+
+    if (hasUnitGaps) {
+      console.log(`**${gaps.length} production file(s) missing test coverage.**`);
+    } else if (hasIntegrationGap) {
+      console.log('**Integration test gap detected — review recommended.** ⚠');
+    } else {
+      console.log('**All production files have corresponding tests.** ✅');
+    }
   }
+
+  // Rule/Skill duplication invariant — runs on every preflight because drift
+  // can be introduced by edits anywhere, not just the current PR's diff.
+  console.log('\n---\n');
+  const duplicationExit = runDuplicationCheck();
+
+  if (hasUnitGaps || duplicationExit !== 0) {
+    process.exit(1);
+  }
+  process.exit(0);
 }
 
 // --- Exports for testing ---

--- a/.claude/skills/orchestrator/rule-skill-duplication-check.js
+++ b/.claude/skills/orchestrator/rule-skill-duplication-check.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+/**
+ * Rule/Skill Duplication Check
+ *
+ * Enforces the invariant from .claude/README.md:
+ *   "Rule prose must not appear verbatim in any skill file."
+ *
+ * Scans every paragraph in .claude/rules/*.md and reports any paragraph
+ * whose normalized form also appears in a .claude/skills/**\/*.md file.
+ *
+ * Exits 0 if no duplication, 1 if any rule paragraph leaked into a skill.
+ *
+ * Usage:
+ *   node .claude/skills/orchestrator/rule-skill-duplication-check.js
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../..');
+const RULES_DIR = join(REPO_ROOT, '.claude/rules');
+const SKILLS_DIR = join(REPO_ROOT, '.claude/skills');
+
+/** Minimum length of a rule paragraph to consider for duplication. Shorter
+ * fragments produce too many false positives (common one-liners, shared
+ * headings). 80 chars empirically balances recall and precision. */
+const MIN_PARAGRAPH_LENGTH = 80;
+
+// --- Filesystem helpers ---
+
+function walk(dir) {
+  const entries = readdirSync(dir);
+  const files = [];
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      files.push(...walk(full));
+    } else if (entry.endsWith('.md')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+// --- Paragraph extraction ---
+
+/** Remove YAML frontmatter from a markdown body. */
+function stripFrontmatter(content) {
+  return content.replace(/^---\n[\s\S]*?\n---\n/, '');
+}
+
+/** Remove fenced code blocks — code is tolerated in both rule and skill. */
+function stripCodeBlocks(content) {
+  return content.replace(/```[\s\S]*?```/g, '');
+}
+
+/** Normalize a paragraph for comparison: collapse whitespace, strip markdown
+ * emphasis marks that are likely to drift between copies. */
+function normalize(text) {
+  return text
+    .replace(/\*\*/g, '')
+    .replace(/\*/g, '')
+    .replace(/`/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Extract candidate paragraphs from a markdown file body. A paragraph is a
+ * blank-line-separated block that: is long enough, is not purely a heading,
+ * and is not purely a list of table pipes. */
+function extractParagraphs(content) {
+  const body = stripCodeBlocks(stripFrontmatter(content));
+  const blocks = body.split(/\n\s*\n/);
+  const paragraphs = [];
+  for (const raw of blocks) {
+    const text = raw.trim();
+    if (text.length < MIN_PARAGRAPH_LENGTH) continue;
+    if (/^#+\s/.test(text)) continue; // heading block
+    if (/^\|[\s\S]*\|$/.test(text) && !/[a-zA-Z]{20,}/.test(text)) continue; // table shell
+    const normalized = normalize(text);
+    if (normalized.length < MIN_PARAGRAPH_LENGTH) continue;
+    paragraphs.push({ original: text, normalized });
+  }
+  return paragraphs;
+}
+
+// --- Main ---
+
+/** Scan all rule files and find paragraphs that appear in any skill file.
+ * Returns an array of violations (empty if none). */
+export function findDuplications() {
+  const ruleFiles = walk(RULES_DIR);
+  const skillFiles = walk(SKILLS_DIR);
+
+  const skillContent = new Map();
+  for (const skillPath of skillFiles) {
+    const raw = readFileSync(skillPath, 'utf-8');
+    skillContent.set(skillPath, normalize(stripCodeBlocks(stripFrontmatter(raw))));
+  }
+
+  const violations = [];
+
+  for (const rulePath of ruleFiles) {
+    const raw = readFileSync(rulePath, 'utf-8');
+    const paragraphs = extractParagraphs(raw);
+    for (const { original, normalized } of paragraphs) {
+      for (const [skillPath, skillBody] of skillContent) {
+        if (skillBody.includes(normalized)) {
+          violations.push({
+            rulePath: relative(REPO_ROOT, rulePath),
+            skillPath: relative(REPO_ROOT, skillPath),
+            excerpt: original.slice(0, 120).replace(/\n/g, ' '),
+          });
+          break;
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+export function run() {
+  const violations = findDuplications();
+
+  console.log('## Rule/Skill Duplication Check\n');
+
+  if (violations.length === 0) {
+    console.log('✅ No rule paragraphs found verbatim in any skill file.');
+    return 0;
+  }
+
+  console.log(`❌ Found ${violations.length} rule paragraph(s) duplicated in skill files:\n`);
+  for (const v of violations) {
+    console.log(`- rule: \`${v.rulePath}\``);
+    console.log(`  skill: \`${v.skillPath}\``);
+    console.log(`  excerpt: "${v.excerpt}..."`);
+    console.log();
+  }
+  console.log('Resolve by keeping the rule as canonical and replacing the skill copy with a cross-reference (see `.claude/README.md`).');
+  return 1;
+}
+
+// --- Entry point ---
+
+const isMainModule = import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('rule-skill-duplication-check.js');
+if (isMainModule) {
+  process.exit(run());
+}

--- a/.claude/skills/test-standards/test-standards.md
+++ b/.claude/skills/test-standards/test-standards.md
@@ -1,20 +1,16 @@
-# Test Standards
+# Test Standards (Procedural Detail)
 
-This document defines testing best practices and anti-patterns for the agent-console project.
+> See [rules/testing.md](../../rules/testing.md) for the declarative rules (core principles, anti-patterns, evaluation criteria, naming conventions, pre-implementation checklist, unit-vs-integration responsibilities). This document covers procedural detail and code patterns.
 
-## Core Principles
-
-### 1. Tests Must Test Production Code
-
-Import and test production code directly. Never duplicate production logic in test files.
+## Tests Must Test Production Code — Worked Example
 
 ```typescript
-// ❌ Wrong: Duplicating logic in test file
+// ❌ Wrong: duplicating logic in the test file
 function cleanupOrphanProcesses(deps: MockDeps) {
   // Re-implementing production logic...
 }
 
-// ✅ Correct: Import and test production code
+// ✅ Correct: import and test production code
 import { SessionManager } from '../session-manager';
 
 describe('SessionManager', () => {
@@ -25,34 +21,16 @@ describe('SessionManager', () => {
 });
 ```
 
-### 2. Test Through Public Interface
-
-If you feel the need to test a private method, reconsider the design.
+## Mock at the Lowest Level — Fetch-Level Pattern
 
 ```typescript
-// ❌ Wrong: Trying to access private method
-// manager['privateMethod']() - Don't do this
-
-// ✅ Correct: Test through public interface
-describe('SessionManager', () => {
-  it('should cleanup orphan processes on initialization', () => {
-    // Test the observable behavior via public API
-  });
-});
-```
-
-### 3. Mock at the Lowest Level
-
-Mock at the communication layer (`fetch`, `WebSocket`, file system) rather than mocking intermediate modules.
-
-```typescript
-// ❌ Avoid: Module-level mocking
+// ❌ Avoid: module-level mocking
 mock.module('../lib/api', () => ({
   deleteWorktree: mock(() => Promise.resolve()),
 }));
 // Problems: bypasses actual API logic, permanent in bun:test
 
-// ✅ Correct: Mock at fetch level
+// ✅ Correct: mock at fetch level
 const originalFetch = globalThis.fetch;
 globalThis.fetch = mock(() => Promise.resolve(new Response()));
 
@@ -62,86 +40,20 @@ afterAll(() => {
 // Benefits: tests URL construction, error handling, etc.
 ```
 
-### 4. Do Not Change Production Code for Testing Without Discussion
+## Dependency Injection Over Module Mocking
 
-Changing production code interfaces solely to make testing easier should not be done without discussion.
+The rule names this as Anti-Pattern #2. The mechanical reason: in bun:test, `mock.module()` is **process-global and permanent**. A single call pollutes every test file that runs in the same process. Past incidents:
 
-```typescript
-// ❌ Wrong: Adding optional dependency injection just for testing without discussion
-class SessionManager {
-  cleanupOrphanProcesses(
-    deps: {
-      loadSessions?: () => PersistedSession[];
-      isProcessAlive?: (pid: number) => boolean;
-    } = {}
-  ): void {
-    // Changed signature just for testing
-  }
-}
-```
-
-If testing requires changes to production code, **consult with the team first**. Changes that improve testability often also improve design (e.g., dependency injection), but this should be a deliberate decision, not an afterthought.
-
-## Evaluation Criteria
-
-### Test Validity
-
-- Tests verify **requirements**, not implementation details
-- Assertions are meaningful and specific
-- Test names clearly describe what is being tested
-- Tests would fail if production code behavior changes
-
-### Coverage
-
-- Happy path is covered
-- Edge cases are considered (empty, null, boundary values)
-- Error scenarios are tested
-- Integration points are verified
-
-### Methodology
-
-- Mocks are used appropriately (not over-mocked)
-- Test isolation is maintained
-- Setup/teardown is clean
-- Follows project testing guidelines
-
-### Maintainability
-
-- Tests are readable without excessive comments
-- Duplication is minimized
-- Test data is clear and purposeful
-
-## Anti-Patterns to Avoid
-
-### 1. Logic Duplication
-
-Test file re-implements production logic instead of importing it.
-
-**Signs:**
-- Test-only classes that mirror production classes
-- Functions in test files that do the same thing as production code
-- Tests that wouldn't break when production code changes
-
-### 2. Module-Level Mocking
-
-Using `mock.module()` or `vi.mock()` instead of fetch-level mocks.
-
-**Problems:**
-- Bypasses actual API function logic (URL construction, error handling)
-- `mock.module()` is permanent in bun:test (cannot be reset)
-- Tests pass even when integration is broken
-
-**Bun-specific: `mock.module()` is process-global and permanent.** Mocking a module in one test file pollutes ALL test files that run in the same process. This has caused production incidents (e.g., mocking `config.js` in deletion tests broke 26+ unrelated tests; centralizing `worktreeService` mock into a shared helper broke 23 MCP tests via import-time side effects).
-
-**`mock.module()` is a code smell, not a testing tool.** If you need `mock.module()` to test something, the production code has a design problem — it depends on a module-level singleton instead of accepting dependencies as parameters. The correct fix is to refactor the production code for DI, not to find clever `mock.module()` workarounds.
+- Mocking `config.js` in deletion tests broke 26+ unrelated tests.
+- Centralizing a `worktreeService` mock into a shared helper broke 23 MCP tests via import-time side effects.
 
 **Common traps that do NOT solve the problem:**
-- "Each test file defines its own `mock.module()`" — still leaks if Bun runs files in the same process
-- "Centralized mock helper that calls `mock.module()` once" — makes it worse: every file that imports the helper triggers the global mock via import side effects
-- "Reset mocks in `beforeEach`" — `mock.module()` cannot be reset in Bun
 
-**Preferred approach: dependency injection over module mocking.**
-When a service depends on other services or configuration, accept them as parameters (constructor or function args) rather than importing a singleton. This project uses `AppContext` for DI — services are injected via Hono middleware context. Route handler tests use `createTestContext()` or `asAppContext()` to inject mocks without `mock.module()`.
+- "Each test file defines its own `mock.module()`" — still leaks if Bun runs files in the same process.
+- "Centralized mock helper that calls `mock.module()` once" — makes it worse: every file that imports the helper triggers the global mock via import-time side effects.
+- "Reset mocks in `beforeEach`" — `mock.module()` cannot be reset in Bun.
+
+**Correct fix: refactor the production code for DI.** When a service depends on other services or configuration, accept them as parameters (constructor or function args) rather than importing a singleton.
 
 ```typescript
 // ❌ mock.module — pollutes other tests, cannot be reset
@@ -167,36 +79,11 @@ export async function deleteWorktree(
 const result = await deleteWorktree(params, { worktreeService: mockService, ... });
 ```
 
-### 3. Private Method Testing
-
-Attempting to test internal/private methods directly.
-
-**Better approach:**
-- Test through public interface
-- If private method is complex enough to test, consider extracting to a separate module
-
-### 4. Boundary Testing Gaps
-
-Missing client-server boundary tests for forms.
-
-**Catches:**
-- `null` vs `undefined` mismatches
-- JSON serialization issues
-- Schema validation mismatches
-
-### 5. Form Testing Gaps
-
-Schema unit tests only (insufficient).
-
-**Required:**
-- Actual form interaction tests
-- Conditional field tests (hidden fields don't block submission)
-- Empty default value handling
-- Validation error message verification
+Route handler tests in this repository use `createTestContext()` or `asAppContext()` to inject mocks without `mock.module()`.
 
 ## Form Component Testing
 
-Forms using React Hook Form + Valibot require component-level tests.
+Forms using React Hook Form + Valibot need component-level tests beyond schema unit tests.
 
 ### Test Conditional Fields When Hidden
 
@@ -219,13 +106,13 @@ it('should show validation error when submitting with empty default', async () =
 });
 ```
 
-### Verify Error Messages
+### Verify Error Message Content (not just existence)
 
 ```typescript
 // ❌ Insufficient: only checks error existence
 expect(screen.getByRole('alert')).toBeTruthy();
 
-// ✅ Correct: verifies message content
+// ✅ Correct: verifies the message text
 expect(screen.getByText('Branch name is required')).toBeTruthy();
 ```
 
@@ -238,11 +125,9 @@ it('should NOT call onSubmit when validation fails', async () => {
 });
 ```
 
-## Client-Server Boundary Testing
+## Client-Server Boundary Testing — Server Bridge Pattern
 
-Test that client sends correct data AND server accepts it correctly.
-
-### Why It Matters
+The bug this pattern catches:
 
 ```typescript
 // Bug: undefined is omitted in JSON
@@ -251,9 +136,9 @@ activityPatterns: askingPatterns ? { askingPatterns } : undefined
 // Server receives nothing, keeps old value instead of clearing
 ```
 
-Unit tests on client or server alone cannot catch this.
+Unit tests on either client or server alone cannot catch this — the bug lives in the serialization boundary.
 
-### Server Bridge Pattern
+### Pattern
 
 ```typescript
 describe('Client-Server Boundary', () => {
@@ -281,26 +166,4 @@ describe('Client-Server Boundary', () => {
 });
 ```
 
-## Test Strategy: Unit vs Integration Responsibilities
-
-**Unit test exhaustiveness vs integration test connectivity — these are separate responsibilities.**
-- **Unit tests**: Each component must exhaustively cover all patterns defined in the spec. A parser must test all event types. A handler must test all supported event types.
-- **Integration tests**: Verify pipeline connectivity (e.g., parser → job handler → handler) with 1-2 representative events. Exhaustive coverage is the unit test's job — do not duplicate it in integration tests.
-- These responsibilities must not be confused.
-
-## Test File Naming Convention
-
-### Test File Naming Convention
-- Test files MUST be named after the production file they test: `foo-bar.ts` → `__tests__/foo-bar.test.ts`
-- Place test files in the `__tests__/` directory at the same level as the production file
-- The acceptance-check script verifies this convention — misnamed test files will be flagged
-
-## Pre-Implementation Checklist
-
-Before writing tests, verify:
-
-- [ ] Importing production code directly (not duplicating logic)
-- [ ] Testing through public interface (not private methods)
-- [ ] Mocking at lowest level (fetch, WebSocket, not modules)
-- [ ] Not following existing bad patterns blindly
-- [ ] Not changing production code just for testing without discussion
+This gives you a single test file that exercises the full round-trip: user event → form serialization → HTTP body → server handler → persisted state. If any step drops or mistransforms data, the test fails.


### PR DESCRIPTION
## Summary

- Defines the rule/skill responsibility boundary in a new `.claude/README.md`: rules are short declarative auto-loaded files; skills are on-demand procedural detail; no verbatim duplication between the two.
- Resolves a concrete drift: `rules/verification.md` (6 steps) and `skills/development-workflow-standards/development-workflow-standards.md` (5 different steps) disagreed on the pre-push checklist. Two skill-only items (CodeRabbit CLI review; full-suite hard rule for production changes) are folded into the rule as the canonical form.
- Strips rule-duplicated content from four skill sub-files (backend / frontend×2 / test / workflow), preserving code examples and procedural detail that do not fit in a rule.
- Adds a grep-based invariant check (`rule-skill-duplication-check.js`) wired into `preflight-check.js` so CI flags future drift automatically.

Closes #651.

## Motivation

Sprint 2026-04-17 discovered that `bun run lint` was documented in two places with the same text, and both copies were fiction — the command actually did nothing at the time. The duplication hid the fact that nobody had verified either copy. Follow-up inspection revealed the same pattern across backend / frontend / test / workflow standards, plus an active drift in the verification checklist.

This PR codifies the invariant, resolves the known drift, and adds a check that prevents the pattern from recurring.

## Approach (per Claude Code official best practices)

Researched the official Claude Code skill documentation before finalizing. Key findings applied:

- **Skills may use `SKILL.md` as a router** and place content in sibling `.md` files. `frontend-standards/` retains two sub-files (`frontend-standards.md` for agent-console-specific patterns, `react-patterns.md` for generic React) — the two are now non-overlapping.
- **Rules are auto-loaded; skills are on-demand.** Short declarative content stays in rules. Long procedural content moves to skills. Cross-reference direction is skill → rule only (rules must be self-contained).
- **No verbatim duplication.** The new grep check enforces this.

## Files

- `.claude/README.md` — new. Boundary definition.
- `.claude/rules/verification.md` — drift resolution (add CodeRabbit step, add hard rule).
- `.claude/skills/{backend,frontend,test,development-workflow}-standards/*.md` — stripped of rule duplicates.
- `.claude/skills/{backend,frontend}-standards/SKILL.md` — router descriptions refreshed.
- `.claude/skills/orchestrator/rule-skill-duplication-check.js` — new grep-based invariant check.
- `.claude/skills/orchestrator/preflight-check.js` — invokes the duplication check; exits non-zero on violation.

## Test plan

- [x] `node .claude/skills/orchestrator/rule-skill-duplication-check.js` — exits 0 locally, zero violations after this PR's cleanup.
- [x] `node .claude/skills/orchestrator/preflight-check.js` — exits 0 locally with combined coverage + duplication check.
- [ ] CI passes (`test`, `check-structure`, `coverage-check` now also runs the duplication invariant).
- [ ] Manual: confirm the new `rules/verification.md` checklist is the single source of truth and matches the skill cross-reference at the top of `development-workflow-standards.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)