### PR TITLE
fix: surface brewing script errors and clarify Node/Bun compatibility

### DIFF
--- a/.claude/skills/brewing/SKILL.md
+++ b/.claude/skills/brewing/SKILL.md
@@ -126,7 +126,7 @@ Keep each section concise. The proposal is a **draft** — the owner may rewrite
 
 Do not write a file. Print (or record elsewhere) a single line:
 
-```
+```text
 skip: PR #<N> — <reason category>: <short explanation>
 ```
 

--- a/.claude/skills/orchestrator/brew-invariants.js
+++ b/.claude/skills/orchestrator/brew-invariants.js
@@ -17,6 +17,11 @@
  *   node .claude/skills/orchestrator/brew-invariants.js <PR number>
  *   node .claude/skills/orchestrator/brew-invariants.js 638 > /tmp/brew-638.md
  *
+ * Runtime: standard ESM + `node:child_process` + `node:fs` only. Compatible
+ * with both Node.js (≥20, tested on v24) and Bun (the project's declared
+ * engine). The entry-point check below uses a Node-compatible pattern so
+ * either runner works.
+ *
  * Output: structured markdown on stdout. Redirect to a file, or let the caller
  * pipe into a Claude session / sub-agent prompt.
  */
@@ -80,16 +85,34 @@ function main() {
     process.exit(1);
   }
 
-  // Full diff, truncated for context hygiene
-  const prDiff = exec(`gh pr diff ${prNumber}`) || '(no diff available)';
+  // Full diff, truncated for context hygiene.
+  // If the fetch fails, surface the error visibly in the output rather than
+  // silently substituting a placeholder — a judging Claude that cannot tell
+  // the difference between "empty diff" and "fetch failed" may propose or
+  // skip for the wrong reason.
+  const prDiffRaw = exec(`gh pr diff ${prNumber}`);
+  const prDiff = prDiffRaw !== null
+    ? prDiffRaw
+    : `⚠ Failed to fetch diff for PR #${prNumber}. \`gh pr diff ${prNumber}\` returned no output. The brewing judgment below may be unreliable — retry after verifying gh auth, or run \`gh pr diff ${prNumber}\` manually to diagnose.`;
   const truncatedDiff = truncate(prDiff, MAX_DIFF_LINES);
 
-  // Linked Issue detection (closes / fixes / resolves)
+  // Linked Issue detection (closes / fixes / resolves).
+  // Same principle as the diff: if the linked issue fetch fails, make the
+  // failure visible so the judge does not silently proceed with missing
+  // context.
   let issueSection = '';
   const issueNumber = extractLinkedIssueNumber(prMeta.body);
   if (issueNumber) {
     const issueRaw = exec(`gh issue view ${issueNumber} --json number,title,body`);
-    if (issueRaw) {
+    if (issueRaw === null) {
+      issueSection = [
+        '',
+        `## Linked Issue #${issueNumber}`,
+        '',
+        `⚠ Failed to fetch Issue #${issueNumber}. \`gh issue view ${issueNumber}\` returned no output. The brewing judgment below may be missing intent/context from the linked Issue — retry after verifying gh auth, or fetch the Issue manually.`,
+        '',
+      ].join('\n');
+    } else {
       try {
         const issue = JSON.parse(issueRaw);
         issueSection = [
@@ -99,8 +122,14 @@ function main() {
           issue.body || '(empty body)',
           '',
         ].join('\n');
-      } catch {
-        issueSection = `\n## Linked Issue #${issueNumber}\n\n(failed to fetch)\n`;
+      } catch (err) {
+        issueSection = [
+          '',
+          `## Linked Issue #${issueNumber}`,
+          '',
+          `⚠ Failed to parse Issue #${issueNumber} response as JSON: ${err.message}. The brewing judgment below may be missing intent/context from the linked Issue.`,
+          '',
+        ].join('\n');
       }
     }
   }
@@ -155,6 +184,14 @@ function main() {
   console.log(lines.join('\n'));
 }
 
-if (import.meta.main) {
+// Entry-point check that works on both Node (import.meta.url === file://<arg0>)
+// and Bun (import.meta.main is true). Node ≥20 and Bun both support ESM with
+// `import.meta.url`; preflight-check.js uses the same pattern.
+const isMainModule =
+  import.meta.main === true ||
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('brew-invariants.js');
+
+if (isMainModule) {
   main();
 }


### PR DESCRIPTION
## Summary

Addresses the 3 CodeRabbit findings from PR [#665](https://github.com/ms2sato/agent-console/pull/665) before the brewing Pilot begins actually running against merged PRs.

### 1. Silent fall-through on `gh` fetch failures (actionable)

**Before**: failed `gh pr diff` → silently replaced with literal `(no diff available)`; failed `gh issue view` → issue section left empty. The judging Claude had no way to distinguish "empty diff" from "fetch failed".

**After**: both failure paths emit a visible ⚠ block telling the judge the fetch failed, with guidance to verify `gh` auth and retry. The judge sees the degradation and can decline to propose on missing context.

### 2. Node / Bun entry-point mismatch (actionable)

**Before**: `if (import.meta.main)` works on Bun and Node ≥24, but on older Node the property is undefined and `main()` silently never runs. Script exits 0 without output.

**After**: explicit multi-runtime check (`import.meta.main === true || import.meta.url === ... || argv[1]?.endsWith(...)`) matching the pattern in `preflight-check.js`. Works on both runners, no silent no-op. Docstring updated with a Runtime section.

### 3. Markdown fence language tag (nitpick)

`.claude/skills/brewing/SKILL.md` line 119-121 — added `text` after the opening fence to satisfy markdownlint MD040.

## Test plan

- [x] `bun test ./.claude/skills/orchestrator/brew-invariants.test.js` — 10 pass (unchanged; pure helpers not touched)
- [x] `node .claude/skills/orchestrator/brew-invariants.js 665` — smoke test produces valid structured output
- [x] Confirmed error-surface branch triggers: temporarily broke the gh command; visible ⚠ block appears in output as designed (reverted)
- [x] `node .claude/skills/orchestrator/rule-skill-duplication-check.js` — clean
- [x] `node .claude/skills/orchestrator/preflight-check.js` — no production code changes (script files in .claude/skills/ are non-production per CLAUDE.md)
- [ ] CI green

## Relation

- Depends on nothing — standalone script / skill cleanup
- Does not conflict with open PRs ([#668](https://github.com/ms2sato/agent-console/pull/668) rules/docs; forthcoming PR D for sprint-retro.js; forthcoming Issue C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)