### PR TITLE
chore: institutionalize glossary-maintenance rule (closes #689)

### DIFF
--- a/.claude/rules/glossary-maintenance.md
+++ b/.claude/rules/glossary-maintenance.md
@@ -1,0 +1,63 @@
+# Glossary Maintenance
+
+`docs/glossary.md` is the canonical source of project terminology. When new domain concepts are introduced, the glossary must be updated **in the same PR** that introduces the concept. This rule defines triggers, roles, and the drift-handling decision tree.
+
+## Why this rule exists
+
+LLM self-review is structurally weak at terminology drift detection. Without an explicit rule + acceptance-check question, the glossary will rot (terms drift, aliases proliferate, contradictions accumulate). This rule converts terminology integrity from "the Orchestrator notices it sometimes" to a mechanical check.
+
+## Triggers — update `docs/glossary.md` when the PR
+
+1. **Adds a new design doc** under `docs/design/` that introduces a new domain concept
+   - Example: adding `docs/design/job-queue.md` with a new `Job` concept → add a `### Job` entry to glossary
+2. **Adds a new type or interface** that represents a domain concept
+   - Example: `packages/shared/src/types/job.ts` exporting `interface Job` → glossary entry
+   - Counter-example: `packages/server/src/lib/format-utils.ts` internal helper types → not a glossary trigger
+3. **Adds a new database schema field** representing a domain concept (not just a column rename)
+   - Example: migration adding `sessions.assignee_id` → glossary entry for `assignee_id`
+   - Counter-example: migration adding `created_at` index → not a glossary trigger
+4. **Adds a new API endpoint or MCP tool parameter name** that names a domain concept
+   - Example: `POST /api/sessions { initiated_by }` field → glossary entry for `initiated_by`
+   - Example: `delegate_to_worktree({ assignee })` parameter → glossary entry for `assignee`
+5. **Modifies an existing design doc's Terminology section** (added, renamed, or revised entries)
+   - Example: `multi-user-shared-setup.md` Terminology section gains `Service User` → mirror in glossary
+6. **Adds a new rule, skill, or narrative** under `.claude/rules/`, `.claude/skills/`, or `docs/narratives/` that **references a project-wide concept**
+   - Example: a new rule mentioning `SharedSession` for the first time across rules → ensure glossary has `SharedSession` (it does — verify the rule's usage matches)
+   - Counter-example: a rule mentioning a CLI flag (`--no-verify`) → not a glossary trigger
+
+If the change does not match any trigger above, glossary update is not required.
+
+## Roles
+
+| Role | Responsibility |
+|---|---|
+| **PR author (primary)** | Identify whether their PR matches a trigger above and update `docs/glossary.md` in the same PR |
+| **Orchestrator (confirmer)** | During acceptance check, mechanically verify glossary integrity via `acceptance-check.js` Q9. If missing, request the agent add the entry before merge |
+| **Owner** | Not in the review path. Drift surfaced by owner is a process failure of PR author + Orchestrator |
+
+## Drift-handling decision tree
+
+When the Orchestrator (or PR author during self-check) finds a term in the codebase or documentation that does not appear in `docs/glossary.md`:
+
+1. **Is the term in scope of this PR's changes?**
+   - **Yes** → Add the entry to `docs/glossary.md` in this PR. Do not defer.
+   - **No** (the term predates the PR) → Continue.
+2. **Is the term used by code or docs the PR is modifying?**
+   - **Yes** → Add the entry in this PR (the PR surfaces the gap; the same PR closes it).
+   - **No** (the term appears only in unrelated parts of the repo) → File a follow-up issue tagged `glossary-drift`. Do not block the PR.
+3. **Is the term a renamed / drifted variant of an existing glossary entry?**
+   - **Yes** → Update both the glossary entry's `Aliases` field and rename in the affected files in this PR.
+   - **No** → Treat as a missing entry per step 1 or 2.
+
+The same decision tree applies when finding contradictions (e.g., two entries describing the same concept with different definitions).
+
+## Cross-references
+
+- **Canonical source**: [`docs/glossary.md`](../../docs/glossary.md) (Maintenance section also summarizes triggers; this rule is the operational expansion)
+- **Acceptance check**: `acceptance-check.js` Q9 — Orchestrator's mechanical verification step during PR review
+- **Sibling rule**: [`pre-pr-completeness.md`](pre-pr-completeness.md) — covers process completeness for new mechanisms; this rule is adjacent (terminology) and orthogonal (Gap-Scan does not include glossary checks)
+- **Future automation**: Issue [#671](https://github.com/ms2sato/agent-console/issues/671) — referenced-but-not-defined linter (separate concern, this rule remains the manual gate until the linter lands)
+
+## How this rule is expected to evolve
+
+When the Issue #671 linter lands, the Orchestrator's manual Q9 check can be downgraded from "mechanical verification step" to "spot-check fallback" since the linter will detect missing entries in CI. Until then, apply Q9 mechanically rather than skipping on the assumption that the agent already updated the glossary.

--- a/.claude/skills/orchestrator/__tests__/acceptance-check.test.js
+++ b/.claude/skills/orchestrator/__tests__/acceptance-check.test.js
@@ -305,15 +305,23 @@ describe('createStdinReader', () => {
 });
 
 describe('getQuestions', () => {
-  it('returns 8 questions', () => {
+  it('returns 9 questions', () => {
     const questions = getQuestions(false);
-    expect(questions).toHaveLength(8);
+    expect(questions).toHaveLength(9);
   });
 
-  it('returns questions with keys q1-q8', () => {
+  it('returns questions with keys q1-q9', () => {
     const questions = getQuestions(false);
     const keys = questions.map(q => q.key);
-    expect(keys).toEqual(['q1', 'q2', 'q3', 'q4', 'q5', 'q6', 'q7', 'q8']);
+    expect(keys).toEqual(['q1', 'q2', 'q3', 'q4', 'q5', 'q6', 'q7', 'q8', 'q9']);
+  });
+
+  it('Q9 references the glossary-maintenance rule', () => {
+    const questions = getQuestions(false);
+    const q9 = questions.find(q => q.key === 'q9');
+    expect(q9.text).toContain('Glossary Integrity');
+    expect(q9.focus).toContain('glossary-maintenance.md');
+    expect(q9.focus).toContain('docs/glossary.md');
   });
 
   it('Q8 references the architectural-invariants skill catalog', () => {

--- a/.claude/skills/orchestrator/acceptance-check.js
+++ b/.claude/skills/orchestrator/acceptance-check.js
@@ -4,7 +4,7 @@
  * Orchestrator Acceptance Check (Interactive STDIN/STDOUT Mode)
  *
  * Full acceptance check requiring human judgment. Guides the Orchestrator
- * through Q1-Q8 in an interactive session via run_process.
+ * through Q1-Q9 in an interactive session via run_process.
  *
  * For mechanical pre-merge checks (CI), use preflight-check.js instead.
  *
@@ -35,7 +35,7 @@ function usage() {
   console.error('Usage:');
   console.error('  node .claude/skills/orchestrator/acceptance-check.js <PR number>');
   console.error('');
-  console.error('This script runs a full interactive acceptance check (Q1-Q8).');
+  console.error('This script runs a full interactive acceptance check (Q1-Q9).');
   console.error('For mechanical pre-merge checks, use preflight-check.js instead.');
   process.exit(1);
 }
@@ -387,6 +387,21 @@ function getQuestions(hasAcceptanceCriteria, { integrationTestMissing = false } 
       ].join('\n  '),
       insufficient: '"Invariants look fine" (without walking the catalog)',
       sufficient: '"I-1: PR adds getCurrentOffset fallback branch. Verified via grep that both readWorkerOutput and getCurrentOffset route through computeSessionDataBaseDir — same identity yields same path. I-2: computeSessionDataBaseDir is the single helper, no inline path construction. I-3: sessionId is the stable identity and is unchanged. I-4: PR does not introduce new persistent state. I-5: N/A (server-only). I-6: job payloads validated via ZJobPayload schema at line 42."',
+    },
+    {
+      key: 'q9',
+      text: 'Q9: Glossary Integrity — If the PR introduces a new domain concept (new type, DB schema field, design doc, MCP tool param, API endpoint name, or rule/skill referencing a project-wide concept), is `docs/glossary.md` updated to reflect it?',
+      focus: [
+        'See `.claude/rules/glossary-maintenance.md` for the trigger list and drift-handling decision tree.',
+        'Mechanical procedure:',
+        '  1. List the new domain-named identifiers introduced by the PR (types, fields, parameters, design-doc concepts).',
+        '  2. For each identifier, grep `docs/glossary.md` for the term.',
+        '  3. Missing entries → request the agent add them in this PR before merge (drift-handling tree, step 1 / 2).',
+        '  4. Renamed/drifted variants → update `Aliases` field of the existing entry.',
+        'If the PR does not introduce any new domain concept (e.g., bug fix, refactor with no naming change, test-only PR), it is acceptable to answer "N/A — PR scope does not introduce new domain concepts" with a one-line justification.',
+      ].join('\n  '),
+      insufficient: '"Glossary looks fine" (without listing introduced identifiers and grepping each)',
+      sufficient: '"PR adds `assignee` parameter to delegate_to_worktree (MCP tool param) and `assigned_at` timestamp field to sessions table (DB schema field). Grepped docs/glossary.md: `assignee` entry exists at line 81 (added in PR #682). `assigned_at` is missing — instructed agent to add a Multi-User Identity entry. No other new domain identifiers in this PR."',
     },
   ];
 }

--- a/.claude/skills/orchestrator/core-responsibilities.md
+++ b/.claude/skills/orchestrator/core-responsibilities.md
@@ -83,7 +83,7 @@
 - If satisfactory, summarize the result for the owner
 
 ## 6. Acceptance Check
-- **Trigger**: Every `[inbound:ci:completed]` event for a PR under the Orchestrator's responsibility. On first CI green, run the full acceptance check (run_process Q1-Q7). On subsequent CI greens (after feedback/fixes), re-read the latest diff (`gh pr diff`) and re-evaluate against acceptance criteria. Never rely on previously-read diffs.
+- **Trigger**: Every `[inbound:ci:completed]` event for a PR under the Orchestrator's responsibility. On first CI green, run the full acceptance check (run_process Q1-Q9). On subsequent CI greens (after feedback/fixes), re-read the latest diff (`gh pr diff`) and re-evaluate against acceptance criteria. Never rely on previously-read diffs.
 - **IMPORTANT: The Orchestrator performs acceptance checks directly.** Do NOT delegate to sub-agents — the accuracy loss from delegation outweighs the time saved.
 - **Run the acceptance check via Interactive Process**: Use `run_process` to start the acceptance check script:
   ```
@@ -104,7 +104,7 @@
   - **Browser check for UI changes**: When the PR modifies client-side components (`packages/client/src/components/`) or acceptance criteria include `manual verification`, the Orchestrator must verify via Chrome DevTools MCP. Start the dev server (`bun run dev`), check the startup log for the actual port (Vite may auto-increment if the default port is in use), navigate to the affected UI, and take screenshots. Use `/browser-qa` skill if available. Do NOT skip this — automated tests alone cannot catch visual/interaction regressions. (Lesson: Sprint 2026-04-05b — port 5173 was in use, Vite silently switched to 5174.)
 - **CI Green + CodeRabbit Complete -> Acceptance Check Flow**:
   0. **Prerequisite: CodeRabbit review must be complete** (status "pass" in `gh pr checks`). If CodeRabbit is pending or rate-limited, wait for it before starting the acceptance check. Do NOT merge a PR without a completed CodeRabbit review.
-  1. Start the acceptance check via `run_process` (see above). Answer Q1-Q7 via `write_process_response`. If the script reports `[No linked Issue]`, instruct the agent to add `Closes #NNN` to the PR body before proceeding. Do not ignore this warning.
+  1. Start the acceptance check via `run_process` (see above). Answer Q1-Q9 via `write_process_response`. If the script reports `[No linked Issue]`, instruct the agent to add `Closes #NNN` to the PR body before proceeding. Do not ignore this warning.
   2. If issues found -> send specific feedback to the agent with concrete fix instructions
   3. If uncertain -> resolve before proceeding:
      a. Self-investigate (read more code, grep for context)
@@ -133,7 +133,7 @@
 - **Important**: Run acceptance checks in parallel when multiple PRs are ready
 - **MANDATORY: Every PR must go through both checks.**
   - **Preflight check** (mechanical): `node .claude/skills/orchestrator/preflight-check.js <PR>` — test coverage validation and rule/skill duplication invariant check. CI runs this automatically.
-  - **Acceptance check** (human judgment): `node .claude/skills/orchestrator/acceptance-check.js <PR>` via `run_process` — full Q1-Q7 interactive review. **Always required for production code changes.** Never skip this — even when the diff looks trivial. (Lesson: Sprint 2026-04-05c — skipping the full acceptance check caused a UI requirement to be missed on #599.)
+  - **Acceptance check** (human judgment): `node .claude/skills/orchestrator/acceptance-check.js <PR>` via `run_process` — full Q1-Q9 interactive review. **Always required for production code changes.** Never skip this — even when the diff looks trivial. (Lesson: Sprint 2026-04-05c — skipping the full acceptance check caused a UI requirement to be missed on #599.)
 
 ## 7. Post-Merge Flow
 

--- a/.claude/skills/orchestrator/preflight-check.js
+++ b/.claude/skills/orchestrator/preflight-check.js
@@ -8,7 +8,7 @@
  * - Integration test gap detection
  *
  * This is the CI-facing script. For full acceptance checks requiring
- * human judgment (Q1-Q7), use acceptance-check.js via run_process.
+ * human judgment (Q1-Q9), use acceptance-check.js via run_process.
  *
  * Local and CI modes produce the same verdict for the same branch state.
  * Both modes use equivalent commands to ensure consistent file lists.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -133,4 +133,6 @@ This glossary is canonical. When the following changes are introduced, the gloss
 
 If a term in the codebase or documentation does not appear here, either it is a drift to fix or a missing entry to add — both belong in the same PR that surfaced the gap.
 
-**Responsibility**: PR author owns the glossary update for their PR. Orchestrator confirms during acceptance check. Automated detection is tracked separately (see Issue [#671](https://github.com/ms2sato/agent-console/issues/671) and Issue [#689](https://github.com/ms2sato/agent-console/issues/689) for `glossary-maintenance` rule integration).
+**Responsibility**: PR author owns the glossary update for their PR. Orchestrator confirms during acceptance check via `acceptance-check.js` Q9 (Glossary Integrity).
+
+**Operational rule**: see [`.claude/rules/glossary-maintenance.md`](../.claude/rules/glossary-maintenance.md) for the full trigger list, role assignments, and drift-handling decision tree. Automated linter detection is tracked separately (Issue [#671](https://github.com/ms2sato/agent-console/issues/671)).


### PR DESCRIPTION
## Summary

Adds the glossary-maintenance rule and Q9 in `acceptance-check.js`, institutionalizing the operational mechanism that PR #685 deferred to a follow-up Issue.

- **New rule**: `.claude/rules/glossary-maintenance.md` — trigger list with concrete file-path examples, role assignments (PR author primary / Orchestrator confirms / owner not in path), drift-handling decision tree
- **Q9 in `acceptance-check.js`**: Glossary Integrity — mechanical procedure (list new domain identifiers introduced by the PR → grep glossary for each → request additions before merge)
- **Cross-link**: `docs/glossary.md` Maintenance section now points to the rule file
- **Sibling fix (bundled)**: `Q1-Q7` / `Q1-Q8` references in `core-responsibilities.md`, `preflight-check.js`, and `acceptance-check.js` header comments updated to `Q1-Q9`. Q8 was added in an earlier sprint without updating the doc references — bundling per the design-principles "grep for sibling call sites" rule

## Why

`docs/glossary.md` (added in PR #685) is canonical, but glossary drift detection is structurally weak in LLM self-review. Without an explicit rule + acceptance-check Q, terms drift, aliases proliferate, and contradictions accumulate. Q9 + the rule convert drift detection from "Orchestrator notices it sometimes" to a mechanical step.

## Pre-PR Gap-Scan applied

- **Q1 (similar mechanism)**: closest sibling is `pre-pr-completeness.md` (process completeness Gap-Scan) — orthogonal concern (terminology vs process); cross-linked, not duplicate.
- **Q1.5 (cross-doc citation accuracy)**: rule cites `docs/glossary.md`, `acceptance-check.js Q9`, `pre-pr-completeness.md`, Issue #671 — all verified against actual code/issues.
- **Q2 (canonical procedure trigger)**: rule auto-loads from `.claude/rules/`. Q9 is invoked by `acceptance-check.js` which is already triggered per `core-responsibilities.md §6` (now updated to `Q1-Q9`).
- **Q3 (failure paths tested)**: `getQuestions()` test updated to expect `Q1-Q9` and verify Q9 references the rule. Existing test coverage style is question-structure-only (Q1-Q8 don't have content unit tests either).
- **Q4 (new file type / lifecycle)**: same type as existing rules in `.claude/rules/`; no new lifecycle.
- **Q5 (rule clarity pass)**: concrete file paths, concrete examples (assignee/initiated_by from PR #682), no prediction-framed statements (the "evolve" note is conditional on Issue #671 linter landing).

## Test plan

- [x] `bun run typecheck` — pass
- [x] `bun run test` — full suite pass (4077 / 0 fail)
- [x] `coderabbit review --agent --base main` — 0 findings
- [x] Pre-PR Gap-Scan applied (above)

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)