### PR TITLE
Fix consecutive newlines splitting in MessageInput

### DIFF
--- a/packages/client/src/components/sessions/MessagePanel.tsx
+++ b/packages/client/src/components/sessions/MessagePanel.tsx
@@ -121,7 +121,7 @@ export const MessagePanel = forwardRef<MessagePanelHandle, MessagePanelProps>(
 
     setSending(true);
     try {
-      await sendWorkerMessage(sessionId, targetWorkerId, content.trim(), files.length > 0 ? files : undefined);
+      await sendWorkerMessage(sessionId, targetWorkerId, content, files.length > 0 ? files : undefined);
       clearDraft();
       setFiles([]);
       setHasUnread(false);

--- a/packages/client/src/components/sessions/__tests__/MessagePanel.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/MessagePanel.test.tsx
@@ -485,6 +485,52 @@ describe('MessagePanel', () => {
     expect(_getDraftsMap().has('session-1:agent-1')).toBe(false);
   });
 
+  it('preserves multiple consecutive newlines when sending message', async () => {
+    const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+    const view = within(container);
+
+    const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+    const messageWithBlankLines = 'First line\n\n\nSecond line after two blank lines\n\n\nThird line';
+
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: messageWithBlankLines } });
+    });
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+    });
+
+    // Message should be sent with exact content including all newlines
+    expect(mockSendWorkerMessage).toHaveBeenCalledWith(
+      'session-1',
+      'agent-1',
+      messageWithBlankLines, // Should NOT be trimmed
+      undefined
+    );
+  });
+
+  it('preserves leading and trailing whitespace in messages', async () => {
+    const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+    const view = within(container);
+
+    const textarea = view.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+    const messageWithWhitespace = '  \n\nMessage with leading/trailing whitespace\n\n  ';
+
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: messageWithWhitespace } });
+    });
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+    });
+
+    // Message should be sent with exact content including all whitespace
+    expect(mockSendWorkerMessage).toHaveBeenCalledWith(
+      'session-1',
+      'agent-1',
+      messageWithWhitespace, // Should NOT be trimmed
+      undefined
+    );
+  });
+
   describe('slash command completion', () => {
     it('shows dropdown when typing /', async () => {
       const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));

--- a/packages/server/src/services/__tests__/interactive-process-manager.test.ts
+++ b/packages/server/src/services/__tests__/interactive-process-manager.test.ts
@@ -367,7 +367,7 @@ describe('InteractiveProcessManager', () => {
       expect(result).toBe(true);
     });
 
-    it('should call writePtyData with CR-converted content on successful write', async () => {
+    it('should call writePtyData with content echoed to PTY on successful write', async () => {
       const process = await manager.runProcess({
         sessionId: 'session-1',
         workerId: 'worker-1',
@@ -389,6 +389,53 @@ describe('InteractiveProcessManager', () => {
       expect(mockWritePtyData).toHaveBeenCalledWith('session-1', 'worker-1', 'hello');
       // injectPtyMessage should NOT be called for writeResponse path
       expect(mockInjectPtyMessage).not.toHaveBeenCalled();
+    });
+
+    it('should preserve LF newlines as soft newlines when echoing multi-line response (Issue #660)', async () => {
+      const process = await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'cat > /dev/null',
+      });
+
+      const deadline = Date.now() + 5000;
+      let result = false;
+      while (Date.now() < deadline) {
+        const info = manager.getProcess(process.id);
+        if (info?.status === 'running') {
+          result = await manager.writeResponse(process.id, 'first\n\n\nsecond');
+          if (result) break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      expect(result).toBe(true);
+      // Newlines must be preserved as \n (soft newlines), not converted to \r
+      // (submit). Converting would split a single response into multiple
+      // submissions echoed to the agent PTY.
+      expect(mockWritePtyData).toHaveBeenCalledWith('session-1', 'worker-1', 'first\n\n\nsecond');
+    });
+
+    it('should normalize CRLF newlines to LF when echoing response', async () => {
+      const process = await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'cat > /dev/null',
+      });
+
+      const deadline = Date.now() + 5000;
+      let result = false;
+      while (Date.now() < deadline) {
+        const info = manager.getProcess(process.id);
+        if (info?.status === 'running') {
+          result = await manager.writeResponse(process.id, 'first\r\nsecond');
+          if (result) break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      expect(result).toBe(true);
+      expect(mockWritePtyData).toHaveBeenCalledWith('session-1', 'worker-1', 'first\nsecond');
     });
 
     it('should not call writePtyData when ptyMessageInjector is not provided', async () => {

--- a/packages/server/src/services/__tests__/pty-message-injection-service.test.ts
+++ b/packages/server/src/services/__tests__/pty-message-injection-service.test.ts
@@ -34,14 +34,35 @@ describe('PtyMessageInjectionService', () => {
     expect(writeInput).toHaveBeenCalledTimes(2);
   });
 
-  it('should convert newlines to carriage returns in content', () => {
+  it('should preserve LF newlines as soft newlines in content (Issue #660)', () => {
     service.injectMessage('s1', 'w1', 'line1\nline2\nline3');
-    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', 'line1\rline2\rline3');
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', 'line1\nline2\nline3');
   });
 
-  it('should convert CRLF to single CR', () => {
+  it('should normalize CRLF to LF (single soft newline) in content', () => {
     service.injectMessage('s1', 'w1', 'line1\r\nline2\r\nline3');
-    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', 'line1\rline2\rline3');
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', 'line1\nline2\nline3');
+  });
+
+  it('preserves multiple consecutive newlines as soft newlines (Issue #660)', () => {
+    // Regression test: previously \n was converted to \r (submit), so 3 blank
+    // lines split a single message into 3 separate submissions to the agent.
+    const result = service.injectMessage('s1', 'w1', 'First line\n\n\nSecond line');
+
+    expect(result).toBe(true);
+    // Newlines preserved verbatim as part of the same message body.
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', 'First line\n\n\nSecond line');
+    // Only ONE write before any timer advances — body is not split.
+    expect(writeInput).toHaveBeenCalledTimes(1);
+
+    // Exactly one final \r submit is queued (no premature submits inside body).
+    jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
+    expect(writeInput).toHaveBeenCalledTimes(2);
+    expect(writeInput).toHaveBeenLastCalledWith('s1', 'w1', '\r');
+
+    // No further writes after the single submit.
+    jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS * 5);
+    expect(writeInput).toHaveBeenCalledTimes(2);
   });
 
   it('should inject content followed by file paths with delays', () => {

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -563,7 +563,7 @@ describe('SessionManager', () => {
       expect(ptyFactory.instances[0].writtenData).toContain('hello world');
     });
 
-    it('should convert newlines to carriage returns in multi-line content', async () => {
+    it('should preserve LF newlines as soft newlines in multi-line content (Issue #660)', async () => {
       const manager = await getSessionManager();
       const session = await manager.createSession({
         type: 'quick',
@@ -576,13 +576,14 @@ describe('SessionManager', () => {
       expect(message).not.toBeNull();
       // Content stored in message should retain original newlines
       expect(message!.content).toBe('line1\nline2\nline3');
-      // PTY input should use carriage returns instead of newlines
+      // PTY input must preserve newlines as soft newlines (\n), not submit (\r).
+      // Converting to \r would split this into 3 separate submissions to the agent.
       const pty = ptyFactory.instances[0];
-      expect(pty.writtenData).toContain('line1\rline2\rline3');
-      expect(pty.writtenData).not.toContain('line1\nline2\nline3');
+      expect(pty.writtenData).toContain('line1\nline2\nline3');
+      expect(pty.writtenData).not.toContain('line1\rline2\rline3');
     });
 
-    it('should handle CRLF line endings from form submissions', async () => {
+    it('should normalize CRLF line endings from form submissions to LF', async () => {
       const manager = await getSessionManager();
       const session = await manager.createSession({
         type: 'quick',
@@ -596,9 +597,11 @@ describe('SessionManager', () => {
       expect(message).not.toBeNull();
       expect(message!.content).toBe('line1\r\nline2\r\nline3');
       const pty = ptyFactory.instances[0];
-      // \r\n should become single \r, not \r\r
-      expect(pty.writtenData).toContain('line1\rline2\rline3');
+      // \r\n should be normalized to a single \n (soft newline), preserving body
+      // structure without triggering submit. See Issue #660.
+      expect(pty.writtenData).toContain('line1\nline2\nline3');
       expect(pty.writtenData).not.toContain('\r\r');
+      expect(pty.writtenData).not.toContain('line1\rline2\rline3');
     });
 
     it('should inject content with file paths when files provided', async () => {

--- a/packages/server/src/services/interactive-process-manager.ts
+++ b/packages/server/src/services/interactive-process-manager.ts
@@ -159,14 +159,16 @@ export class InteractiveProcessManager {
     }
 
     try {
-      // Echo response content to worker PTY (CR-converted, no Enter yet).
-      // The Enter (\r) will be sent by writePtyNotification when process
-      // output settles and onOutput is called.
+      // Echo response content to worker PTY (newlines normalized to LF so
+      // they remain soft newlines, no Enter yet). The Enter (\r) will be sent
+      // by writePtyNotification when process output settles and onOutput is
+      // called. See Issue #660 — converting \n to \r here previously caused
+      // multi-line responses to be submitted as multiple messages.
       if (this.ptyMessageInjector) {
         this.ptyMessageInjector.writePtyData(
           stored.info.sessionId,
           stored.info.workerId,
-          content.replace(/\r?\n/g, '\r'),
+          content.replace(/\r?\n/g, '\n'),
         );
       }
 

--- a/packages/server/src/services/pty-message-injection-service.ts
+++ b/packages/server/src/services/pty-message-injection-service.ts
@@ -18,15 +18,21 @@ export class PtyMessageInjectionService {
 
   /**
    * Build message parts from content and file paths, then inject into PTY.
-   * Content newlines are converted to carriage returns for TUI compatibility.
-   * Remaining parts and a final Enter are queued with delays so TUI agents
-   * can process each input sequentially.
+   * Content newlines (CRLF or LF from browser form submissions) are normalized
+   * to LF so they remain soft newlines inside the message body — only the
+   * final delayed CR (\r) acts as the submit keystroke. Remaining parts and
+   * a final Enter are queued with delays so TUI agents can process each
+   * input sequentially.
+   *
+   * See Issue #660: previously this converted \r?\n to \r, which caused any
+   * embedded newline to be interpreted as submit and split a single message
+   * into multiple submissions.
    *
    * Returns true if the first part was successfully written, false otherwise.
    */
   injectMessage(sessionId: string, workerId: string, content: string, filePaths?: string[]): boolean {
     const parts: string[] = [];
-    if (content) parts.push(content.replace(/\r?\n/g, '\r'));
+    if (content) parts.push(content.replace(/\r?\n/g, '\n'));
     if (filePaths && filePaths.length > 0) {
       parts.push(...filePaths);
     }


### PR DESCRIPTION
## Summary

- Fixes Issue #660 where MessageInput with consecutive empty lines (空白行 2 行+) caused messages to be split into multiple parts with partial line erasure (data loss)
- **Root cause**: Server-side `\r?\n` → `\r` conversion treating newlines as submit keystrokes instead of preserving them as soft newlines
- **Client-side fix**: Remove `content.trim()` in MessagePanel.tsx to preserve leading/trailing whitespace  
- **Server-side fix**: Change `\r?\n` → `\r` conversion to preserve `\n` as soft newlines in both pty-message-injection-service.ts and interactive-process-manager.ts

## Test plan

- [x] Added regression tests for consecutive newline preservation in MessagePanel
- [x] Added server-side tests for newline handling in pty-message-injection-service and interactive-process-manager
- [x] Full test suite passes (2600+ tests) with zero failures
- [x] Build verification completed for all packages
- [x] Baseline testing confirms no regression from changes

## Real-device verification status

- Dev environment で送信機能が main baseline からの障害で動作せず (Send disabled / textarea unchanged / no server log) 、Real-device verification は実施できませんでした
- 修正の副作用ではないことは `git stash` での baseline 比較で確認済 (修正前から同症状)
- Merge 後に owner 環境で実機確認推奨。owner 環境で過去再現した症状 (分割 + 抹消) が消えれば修正効果は実証されます
- Dev env の送信機能障害は本 PR とは独立、別途切り分け推奨 (Orchestrator が判断)

## Technical details

**Files modified:**
- `packages/client/src/components/sessions/MessagePanel.tsx` - Removed content trimming
- `packages/server/src/services/pty-message-injection-service.ts` - Fixed newline conversion
- `packages/server/src/services/interactive-process-manager.ts` - Fixed sibling newline conversion  
- Added comprehensive test coverage for all changes

**Sibling analysis**: Grep confirmed both server-side call sites with the problematic `\r?\n` → `\r` pattern were identified and fixed for consistency.

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)