### PR TITLE
docs: pin down brewing trigger to Post-Merge Flow §7f

### DIFF
--- a/.claude/skills/brewing/SKILL.md
+++ b/.claude/skills/brewing/SKILL.md
@@ -9,6 +9,16 @@ This skill is the rubric for **醸造 (brewing)** — the process of surfacing n
 
 A brewing session takes a single merged PR, asks *"did this PR reveal a class of bug or constraint that should be captured as a new I-N entry?"*, and either writes a draft proposal or records a skip.
 
+## When to invoke
+
+**Pilot period (2026-04-18 — 2026-05-02):** Run brewing after **every merged PR** in agent-console, as step **7f** of the Orchestrator's Post-Merge Flow (see `.claude/skills/orchestrator/core-responsibilities.md` §7f). This is the current operational contract.
+
+**Outside the Pilot window**: TBD. At Pilot end (2026-05-02), owner and Orchestrator evaluate `docs/context-store/brewing-log.md` and `_proposals/` acceptance rate, then decide: continue as-is, tighten / loosen frequency, or retire.
+
+**Not applicable**:
+- PRs that never reach main (closed / abandoned) — skip entirely
+- Horizontal deployments outside agent-console (e.g., conteditor) — have their own Pilot design, not yet underway
+
 ## Role separation
 
 | Component | Role |
@@ -140,7 +150,7 @@ Reason categories: `docs-only`, `test-only`, `pure-refactor`, `single-callsite`,
 
 - Invoked via: `node .claude/skills/orchestrator/brew-invariants.js <PR>`
 - Results reviewed by: owner (accept → edit catalog) or CTO (pre-review)
-- Metrics tracked in: `docs/context-store/backtest-log.md` (for Pilot) or future dashboards
+- Metrics tracked in: `docs/context-store/brewing-log.md` (§2 Live Pilot Log, updated per §7f invocation) or future dashboards
 
 ## Rubric reminders for the judge (quick reference)
 

--- a/.claude/skills/orchestrator/core-responsibilities.md
+++ b/.claude/skills/orchestrator/core-responsibilities.md
@@ -168,3 +168,26 @@ Only remove worktrees for sessions that have completed their task and whose PR h
 4. After approval, re-invoke `ExitWorktree` with `action: "remove"` and `discard_changes: true`.
 
 This is a recurring interaction between GitHub's squash-merge default and the tool's strict branch-commit comparison. Do not use `discard_changes: true` proactively without owner approval, even when you are sure the content landed.
+
+### 7f. Brewing (Pilot 2026-04-18 — 2026-05-02)
+
+After 7a-7e, run brewing against the just-merged PR:
+
+```bash
+node .claude/skills/orchestrator/brew-invariants.js <merged-PR>
+```
+
+The script prints structured brewing context (PR metadata, linked Issue, diff) to stdout. Read the context, then apply the rubric in `.claude/skills/brewing/SKILL.md`:
+
+- **If all four catalog criteria hold** (cross-cutting / high-leverage / named failure / concrete incident), and no existing I-N in `.claude/skills/architectural-invariants/SKILL.md` covers it: write a proposal to `docs/context-store/_proposals/I-<next>-<slug>-pr<PR>.md`. Notify the owner via `write_memo` or add the PR to the Review Queue.
+- **Otherwise**: append one row to `docs/context-store/brewing-log.md` under the Live Pilot Log section:
+  ```
+  | YYYY-MM-DD | #<PR> | skip | <reason-category>: <short explanation> |
+  ```
+  Reason categories: `docs-only`, `test-only`, `pure-refactor`, `single-callsite`, `duplicates-I-<M>`, `other`.
+
+**Why**: Brewing surfaces candidate architectural invariants from shipped code. Running after merge (not before) ensures the diff is stable and the pattern has actually landed in main. Propagation value: a new invariant added to the catalog protects all subsequent PRs via acceptance-check Q8, not just the PR that surfaced it.
+
+**Pilot end date**: 2026-05-02. At the end of the Pilot, review `brewing-log.md` metrics and `_proposals/` acceptance rate to decide: continue, adjust frequency, or retire.
+
+**Future direction**: Wrap 7a-7c + 7f into a single `post-merge.js` runner for consistency. 7d / 7e remain manual per-session due to state-dependent judgment. Deferred until brewing Pilot stabilizes (post 2026-05-02 review).

--- a/docs/context-store/brewing-log.md
+++ b/docs/context-store/brewing-log.md
@@ -1,7 +1,17 @@
-# Brewing Pilot — Backtest Log
+# Brewing Log
 
-**Date:** 2026-04-18
-**Pilot commit:** feat/brewing-pilot
+Ongoing record of brewing session decisions on merged PRs. Maintained by the Orchestrator as step 7f of the Post-Merge Flow (see `.claude/skills/orchestrator/core-responsibilities.md` §7f).
+
+## Sections
+
+- **§1. Initial Backtest (2026-04-18)** — pre-Pilot validation on 4 historical PRs + 1 counterfactual, establishing precision and recall signals before Live Pilot began.
+- **§2. Live Pilot Log (2026-04-18 — 2026-05-02)** — append one row per merged PR during the Pilot window.
+- **§3. Metrics & Learnings** — populated at Pilot end (2026-05-02).
+
+---
+
+## §1. Initial Backtest (2026-04-18)
+
 **Judge:** Orchestrator session `5637ab94-13f6-4f03-8df7-31c66f87fe3d` (agent-console)
 **Catalog at test time:** `.claude/skills/architectural-invariants/SKILL.md` contains I-1..I-7
 
@@ -132,16 +142,54 @@ would need to tighten wording but would not need to re-derive the concept.
    The brewing skill's "read catalog before proposing" instruction is
    load-bearing.
 5. **Borderline cases need recorded reasoning even when skipped.** #655 is
-   arguably proposable. Recording the argument for/against in `backtest-log`
+   arguably proposable. Recording the argument for/against in the log
    captures the judgment for future brewing sessions to grep against.
 
 ## Open questions for Pilot evolution
 
-- **Automation level.** Currently runs on human trigger. PR merge hook or
-  daily cron would produce real Pilot data over weeks.
+- **Automation level.** Currently runs on human trigger per §7f. PR merge
+  hook or `create_timer` based invocation could produce real Pilot data
+  without Orchestrator intervention.
 - **Metrics durability.** This log is hand-maintained. A `bun run brew:metrics`
   aggregator could count proposals / skips / acceptances from directory state.
-- **conteditor horizontal deployment.** After 2 weeks of agent-console Pilot,
-  port brewing to conteditor where `architectural-invariants` catalog does not
-  yet exist. That deployment is both (a) initial-populate brewing from past
-  PRs and (b) ongoing brewing — a richer Pilot.
+- **conteditor horizontal deployment.** After the agent-console Pilot (ending
+  2026-05-02), port brewing to conteditor where `architectural-invariants`
+  catalog does not yet exist. That deployment is both (a) initial-populate
+  brewing from past PRs and (b) ongoing brewing — a richer Pilot.
+
+---
+
+## §2. Live Pilot Log (2026-04-18 — 2026-05-02)
+
+Append one row per merged agent-console PR brewed during the Pilot window. Reason categories: `docs-only`, `test-only`, `pure-refactor`, `single-callsite`, `duplicates-I-<M>`, `other`.
+
+| Date | PR | Decision | Reason / Link |
+|------|------|------|------|
+| _(first row appended on first Pilot brewing after this PR merges)_ | | | |
+
+For `propose` rows, link to the proposal file in `_proposals/` in the "Reason / Link" column. For `skip` rows, write the reason category and a short explanation.
+
+### Running brewing (reminder)
+
+```bash
+# After each PR merge, as part of Post-Merge Flow step 7f:
+node .claude/skills/orchestrator/brew-invariants.js <merged-PR>
+# Then apply .claude/skills/brewing/SKILL.md rubric and append row below.
+```
+
+---
+
+## §3. Metrics & Learnings (populated at Pilot end, 2026-05-02)
+
+### Counts
+- Total PRs brewed: _TBD_
+- Proposals generated: _TBD_
+- Proposals accepted into catalog: _TBD_
+- Proposals rejected (moved to `_rejected/`): _TBD_
+- Skip distribution: _TBD_
+
+### Qualitative learnings
+_TBD at Pilot end._
+
+### Decision
+_TBD: continue / tighten / loosen / retire._


### PR DESCRIPTION
## Summary

Closes the trigger-documentation gap in PR [#665](https://github.com/ms2sato/agent-console/pull/665) before it merges, so the brewing Pilot does not run empty once the infrastructure lands.

**Stacked on `feat/brewing-pilot`** — auto-retargets to `main` once [#665](https://github.com/ms2sato/agent-console/pull/665) merges.

## What's added

### 1. `core-responsibilities.md` §7f (new subsection)

Wires brewing into the Orchestrator's Post-Merge Flow:

- **When**: after step 7e, for every merged agent-console PR during the Pilot window (2026-04-18 — 2026-05-02)
- **Command**: `node .claude/skills/orchestrator/brew-invariants.js <merged-PR>`
- **Decision branch**: propose → file in `_proposals/`; skip → one-line row in `brewing-log.md` §2 with reason category
- **Pilot end**: 2026-05-02 — review log and decide continue / tighten / loosen / retire
- **Future direction footnote**: eventually 7a-7c + 7f wrap into a `post-merge.js` runner. Deferred until Pilot stabilizes.

### 2. `brewing/SKILL.md` "When to invoke" (new section)

States the Pilot contract explicitly inside the rubric skill so a judging Claude cannot miss it. Covers scope boundaries: abandoned PRs / horizontal deployments are out of scope.

### 3. `backtest-log.md` → `brewing-log.md` (rename + restructure)

`git mv` preserves history. Restructured into three sections:

- **§1 Initial Backtest (2026-04-18)** — existing pre-Pilot validation content
- **§2 Live Pilot Log (2026-04-18 — 2026-05-02)** — table with header ready for per-PR append during the Pilot
- **§3 Metrics & Learnings** — populated at Pilot end

## Why this is separate from #665

#665 ships the brewing infrastructure (skill / script / directories / tests / backtest). This PR ships the operational contract that tells future Orchestrator sessions **when to invoke it**. They split because:

- #665 is self-contained machinery; this PR is workflow integration.
- Owner explicitly requested "A: 新 PR で documentation gap を埋める" rather than amending the existing open PR.
- Stacking keeps each PR's review surface focused.

## Test plan

- [x] `core-responsibilities.md` §7f has clear decision branch and Pilot time-box
- [x] `brewing/SKILL.md` "When to invoke" section is present and cross-linked to §7f
- [x] `brewing-log.md` rename preserved via `git mv` (visible in diff stat as R)
- [x] §2 table has a ready append slot for the first live Pilot entry
- [x] `node .claude/skills/orchestrator/rule-skill-duplication-check.js` clean
- [x] `node .claude/skills/orchestrator/preflight-check.js` clean (no production code changes)
- [x] References to `backtest-log.md` in `brewing/SKILL.md` updated to `brewing-log.md`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)