### PR TITLE
[AI] closed #658 chore: add root-cause bundle/split run book to .claude/rules/design-principles.md

### DIFF
--- a/.claude/rules/design-principles.md
+++ b/.claude/rules/design-principles.md
@@ -14,6 +14,8 @@ These principles apply to all code changes in this project.
 
 **Speak up about issues.** When you notice something problematic outside the current task scope, mention it as a supplementary note.
 
+**Grep for sibling call sites before implementing root-cause fixes.** When a fix changes a pattern (e.g., removing defensive invalidation, changing a contract, renaming a helper), grep the repository for all sites using the same pattern. If sibling sites exist, present a bundle-or-leave decision to the owner with Option A (bundle the sibling fixes for contract consistency) and Option B (leave them for a follow-up). Do not silently leave siblings inconsistent with the new contract.
+
 **Ask when uncertain.** When uncertain about a design decision, ask the user for confirmation.
 
 **Validate task assumptions before implementing.** Understand WHY the task is needed. If a task assumes existing behavior that seems questionable, verify whether that assumption is correct before implementing.


### PR DESCRIPTION
## Summary

- Adds the "Grep for sibling call sites before implementing root-cause fixes" run book to `.claude/rules/design-principles.md`, placed alongside "Speak up about issues" per Issue guidance.
- Codifies the grep → bundle/split → Option A/B pattern that worked during #648 so future agents reach the same pattern without being told.

## Acceptance Criteria

- [x] `.claude/rules/design-principles.md` contains the new run book, placed alongside "Speak up about issues".
- [x] `.claude/skills/orchestrator/rule-skill-duplication-check.js` still passes (verified locally — no duplication introduced).
- [x] At least one agent definition that commonly receives root-cause fixes references or inherits from this rule. **Satisfied via path-based auto-loading**: `design-principles.md` has no frontmatter path filter, so it auto-loads for every agent (including `backend-specialist` and `frontend-specialist`) on any file change. No per-agent explicit reference needed.

## Test plan

- [x] `node .claude/skills/orchestrator/rule-skill-duplication-check.js` → clean.
- [x] `coderabbit review --agent --base main` → 0 findings.
- [x] Pure docs addition — no code tests required (per Issue `chore` scope).

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)