### PR TITLE
chore: add FK constraint to sessions.created_by (migration v19) and reconcile docs drift

### DIFF
--- a/docs/design/multi-user-shared-setup.md
+++ b/docs/design/multi-user-shared-setup.md
@@ -202,7 +202,9 @@ This gives the service user the minimum privilege needed: the ability to start a
 - `packages/server/src/database/connection.ts` — Migration v14:
   - `CREATE TABLE users (id TEXT PRIMARY KEY, os_uid INTEGER, username TEXT NOT NULL, home_dir TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)`
   - `CREATE UNIQUE INDEX idx_users_os_uid ON users(os_uid) WHERE os_uid IS NOT NULL`
-  - `ALTER TABLE sessions ADD COLUMN created_by TEXT REFERENCES users(id)`
+  - `ALTER TABLE sessions ADD COLUMN created_by TEXT` (FK constraint deferred to v19)
+  
+  > **Migration Note**: The foreign key constraint `REFERENCES users(id) ON DELETE SET NULL` was deferred to migration v19 due to SQLite's table-recreation requirement for adding constraints. Migration v14 added the column without constraint; v19 recreated the table with the FK constraint.
 
 ### Phase 3: UserMode (Backend)
 

--- a/docs/design/shared-orchestrator-session.md
+++ b/docs/design/shared-orchestrator-session.md
@@ -61,7 +61,7 @@ $AGENT_CONSOLE_HOME/data.db        ← single DB (unchanged)
 
 The shared-account mechanism reuses the existing `users` and `sessions` shape; the minimum required schema additions are listed in Schema Notes below (a `sessions.initiated_by` column, and a `repositories.remote_url` column when a repository is registered from a URL rather than an existing local path).
 
-Note on `sessions.created_by`: the column is a plain `text` with no foreign-key DDL (see `packages/server/src/database/connection.ts` migration v14 — `addColumn('created_by', 'text')`). Association with `users.id` is maintained by the application layer. Whether to add a DB-level foreign key later is a separate decision (tracked in Issue [#680](https://github.com/ms2sato/agent-console/issues/680)).
+Note on `sessions.created_by`: the column includes a database-level foreign key constraint `REFERENCES users(id) ON DELETE SET NULL` (see `packages/server/src/database/connection.ts` migration v19). Migration v14 originally added the column without constraint; v19 recreated the table with the FK constraint using SQLite's table-recreation pattern (resolved Issue [#680](https://github.com/ms2sato/agent-console/issues/680)).
 
 ### Identity layer — one or more additional OS accounts
 

--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -114,7 +114,7 @@ import { WorkerOutputFileManager } from '../lib/worker-output-file.js';
 import { SystemCapabilitiesService } from '../services/system-capabilities-service.js';
 import { WorktreeService } from '../services/worktree-service.js';
 import type { AppBindings } from '../app-context.js';
-import { asAppContext, TEST_AUTH_USER } from './test-utils.js';
+import { asAppContext, TEST_AUTH_USER, ensureTestAuthUser } from './test-utils.js';
 import { SingleUserMode } from '../services/user-mode.js';
 
 // =============================================================================
@@ -174,6 +174,10 @@ describe('API Routes Integration', () => {
     // Close any existing database connection and initialize fresh in-memory database
     await closeDatabase();
     await initializeDatabase(':memory:');
+
+    // Seed the canonical test user so sessions created via the API can satisfy
+    // the v19 FK constraint sessions.created_by -> users(id).
+    await ensureTestAuthUser(getDatabase());
 
     // Set up mock system capabilities
     const mockCapabilities = new SystemCapabilitiesService();

--- a/packages/server/src/__tests__/test-utils.ts
+++ b/packages/server/src/__tests__/test-utils.ts
@@ -27,6 +27,8 @@ import { setupMemfs, cleanupMemfs } from './utils/mock-fs-helper.js';
 import { resetProcessMock } from './utils/mock-process-helper.js';
 import { resetGitMocks } from './utils/mock-git-helper.js';
 import { initializeDatabase, closeDatabase } from '../database/connection.js';
+import type { Kysely } from 'kysely';
+import type { Database } from '../database/schema.js';
 import type { AppBindings, AppContext } from '../app-context.js';
 import { SingleUserMode } from '../services/user-mode.js';
 import { bunPtyProvider } from '../lib/pty-provider.js';
@@ -84,7 +86,14 @@ export async function setupTestEnvironment(): Promise<void> {
   process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
 
   // Initialize in-memory database (bypasses native file operations)
-  await initializeDatabase(':memory:');
+  const db = await initializeDatabase(':memory:');
+
+  // Seed the canonical test user so that sessions can satisfy the v19
+  // FK constraint (sessions.created_by REFERENCES users(id)). Production
+  // upserts the server-process user during SingleUserMode.create();
+  // tests construct SingleUserMode directly with TEST_AUTH_USER, so the
+  // matching users row has to be inserted explicitly.
+  await ensureTestAuthUser(db);
 
   // Reset PTY tracking
   mockPtyInstances.length = 0;
@@ -98,6 +107,26 @@ export async function setupTestEnvironment(): Promise<void> {
 
   // Reset open mock
   mockOpen.mockClear();
+}
+
+/**
+ * Insert (or no-op if already present) the canonical test user row used
+ * by tests that construct SingleUserMode with TEST_AUTH_USER. Required
+ * since v19 added a FK constraint sessions.created_by -> users(id).
+ */
+export async function ensureTestAuthUser(db: Kysely<Database>): Promise<void> {
+  await db
+    .insertInto('users')
+    .values({
+      id: TEST_AUTH_USER.id,
+      os_uid: null,
+      username: TEST_AUTH_USER.username,
+      home_dir: TEST_AUTH_USER.homeDir,
+      created_at: '2024-01-01T00:00:00.000Z',
+      updated_at: '2024-01-01T00:00:00.000Z',
+    })
+    .onConflict((oc) => oc.column('id').doNothing())
+    .execute();
 }
 
 /**

--- a/packages/server/src/__tests__/test-utils.ts
+++ b/packages/server/src/__tests__/test-utils.ts
@@ -110,6 +110,20 @@ export async function setupTestEnvironment(): Promise<void> {
 }
 
 /**
+ * Default AuthUser for tests.
+ * Used when tests need a simple user identity without setting up a UserRepository.
+ *
+ * Declared before any function that references it so the value is initialised
+ * before module-evaluation-order-sensitive callers (e.g. a top-level test that
+ * imports a helper which closes over `TEST_AUTH_USER`).
+ */
+export const TEST_AUTH_USER = {
+  id: 'test-user-id',
+  username: 'testuser',
+  homeDir: '/home/testuser',
+} as const;
+
+/**
  * Insert (or no-op if already present) the canonical test user row used
  * by tests that construct SingleUserMode with TEST_AUTH_USER. Required
  * since v19 added a FK constraint sessions.created_by -> users(id).
@@ -165,16 +179,6 @@ export async function createTestApp(appContext?: Partial<AppContext>): Promise<H
 export function getTestConfigDir(): string {
   return TEST_CONFIG_DIR;
 }
-
-/**
- * Default AuthUser for tests.
- * Used when tests need a simple user identity without setting up a UserRepository.
- */
-export const TEST_AUTH_USER = {
-  id: 'test-user-id',
-  username: 'testuser',
-  homeDir: '/home/testuser',
-} as const;
 
 /**
  * Create an AppContext from a partial object for testing.

--- a/packages/server/src/database/__tests__/migration-v18.test.ts
+++ b/packages/server/src/database/__tests__/migration-v18.test.ts
@@ -212,7 +212,7 @@ describe('migration v18 (session-data-path)', () => {
     const db = await initializeDatabase(':memory:');
 
     const versionRes = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
-    expect(versionRes.rows[0]?.user_version).toBe(18);
+    expect(versionRes.rows[0]?.user_version).toBe(19);
 
     // Insert a quick session without specifying recovery_state; the DB
     // default should apply.

--- a/packages/server/src/database/__tests__/migration-v19.test.ts
+++ b/packages/server/src/database/__tests__/migration-v19.test.ts
@@ -11,12 +11,18 @@
  *     the production implementation.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { sql, Kysely } from 'kysely';
 import { BunSqliteDialect } from 'kysely-bun-sqlite';
 import { Database as BunDatabase } from 'bun:sqlite';
+import * as fsPromises from 'fs/promises';
 import type { Database } from '../schema.js';
-import { initializeDatabase, closeDatabase, migrateToV19 } from '../connection.js';
+import {
+  initializeDatabase,
+  closeDatabase,
+  migrateToV19,
+  backupDatabaseFile,
+} from '../connection.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 
 const TEST_CONFIG_DIR = '/test/config';
@@ -436,5 +442,154 @@ describe('migration v19 (sessions.created_by FK constraint)', () => {
     expect(sessions[1].created_by).toBeNull();
 
     await db.destroy();
+  });
+
+  describe('pre-flight database backup', () => {
+    /**
+     * The migration-v19 backup logic copies the SQLite file via
+     * `fs.promises.copyFile`. The test file already mocks `fs/promises` via
+     * memfs, so:
+     *   - Pre-seeding a memfs file at `dbPath` lets us assert `copyFile`
+     *     was actually invoked and produced a sibling file with the same
+     *     bytes.
+     *   - The Kysely database used to drive the migration is independent
+     *     of that memfs file (Bun's native SQLite cannot read memfs paths),
+     *     which is fine: backup correctness and migration correctness are
+     *     orthogonal here. The migration only needs `dbPath` to know
+     *     *where* to write the backup, not to read SQL from it.
+     */
+    it('takes a backup before migrating and proceeds with migration', async () => {
+      const dbPath = `${TEST_CONFIG_DIR}/agentconsole.db`;
+      const fakeDbBytes = 'SQLITE format 3 -pretend-db-content';
+      // memfs-backed source file. Migration backup will copy these bytes.
+      setupMemfs({
+        [dbPath]: fakeDbBytes,
+      });
+
+      const db = await seedV18Database({
+        users: [{ id: 'u', os_uid: 1, username: 'a', home_dir: '/h' }],
+        sessions: [
+          {
+            id: 's',
+            type: 'worktree',
+            location_path: '/tmp/x',
+            repository_id: null,
+            worktree_id: null,
+            created_by: 'u',
+          },
+        ],
+      });
+
+      await migrateToV19(db, dbPath);
+
+      // Migration progressed past version bump.
+      const versionRes = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
+      expect(versionRes.rows[0]?.user_version).toBe(19);
+
+      // Exactly one backup file was written next to the source.
+      const dirEntries = await fsPromises.readdir(TEST_CONFIG_DIR);
+      const backups = dirEntries.filter((name) =>
+        name.startsWith('agentconsole.db.bak.v18-to-v19.')
+      );
+      expect(backups).toHaveLength(1);
+
+      // Backup file name encodes the version transition AND a colon-free
+      // timestamp suffix. We don't pin the exact timestamp (it is now()),
+      // but we do pin the structural shape — `T??-??-??-???Z` — so a
+      // future change that drops the colon-replacement step would fail
+      // here rather than producing un-portable filenames.
+      const backupName = backups[0];
+      expect(backupName).toMatch(
+        /^agentconsole\.db\.bak\.v18-to-v19\.\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/
+      );
+
+      // Backup content matches the source bytes.
+      const backupContent = await fsPromises.readFile(`${TEST_CONFIG_DIR}/${backupName}`, 'utf-8');
+      expect(backupContent).toBe(fakeDbBytes);
+
+      await db.destroy();
+    });
+
+    it('aborts the migration when the backup copy fails', async () => {
+      const dbPath = `${TEST_CONFIG_DIR}/agentconsole.db`;
+      setupMemfs({
+        [dbPath]: 'irrelevant',
+      });
+
+      const db = await seedV18Database({
+        users: [],
+        sessions: [
+          {
+            id: 's',
+            type: 'quick',
+            location_path: '/tmp/q',
+            repository_id: null,
+            worktree_id: null,
+            created_by: null,
+          },
+        ],
+      });
+
+      // Force the backup copy to fail. The migration must surface the
+      // error AND leave the schema untouched (user_version stays at 18,
+      // sessions table keeps its v18 shape with no FK on created_by).
+      const copySpy = spyOn(fsPromises, 'copyFile').mockImplementation(() => {
+        return Promise.reject(new Error('disk full'));
+      });
+
+      try {
+        await expect(migrateToV19(db, dbPath)).rejects.toThrow('disk full');
+
+        const versionRes = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
+        expect(versionRes.rows[0]?.user_version).toBe(18);
+
+        // Sanity-check that the FK was not silently introduced. v18's
+        // sessions table has no FK clause referencing users.
+        const tblRes = await sql<{ sql: string }>`
+          SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'sessions'
+        `.execute(db);
+        expect(tblRes.rows[0]?.sql ?? '').not.toContain('REFERENCES users(id)');
+      } finally {
+        copySpy.mockRestore();
+      }
+
+      await db.destroy();
+    });
+
+    it('skips the backup for in-memory databases', async () => {
+      const db = await seedV18Database({
+        users: [],
+        sessions: [],
+      });
+
+      // No source file exists, but the migration must still succeed
+      // because `:memory:` opts out of backup entirely. A spy ensures
+      // the copy was not even attempted.
+      const copySpy = spyOn(fsPromises, 'copyFile');
+
+      try {
+        await migrateToV19(db, ':memory:');
+        expect(copySpy).not.toHaveBeenCalled();
+
+        const versionRes = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
+        expect(versionRes.rows[0]?.user_version).toBe(19);
+      } finally {
+        copySpy.mockRestore();
+      }
+
+      await db.destroy();
+    });
+
+    it('backupDatabaseFile returns null and performs no copy for in-memory databases', async () => {
+      const copySpy = spyOn(fsPromises, 'copyFile');
+
+      try {
+        const result = await backupDatabaseFile(':memory:', 18, 19);
+        expect(result).toBeNull();
+        expect(copySpy).not.toHaveBeenCalled();
+      } finally {
+        copySpy.mockRestore();
+      }
+    });
   });
 });

--- a/packages/server/src/database/__tests__/migration-v19.test.ts
+++ b/packages/server/src/database/__tests__/migration-v19.test.ts
@@ -1,0 +1,487 @@
+/**
+ * Migration v19 tests — sessions.created_by FK constraint addition.
+ *
+ * Strategy:
+ *   - `adds FK constraint to created_by` test exercises the real production path
+ *     via `initializeDatabase(':memory:')`.
+ *   - FK behavior tests construct a v18-shaped schema directly against a raw
+ *     Bun SQLite instance, seed it with users and sessions, then re-apply the same
+ *     DDL that the production `migrateToV19` performs (kept in `runV19Migration`
+ *     here). Table-recreation pattern is required because SQLite doesn't support
+ *     ALTER TABLE ADD CONSTRAINT.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { sql, Kysely } from 'kysely';
+import { BunSqliteDialect } from 'kysely-bun-sqlite';
+import { Database as BunDatabase } from 'bun:sqlite';
+import type { Database } from '../schema.js';
+import { initializeDatabase, closeDatabase } from '../connection.js';
+import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
+
+const TEST_CONFIG_DIR = '/test/config';
+
+interface SeedUser {
+  id: string;
+  os_uid: number | null;
+  username: string;
+  home_dir: string;
+}
+
+interface SeedSession {
+  id: string;
+  type: 'worktree' | 'quick';
+  location_path: string;
+  repository_id: string | null;
+  worktree_id: string | null;
+  created_by: string | null;
+}
+
+/**
+ * Build a v18-shaped database seeded with the caller's rows.
+ * Creates users, sessions, and repositories tables with v18 schema (no FK constraint on created_by).
+ */
+async function seedV18Database(options: {
+  users: SeedUser[];
+  sessions: SeedSession[];
+}): Promise<Kysely<Database>> {
+  const bunDb = new BunDatabase(':memory:');
+  const db = new Kysely<Database>({
+    dialect: new BunSqliteDialect({ database: bunDb }),
+  });
+
+  await sql`PRAGMA foreign_keys = ON`.execute(db);
+
+  // Create v18 schema: users table and sessions table WITHOUT FK constraint on created_by
+  bunDb.exec(`
+    CREATE TABLE users (
+      id TEXT PRIMARY KEY,
+      os_uid INTEGER,
+      username TEXT NOT NULL,
+      home_dir TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX idx_users_os_uid ON users(os_uid) WHERE os_uid IS NOT NULL;
+
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      location_path TEXT NOT NULL,
+      server_pid INTEGER,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      initial_prompt TEXT,
+      title TEXT,
+      repository_id TEXT,
+      worktree_id TEXT,
+      paused_at TEXT,
+      parent_session_id TEXT,
+      parent_worker_id TEXT,
+      created_by TEXT,
+      data_scope TEXT,
+      data_scope_slug TEXT,
+      recovery_state TEXT NOT NULL DEFAULT 'healthy',
+      orphaned_at INTEGER,
+      orphaned_reason TEXT
+    );
+
+    CREATE TABLE repositories (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      path TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      setup_command TEXT,
+      env_vars TEXT,
+      description TEXT,
+      cleanup_command TEXT,
+      default_agent_id TEXT
+    );
+
+    PRAGMA user_version = 18;
+  `);
+
+  // Insert test data
+  const insertUser = bunDb.prepare(
+    `INSERT INTO users (id, os_uid, username, home_dir, created_at, updated_at)
+     VALUES (?, ?, ?, ?, '2024-01-01T00:00:00.000Z', '2024-01-01T00:00:00.000Z')`
+  );
+  for (const user of options.users) {
+    insertUser.run(user.id, user.os_uid, user.username, user.home_dir);
+  }
+
+  const insertSess = bunDb.prepare(
+    `INSERT INTO sessions (id, type, location_path, repository_id, worktree_id, created_by,
+       created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, '2024-01-01T00:00:00.000Z', '2024-01-01T00:00:00.000Z')`
+  );
+  for (const sess of options.sessions) {
+    insertSess.run(
+      sess.id,
+      sess.type,
+      sess.location_path,
+      sess.repository_id,
+      sess.worktree_id,
+      sess.created_by
+    );
+  }
+
+  return db;
+}
+
+/**
+ * Apply the v19 migration body (table recreation with FK constraint) against a caller-
+ * owned DB. Kept in sync with `migrateToV19` in connection.ts.
+ */
+async function runV19Migration(db: Kysely<Database>): Promise<void> {
+  // Idempotency guard mirrors `migrateToV19`.
+  const versionResult = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
+  const currentVersion = versionResult.rows[0]?.user_version ?? 0;
+  if (currentVersion >= 19) {
+    return;
+  }
+
+  // FK toggling cannot happen inside a transaction.
+  await sql`PRAGMA foreign_keys = OFF`.execute(db);
+
+  try {
+    const objectsResult = await sql<{
+      type: string;
+      name: string;
+      sql: string | null;
+    }>`
+      SELECT type, name, sql
+      FROM sqlite_master
+      WHERE tbl_name = 'sessions'
+        AND type IN ('index', 'trigger')
+        AND name NOT LIKE 'sqlite_autoindex%'
+    `.execute(db);
+    const objectsToRestore = objectsResult.rows.filter((row) => row.sql !== null);
+
+    await db.transaction().execute(async (trx) => {
+      await sql`ALTER TABLE sessions RENAME TO sessions_old`.execute(trx);
+
+      await sql`
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          type TEXT NOT NULL,
+          location_path TEXT NOT NULL,
+          server_pid INTEGER,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+          initial_prompt TEXT,
+          title TEXT,
+          repository_id TEXT,
+          worktree_id TEXT,
+          paused_at TEXT,
+          parent_session_id TEXT,
+          parent_worker_id TEXT,
+          created_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+          data_scope TEXT,
+          data_scope_slug TEXT,
+          recovery_state TEXT NOT NULL DEFAULT 'healthy',
+          orphaned_at INTEGER,
+          orphaned_reason TEXT
+        )
+      `.execute(trx);
+
+      await sql`
+        INSERT INTO sessions (
+          id, type, location_path, server_pid, created_at, updated_at,
+          initial_prompt, title, repository_id, worktree_id, paused_at,
+          parent_session_id, parent_worker_id, created_by, data_scope,
+          data_scope_slug, recovery_state, orphaned_at, orphaned_reason
+        )
+        SELECT
+          id, type, location_path, server_pid, created_at, updated_at,
+          initial_prompt, title, repository_id, worktree_id, paused_at,
+          parent_session_id, parent_worker_id, created_by, data_scope,
+          data_scope_slug, recovery_state, orphaned_at, orphaned_reason
+        FROM sessions_old
+      `.execute(trx);
+
+      await sql`DROP TABLE sessions_old`.execute(trx);
+
+      for (const obj of objectsToRestore) {
+        await sql.raw(obj.sql as string).execute(trx);
+      }
+
+      await sql`PRAGMA user_version = 19`.execute(trx);
+    });
+
+    const fkCheck = await sql<{ table: string; rowid: number; parent: string; fkid: number }>`
+      PRAGMA foreign_key_check
+    `.execute(db);
+    if (fkCheck.rows.length > 0) {
+      throw new Error(
+        `Foreign key check failed after v19 migration: ${JSON.stringify(fkCheck.rows)}`
+      );
+    }
+  } finally {
+    await sql`PRAGMA foreign_keys = ON`.execute(db);
+  }
+}
+
+describe('migration v19 (sessions.created_by FK constraint)', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    setupMemfs({
+      [`${TEST_CONFIG_DIR}/.keep`]: '',
+    });
+    process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+    cleanupMemfs();
+  });
+
+  it('adds FK constraint to created_by column', async () => {
+    // Exercise the real production migration path end-to-end.
+    const db = await initializeDatabase(':memory:');
+
+    const versionRes = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
+    expect(versionRes.rows[0]?.user_version).toBe(19);
+
+    // Verify FK constraint exists by checking sqlite_master
+    const fkInfo = await sql<{ sql: string }>`
+      SELECT sql FROM sqlite_master
+      WHERE type = 'table' AND name = 'sessions'
+    `.execute(db);
+
+    const createTableSql = fkInfo.rows[0]?.sql ?? '';
+    expect(createTableSql).toContain('REFERENCES users(id)');
+    expect(createTableSql).toContain('ON DELETE SET NULL');
+  });
+
+  it('preserves existing session data during table recreation', async () => {
+    const testUsers = [
+      { id: 'user-1', os_uid: 1001, username: 'alice', home_dir: '/home/alice' },
+      { id: 'user-2', os_uid: null, username: 'bob', home_dir: '/home/bob' },
+    ];
+
+    const testSessions = [
+      {
+        id: 'sess-1',
+        type: 'worktree' as const,
+        location_path: '/tmp/repo1',
+        repository_id: null,
+        worktree_id: null,
+        created_by: 'user-1',
+      },
+      {
+        id: 'sess-2',
+        type: 'quick' as const,
+        location_path: '/tmp/quick',
+        repository_id: null,
+        worktree_id: null,
+        created_by: null, // pre-v14 session
+      },
+    ];
+
+    const db = await seedV18Database({
+      users: testUsers,
+      sessions: testSessions,
+    });
+
+    await runV19Migration(db);
+
+    // Verify all data preserved
+    const sessions = await db
+      .selectFrom('sessions')
+      .selectAll()
+      .orderBy('id')
+      .execute();
+
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0].id).toBe('sess-1');
+    expect(sessions[0].created_by).toBe('user-1');
+    expect(sessions[0].location_path).toBe('/tmp/repo1');
+
+    expect(sessions[1].id).toBe('sess-2');
+    expect(sessions[1].created_by).toBeNull(); // pre-v14 NULL preserved
+    expect(sessions[1].location_path).toBe('/tmp/quick');
+
+    await db.destroy();
+  });
+
+  it('enforces FK constraint: user deletion sets sessions.created_by to NULL', async () => {
+    const testUsers = [
+      { id: 'user-to-delete', os_uid: 1001, username: 'temp', home_dir: '/home/temp' },
+    ];
+
+    const testSessions = [
+      {
+        id: 'sess-orphan',
+        type: 'worktree' as const,
+        location_path: '/tmp/will-orphan',
+        repository_id: null,
+        worktree_id: null,
+        created_by: 'user-to-delete',
+      },
+    ];
+
+    const db = await seedV18Database({
+      users: testUsers,
+      sessions: testSessions,
+    });
+
+    await runV19Migration(db);
+
+    // Verify session references user before deletion
+    let session = await db
+      .selectFrom('sessions')
+      .select(['id', 'created_by'])
+      .where('id', '=', 'sess-orphan')
+      .executeTakeFirstOrThrow();
+    expect(session.created_by).toBe('user-to-delete');
+
+    // Delete the user
+    await db
+      .deleteFrom('users')
+      .where('id', '=', 'user-to-delete')
+      .execute();
+
+    // Verify session.created_by was set to NULL by FK constraint
+    session = await db
+      .selectFrom('sessions')
+      .select(['id', 'created_by'])
+      .where('id', '=', 'sess-orphan')
+      .executeTakeFirstOrThrow();
+    expect(session.created_by).toBeNull();
+
+    await db.destroy();
+  });
+
+  it('preserves existing indexes and triggers during table recreation', async () => {
+    const db = await seedV18Database({
+      users: [],
+      sessions: [],
+    });
+
+    // Add a test index to sessions table
+    await sql`CREATE INDEX test_sessions_type_idx ON sessions(type)`.execute(db);
+
+    // Get all indexes/triggers before migration
+    const beforeObjects = await sql<{
+      type: string;
+      name: string;
+      sql: string | null;
+    }>`
+      SELECT type, name, sql
+      FROM sqlite_master
+      WHERE tbl_name = 'sessions' AND type IN ('index', 'trigger')
+      AND name NOT LIKE 'sqlite_autoindex%'
+    `.execute(db);
+
+    await runV19Migration(db);
+
+    // Get all indexes/triggers after migration
+    const afterObjects = await sql<{
+      type: string;
+      name: string;
+      sql: string | null;
+    }>`
+      SELECT type, name, sql
+      FROM sqlite_master
+      WHERE tbl_name = 'sessions' AND type IN ('index', 'trigger')
+      AND name NOT LIKE 'sqlite_autoindex%'
+    `.execute(db);
+
+    // Verify all non-automatic indexes/triggers are preserved
+    expect(afterObjects.rows).toHaveLength(beforeObjects.rows.length);
+
+    const afterNames = afterObjects.rows.map(r => r.name);
+    expect(afterNames).toContain('test_sessions_type_idx');
+
+    await db.destroy();
+  });
+
+  it('migration is idempotent: running twice has no effect', async () => {
+    const testUsers = [
+      { id: 'user-1', os_uid: 1001, username: 'alice', home_dir: '/home/alice' },
+    ];
+
+    const testSessions = [
+      {
+        id: 'sess-1',
+        type: 'worktree' as const,
+        location_path: '/tmp/repo1',
+        repository_id: null,
+        worktree_id: null,
+        created_by: 'user-1',
+      },
+    ];
+
+    const db = await seedV18Database({
+      users: testUsers,
+      sessions: testSessions,
+    });
+
+    // Run migration twice
+    await runV19Migration(db);
+    await runV19Migration(db);
+
+    // Verify schema version is correct
+    const versionRes = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
+    expect(versionRes.rows[0]?.user_version).toBe(19);
+
+    // Verify data is still intact
+    const sessions = await db.selectFrom('sessions').selectAll().execute();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('sess-1');
+    expect(sessions[0].created_by).toBe('user-1');
+
+    await db.destroy();
+  });
+
+  it('handles sessions with NULL created_by (pre-v14 compatibility)', async () => {
+    const testUsers = [
+      { id: 'user-1', os_uid: 1001, username: 'alice', home_dir: '/home/alice' },
+    ];
+
+    const testSessions = [
+      {
+        id: 'sess-old',
+        type: 'quick' as const,
+        location_path: '/tmp/old',
+        repository_id: null,
+        worktree_id: null,
+        created_by: null, // pre-v14 session
+      },
+      {
+        id: 'sess-new',
+        type: 'worktree' as const,
+        location_path: '/tmp/new',
+        repository_id: null,
+        worktree_id: null,
+        created_by: 'user-1', // post-v14 session
+      },
+    ];
+
+    const db = await seedV18Database({
+      users: testUsers,
+      sessions: testSessions,
+    });
+
+    await runV19Migration(db);
+
+    const sessions = await db
+      .selectFrom('sessions')
+      .selectAll()
+      .orderBy('id')
+      .execute();
+
+    expect(sessions).toHaveLength(2);
+
+    // Pre-v14 session keeps NULL created_by
+    expect(sessions[0].id).toBe('sess-new');
+    expect(sessions[0].created_by).toBe('user-1');
+
+    expect(sessions[1].id).toBe('sess-old');
+    expect(sessions[1].created_by).toBeNull();
+
+    await db.destroy();
+  });
+});

--- a/packages/server/src/database/__tests__/migration-v19.test.ts
+++ b/packages/server/src/database/__tests__/migration-v19.test.ts
@@ -160,10 +160,8 @@ async function runV19Migration(db: Kysely<Database>): Promise<void> {
     const objectsToRestore = objectsResult.rows.filter((row) => row.sql !== null);
 
     await db.transaction().execute(async (trx) => {
-      await sql`ALTER TABLE sessions RENAME TO sessions_old`.execute(trx);
-
       await sql`
-        CREATE TABLE sessions (
+        CREATE TABLE sessions_new (
           id TEXT PRIMARY KEY,
           type TEXT NOT NULL,
           location_path TEXT NOT NULL,
@@ -187,7 +185,7 @@ async function runV19Migration(db: Kysely<Database>): Promise<void> {
       `.execute(trx);
 
       await sql`
-        INSERT INTO sessions (
+        INSERT INTO sessions_new (
           id, type, location_path, server_pid, created_at, updated_at,
           initial_prompt, title, repository_id, worktree_id, paused_at,
           parent_session_id, parent_worker_id, created_by, data_scope,
@@ -198,10 +196,11 @@ async function runV19Migration(db: Kysely<Database>): Promise<void> {
           initial_prompt, title, repository_id, worktree_id, paused_at,
           parent_session_id, parent_worker_id, created_by, data_scope,
           data_scope_slug, recovery_state, orphaned_at, orphaned_reason
-        FROM sessions_old
+        FROM sessions
       `.execute(trx);
 
-      await sql`DROP TABLE sessions_old`.execute(trx);
+      await sql`DROP TABLE sessions`.execute(trx);
+      await sql`ALTER TABLE sessions_new RENAME TO sessions`.execute(trx);
 
       for (const obj of objectsToRestore) {
         await sql.raw(obj.sql as string).execute(trx);
@@ -253,6 +252,38 @@ describe('migration v19 (sessions.created_by FK constraint)', () => {
     const createTableSql = fkInfo.rows[0]?.sql ?? '';
     expect(createTableSql).toContain('REFERENCES users(id)');
     expect(createTableSql).toContain('ON DELETE SET NULL');
+  });
+
+  it('preserves dependent FK references on the workers table', async () => {
+    // Regression: SQLite ≥ 3.25 rewrites FK declarations in dependent tables
+    // when ALTER TABLE RENAME affects the referenced table. The original v19
+    // migration used "RENAME sessions TO sessions_old" which silently rewrote
+    // workers.session_id to point at sessions_old; after we then dropped
+    // sessions_old, the workers FK was dangling and any DELETE on workers
+    // raised "no such table: main.sessions_old" on SQLite ≥ 3.25 (e.g. CI).
+    // The migration now uses the inverse pattern (create sessions_new, copy,
+    // drop sessions, rename sessions_new to sessions) to keep dependent FK
+    // references pointing at `sessions`.
+    const db = await initializeDatabase(':memory:');
+
+    const fkRows = await sql<{
+      id: number;
+      seq: number;
+      table: string;
+      from: string;
+      to: string;
+    }>`PRAGMA foreign_key_list(workers)`.execute(db);
+
+    const sessionFk = fkRows.rows.find((row) => row.from === 'session_id');
+    expect(sessionFk).toBeDefined();
+    expect(sessionFk!.table).toBe('sessions');
+
+    // Sanity: a DELETE that engages the FK (workers references sessions)
+    // must not throw. Pre-fix this raised "no such table: main.sessions_old".
+    await db
+      .deleteFrom('workers')
+      .where('session_id', '=', 'no-such-session')
+      .execute();
   });
 
   it('preserves existing session data during table recreation', async () => {

--- a/packages/server/src/database/__tests__/migration-v19.test.ts
+++ b/packages/server/src/database/__tests__/migration-v19.test.ts
@@ -5,10 +5,10 @@
  *   - `adds FK constraint to created_by` test exercises the real production path
  *     via `initializeDatabase(':memory:')`.
  *   - FK behavior tests construct a v18-shaped schema directly against a raw
- *     Bun SQLite instance, seed it with users and sessions, then re-apply the same
- *     DDL that the production `migrateToV19` performs (kept in `runV19Migration`
- *     here). Table-recreation pattern is required because SQLite doesn't support
- *     ALTER TABLE ADD CONSTRAINT.
+ *     Bun SQLite instance, seed it with users and sessions, then invoke the
+ *     production `migrateToV19` directly. This ensures tests run against the
+ *     real migration code with no risk of drift between a test-local copy and
+ *     the production implementation.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
@@ -16,7 +16,7 @@ import { sql, Kysely } from 'kysely';
 import { BunSqliteDialect } from 'kysely-bun-sqlite';
 import { Database as BunDatabase } from 'bun:sqlite';
 import type { Database } from '../schema.js';
-import { initializeDatabase, closeDatabase } from '../connection.js';
+import { initializeDatabase, closeDatabase, migrateToV19 } from '../connection.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 
 const TEST_CONFIG_DIR = '/test/config';
@@ -39,7 +39,10 @@ interface SeedSession {
 
 /**
  * Build a v18-shaped database seeded with the caller's rows.
- * Creates users, sessions, and repositories tables with v18 schema (no FK constraint on created_by).
+ * Creates the users and sessions tables with v18 schema (no FK constraint on
+ * created_by). Only the tables required by the v19 migration are created;
+ * dependent tables not referenced by `migrateToV19` (e.g. `repositories`,
+ * `worktrees`, `workers`) are intentionally omitted to keep the seed minimal.
  */
 async function seedV18Database(options: {
   users: SeedUser[];
@@ -86,19 +89,6 @@ async function seedV18Database(options: {
       orphaned_reason TEXT
     );
 
-    CREATE TABLE repositories (
-      id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      path TEXT NOT NULL UNIQUE,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-      setup_command TEXT,
-      env_vars TEXT,
-      description TEXT,
-      cleanup_command TEXT,
-      default_agent_id TEXT
-    );
-
     PRAGMA user_version = 18;
   `);
 
@@ -128,98 +118,6 @@ async function seedV18Database(options: {
   }
 
   return db;
-}
-
-/**
- * Apply the v19 migration body (table recreation with FK constraint) against a caller-
- * owned DB. Kept in sync with `migrateToV19` in connection.ts.
- */
-async function runV19Migration(db: Kysely<Database>): Promise<void> {
-  // Idempotency guard mirrors `migrateToV19`.
-  const versionResult = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
-  const currentVersion = versionResult.rows[0]?.user_version ?? 0;
-  if (currentVersion >= 19) {
-    return;
-  }
-
-  // FK toggling cannot happen inside a transaction.
-  await sql`PRAGMA foreign_keys = OFF`.execute(db);
-
-  try {
-    const objectsResult = await sql<{
-      type: string;
-      name: string;
-      sql: string | null;
-    }>`
-      SELECT type, name, sql
-      FROM sqlite_master
-      WHERE tbl_name = 'sessions'
-        AND type IN ('index', 'trigger')
-        AND name NOT LIKE 'sqlite_autoindex%'
-    `.execute(db);
-    const objectsToRestore = objectsResult.rows.filter((row) => row.sql !== null);
-
-    await db.transaction().execute(async (trx) => {
-      await sql`
-        CREATE TABLE sessions_new (
-          id TEXT PRIMARY KEY,
-          type TEXT NOT NULL,
-          location_path TEXT NOT NULL,
-          server_pid INTEGER,
-          created_at TEXT NOT NULL DEFAULT (datetime('now')),
-          updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-          initial_prompt TEXT,
-          title TEXT,
-          repository_id TEXT,
-          worktree_id TEXT,
-          paused_at TEXT,
-          parent_session_id TEXT,
-          parent_worker_id TEXT,
-          created_by TEXT REFERENCES users(id) ON DELETE SET NULL,
-          data_scope TEXT,
-          data_scope_slug TEXT,
-          recovery_state TEXT NOT NULL DEFAULT 'healthy',
-          orphaned_at INTEGER,
-          orphaned_reason TEXT
-        )
-      `.execute(trx);
-
-      await sql`
-        INSERT INTO sessions_new (
-          id, type, location_path, server_pid, created_at, updated_at,
-          initial_prompt, title, repository_id, worktree_id, paused_at,
-          parent_session_id, parent_worker_id, created_by, data_scope,
-          data_scope_slug, recovery_state, orphaned_at, orphaned_reason
-        )
-        SELECT
-          id, type, location_path, server_pid, created_at, updated_at,
-          initial_prompt, title, repository_id, worktree_id, paused_at,
-          parent_session_id, parent_worker_id, created_by, data_scope,
-          data_scope_slug, recovery_state, orphaned_at, orphaned_reason
-        FROM sessions
-      `.execute(trx);
-
-      await sql`DROP TABLE sessions`.execute(trx);
-      await sql`ALTER TABLE sessions_new RENAME TO sessions`.execute(trx);
-
-      for (const obj of objectsToRestore) {
-        await sql.raw(obj.sql as string).execute(trx);
-      }
-
-      await sql`PRAGMA user_version = 19`.execute(trx);
-    });
-
-    const fkCheck = await sql<{ table: string; rowid: number; parent: string; fkid: number }>`
-      PRAGMA foreign_key_check
-    `.execute(db);
-    if (fkCheck.rows.length > 0) {
-      throw new Error(
-        `Foreign key check failed after v19 migration: ${JSON.stringify(fkCheck.rows)}`
-      );
-    }
-  } finally {
-    await sql`PRAGMA foreign_keys = ON`.execute(db);
-  }
 }
 
 describe('migration v19 (sessions.created_by FK constraint)', () => {
@@ -316,7 +214,7 @@ describe('migration v19 (sessions.created_by FK constraint)', () => {
       sessions: testSessions,
     });
 
-    await runV19Migration(db);
+    await migrateToV19(db);
 
     // Verify all data preserved
     const sessions = await db
@@ -358,7 +256,7 @@ describe('migration v19 (sessions.created_by FK constraint)', () => {
       sessions: testSessions,
     });
 
-    await runV19Migration(db);
+    await migrateToV19(db);
 
     // Verify session references user before deletion
     let session = await db
@@ -406,7 +304,7 @@ describe('migration v19 (sessions.created_by FK constraint)', () => {
       AND name NOT LIKE 'sqlite_autoindex%'
     `.execute(db);
 
-    await runV19Migration(db);
+    await migrateToV19(db);
 
     // Get all indexes/triggers after migration
     const afterObjects = await sql<{
@@ -420,8 +318,19 @@ describe('migration v19 (sessions.created_by FK constraint)', () => {
       AND name NOT LIKE 'sqlite_autoindex%'
     `.execute(db);
 
-    // Verify all non-automatic indexes/triggers are preserved
+    // Verify all non-automatic indexes/triggers are preserved with identical
+    // DDL. A simple length comparison would miss cases where an object was
+    // recreated under the same name but with a different definition; matching
+    // by name and asserting `sql` equality catches such drift.
     expect(afterObjects.rows).toHaveLength(beforeObjects.rows.length);
+
+    const beforeByName = new Map(beforeObjects.rows.map((row) => [row.name, row]));
+    for (const after of afterObjects.rows) {
+      const before = beforeByName.get(after.name);
+      expect(before).toBeDefined();
+      expect(after.type).toBe(before!.type);
+      expect(after.sql).toBe(before!.sql);
+    }
 
     const afterNames = afterObjects.rows.map(r => r.name);
     expect(afterNames).toContain('test_sessions_type_idx');
@@ -451,8 +360,8 @@ describe('migration v19 (sessions.created_by FK constraint)', () => {
     });
 
     // Run migration twice
-    await runV19Migration(db);
-    await runV19Migration(db);
+    await migrateToV19(db);
+    await migrateToV19(db);
 
     // Verify schema version is correct
     const versionRes = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
@@ -463,6 +372,19 @@ describe('migration v19 (sessions.created_by FK constraint)', () => {
     expect(sessions).toHaveLength(1);
     expect(sessions[0].id).toBe('sess-1');
     expect(sessions[0].created_by).toBe('user-1');
+
+    // Re-verify FK behavior is still active after the second (no-op) run.
+    // The idempotency guard must not silently drop the FK constraint.
+    await db
+      .deleteFrom('users')
+      .where('id', '=', 'user-1')
+      .execute();
+    const afterDelete = await db
+      .selectFrom('sessions')
+      .select(['id', 'created_by'])
+      .where('id', '=', 'sess-1')
+      .executeTakeFirstOrThrow();
+    expect(afterDelete.created_by).toBeNull();
 
     await db.destroy();
   });
@@ -496,7 +418,7 @@ describe('migration v19 (sessions.created_by FK constraint)', () => {
       sessions: testSessions,
     });
 
-    await runV19Migration(db);
+    await migrateToV19(db);
 
     const sessions = await db
       .selectFrom('sessions')

--- a/packages/server/src/database/__tests__/migration.test.ts
+++ b/packages/server/src/database/__tests__/migration.test.ts
@@ -1432,7 +1432,9 @@ describe('migration', () => {
       expect(rows[0].created_by).toBeNull();
     });
 
-    it('should set schema version to 19 (latest)', async () => {
+    it('should advance schema version past v14 to the latest', async () => {
+      // initializeDatabase runs every migration up to current; this just
+      // confirms the v14 step is part of that chain (final version is 19).
       const db = await initializeDatabase(':memory:');
 
       const { sql } = await import('kysely');
@@ -1468,7 +1470,9 @@ describe('migration', () => {
       expect(rows[0].created_at).toBe('2024-01-01T00:00:00.000Z');
     });
 
-    it('should set schema version to 19 (latest)', async () => {
+    it('should advance schema version past v16 to the latest', async () => {
+      // initializeDatabase runs every migration up to current; this just
+      // confirms the v16 step is part of that chain (final version is 19).
       const db = await initializeDatabase(':memory:');
 
       const { sql } = await import('kysely');

--- a/packages/server/src/database/__tests__/migration.test.ts
+++ b/packages/server/src/database/__tests__/migration.test.ts
@@ -643,7 +643,7 @@ describe('migration', () => {
       // Verify the schema version is the latest
       const { sql } = await import('kysely');
       const result = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
-      expect(result.rows[0]?.user_version).toBe(18);
+      expect(result.rows[0]?.user_version).toBe(19);
 
       // Verify description column exists by inserting and reading a repository with description
       await db
@@ -738,7 +738,7 @@ describe('migration', () => {
       // Verify the schema version is the latest
       const { sql } = await import('kysely');
       const result = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
-      expect(result.rows[0]?.user_version).toBe(18);
+      expect(result.rows[0]?.user_version).toBe(19);
 
       // First create a repository (foreign key dependency)
       await db
@@ -1372,6 +1372,20 @@ describe('migration', () => {
     it('should add created_by column to sessions table', async () => {
       const db = await initializeDatabase(':memory:');
 
+      // v19 added FK constraint sessions.created_by -> users(id), so the
+      // referenced user must exist before the session can be inserted.
+      await db
+        .insertInto('users')
+        .values({
+          id: 'alice',
+          os_uid: null,
+          username: 'alice',
+          home_dir: '/home/alice',
+          created_at: '2024-01-01T00:00:00.000Z',
+          updated_at: '2024-01-01T00:00:00.000Z',
+        })
+        .execute();
+
       await db
         .insertInto('sessions')
         .values({
@@ -1418,12 +1432,12 @@ describe('migration', () => {
       expect(rows[0].created_by).toBeNull();
     });
 
-    it('should set schema version to 18 (latest)', async () => {
+    it('should set schema version to 19 (latest)', async () => {
       const db = await initializeDatabase(':memory:');
 
       const { sql } = await import('kysely');
       const result = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
-      expect(result.rows[0]?.user_version).toBe(18);
+      expect(result.rows[0]?.user_version).toBe(19);
     });
   });
 
@@ -1454,12 +1468,12 @@ describe('migration', () => {
       expect(rows[0].created_at).toBe('2024-01-01T00:00:00.000Z');
     });
 
-    it('should set schema version to 18 (latest)', async () => {
+    it('should set schema version to 19 (latest)', async () => {
       const db = await initializeDatabase(':memory:');
 
       const { sql } = await import('kysely');
       const result = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
-      expect(result.rows[0]?.user_version).toBe(18);
+      expect(result.rows[0]?.user_version).toBe(19);
     });
   });
 

--- a/packages/server/src/database/connection.ts
+++ b/packages/server/src/database/connection.ts
@@ -253,6 +253,10 @@ async function runMigrations(database: Kysely<Database>): Promise<void> {
   if (currentVersion < 18) {
     await migrateToV18(database);
   }
+
+  if (currentVersion < 19) {
+    await migrateToV19(database);
+  }
 }
 
 /**
@@ -997,6 +1001,145 @@ async function migrateToV18(database: Kysely<Database>): Promise<void> {
     },
     'Migration to v18 completed'
   );
+}
+
+/**
+ * Migration v19: Add FK constraint to sessions.created_by referencing users(id) ON DELETE SET NULL.
+ *
+ * SQLite does not support ALTER TABLE ADD CONSTRAINT, so we use the standard
+ * table-recreation pattern (https://www.sqlite.org/lang_altertable.html#otheralter):
+ *   1. PRAGMA foreign_keys = OFF (must be outside transaction)
+ *   2. Snapshot existing index/trigger DDL on the sessions table
+ *   3. Inside a transaction:
+ *      a. Rename sessions to sessions_old
+ *      b. Create the new sessions table with the FK constraint
+ *      c. Copy all rows from sessions_old to sessions
+ *      d. Drop sessions_old
+ *      e. Recreate the captured indexes/triggers
+ *      f. PRAGMA user_version = 19
+ *   4. PRAGMA foreign_key_check
+ *   5. PRAGMA foreign_keys = ON
+ *
+ * Idempotent: if user_version is already >= 19 the function returns early.
+ * pre-v14 NULL `created_by` rows are preserved as NULL — the FK is satisfied
+ * by NULL.
+ */
+async function migrateToV19(database: Kysely<Database>): Promise<void> {
+  // Idempotency guard: if the migration has already been applied (e.g. on
+  // re-run against a v19+ database) return without touching the schema. The
+  // production gate in `runMigrations` already prevents this, but the same
+  // function is invoked from tests and should be safe to re-run.
+  const versionResult = await sql<{ user_version: number }>`PRAGMA user_version`.execute(database);
+  const currentVersion = versionResult.rows[0]?.user_version ?? 0;
+  if (currentVersion >= 19) {
+    logger.info({ currentVersion }, 'Skipping migration to v19: already applied');
+    return;
+  }
+
+  logger.info('Running migration to v19: Adding FK constraint to sessions.created_by');
+
+  // FK toggling cannot happen inside a transaction. Disable FK enforcement
+  // for the duration of the rebuild so the rename/drop steps don't trip on
+  // dependent constraints.
+  await sql`PRAGMA foreign_keys = OFF`.execute(database);
+
+  try {
+    // Snapshot non-automatic indexes and triggers attached to the sessions
+    // table BEFORE dropping it. SQLite drops these automatically when the
+    // backing table is dropped, so we recreate them after the new table is in
+    // place. `sqlite_autoindex%` are implicit (PRIMARY KEY/UNIQUE) and are
+    // re-created automatically by the new CREATE TABLE.
+    const objectsResult = await sql<{
+      type: string;
+      name: string;
+      sql: string | null;
+    }>`
+      SELECT type, name, sql
+      FROM sqlite_master
+      WHERE tbl_name = 'sessions'
+        AND type IN ('index', 'trigger')
+        AND name NOT LIKE 'sqlite_autoindex%'
+    `.execute(database);
+    const objectsToRestore = objectsResult.rows.filter((row) => row.sql !== null);
+
+    await database.transaction().execute(async (trx) => {
+      // Step 1: rename existing table out of the way.
+      await sql`ALTER TABLE sessions RENAME TO sessions_old`.execute(trx);
+
+      // Step 2: create the new table with the FK constraint. Column order
+      // and types mirror the v18 schema; the only addition is the inline
+      // FK clause on `created_by`.
+      await sql`
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          type TEXT NOT NULL,
+          location_path TEXT NOT NULL,
+          server_pid INTEGER,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+          initial_prompt TEXT,
+          title TEXT,
+          repository_id TEXT,
+          worktree_id TEXT,
+          paused_at TEXT,
+          parent_session_id TEXT,
+          parent_worker_id TEXT,
+          created_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+          data_scope TEXT,
+          data_scope_slug TEXT,
+          recovery_state TEXT NOT NULL DEFAULT 'healthy',
+          orphaned_at INTEGER,
+          orphaned_reason TEXT
+        )
+      `.execute(trx);
+
+      // Step 3: copy data. Listing columns explicitly guards against any
+      // future column-order drift between the old and new tables.
+      await sql`
+        INSERT INTO sessions (
+          id, type, location_path, server_pid, created_at, updated_at,
+          initial_prompt, title, repository_id, worktree_id, paused_at,
+          parent_session_id, parent_worker_id, created_by, data_scope,
+          data_scope_slug, recovery_state, orphaned_at, orphaned_reason
+        )
+        SELECT
+          id, type, location_path, server_pid, created_at, updated_at,
+          initial_prompt, title, repository_id, worktree_id, paused_at,
+          parent_session_id, parent_worker_id, created_by, data_scope,
+          data_scope_slug, recovery_state, orphaned_at, orphaned_reason
+        FROM sessions_old
+      `.execute(trx);
+
+      // Step 4: drop the old table.
+      await sql`DROP TABLE sessions_old`.execute(trx);
+
+      // Step 5: recreate captured indexes/triggers. Each row's `sql` is the
+      // exact CREATE statement SQLite stored, so re-executing it restores the
+      // object on the rebuilt table.
+      for (const obj of objectsToRestore) {
+        await sql.raw(obj.sql as string).execute(trx);
+      }
+
+      // Step 6: bump the schema version inside the transaction so that a
+      // failure anywhere above leaves the version unchanged.
+      await sql`PRAGMA user_version = 19`.execute(trx);
+    });
+
+    // Verify the rebuild left no dangling FK references.
+    const fkCheck = await sql<{ table: string; rowid: number; parent: string; fkid: number }>`
+      PRAGMA foreign_key_check
+    `.execute(database);
+    if (fkCheck.rows.length > 0) {
+      throw new Error(
+        `Foreign key check failed after v19 migration: ${JSON.stringify(fkCheck.rows)}`
+      );
+    }
+  } finally {
+    // Always re-enable FK enforcement, even if the migration failed.
+    await sql`PRAGMA foreign_keys = ON`.execute(database);
+  }
+
+  logger.info('Migration to v19 completed');
 }
 
 /**

--- a/packages/server/src/database/connection.ts
+++ b/packages/server/src/database/connection.ts
@@ -3,6 +3,7 @@ import { BunSqliteDialect } from 'kysely-bun-sqlite';
 import { Database as BunDatabase } from 'bun:sqlite';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
 import * as v from 'valibot';
 import type { AgentDefinition } from '@agent-console/shared';
 import { AgentDefinitionSchema } from '@agent-console/shared';
@@ -23,6 +24,47 @@ const logger = createLogger('database');
  */
 function isDuplicateColumnError(error: unknown): boolean {
   return error instanceof Error && error.message.includes('duplicate column name');
+}
+
+/**
+ * Sentinel value used by callers (and tests) to opt out of pre-migration
+ * backup. Matches the path that Bun SQLite uses for in-memory databases.
+ */
+const IN_MEMORY_DB_PATH = ':memory:';
+
+/**
+ * Create a sibling backup copy of the SQLite database file before running a
+ * disruptive migration (e.g. table-recreation in v19).
+ *
+ * The backup file lives next to the database with a deterministic suffix that
+ * encodes the version transition and a timestamp, e.g.:
+ *   /path/to/agentconsole.db.bak.v18-to-v19.2026-04-25T20-39-00-000Z
+ *
+ * Behaviour:
+ *   - In-memory databases (`:memory:`) are skipped — there is no file to copy.
+ *     Returns `null` so callers can distinguish "skipped" from "succeeded".
+ *   - On copy failure, the underlying error is re-thrown unchanged so the
+ *     caller can abort the migration without bumping the schema version.
+ *   - Colons and dots in the ISO-8601 timestamp are replaced with `-` so the
+ *     filename is portable across filesystems.
+ *
+ * @returns The absolute path to the backup file, or `null` when skipped.
+ */
+export async function backupDatabaseFile(
+  dbPath: string,
+  fromVersion: number,
+  toVersion: number
+): Promise<string | null> {
+  if (dbPath === IN_MEMORY_DB_PATH) {
+    return null;
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = `${dbPath}.bak.v${fromVersion}-to-v${toVersion}.${timestamp}`;
+
+  await fsPromises.copyFile(dbPath, backupPath);
+
+  return backupPath;
 }
 
 let db: Kysely<Database> | null = null;
@@ -109,7 +151,7 @@ async function doInitializeDatabase(customDbPath?: string): Promise<Kysely<Datab
   await sql`PRAGMA foreign_keys = ON`.execute(database);
 
   // Run schema migrations
-  await runMigrations(database);
+  await runMigrations(database, dbPath);
 
   // Migrate data from JSON (one-time, skip for in-memory database)
   if (!isInMemory) {
@@ -165,7 +207,7 @@ export async function createDatabaseForTest(): Promise<Kysely<Database>> {
   await sql`PRAGMA foreign_keys = ON`.execute(database);
 
   // Run schema migrations
-  await runMigrations(database);
+  await runMigrations(database, IN_MEMORY_DB_PATH);
 
   return database;
 }
@@ -173,8 +215,13 @@ export async function createDatabaseForTest(): Promise<Kysely<Database>> {
 /**
  * Run database migrations based on PRAGMA user_version.
  * Each migration increments the version number.
+ *
+ * @param dbPath - Filesystem path of the database, or `:memory:` for an
+ *                 in-memory database. Migrations that need to take a
+ *                 pre-flight backup (e.g. v19) use this to locate the file
+ *                 and skip the backup for in-memory databases.
  */
-async function runMigrations(database: Kysely<Database>): Promise<void> {
+async function runMigrations(database: Kysely<Database>, dbPath: string): Promise<void> {
   // Get current schema version using PRAGMA user_version
   const result = await sql<{ user_version: number }>`PRAGMA user_version`.execute(database);
   const currentVersion = result.rows[0]?.user_version ?? 0;
@@ -255,7 +302,7 @@ async function runMigrations(database: Kysely<Database>): Promise<void> {
   }
 
   if (currentVersion < 19) {
-    await migrateToV19(database);
+    await migrateToV19(database, dbPath);
   }
 }
 
@@ -1019,9 +1066,12 @@ async function migrateToV18(database: Kysely<Database>): Promise<void> {
  * because no dependent table references `sessions_new`.
  *
  * Sequence:
- *   1. PRAGMA foreign_keys = OFF (must be outside transaction)
- *   2. Snapshot existing index/trigger DDL on the sessions table
- *   3. Inside a transaction:
+ *   1. Pre-flight backup of the database file (skipped for `:memory:`).
+ *      A backup failure aborts the migration before any schema change so the
+ *      caller can recover from a known-good state.
+ *   2. PRAGMA foreign_keys = OFF (must be outside transaction)
+ *   3. Snapshot existing index/trigger DDL on the sessions table
+ *   4. Inside a transaction:
  *      a. Create sessions_new with the FK constraint
  *      b. Copy all rows from sessions to sessions_new
  *      c. Drop sessions
@@ -1029,15 +1079,25 @@ async function migrateToV18(database: Kysely<Database>): Promise<void> {
  *      e. Recreate the captured indexes/triggers
  *      f. PRAGMA foreign_key_check (rolls back on violation)
  *      g. PRAGMA user_version = 19
- *   4. PRAGMA foreign_keys = ON
+ *   5. PRAGMA foreign_keys = ON
  *
  * Idempotent: if user_version is already >= 19 the function returns early.
  * pre-v14 NULL `created_by` rows are preserved as NULL — the FK is satisfied
  * by NULL.
  *
+ * @param database - Kysely database handle to migrate.
+ * @param dbPath   - Filesystem path of the database. Defaults to `:memory:`
+ *                   so direct test invocations against an in-memory Kysely
+ *                   instance opt out of the backup step automatically. When
+ *                   called from `runMigrations` against a real file, the
+ *                   real path is supplied and a backup is taken.
+ *
  * @internal Exported for testing.
  */
-export async function migrateToV19(database: Kysely<Database>): Promise<void> {
+export async function migrateToV19(
+  database: Kysely<Database>,
+  dbPath: string = IN_MEMORY_DB_PATH
+): Promise<void> {
   // Idempotency guard: if the migration has already been applied (e.g. on
   // re-run against a v19+ database) return without touching the schema. The
   // production gate in `runMigrations` already prevents this, but the same
@@ -1047,6 +1107,15 @@ export async function migrateToV19(database: Kysely<Database>): Promise<void> {
   if (currentVersion >= 19) {
     logger.info({ currentVersion }, 'Skipping migration to v19: already applied');
     return;
+  }
+
+  // Take a pre-flight backup BEFORE any schema mutation. A copy failure
+  // throws and aborts the migration so user_version stays at 18 and the
+  // caller can investigate (disk full, permissions, etc.) without a
+  // partially-rebuilt sessions table. Skipped for in-memory databases.
+  const backupPath = await backupDatabaseFile(dbPath, 18, 19);
+  if (backupPath !== null) {
+    logger.info({ backupPath }, 'Database backup created');
   }
 
   logger.info('Running migration to v19: Adding FK constraint to sessions.created_by');

--- a/packages/server/src/database/connection.ts
+++ b/packages/server/src/database/connection.ts
@@ -1007,14 +1007,25 @@ async function migrateToV18(database: Kysely<Database>): Promise<void> {
  * Migration v19: Add FK constraint to sessions.created_by referencing users(id) ON DELETE SET NULL.
  *
  * SQLite does not support ALTER TABLE ADD CONSTRAINT, so we use the standard
- * table-recreation pattern (https://www.sqlite.org/lang_altertable.html#otheralter):
+ * table-recreation pattern (https://www.sqlite.org/lang_altertable.html#otheralter).
+ * To avoid SQLite ≥ 3.25.0's default "ALTER TABLE RENAME also rewrites foreign-key
+ * references in dependent tables" behavior — which would silently rewrite
+ * `workers.session_id REFERENCES sessions(id)` to point at `sessions_old` and
+ * leave the FK dangling after we drop `sessions_old` — we use the inverse
+ * recreate pattern: build the new table under a temporary name, copy data,
+ * drop the original table, then rename the new table into place. After the
+ * final rename completes, dependent FK declarations still reference `sessions`
+ * (the canonical name), and SQLite's RENAME-based FK rewrite leaves them alone
+ * because no dependent table references `sessions_new`.
+ *
+ * Sequence:
  *   1. PRAGMA foreign_keys = OFF (must be outside transaction)
  *   2. Snapshot existing index/trigger DDL on the sessions table
  *   3. Inside a transaction:
- *      a. Rename sessions to sessions_old
- *      b. Create the new sessions table with the FK constraint
- *      c. Copy all rows from sessions_old to sessions
- *      d. Drop sessions_old
+ *      a. Create sessions_new with the FK constraint
+ *      b. Copy all rows from sessions to sessions_new
+ *      c. Drop sessions
+ *      d. Rename sessions_new to sessions
  *      e. Recreate the captured indexes/triggers
  *      f. PRAGMA user_version = 19
  *   4. PRAGMA foreign_key_check
@@ -1063,14 +1074,11 @@ async function migrateToV19(database: Kysely<Database>): Promise<void> {
     const objectsToRestore = objectsResult.rows.filter((row) => row.sql !== null);
 
     await database.transaction().execute(async (trx) => {
-      // Step 1: rename existing table out of the way.
-      await sql`ALTER TABLE sessions RENAME TO sessions_old`.execute(trx);
-
-      // Step 2: create the new table with the FK constraint. Column order
+      // Step 1: create the new table under a temporary name. Column order
       // and types mirror the v18 schema; the only addition is the inline
       // FK clause on `created_by`.
       await sql`
-        CREATE TABLE sessions (
+        CREATE TABLE sessions_new (
           id TEXT PRIMARY KEY,
           type TEXT NOT NULL,
           location_path TEXT NOT NULL,
@@ -1093,10 +1101,10 @@ async function migrateToV19(database: Kysely<Database>): Promise<void> {
         )
       `.execute(trx);
 
-      // Step 3: copy data. Listing columns explicitly guards against any
+      // Step 2: copy data. Listing columns explicitly guards against any
       // future column-order drift between the old and new tables.
       await sql`
-        INSERT INTO sessions (
+        INSERT INTO sessions_new (
           id, type, location_path, server_pid, created_at, updated_at,
           initial_prompt, title, repository_id, worktree_id, paused_at,
           parent_session_id, parent_worker_id, created_by, data_scope,
@@ -1107,11 +1115,18 @@ async function migrateToV19(database: Kysely<Database>): Promise<void> {
           initial_prompt, title, repository_id, worktree_id, paused_at,
           parent_session_id, parent_worker_id, created_by, data_scope,
           data_scope_slug, recovery_state, orphaned_at, orphaned_reason
-        FROM sessions_old
+        FROM sessions
       `.execute(trx);
 
-      // Step 4: drop the old table.
-      await sql`DROP TABLE sessions_old`.execute(trx);
+      // Step 3: drop the original table. Indexes and triggers attached to it
+      // are dropped automatically by SQLite; we recreate them in step 5.
+      await sql`DROP TABLE sessions`.execute(trx);
+
+      // Step 4: rename the new table into place. After this rename, any
+      // dependent FK declarations (e.g. workers.session_id) continue to
+      // reference `sessions` because no dependent table references
+      // `sessions_new` — so SQLite's FK-rewrite-on-rename has nothing to do.
+      await sql`ALTER TABLE sessions_new RENAME TO sessions`.execute(trx);
 
       // Step 5: recreate captured indexes/triggers. Each row's `sql` is the
       // exact CREATE statement SQLite stored, so re-executing it restores the

--- a/packages/server/src/database/connection.ts
+++ b/packages/server/src/database/connection.ts
@@ -1027,15 +1027,17 @@ async function migrateToV18(database: Kysely<Database>): Promise<void> {
  *      c. Drop sessions
  *      d. Rename sessions_new to sessions
  *      e. Recreate the captured indexes/triggers
- *      f. PRAGMA user_version = 19
- *   4. PRAGMA foreign_key_check
- *   5. PRAGMA foreign_keys = ON
+ *      f. PRAGMA foreign_key_check (rolls back on violation)
+ *      g. PRAGMA user_version = 19
+ *   4. PRAGMA foreign_keys = ON
  *
  * Idempotent: if user_version is already >= 19 the function returns early.
  * pre-v14 NULL `created_by` rows are preserved as NULL — the FK is satisfied
  * by NULL.
+ *
+ * @internal Exported for testing.
  */
-async function migrateToV19(database: Kysely<Database>): Promise<void> {
+export async function migrateToV19(database: Kysely<Database>): Promise<void> {
   // Idempotency guard: if the migration has already been applied (e.g. on
   // re-run against a v19+ database) return without touching the schema. The
   // production gate in `runMigrations` already prevents this, but the same
@@ -1135,20 +1137,24 @@ async function migrateToV19(database: Kysely<Database>): Promise<void> {
         await sql.raw(obj.sql as string).execute(trx);
       }
 
-      // Step 6: bump the schema version inside the transaction so that a
+      // Step 6: verify the rebuild left no dangling FK references. Performed
+      // inside the transaction so any violation triggers a rollback rather
+      // than leaving the database in a partially-committed state with a
+      // bumped schema version. PRAGMA foreign_key_check is read-only and
+      // safe to run within a transaction.
+      const fkCheck = await sql<{ table: string; rowid: number; parent: string; fkid: number }>`
+        PRAGMA foreign_key_check
+      `.execute(trx);
+      if (fkCheck.rows.length > 0) {
+        throw new Error(
+          `Foreign key check failed after v19 migration: ${JSON.stringify(fkCheck.rows)}`
+        );
+      }
+
+      // Step 7: bump the schema version inside the transaction so that a
       // failure anywhere above leaves the version unchanged.
       await sql`PRAGMA user_version = 19`.execute(trx);
     });
-
-    // Verify the rebuild left no dangling FK references.
-    const fkCheck = await sql<{ table: string; rowid: number; parent: string; fkid: number }>`
-      PRAGMA foreign_key_check
-    `.execute(database);
-    if (fkCheck.rows.length > 0) {
-      throw new Error(
-        `Foreign key check failed after v19 migration: ${JSON.stringify(fkCheck.rows)}`
-      );
-    }
   } finally {
     // Always re-enable FK enforcement, even if the migration failed.
     await sql`PRAGMA foreign_keys = ON`.execute(database);

--- a/packages/server/src/services/__tests__/session-ownership.test.ts
+++ b/packages/server/src/services/__tests__/session-ownership.test.ts
@@ -39,6 +39,23 @@ describe('Session Ownership (createdBy)', () => {
     await initializeDatabase(':memory:');
 
     const db = getDatabase();
+    // Seed the user rows referenced by these tests' createdBy values.
+    // Required since v19 added a FK constraint sessions.created_by -> users(id).
+    for (const userId of ['test-user-id', 'alice', 'bob', 'charlie', 'dave', 'operator']) {
+      await db
+        .insertInto('users')
+        .values({
+          id: userId,
+          os_uid: null,
+          username: userId,
+          home_dir: `/home/${userId}`,
+          created_at: '2024-01-01T00:00:00.000Z',
+          updated_at: '2024-01-01T00:00:00.000Z',
+        })
+        .onConflict((oc) => oc.column('id').doNothing())
+        .execute();
+    }
+
     testJobQueue = new JobQueue(db, { concurrency: 1 });
     registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
 


### PR DESCRIPTION
Closes #680

## Summary

Adds foreign key constraint `REFERENCES users(id) ON DELETE SET NULL` to `sessions.created_by` column via migration v19 using SQLite table-recreation pattern.

## Test Plan

✅ All Issue #680 Acceptance Criteria verified:

- **Migration v19 implementation**: SQLite table-recreation pattern (ALTER TABLE ADD CONSTRAINT not supported)
- **FK constraint behavior**: User deletion sets sessions.created_by to NULL via ON DELETE SET NULL
- **Data preservation**: All existing session data maintained during table recreation
- **Index/trigger restoration**: sqlite_master query preserves all attached indexes/triggers  
- **Migration idempotency**: Multiple runs safe, early return if user_version >= 19
- **Pre-v14 NULL row compatibility**: NULL created_by values preserved
- **Full test suite**: `bun run test` - 4009 total tests pass (client 1359 + server 2338 + shared 288 + integration 24)
- **Type check**: `bun run build` passes (includes typecheck)
- **Docs updated**: 
  - `docs/design/multi-user-shared-setup.md` §Phase 2 migration history footnote
  - `docs/design/shared-orchestrator-session.md` FK constraint existence noted

## Technical Details

- **backend-specialist delegation** per CLAUDE.md subagent policy
- **TDD approach**: failing tests created first, implementation makes them pass
- **Table-recreation pattern**: PRAGMA foreign_keys OFF → rename → recreate with FK → restore data → restore objects → foreign_key_check
- **Test coverage**: 6 migration v19 specific tests (23 expect() calls) all pass

## Note

Local CodeRabbit CLI rate-limited during this sprint (Issue #653 fallback). Relying on GitHub-side CodeRabbit bot review in this PR.