### PR TITLE
docs: log first Pilot brewing result (PR #672, skip: docs-only)

### DIFF
--- a/docs/context-store/brewing-log.md
+++ b/docs/context-store/brewing-log.md
@@ -165,7 +165,7 @@ Append one row per merged agent-console PR brewed during the Pilot window. Reaso
 
 | Date | PR | Decision | Reason / Link |
 |------|------|------|------|
-| _(first row appended on first Pilot brewing after this PR merges)_ | | | |
+| 2026-04-18 | [#672](https://github.com/ms2sato/agent-console/pull/672) | skip | `docs-only`: diff touches only `.claude/rules/design-principles.md` (+2 insertions). Added content is a process principle ("grep for sibling call sites before root-cause fixes"), not an architectural code invariant. All 4 catalog criteria fail — no mechanical detection heuristic, no named failure-mode at the code/data level. |
 
 For `propose` rows, link to the proposal file in `_proposals/` in the "Reason / Link" column. For `skip` rows, write the reason category and a short explanation.
 


### PR DESCRIPTION
## Summary

First entry in `docs/context-store/brewing-log.md` §2 Live Pilot Log — initial brewing invocation on PR [#672](https://github.com/ms2sato/agent-console/pull/672) (root-cause run book addition) following Post-Merge Flow §7f on 2026-04-18.

**Decision: skip (docs-only)**

## Rubric walk

- **Cross-cutting?** No — docs change confined to one rule file.
- **High-leverage detection?** No — added content is a process principle (grep for sibling call sites), not a mechanical invariant check.
- **Named failure mode?** No at the code/data level. The principle addresses a process gap, not a code-behaviour class.
- **Concrete past incident?** [#648](https://github.com/ms2sato/agent-console/issues/648) cited in Issue body, but the incident was resolved via principle application, not via a missing architectural-invariant.

Skip gate `docs-only` applies cleanly. No proposal written.

## Why this PR exists

Per §7f, every merged agent-console PR during the Pilot window (2026-04-18 — 2026-05-02) receives a brewing invocation; the decision is appended to `brewing-log.md` §2. This is the first such entry.

## Recursion concern

This log-maintenance PR is itself a candidate for §7f brewing on next merge. Expected outcome: same `skip: docs-only` (diff touches only `docs/context-store/brewing-log.md`). No risk of infinite loop — each iteration is `skip` with no proposal.

## Test plan

- [x] `node .claude/skills/orchestrator/rule-skill-duplication-check.js` — clean (no rule/skill touched)
- [x] `node .claude/skills/orchestrator/preflight-check.js` — no production patterns changed
- [ ] CI green

## Authority

Orchestrator-mergeable (documentation-only, `docs/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)