### PR TITLE
fix: validate fromSessionId in send_session_message (Issue #690)

### DIFF
--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -818,11 +818,16 @@ describe('MCP Server Tools', () => {
         locationPath: '/test/path',
         agentId: 'claude-code',
       });
+      const senderSession = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/sender-path',
+        agentId: 'claude-code',
+      });
 
       const response = await callTool(app, mcpSessionId, 'send_session_message', {
         toSessionId: session.id,
         content: 'task completed successfully',
-        fromSessionId: 'test-sender',
+        fromSessionId: senderSession.id,
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -838,13 +843,18 @@ describe('MCP Server Tools', () => {
         locationPath: '/test/path',
         agentId: 'claude-code',
       });
+      const senderSession = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/sender-path',
+        agentId: 'claude-code',
+      });
 
       const messageContent = JSON.stringify({ status: 'completed', summary: 'All tests pass' });
 
       const response = await callTool(app, mcpSessionId, 'send_session_message', {
         toSessionId: session.id,
         content: messageContent,
-        fromSessionId: 'sender-session',
+        fromSessionId: senderSession.id,
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -862,22 +872,27 @@ describe('MCP Server Tools', () => {
         locationPath: '/test/path',
         agentId: 'claude-code',
       });
+      const senderSession = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/sender-path',
+        agentId: 'claude-code',
+      });
 
-      // The agent worker's PTY is the first instance created
+      // The target agent worker's PTY is the first instance created
       const mockPty = ptyFactory.instances[0];
       expect(mockPty).toBeDefined();
 
       await callTool(app, mcpSessionId, 'send_session_message', {
         toSessionId: session.id,
         content: 'check this out',
-        fromSessionId: 'sender-session-123',
+        fromSessionId: senderSession.id,
       }, nextId++);
 
       // Verify PTY received the inbound:message notification
       const allWritten = mockPty.writtenData.join('');
       expect(allWritten).toContain('[internal:message]');
       expect(allWritten).toContain('source=session');
-      expect(allWritten).toContain('from=sender-session-123');
+      expect(allWritten).toContain(`from=${senderSession.id}`);
       expect(allWritten).toContain('intent=triage');
     });
 
@@ -887,6 +902,11 @@ describe('MCP Server Tools', () => {
         const session = await sessionManager.createSession({
           type: 'quick',
           locationPath: '/test/path',
+          agentId: 'claude-code',
+        });
+        const senderSession = await sessionManager.createSession({
+          type: 'quick',
+          locationPath: '/test/sender-path',
           agentId: 'claude-code',
         });
 
@@ -899,7 +919,7 @@ describe('MCP Server Tools', () => {
         await callTool(app, mcpSessionId, 'send_session_message', {
           toSessionId: session.id,
           content: 'split test',
-          fromSessionId: 'sender-abc',
+          fromSessionId: senderSession.id,
         }, nextId++);
 
         // Before the timer fires, notification text + reply instructions should be written
@@ -909,7 +929,7 @@ describe('MCP Server Tools', () => {
         // The notification text should NOT end with \n (no trailing newline)
         expect(mockPty.writtenData[0].endsWith('\n')).toBe(false);
         expect(mockPty.writtenData[1]).toContain('[Reply Instructions]');
-        expect(mockPty.writtenData[1]).toContain('sender-abc');
+        expect(mockPty.writtenData[1]).toContain(senderSession.id);
 
         // Advance past the 150ms delay
         jest.advanceTimersByTime(150);
@@ -928,6 +948,11 @@ describe('MCP Server Tools', () => {
         locationPath: '/test/path',
         agentId: 'claude-code',
       });
+      const senderSession = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/sender-path',
+        agentId: 'claude-code',
+      });
 
       const mockPty = ptyFactory.instances[0];
       expect(mockPty).toBeDefined();
@@ -935,13 +960,13 @@ describe('MCP Server Tools', () => {
       await callTool(app, mcpSessionId, 'send_session_message', {
         toSessionId: session.id,
         content: 'need your help',
-        fromSessionId: 'requester-session-456',
+        fromSessionId: senderSession.id,
       }, nextId++);
 
       // Reply instructions are the second write (index 1), after the notification (index 0)
       const replyInstructions = mockPty.writtenData[1];
       expect(replyInstructions).toContain('[Reply Instructions]');
-      expect(replyInstructions).toContain('toSessionId: "requester-session-456"');
+      expect(replyInstructions).toContain(`toSessionId: "${senderSession.id}"`);
       expect(replyInstructions).toContain('AGENT_CONSOLE_SESSION_ID');
     });
 
@@ -980,6 +1005,11 @@ describe('MCP Server Tools', () => {
         locationPath: '/test/path',
         agentId: 'claude-code',
       });
+      const senderSession = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/sender-path',
+        agentId: 'claude-code',
+      });
 
       const agentWorker = session.workers.find((w) => w.type === 'agent');
       expect(agentWorker).toBeDefined();
@@ -988,13 +1018,13 @@ describe('MCP Server Tools', () => {
         toSessionId: session.id,
         toWorkerId: agentWorker!.id,
         content: 'explicit target message',
-        fromSessionId: 'sender-x',
+        fromSessionId: senderSession.id,
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
 
       const data = parseToolResult(response) as { messageId: string; path: string };
-      expect(data.messageId).toContain('sender-x');
+      expect(data.messageId).toContain(senderSession.id);
       expect(data.path).toBeDefined();
 
       // Verify file content
@@ -1008,13 +1038,18 @@ describe('MCP Server Tools', () => {
         locationPath: '/test/path',
         agentId: 'claude-code',
       });
+      const senderSession = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/sender-path',
+        agentId: 'claude-code',
+      });
 
       const oversizedContent = 'x'.repeat(64 * 1024 + 1);
 
       const response = await callTool(app, mcpSessionId, 'send_session_message', {
         toSessionId: session.id,
         content: oversizedContent,
-        fromSessionId: 'test-sender',
+        fromSessionId: senderSession.id,
       }, nextId++);
       const data = parseToolResult(response) as { error: string };
 
@@ -1037,11 +1072,16 @@ describe('MCP Server Tools', () => {
         locationPath: '/test/repo',
         agentId: 'claude-code',
       });
+      const senderSession = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/sender-path',
+        agentId: 'claude-code',
+      });
 
       const response = await callTool(app, mcpSessionId, 'send_session_message', {
         toSessionId: targetSession.id,
         content: 'hello worktree',
-        fromSessionId: 'sender-1',
+        fromSessionId: senderSession.id,
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -1050,6 +1090,39 @@ describe('MCP Server Tools', () => {
       // Path must be rooted under the repository scope, not _quick.
       expect(data.path).toContain(`${TEST_CONFIG_DIR}/repositories/test-repo/messages/`);
       expect(data.path).not.toContain(`${TEST_CONFIG_DIR}/_quick/`);
+    });
+
+    // Regression test for Issue #690 — non-existent fromSessionId rejected.
+    // Before the defense-in-depth fix, the server accepted any string and the
+    // resulting message recorded a session id that the receiver could not reply to.
+    it('should return error when fromSessionId does not reference an existing session', async () => {
+      const targetSession = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+
+      const response = await callTool(app, mcpSessionId, 'send_session_message', {
+        toSessionId: targetSession.id,
+        content: 'this should be rejected',
+        // Plausible-looking but unknown sender id (the bug observed in production
+        // recorded ids that passed the regex validator but did not exist).
+        fromSessionId: 'e8094e4c-8de0-43ce-8c41-6b82b9e7ed31',
+      }, nextId++);
+      const data = parseToolResult(response) as { error: string };
+
+      expect(response.result?.isError).toBe(true);
+      expect(data.error).toContain('Sender session');
+      expect(data.error).toContain('e8094e4c-8de0-43ce-8c41-6b82b9e7ed31');
+      expect(data.error).toContain('not found');
+
+      // No PTY notification should have been delivered — the message must not
+      // be persisted at all when the sender id is invalid.
+      const allPtyWrites = ptyFactory.instances
+        .map((p) => p.writtenData.join(''))
+        .join('|||');
+      expect(allPtyWrites).not.toContain('[internal:message]');
+      expect(allPtyWrites).not.toContain('e8094e4c-8de0-43ce-8c41-6b82b9e7ed31');
     });
 
     it('should return validation error when fromSessionId is omitted', async () => {

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -389,7 +389,23 @@ export function createMcpApp(deps: McpDependencies): Hono {
           resolvedWorkerId = agentWorkers[0].id;
         }
 
-        // 3. Resolve the path via SessionManager so we use the canonical
+        // 3. Validate sender session (defense-in-depth against agents that pass
+        //    a stale or hallucinated fromSessionId — see Issue #690).
+        //    The agent is expected to source this from AGENT_CONSOLE_SESSION_ID,
+        //    but LLM-driven tool calls have been observed substituting an unrelated
+        //    session id intermittently. Rejecting unknown senders fails fast so
+        //    the agent can self-correct, and prevents Reply Instructions from
+        //    being generated with an unreplyable target.
+        const senderSession = sessionManager.getSession(fromSessionId);
+        if (!senderSession) {
+          return errorResult(
+            `Sender session ${fromSessionId} not found. ` +
+              `fromSessionId must reference an existing session — ` +
+              `agents should source it from the AGENT_CONSOLE_SESSION_ID environment variable.`,
+          );
+        }
+
+        // 4. Resolve the path via SessionManager so we use the canonical
         //    persisted slug — the in-memory `repositoryName` is a display
         //    name that may differ from the on-disk slug.
         const resolver = sessionManager.getPathResolverForSessionId(toSessionId);
@@ -404,10 +420,9 @@ export function createMcpApp(deps: McpDependencies): Hono {
           resolver,
         });
 
-        // 4. PTY notification (best-effort -- message file is already written)
+        // 5. PTY notification (best-effort -- message file is already written)
         try {
-          const senderTitle =
-            sessionManager.getSession(fromSessionId)?.title ?? fromSessionId;
+          const senderTitle = senderSession.title ?? fromSessionId;
 
           const writeInput = (data: string) =>
             sessionManager.writeWorkerInput(toSessionId, resolvedWorkerId, data);


### PR DESCRIPTION
## Summary
- Fixed intermittent bug where `send_session_message` MCP tool recorded non-existent session IDs as `fromSessionId`
- Added defense-in-depth server-side validation 
- Added regression test exercising the mismatch path

## Root Cause (Issue #690 Hypothesis #1 confirmed)

Agent (Claude Code) intermittently passes a `fromSessionId` that doesn't match its `AGENT_CONSOLE_SESSION_ID` env var due to LLM tool-call non-determinism. The model occasionally substitutes session IDs observed elsewhere in context instead of reading the environment variable.

Server-side validation was missing: the handler accepted any format-valid UUID without checking session existence, causing unreplyable "Reply Instructions" in received messages.

## Fix Details

**Defense-in-depth validation** in `packages/server/src/mcp/mcp-server.ts`:
- Added sender session existence check after target validation
- Returns structured error for non-existent `fromSessionId` with guidance to use `AGENT_CONSOLE_SESSION_ID`
- Aligns with pattern consistency (all other MCP tools validate session existence)
- Simplified fallback logic since sender session is guaranteed to exist

**Benefits:**
- Fail fast and loud → agents get immediate error to self-correct
- No more unreplyable Reply Instructions in notifications
- Pattern consistency with other MCP tools

## Tests
- **New regression test** using actual UUID from bug report (`e8094e4c-8de0-43ce-8c41-6b82b9e7ed31`)
- **Updated 7 existing tests** to use real sender sessions instead of hardcoded strings
- **Preserved existing failure-path tests** (hit error conditions before new validation)

## Test Results
```
bun run typecheck — PASS (all packages)
bun run test    — TEST_EXIT: 0
  @agent-console/server: 2387 pass, 0 fail
  @agent-console/client: 1361 pass, 2 skip, 0 fail  
  @agent-console/shared: 306 pass, 0 fail
  @agent-console/integration: 24 pass, 0 fail
```

## Closes
Fixes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)