### PR TITLE
docs: sprint retrospective improvements (2026-04-18)

### DIFF
--- a/.claude/rules/pre-pr-completeness.md
+++ b/.claude/rules/pre-pr-completeness.md
@@ -1,0 +1,43 @@
+# Pre-PR Completeness Gap-Scan
+
+Before opening a PR that introduces a **new skill, script, rule, file type, or canonical procedure**, walk this 4-question mechanical checklist. Each question should take 30 seconds to 2 minutes. If any answer is "unsure", resolve before pushing.
+
+## The four questions
+
+1. **Does a similar existing mechanism already exist?**
+   - `ls` the relevant directories (`.claude/rules/`, `.claude/skills/`, `.claude/skills/orchestrator/`, `scripts/`, `packages/*/src/`)
+   - `grep -r` for keywords from the proposal (concept name, file pattern, command)
+   - Read any file that looks relevant, even briefly
+   - If a similar mechanism exists: is this new thing a genuine extension, a replacement, or a duplicate? Duplicate → stop and reuse. Extension → cross-link. Replacement → document migration.
+2. **Is the invocation or trigger of this new thing documented in a canonical procedure?**
+   - If it is a script or a skill that needs to run at a specific point, find where that point is described (e.g., `core-responsibilities.md §N`, `sprint-lifecycle.md`, or equivalent)
+   - Add the invocation instruction there in the same PR
+   - A future Orchestrator or agent that follows the canonical procedure must be able to execute this new thing without reading the PR description
+3. **If this has tests, are failure paths tested?**
+   - Unit tests: happy path + at least one failure / edge case (empty input, invalid input, boundary value)
+   - Integration tests where applicable per `test-trigger.md`
+   - "What happens when the underlying call fails silently" is a common blind spot — ask it explicitly
+4. **If this adds a new file type or directory, is the full lifecycle (create / read / update / delete / rename / archive) documented in a README or skill?**
+   - Who creates it, when? Who reads it, when?
+   - What moves it (accept / reject / archive)?
+   - What should never be done to it (e.g., "never silently delete rejected entries")?
+
+## When to apply
+
+- **Required** for PRs that introduce:
+  - A new script in `.claude/skills/**` or `scripts/**`
+  - A new rule in `.claude/rules/**` or skill in `.claude/skills/**`
+  - A new directory under `docs/` or `.context-store/` (or similar infrastructure)
+  - A new canonical procedure step (e.g., new subsection in `core-responsibilities.md §N`)
+- **Optional but encouraged** for any production code PR touching infrastructure or cross-cutting patterns
+- **Not required** for single-file bug fixes, typo corrections, or test-only additions
+
+## Why
+
+The Orchestrator's self-review is calibrated for *content correctness* (does the code do what it claims?). It is structurally weak on *completeness* ("what else should also be here?"). Both substantive defects surfaced in Sprint 2026-04-18 — the initial `file-test-map.md` proposal duplicating existing `test-trigger.md`, and the missing Post-Merge Flow `§7f` trigger documentation for the brewing system — were caught by the owner, not by self-review. A mechanical checklist converts the owner-catch burden into a self-catch habit.
+
+Cross-reference: `memory/feedback_check_existing_before_proposing.md` captured the first incident as a single-case reminder; this rule generalizes it into a process gate.
+
+## How this rule is expected to decay
+
+As the Orchestrator develops completeness instincts, these questions may become automatic and the explicit checklist may be retired. Until then, apply mechanically rather than skipping on the assumption that the answer is obvious.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -49,6 +49,16 @@ Follow GitHub-Flow. The `main` branch is always kept GREEN.
 - **Conflict assessment before PR:** Always check conflicts with latest main before opening a PR.
 - **Never merge PRs:** Merging is always the user's decision.
 
+### Force-Push and Rebase Gating
+
+`git push --force` and `git push --force-with-lease` require **explicit per-PR approval from the owner**. A general "merge this sequence" approval does NOT imply force-push approval for individual PRs within the sequence. Always confirm before force-pushing, even when the technical need is obvious (e.g., stacked PRs broken by squash-merge of the base PR).
+
+The same applies to `git rebase` on a pushed branch: if the rebase will require force-push to publish, get approval first.
+
+When the situation is a known operational pattern (stacked PR + base squash-merge), prefer to describe the patch set (commit subjects) and the intended rebase target, then request approval. Do not perform force-push "to save a round trip" — the memory `feedback_no_unauthorized_rebase.md` captures the reasoning.
+
+This rule does not apply to the initial push of a brand-new feature branch (no force involved) or to rebasing a local branch that has never been pushed (no remote divergence).
+
 ## Testing Requirements
 
 - **Testing with code changes:** Always update or add tests. Code without tests is incomplete.

--- a/docs/context-store/README.md
+++ b/docs/context-store/README.md
@@ -1,0 +1,45 @@
+# Context Store
+
+This directory is a dynamic layer that sits alongside `docs/design/` (long-form design documents), `.claude/rules/` (always-loaded constraints), and `.claude/skills/` (condition-triggered procedures). It is the fourth layer in the project's knowledge architecture.
+
+The design intent comes from the Sprint 2026-04-18 design discussion summarized in `docs/narratives/2026-04-18-brewing-pilot-founding.md`. In short: the CTO ("Orchestrator" in this project) is not only a dispatcher — it is also a *brewing device* that surfaces tacit knowledge into explicit, queryable artifacts over time. The Context Store is where those artifacts land.
+
+## Currently populated
+
+As of the brewing Pilot (2026-04-18 — 2026-05-02), only the brewing pipeline produces artifacts in this directory:
+
+| Path | Purpose | Maintained by |
+|---|---|---|
+| `_proposals/` | Draft architectural-invariant proposals awaiting owner review | `brew-invariants.js` + the invoking Claude applying `.claude/skills/brewing/SKILL.md` |
+| `_rejected/` | Proposals the owner declined, kept with reject reasons | Reviewer (owner or CTO) |
+| `brewing-log.md` | Record of brewing decisions (skip / propose) on merged PRs | Orchestrator as step 7f of Post-Merge Flow |
+
+The trigger and rubric for brewing are specified in:
+
+- `.claude/skills/orchestrator/core-responsibilities.md` §7f (when)
+- `.claude/skills/brewing/SKILL.md` (how to judge)
+
+## Intentionally empty (Phase 2 candidates)
+
+The original design framing (`docs/narratives/2026-04-18-brewing-pilot-founding.md`) anticipates additional Context Store artifacts once Phase 1 brewing mechanics are proven. Phase 2 candidates, identified by the conteditor CTO during the same Sprint:
+
+- **Task-specific 参照 index** — "for this task, reference these existing implementations" (replaces manual grep during dispatch)
+- **Decision Log** — "why this pattern was adopted" (ADR-style summaries that prevent re-deriving the same decision)
+- **Worker 実績 profile** — "which agent is strong / weak at what" (informs dispatch routing)
+
+These are *not* scaffolded yet. The Context Store grows only as brewing is validated and specific needs surface from real operation. The decision on whether to populate them is scheduled for 2026-05-02 (Pilot end review).
+
+## Principles for future expansion
+
+When adding a new artifact type to this directory:
+
+1. Apply `.claude/rules/pre-pr-completeness.md` — the 4-question gap-scan.
+2. Document the artifact's full lifecycle in a dedicated README within the new subdirectory.
+3. Wire the trigger into the appropriate canonical procedure (`core-responsibilities.md`, `sprint-lifecycle.md`, or a new section if the trigger does not fit existing phases).
+4. If the artifact requires a brewing agent, extend `.claude/skills/brewing/SKILL.md` with a sub-rubric rather than creating a parallel rubric file.
+
+## What this directory is not
+
+- **Not a replacement for `.claude/rules/` or `.claude/skills/`.** Rules are always-loaded prescriptions; skills are condition-triggered procedures. Context Store artifacts are dynamic data / queryable records that a judging Claude reads on demand.
+- **Not a staging area for design documents.** Long-form design belongs in `docs/design/`. Context Store is for artifacts that evolve continuously and are queried per-task, not for one-shot design documents.
+- **Not a task tracker.** In-flight work lives in GitHub Issues and `memory/project_sprint_status.md`, not here.


### PR DESCRIPTION
## Summary

Sprint 2026-04-18 retrospective produced three concrete improvements bundled in one PR:

1. **`.claude/rules/pre-pr-completeness.md`** (new rule) — a 4-question mechanical checklist the Orchestrator walks before opening a PR that introduces new infrastructure. Generalizes the single-case reminder in `memory/feedback_check_existing_before_proposing.md` into a process gate.
2. **`.claude/rules/workflow.md`** — adds an explicit "Force-Push and Rebase Gating" subsection under Branching Strategy. Previously this was only in memory; making it explicit helps future Orchestrator sessions.
3. **`docs/context-store/README.md`** (new) — explains current population (brewing artifacts) vs intentionally-unscaffolded Phase 2 candidates. Prevents misinterpreting the directory's scope.

## Why bundled

All three are docs-only rule / directory-README additions. No overlapping concerns with other open PRs. Reviewing as a single unit matches their shared origin (Sprint 2026-04-18 retrospective).

## Rationale (from retrospective)

### Pre-PR Completeness Gap-Scan

Two substantive defects this sprint were caught by the owner, not by my self-review:
- Initial `file-test-map.md` proposal duplicated existing `.claude/rules/test-trigger.md` — 3 hours of design discussion avoidable with a 10-minute `ls` + `grep`
- Missing `§7f` trigger documentation in `core-responsibilities.md` — would have left the brewing Pilot dormant across sessions

Both are **completeness gaps**, not content defects. The Orchestrator's self-review handles content but leaks on "what else should be here". The 4 questions convert the pattern into a mechanical habit.

### Force-Push Gating

During #667 merge (stacked on #665 → squash-merge conflict → rebase + force-push), the memory `feedback_no_unauthorized_rebase.md` was load-bearing. CLAUDE.md's only mention of force-push was implicit. Making it explicit in `rules/workflow.md` ensures future Orchestrator sessions follow the same discipline without relying on memory retrieval.

### context-store README

PR #665 shipped `docs/context-store/_proposals/` and `_rejected/` but the root directory had no README. A future reader opening `docs/context-store/` could reasonably expect to find the rich CS layer described in the original design discussion (project model / architecture map / decision log etc.) and be confused when only brewing pipeline files are present. The README clarifies current state and Phase 2 roadmap.

## Test plan

- [x] `node .claude/skills/orchestrator/rule-skill-duplication-check.js` — clean
- [x] `node .claude/skills/orchestrator/preflight-check.js` — no production changes
- [x] New rule is self-contained (no references to not-yet-existing files)
- [x] workflow.md edit preserves existing content (verified via git diff)
- [x] context-store README cross-links to SKILL.md §7f and `brewing/SKILL.md` (both now on main)
- [ ] CI green

## Relation to other open PRs

- PR B (brewing script fixes, CR findings on #665) — separate, forthcoming
- PR D (sprint-retro.js default window + progress, closes #662) — separate, forthcoming
- Issue C (referenced-but-not-defined linter) — separate, forthcoming

All three are independent scope and can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)