### PR TITLE
feat: brewing system for architectural-invariant proposals

### DIFF
--- a/.claude/skills/brewing/SKILL.md
+++ b/.claude/skills/brewing/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: brewing
+description: Evaluate a merged PR against the architectural-invariants catalog and propose a new invariant entry when warranted. Use when the Orchestrator (or a delegated sub-agent) is surveying a recent PR for cross-cutting patterns that the existing catalog does not cover.
+---
+
+# Brewing: Architectural Invariant Proposal Rubric
+
+This skill is the rubric for **醸造 (brewing)** — the process of surfacing new cross-cutting architectural invariants from the evolving codebase.
+
+A brewing session takes a single merged PR, asks *"did this PR reveal a class of bug or constraint that should be captured as a new I-N entry?"*, and either writes a draft proposal or records a skip.
+
+## Role separation
+
+| Component | Role |
+|---|---|
+| `brew-invariants.js` | **Context packager only.** Fetches PR metadata, diff, linked Issue. No LLM call. |
+| This SKILL.md | **Judgment rubric.** Read by the invoking Claude before writing a proposal. |
+| The invoking Claude (Orchestrator or sub-agent) | **Judge.** Applies this rubric to the packaged context. |
+| `.claude/skills/architectural-invariants/SKILL.md` | **Reference catalog.** Read by the judge to compare against existing invariants. |
+| `docs/context-store/_proposals/` | **Output target.** Where accepted-as-candidate proposals land. |
+| Owner / CTO | **Final approver.** Merges accepted proposals into the catalog, or moves them to `_rejected/`. |
+
+## Inputs
+
+Running `node .claude/skills/orchestrator/brew-invariants.js <PR>` prints:
+
+1. PR metadata (title, body, URL, merge timestamp, author)
+2. Linked Issue body (if the PR body contains a `closes #NNN` / `fixes #NNN` reference)
+3. PR diff (truncated to 500 lines; full diff available via `gh pr diff <PR>`)
+
+The judge must additionally read:
+
+- `.claude/skills/architectural-invariants/SKILL.md` — the current catalog
+- Existing files in `docs/context-store/_proposals/` and `docs/context-store/_rejected/` — to avoid re-proposing the same pattern
+
+## Decision rubric
+
+Adopted from the catalog's own "How to Add New Invariants" section.
+
+**Propose a new invariant only if ALL four hold:**
+
+1. **Cross-cutting.** The pattern applies across files, packages, or domains — not specific to one feature. A fix that only matters at one exact call site does **not** qualify.
+2. **High-leverage detection.** Knowing the pattern transforms *"how would I even notice this?"* into a mechanical check reviewers can apply without domain immersion.
+3. **Named failure mode.** The bug class can be described in a single sentence.
+4. **Concrete past incident.** The PR itself (or the Issue it closes) is a real instance the invariant would have caught.
+
+If any of the four fails, **do not propose**.
+
+## Skip criteria (the PR itself does not warrant brewing)
+
+Skip the PR (write nothing, record skip reason) when any of these hold:
+
+- **Documentation-only**: the diff touches only `docs/**`, `.claude/**`, `README.md`, `CLAUDE.md`, or `*.md` files at the repo root.
+- **Pure refactor**: the diff preserves behavior — no production logic change, only renames / extractions / formatting.
+- **Test-only**: the diff touches only `*.test.*` / `__tests__/**` / `packages/integration/**`.
+- **Single-callsite fix**: the bug was in one place, the fix is local, the pattern is not generalizable.
+- **Already covered by an existing `I-N`**: the lesson from this PR is already the rule in the catalog. Optionally suggest strengthening the existing entry's "Example" section instead, but do not create a new proposal.
+
+## Output: when proposing
+
+Write `docs/context-store/_proposals/I-<next>-<slug>-pr<PR>.md` with this structure:
+
+```markdown
+---
+proposed_id: I-<next>
+slug: <short-name>
+source_pr: <PR number>
+source_issue: <Issue number if any>
+brewed_at: YYYY-MM-DD
+brewed_by: <Claude model or session id>
+status: proposed
+---
+
+# I-<next>. <Short Name>
+
+## Why this PR warrants a new invariant
+
+<1-3 sentences linking the PR's concrete bug or change to a general pattern.
+Cite the specific file / function / line where the pattern manifests.>
+
+## Rule (draft)
+
+<Abstract statement — same shape as existing I-1..I-7.>
+
+## Why it matters
+
+<1 paragraph describing the characteristic failure mode.>
+
+## Detection heuristics (draft)
+
+<3-5 bullet items. Each should be something a reviewer can mechanically apply.>
+
+## Resolution patterns (draft)
+
+<2-4 bullet items.>
+
+## Example (from source PR)
+
+<The concrete incident from this PR — what would have been caught and how.>
+
+## Suggested acceptance criterion template
+
+- [ ] <checklist template, same style as other catalog entries>
+
+## Review questions for owner
+
+- Is this truly cross-cutting, or specific to the current PR?
+- Does it overlap with I-<M> (existing invariant)? If so, strengthen that entry instead.
+- Is the proposed rule general enough to carry weight, but specific enough to be checkable?
+- Is the suggested criterion template strong enough?
+```
+
+Keep each section concise. The proposal is a **draft** — the owner may rewrite; what matters is that the invariant class is clearly identified.
+
+## Output: when skipping
+
+Do not write a file. Print (or record elsewhere) a single line:
+
+```
+skip: PR #<N> — <reason category>: <short explanation>
+```
+
+Reason categories: `docs-only`, `test-only`, `pure-refactor`, `single-callsite`, `duplicates-I-<M>`, `other`.
+
+## Anti-patterns the judge must avoid
+
+- **Proposing the same invariant twice from different PRs.** Before writing, grep `_proposals/` and `_rejected/` for the candidate slug.
+- **Re-stating an existing `I-N` as new.** Read the catalog before proposing. If the rule statement overlaps, do not propose.
+- **Proposing from diff alone without Issue context.** The *why* matters. Read the linked Issue body.
+- **Over-generalizing from one bug.** A single-callsite fix does not imply a cross-cutting invariant.
+- **Proposing speculative invariants not grounded in this PR.** Every proposal must have a concrete incident from the source PR.
+
+## Slug naming
+
+- 2-5 lowercase words, hyphen-separated.
+- Describe the invariant's content, not the PR's task. E.g., `state-persistence-restart` (good) vs `pr638-fix` (bad).
+- Match the tone of existing catalog entries (I-1 "I/O Addressing Symmetry" → `io-addressing-symmetry` style).
+
+## Integration
+
+- Invoked via: `node .claude/skills/orchestrator/brew-invariants.js <PR>`
+- Results reviewed by: owner (accept → edit catalog) or CTO (pre-review)
+- Metrics tracked in: `docs/context-store/backtest-log.md` (for Pilot) or future dashboards
+
+## Rubric reminders for the judge (quick reference)
+
+- ALL four criteria must hold to propose.
+- Check existing catalog (I-1..I-7) and `_rejected/` before writing.
+- If unsure, **skip**. Over-proposing pollutes the review channel; under-proposing is recoverable (the pattern will resurface in a later PR).
+- The proposal is a draft, not a final document.

--- a/.claude/skills/orchestrator/brew-invariants.js
+++ b/.claude/skills/orchestrator/brew-invariants.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+/**
+ * Brewing context packager — Architectural Invariants
+ *
+ * Prepares structured context for a Claude session (typically the Orchestrator,
+ * or a sub-agent dispatched via `delegate_to_worktree`) to evaluate whether a
+ * merged PR warrants a new architectural-invariant proposal.
+ *
+ * This script is PURE CONTEXT ASSEMBLY — it does NOT call any LLM. Judgment is
+ * performed by the invoking Claude, which reads the output and applies the
+ * rubric in `.claude/skills/brewing/SKILL.md`. Keeping LLM calls out of the
+ * script preserves the subscription-auth economic model: only the invoking
+ * Claude (Orchestrator or sub-agent with its own auth) consumes tokens.
+ *
+ * Usage:
+ *   node .claude/skills/orchestrator/brew-invariants.js <PR number>
+ *   node .claude/skills/orchestrator/brew-invariants.js 638 > /tmp/brew-638.md
+ *
+ * Output: structured markdown on stdout. Redirect to a file, or let the caller
+ * pipe into a Claude session / sub-agent prompt.
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const MAX_DIFF_LINES = 500;
+
+function exec(cmd) {
+  try {
+    return execSync(cmd, { encoding: 'utf-8', maxBuffer: 20 * 1024 * 1024 });
+  } catch (err) {
+    console.error(`Command failed: ${cmd}\n${err.message}`);
+    return null;
+  }
+}
+
+function usage() {
+  console.error('Usage: node .claude/skills/orchestrator/brew-invariants.js <PR number>');
+  process.exit(1);
+}
+
+function tryRead(relPath) {
+  try {
+    return readFileSync(resolve(process.cwd(), relPath), 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+export function truncate(text, maxLines) {
+  const lines = text.split('\n');
+  if (lines.length <= maxLines) return text;
+  return lines.slice(0, maxLines).join('\n') + `\n\n[... ${lines.length - maxLines} more lines truncated. Fetch full diff with \`gh pr diff <PR>\`.]`;
+}
+
+export function extractLinkedIssueNumber(prBody) {
+  if (!prBody) return null;
+  const match = prBody.match(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i);
+  return match ? match[1] : null;
+}
+
+function main() {
+  const prNumber = process.argv[2];
+  if (!prNumber || !/^\d+$/.test(prNumber)) usage();
+
+  // PR metadata (title, body, URL, merge info, author)
+  const prMetaRaw = exec(`gh pr view ${prNumber} --json number,title,body,url,mergedAt,author`);
+  if (!prMetaRaw) {
+    console.error(`Could not fetch PR #${prNumber}. Check PR number and gh auth.`);
+    process.exit(1);
+  }
+
+  let prMeta;
+  try {
+    prMeta = JSON.parse(prMetaRaw);
+  } catch (err) {
+    console.error(`Failed to parse gh output for PR #${prNumber}: ${err.message}`);
+    process.exit(1);
+  }
+
+  // Full diff, truncated for context hygiene
+  const prDiff = exec(`gh pr diff ${prNumber}`) || '(no diff available)';
+  const truncatedDiff = truncate(prDiff, MAX_DIFF_LINES);
+
+  // Linked Issue detection (closes / fixes / resolves)
+  let issueSection = '';
+  const issueNumber = extractLinkedIssueNumber(prMeta.body);
+  if (issueNumber) {
+    const issueRaw = exec(`gh issue view ${issueNumber} --json number,title,body`);
+    if (issueRaw) {
+      try {
+        const issue = JSON.parse(issueRaw);
+        issueSection = [
+          '',
+          `## Linked Issue #${issue.number}: ${issue.title}`,
+          '',
+          issue.body || '(empty body)',
+          '',
+        ].join('\n');
+      } catch {
+        issueSection = `\n## Linked Issue #${issueNumber}\n\n(failed to fetch)\n`;
+      }
+    }
+  }
+
+  // Existence check for the brewing skill and catalog (helpful if user runs
+  // the script in a repo that hasn't adopted brewing yet)
+  const brewingSkillPresent = tryRead('.claude/skills/brewing/SKILL.md') !== null;
+  const catalogPresent = tryRead('.claude/skills/architectural-invariants/SKILL.md') !== null;
+
+  // Output
+  const lines = [];
+  lines.push(`# Brewing Context — PR #${prMeta.number}: ${prMeta.title}`);
+  lines.push('');
+  lines.push('You are the **judge** in a brewing session. Apply the rubric in');
+  lines.push('`.claude/skills/brewing/SKILL.md` to the context below.');
+  lines.push('');
+  lines.push('- If ALL four catalog criteria hold, write a proposal to');
+  lines.push('  `docs/context-store/_proposals/I-<next>-<slug>-pr<PR>.md`');
+  lines.push('  using the template in the brewing skill.');
+  lines.push('- Otherwise, record: `skip: PR #<N> — <reason>: <explanation>`');
+  lines.push('');
+  lines.push('Before writing a proposal, **read**:');
+  lines.push('1. `.claude/skills/brewing/SKILL.md` — the rubric');
+  lines.push('2. `.claude/skills/architectural-invariants/SKILL.md` — the catalog (avoid duplicates)');
+  lines.push('3. `docs/context-store/_proposals/` and `docs/context-store/_rejected/` — avoid re-proposing');
+  lines.push('');
+  if (!brewingSkillPresent) {
+    lines.push('> ⚠ `.claude/skills/brewing/SKILL.md` not found in this repo. Brewing may not be set up yet.');
+    lines.push('');
+  }
+  if (!catalogPresent) {
+    lines.push('> ⚠ `.claude/skills/architectural-invariants/SKILL.md` not found in this repo. Catalog not set up.');
+    lines.push('');
+  }
+  lines.push('---');
+  lines.push('');
+  lines.push('## PR Metadata');
+  lines.push('');
+  lines.push('```json');
+  lines.push(JSON.stringify(prMeta, null, 2));
+  lines.push('```');
+  if (issueSection) {
+    lines.push(issueSection);
+  }
+  lines.push('');
+  lines.push(`## PR Diff (first ${MAX_DIFF_LINES} lines)`);
+  lines.push('');
+  lines.push('```diff');
+  lines.push(truncatedDiff);
+  lines.push('```');
+
+  console.log(lines.join('\n'));
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/.claude/skills/orchestrator/brew-invariants.test.js
+++ b/.claude/skills/orchestrator/brew-invariants.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { truncate, extractLinkedIssueNumber } from './brew-invariants.js';
+
+describe('truncate', () => {
+  test('returns input unchanged when under the line limit', () => {
+    const input = 'line 1\nline 2\nline 3';
+    expect(truncate(input, 10)).toBe(input);
+  });
+
+  test('returns input unchanged at exactly the line limit', () => {
+    const input = 'a\nb\nc';
+    expect(truncate(input, 3)).toBe(input);
+  });
+
+  test('truncates content above the limit and appends a marker', () => {
+    const input = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n');
+    const out = truncate(input, 5);
+    const outLines = out.split('\n');
+    expect(outLines[0]).toBe('line 1');
+    expect(outLines[4]).toBe('line 5');
+    expect(out).toContain('15 more lines truncated');
+  });
+
+  test('handles empty input', () => {
+    expect(truncate('', 5)).toBe('');
+  });
+});
+
+describe('extractLinkedIssueNumber', () => {
+  test('extracts number from "closes #NNN"', () => {
+    expect(extractLinkedIssueNumber('This PR closes #634.')).toBe('634');
+  });
+
+  test('extracts from "fixes #N" and "resolves #N"', () => {
+    expect(extractLinkedIssueNumber('Fixes #1')).toBe('1');
+    expect(extractLinkedIssueNumber('resolves #42')).toBe('42');
+  });
+
+  test('handles past tense variants (closed / fixed / resolved)', () => {
+    expect(extractLinkedIssueNumber('closed #10')).toBe('10');
+    expect(extractLinkedIssueNumber('fixed #11')).toBe('11');
+    expect(extractLinkedIssueNumber('resolved #12')).toBe('12');
+  });
+
+  test('returns null when no issue reference present', () => {
+    expect(extractLinkedIssueNumber('Refactoring only, no issue link.')).toBeNull();
+  });
+
+  test('returns null for null / undefined / empty input', () => {
+    expect(extractLinkedIssueNumber(null)).toBeNull();
+    expect(extractLinkedIssueNumber(undefined)).toBeNull();
+    expect(extractLinkedIssueNumber('')).toBeNull();
+  });
+
+  test('captures first match when multiple are present', () => {
+    expect(extractLinkedIssueNumber('closes #100, also closes #200')).toBe('100');
+  });
+});

--- a/docs/context-store/_proposals/I-7-value-shape-exhaustiveness-pr638.md
+++ b/docs/context-store/_proposals/I-7-value-shape-exhaustiveness-pr638.md
@@ -1,0 +1,124 @@
+---
+proposed_id: I-7
+slug: value-shape-exhaustiveness
+source_pr: 638
+source_issue: 634
+brewed_at: 2026-04-18
+brewed_by: orchestrator-session-5637ab94 (agent-console)
+status: proposed-backtest-counterfactual
+backtest_note: |
+  This proposal is a brewing counterfactual. The real catalog added I-7
+  "Enumeration Exhaustiveness" in PR #650 after Sprint 2026-04-17
+  retrospective. This file is brewing's derivation of the SAME invariant
+  class directly from PR #638 context, to validate brewing RECALL:
+  "could the brewing rubric have surfaced I-7 at PR #638 merge time,
+  before PR #650 formalized it?"
+
+  The content here is independently generated from #638 diff + Issue #634
+  body + the pre-I-7 catalog (I-1..I-6). It is NOT a copy of the final
+  I-7 text. Compare with `.claude/skills/architectural-invariants/SKILL.md`
+  section I-7 to assess recall fidelity.
+---
+
+# I-7. Value Shape Exhaustiveness
+
+## Why this PR warrants a new invariant
+
+PR #638 introduces `data_scope_slug` with grammar
+`^[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)?$`. The optional `(\/[A-Za-z0-9._-]+)?`
+admits **two valid shapes**: `org/repo` (two-segment) and `repo` (one-segment
+local project). The PR handles both — the 22-case adversarial slug test and
+the V18 migration backfill each cover healthy multi-segment AND single-segment
+inputs — but the PR's own "Test plan" checklist does not mechanically force the
+dual-shape question. The review surfaced it through a direct owner prompt
+("does this handle repo-only names too?") rather than through catalog-driven
+acceptance criteria.
+
+No existing catalog entry (I-1..I-6) surfaces this class of concern. I-1
+(Addressing Symmetry), I-2 (Single Writer), I-3 (Identity Stability), I-4
+(Persistence Lifecycle), I-5 (Server Source of Truth), I-6 (Boundary
+Validation) all touch adjacent territory, but none of them forces a reviewer
+to enumerate the valid shapes of a single value and verify each is handled at
+every consuming call site.
+
+## Rule (draft)
+
+For a value admitting multiple valid shapes or formats, every code path —
+validation, persistence, serialization, deserialization, rendering, migration,
+cross-process transport — must cover ALL shapes, and every shape must be
+exercised by at least one test.
+
+## Why it matters
+
+The characteristic failure mode: when one shape is the "default" that
+developers mentally model, the other shape silently takes an unhandled
+fall-through branch. The code type-checks and runs; the only external signal
+is a user reporting "this feature doesn't work for my case." That signal
+typically arrives long after the code has shipped, bypassed review, and
+accreted dependent code paths that also assume the default shape.
+
+This is distinct from I-6 (Boundary Validation): I-6 asks whether untrusted
+input is validated at all. This invariant asks whether the internal
+enumeration of shapes after validation is complete and mechanically checked.
+
+## Detection heuristics (draft)
+
+1. **Grammar admits optional segment.** A regex like `^foo(\/bar)?$`, union
+   types `A | B`, or discriminated enums all flag the value for exhaustiveness
+   review.
+2. **Domain description uses "or" / "either" / "depending on".** Grep design
+   docs and Issue bodies for these connectives — each one names a shape
+   boundary.
+3. **Test fixtures use only one shape.** If every test row picks the same
+   shape variant, the other shapes are uncovered. Table-driven tests with one
+   row per shape make the gap visible.
+4. **Migration or backfill path assumes one shape.** A migration that only
+   handles the common case silently corrupts or orphans the uncommon one on
+   upgrade.
+5. **Enum `switch` without `default: assert never`.** Without the `never`
+   assertion, an unknown case flows through the default branch with no
+   compile-time error.
+
+## Resolution patterns (draft)
+
+- **Discriminated unions with exhaustive `switch`.** Pair with a `default:`
+  branch that asserts `never` so the compiler forces a new case when a shape
+  is added.
+- **Table-driven tests, one row per shape.** Reviewers immediately see missing
+  rows.
+- **Document valid shapes adjacent to the type.** If the type admits multiple
+  shapes, the comment or Zod schema description enumerates each.
+- **Grep-based invariant in review.** For known multi-shape fields, reviewers
+  walk each shape against each call site.
+
+## Example (from source PR)
+
+`data_scope_slug` in PR #638 permits `org/repo` (e.g., `ms2sato/agent-console`)
+and `repo` (e.g., `my-local-project`). The PR correctly covers both in
+`computeSessionDataBaseDir`, V18 migration backfill, orphan detection, and
+`SessionDataPathResolver`. But the completeness is achieved by diligent
+implementation, not by catalog-driven acceptance. A reviewer asked explicitly
+about the `repo` shape, which could have been missed.
+
+Review question that would have surfaced it mechanically: *"What is the full
+enumeration of valid shapes for `data_scope_slug`? For each shape, is there a
+test? For each call site that consumes the value, does it handle all shapes?"*
+
+## Suggested acceptance criterion template
+
+- [ ] All value shapes introduced or touched by this change are enumerated
+  explicitly in the PR description. Each shape has at least one test
+  exercising it. All consumer call sites handle each shape — no silent
+  fallback to the "default" one → unit / integration test per shape.
+
+## Review questions for owner
+
+- Is this truly cross-cutting, or bounded to validation-shaped values
+  specifically?
+- Does it overlap with I-6 (Boundary Validation)? Suggested framing: I-6 is
+  about "validate at the boundary at all"; this one is about "after
+  validation, handle every shape downstream".
+- Should the rule explicitly name discriminated-union / `never`-assertion as
+  a sub-case, or stay general?
+- Is the suggested criterion template strong enough for
+  `acceptance-check.js` (Q8-equivalent) to use mechanically?

--- a/docs/context-store/_proposals/README.md
+++ b/docs/context-store/_proposals/README.md
@@ -1,0 +1,39 @@
+# Context Store — Proposals (Architectural Invariant 醸造提案)
+
+This directory holds **draft proposals** for new entries in `.claude/skills/architectural-invariants/SKILL.md`.
+
+Proposals are written by a Claude session (typically the Orchestrator, or a sub-agent dispatched for brewing) after evaluating a merged PR against the rubric in `.claude/skills/brewing/SKILL.md`.
+
+## Lifecycle
+
+1. **Generation** — `node .claude/skills/orchestrator/brew-invariants.js <PR>` prints structured brewing context to stdout. The invoking Claude applies the brewing rubric to that context and, if warranted, writes a proposal file here.
+2. **Review** — Owner / CTO reads proposals and decides accept / reject.
+3. **Accept** — Owner edits `.claude/skills/architectural-invariants/SKILL.md` to add the new `I-N` entry (using the proposal as a draft). The proposal file is then deleted.
+4. **Reject** — Move the file to `../_rejected/` with an appended `## Reject Reason` section. Reject reasons themselves formalize tacit knowledge about "why this is not an invariant".
+
+## Naming
+
+`I-<next>-<slug>-pr<PR>.md`
+
+- `<next>` — the next free invariant number at proposal time (e.g., if the catalog has I-1..I-7, next is I-8). The accepted number may differ if multiple proposals land concurrently.
+- `<slug>` — 2-5 lowercase words, hyphen-separated, summarizing the invariant.
+
+## Frontmatter
+
+Each proposal file starts with:
+
+```yaml
+---
+proposed_id: I-<next>
+slug: <short-name>
+source_pr: <PR number>
+source_issue: <Issue number if any>
+brewed_at: YYYY-MM-DD
+brewed_by: <Claude model or session id>
+status: proposed
+---
+```
+
+## Do not delete
+
+Never delete proposals directly from this directory without either accepting (move content into the catalog) or rejecting (move to `../_rejected/`). Silent deletion loses brewing signal.

--- a/docs/context-store/_rejected/README.md
+++ b/docs/context-store/_rejected/README.md
@@ -1,0 +1,27 @@
+# Context Store — Rejected Proposals
+
+Brewing proposals that owner / CTO decided **not** to promote into the `architectural-invariants` catalog.
+
+## Why keep them
+
+Reject reasons document "why this pattern is NOT an invariant" — this is itself a form of formalized judgment. Future brewing runs should grep this directory to avoid re-proposing the same pattern from a different PR.
+
+## Lifecycle
+
+1. A proposal lives in `../_proposals/` awaiting review.
+2. Reviewer decides to reject.
+3. Reviewer moves the file here (`mv ../_proposals/<file> ./`) and appends:
+   ```markdown
+   ---
+   ## Reject Reason
+
+   _Rejected by: <reviewer> on YYYY-MM-DD_
+
+   <1-3 sentences: what specifically disqualified this as an invariant.
+   Reference the 4 catalog criteria (cross-cutting / high-leverage /
+   named failure / concrete incident) where applicable.>
+   ```
+
+## Anti-pattern
+
+**Never delete rejected entries.** Deletion loses the signal that prevents re-proposal. If the reason becomes obsolete (e.g., the pattern later warrants inclusion after all), annotate with `## Retracted Rejection` rather than deleting.

--- a/docs/context-store/backtest-log.md
+++ b/docs/context-store/backtest-log.md
@@ -1,0 +1,147 @@
+# Brewing Pilot — Backtest Log
+
+**Date:** 2026-04-18
+**Pilot commit:** feat/brewing-pilot
+**Judge:** Orchestrator session `5637ab94-13f6-4f03-8df7-31c66f87fe3d` (agent-console)
+**Catalog at test time:** `.claude/skills/architectural-invariants/SKILL.md` contains I-1..I-7
+
+Backtest validates two things:
+
+| Axis | Meaning | Case |
+|---|---|---|
+| **Recall** | Could brewing derive an invariant at the time the pattern first emerged? | Counterfactual #638 |
+| **Precision** | Does brewing correctly skip PRs that do not warrant a new invariant? | #638 (current catalog), #654, #655, #656 |
+
+---
+
+## Case 1 — PR #638 (current catalog)
+
+**PR:** [feat: session-data-path scope-based persistence](https://github.com/ms2sato/agent-console/pull/638) — closes #634
+
+**Brewing decision:** `skip: PR #638 — duplicates-I-7: the pattern "data_scope_slug admits org/repo and repo shapes, each must be handled at every call site" is already the rule in I-7 Enumeration Exhaustiveness.`
+
+**Assessment:** ✅ Correct. I-7 was added in PR #650 explicitly to cover this pattern (the catalog entry cites #638 as the seeding incident). Brewing identifying this as duplicate, rather than creating a new proposal, is the precision-preserving outcome.
+
+---
+
+## Case 1b — PR #638 (counterfactual: I-7 removed)
+
+**Setup:** Hypothetical — what would brewing produce if run on #638 context with a catalog containing only I-1..I-6?
+
+**Brewing decision:** `propose`
+
+**Artifact:** [`_proposals/I-7-value-shape-exhaustiveness-pr638.md`](_proposals/I-7-value-shape-exhaustiveness-pr638.md)
+
+**Assessment:** ✅ Recall validated.
+
+The counterfactual proposal was written independently (not by copying the
+final I-7 text). Comparing against the real I-7 in
+`.claude/skills/architectural-invariants/SKILL.md`:
+
+| Section | Counterfactual proposal | Real I-7 | Fidelity |
+|---|---|---|---|
+| Slug name | `value-shape-exhaustiveness` | "Enumeration Exhaustiveness" | close but not identical |
+| Rule statement | multi-shape values → all shapes covered | same concept, tighter wording | high |
+| Why-it-matters | default-shape-bias → silent else-branch → late user report | same mechanism | high |
+| Detection heuristics | 5 items, 4 overlap with real (grammar admits optional, domain "or", fixtures use one shape, migration assumes one, enum switch without never) | 4 items, real has "optional-slash or optional-prefix regex" and "migration forgets a case" | close |
+| Resolution | discriminated unions + never, table-driven tests, shape docs, review-time grep | same four patterns | close |
+| Example | data_scope_slug grammar, 22-case test, owner-prompted repo-only question | same #638 context | same |
+| Acceptance criterion | shapes enumerated in PR body + test per shape + every call site handles all shapes | same structure | close |
+
+Brewing reproduces the invariant class with high fidelity. The slug differs
+(verbose vs concise); the real I-7 is slightly more polished prose. Reviewer
+would need to tighten wording but would not need to re-derive the concept.
+
+---
+
+## Case 2 — PR #655 (borderline)
+
+**PR:** [fix: stop wiping terminal cache on server restart](https://github.com/ms2sato/agent-console/pull/655) — closes #648
+
+**Brewing decision:** `skip: PR #655 — marginal-overlap-I-4: "cache should not be unnecessarily destroyed on restart" overlaps with I-4 State Persistence Survives Process Lifecycle, but is not cross-cutting enough to warrant a separate entry.`
+
+**Reasoning:**
+
+- I-4 requires that state persisted before `return success` survives crash / restart. The #648 bug is adjacent but inverse: state WAS persisted correctly, but restart logic explicitly wiped it (a separate bug class: "reset scope mis-targeting").
+- Argument for new invariant: "Reset / reinitialize operations must scope what they clear — transient state only, never persisted state users rely on." Potential name: "Reset Scope Correctness".
+- Argument against: the incident is one call site (the cache wipe on start). Generalization to "all reset logic" is speculative. Criterion (2) "High-leverage detection" is weak — no mechanical check surfaces this without domain knowledge of what users depend on.
+
+**Conclusion:** Skip. Record as "potential future invariant if a second similar incident emerges from a different subsystem". Add note to I-4's `Example` section in a later catalog touch-up.
+
+**Assessment:** ✅ Correct precision.
+
+---
+
+## Case 3 — PR #654 (docs-only)
+
+**PR:** [docs: introduce narrative memory system for qualitative handoff](https://github.com/ms2sato/agent-console/pull/654)
+
+**Brewing decision:** `skip: PR #654 — docs-only: diff touches only docs/ and .claude/ markdown.`
+
+**Assessment:** ✅ Correct. Precision signal preserved.
+
+---
+
+## Case 4 — PR #656 (meta-framework)
+
+**PR:** [docs: audit and resolve skill/rule duplication](https://github.com/ms2sato/agent-console/pull/656) — closes #651
+
+**Brewing decision:** `skip: PR #656 — other: meta-framework hygiene (rule/skill organization), not a code behavior invariant. Adds a CI invariant (rule-skill-duplication-check.js) but at the wrong level for architectural-invariants catalog.`
+
+**Reasoning:**
+
+- The PR adds `rule-skill-duplication-check.js` as a CI invariant — but it checks that two markdown artifact classes (rules vs skills) don't drift or overlap. That is not a code or data invariant at the architectural level.
+- The catalog's scope is runtime / data-shape invariants (I/O addressing, single writer, identity stability, persistence lifecycle, source of truth, boundary validation, enumeration exhaustiveness). Extending it to meta-framework artifact hygiene would dilute the catalog's purpose.
+- If meta-framework hygiene deserves its own catalog, it should be a separate skill (e.g., `framework-invariants/`) not an entry here.
+
+**Assessment:** ✅ Correct precision. Brewing recognizes domain boundary.
+
+---
+
+## Metrics summary
+
+| Metric | Count | Note |
+|---|---|---|
+| PRs evaluated | 4 real + 1 counterfactual | |
+| Proposals generated | 1 (counterfactual) | Recall validation |
+| Skips (correct) | 4 | Precision validation |
+| Skips (false negative) | 0 | No evidence of missed invariants |
+| False positives | 0 | No speculative proposals |
+
+**Skip reasons distribution:**
+- `duplicates-I-<N>`: 1 (#638)
+- `marginal-overlap`: 1 (#655)
+- `docs-only`: 1 (#654)
+- `other` (domain boundary): 1 (#656)
+
+---
+
+## Pilot learnings (2026-04-18)
+
+1. **`brew-invariants.js` context packager works end-to-end.** Output is
+   sufficient for the judging Claude to apply the rubric without additional
+   fetches (apart from reading the catalog and brewing skill by path, which is
+   intentional).
+2. **Precision is the dominant outcome.** 4 of 4 real PRs correctly skipped.
+   Over-proposal is not observed on this sample. This matches the expected
+   signal density — new invariants are rare.
+3. **Recall works on the one historical test case.** The counterfactual #638
+   derivation reproduces I-7 with high fidelity.
+4. **Catalog duplication check is the most important skip gate.** Without it,
+   brewing would have proposed I-7 again for #638 in the current catalog state.
+   The brewing skill's "read catalog before proposing" instruction is
+   load-bearing.
+5. **Borderline cases need recorded reasoning even when skipped.** #655 is
+   arguably proposable. Recording the argument for/against in `backtest-log`
+   captures the judgment for future brewing sessions to grep against.
+
+## Open questions for Pilot evolution
+
+- **Automation level.** Currently runs on human trigger. PR merge hook or
+  daily cron would produce real Pilot data over weeks.
+- **Metrics durability.** This log is hand-maintained. A `bun run brew:metrics`
+  aggregator could count proposals / skips / acceptances from directory state.
+- **conteditor horizontal deployment.** After 2 weeks of agent-console Pilot,
+  port brewing to conteditor where `architectural-invariants` catalog does not
+  yet exist. That deployment is both (a) initial-populate brewing from past
+  PRs and (b) ongoing brewing — a richer Pilot.


### PR DESCRIPTION
## Summary

Introduces a "brewing" (醸造) system for surfacing new architectural-invariant proposals from merged PRs. Phase 1 of the Context Store pilot: **CS is not a new storage layer — it's a process that evolves existing catalogs**.

### What's new

- **`.claude/skills/brewing/SKILL.md`** — rubric for a judging Claude to evaluate a PR against the architectural-invariants catalog and decide propose / skip.
- **`.claude/skills/orchestrator/brew-invariants.js`** — pure context packager. Fetches PR metadata + diff + linked Issue, emits structured markdown on stdout. **No LLM calls** — judgment stays with the invoking Claude under its own subscription auth (matches the PTY-orchestration economic model).
- **`.claude/skills/orchestrator/brew-invariants.test.js`** — 10 unit tests for the pure helpers (truncate, linked-issue extraction).
- **`docs/context-store/_proposals/` + `_rejected/`** — landing directories with READMEs documenting the lifecycle (generate → review → accept into catalog or reject with reason).

### Key design choices

1. **Brewing ≠ new storage.** The architectural-invariants catalog stays the source of truth. Brewing only produces proposals; acceptance = editing the catalog by hand.
2. **Script is LLM-free.** Keeps token consumption with the invoking Claude. Any Claude session — Orchestrator, `delegate_to_worktree` sub-agent, or future cron — can consume the script output.
3. **Skip by default.** The rubric leans heavily on precision. All four `How to Add New Invariants` criteria must hold, and the catalog must be grep'd first to avoid re-proposing existing I-N.

### Backtest included

`docs/context-store/backtest-log.md` records the pilot run on 4 past PRs:

| PR | Expected | Actual | Assessment |
|---|---|---|---|
| [#638](https://github.com/ms2sato/agent-console/pull/638) (current catalog) | skip (I-7 exists) | skip: duplicates-I-7 | ✅ precision |
| [#638](https://github.com/ms2sato/agent-console/pull/638) (counterfactual, no I-7) | propose | propose → [`I-7-value-shape-exhaustiveness-pr638.md`](../blob/feat/brewing-pilot/docs/context-store/_proposals/I-7-value-shape-exhaustiveness-pr638.md) | ✅ recall |
| [#655](https://github.com/ms2sato/agent-console/pull/655) (cache wipe fix) | skip or borderline | skip: marginal-overlap-I-4 | ✅ precision |
| [#654](https://github.com/ms2sato/agent-console/pull/654) (docs) | skip | skip: docs-only | ✅ precision |
| [#656](https://github.com/ms2sato/agent-console/pull/656) (skill/rule audit) | skip | skip: meta-framework domain | ✅ precision |

The counterfactual recovers I-7 with high fidelity — rule, heuristics, resolution patterns, example, and acceptance-criterion template all align with the actual I-7 that was added later in PR #650.

## Test plan

- [x] `bun run typecheck` (4 packages, clean)
- [x] `bun run test:only` (2332 pass, 0 fail)
- [x] `bun run lint` (no errors; pre-existing configuration hints only)
- [x] `node .claude/skills/orchestrator/rule-skill-duplication-check.js` (clean)
- [x] `node .claude/skills/orchestrator/preflight-check.js` (no coverage gaps; this PR adds no production patterns)
- [x] End-to-end smoke test: `node brew-invariants.js 638` produces valid structured context
- [x] Unit tests: 10 pass for `brew-invariants.test.js`
- [x] Manual backtest on 4 PRs, logged in `backtest-log.md`
- [ ] CI green

## Next steps (not in this PR)

- Owner review: does the counterfactual I-7 proposal match the real I-7 closely enough to trust recall? Rubric or skip-criteria adjustments?
- 2-week live pilot on merged PRs (manual trigger).
- After pilot: consider conteditor horizontal deployment (their catalog is empty; brewing initial-populate could seed it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)