### PR TITLE
fix: ci:completed event reflects PR statusCheckRollup not per-run (closes #699)

### DIFF
--- a/packages/server/src/services/__tests__/ci-completion-checker.test.ts
+++ b/packages/server/src/services/__tests__/ci-completion-checker.test.ts
@@ -19,20 +19,31 @@ function createEmptyStream(): ReadableStream<Uint8Array> {
   return createReadableStream('');
 }
 
-let mockSpawnResult: {
+type MockSpawnResult = {
   exited: Promise<number>;
   stdout: ReadableStream<Uint8Array>;
   stderr: ReadableStream<Uint8Array>;
   kill: () => void;
 };
 
-function setSpawnResponse(stdout: string, exitCode = 0, stderr = '') {
-  mockSpawnResult = {
+let mockSpawnResult: MockSpawnResult;
+let spawnResponseQueue: MockSpawnResult[] = [];
+
+function makeSpawnResult(stdout: string, exitCode = 0, stderr = ''): MockSpawnResult {
+  return {
     exited: Promise.resolve(exitCode),
     stdout: createReadableStream(stdout),
     stderr: createReadableStream(stderr),
     kill: () => {},
   };
+}
+
+function setSpawnResponse(stdout: string, exitCode = 0, stderr = '') {
+  mockSpawnResult = makeSpawnResult(stdout, exitCode, stderr);
+}
+
+function enqueueSpawnResponse(stdout: string, exitCode = 0, stderr = '') {
+  spawnResponseQueue.push(makeSpawnResult(stdout, exitCode, stderr));
 }
 
 function makeWorkflowRunsResponse(runs: Array<{
@@ -51,11 +62,15 @@ function makeWorkflowRunsResponse(runs: Array<{
 describe('ci-completion-checker', () => {
   beforeEach(() => {
     spawnCalls = [];
+    spawnResponseQueue = [];
     setSpawnResponse('[{}]');
 
     (Bun as { spawn: typeof Bun.spawn }).spawn = ((args: string[], options?: Record<string, unknown>) => {
       spawnCalls.push({ args, options: options || {} });
-      return mockSpawnResult;
+      // Prefer queued responses (one per call) when present; otherwise fall back
+      // to the singleton mockSpawnResult (preserves backwards-compatibility with
+      // existing single-response tests).
+      return spawnResponseQueue.shift() ?? mockSpawnResult;
     }) as typeof Bun.spawn;
   });
 
@@ -236,5 +251,238 @@ describe('ci-completion-checker', () => {
     expect(result!.allCompleted).toBe(false);
     expect(result!.totalWorkflows).toBe(1);
     expect(result!.successCount).toBe(0);
+  });
+
+  describe('PR statusCheckRollup mode', () => {
+    type RollupCheckRun = {
+      __typename: 'CheckRun';
+      name: string;
+      status: string;
+      conclusion: string | null;
+    };
+    type RollupStatusContext = {
+      __typename: 'StatusContext';
+      context: string;
+      state: string;
+    };
+    type RollupEntry = RollupCheckRun | RollupStatusContext;
+
+    function makePRListResponse(prs: Array<{
+      number: number;
+      headRefOid: string;
+      statusCheckRollup: RollupEntry[];
+    }>): string {
+      return JSON.stringify(prs);
+    }
+
+    it('reports allCompleted false when latest commit on PR has a failing CheckRun', async () => {
+      // MAIN BUG TEST — webhook fires for the PR HEAD commit, but the rollup
+      // for that commit contains a failure. Event must NOT report all-passed.
+      enqueueSpawnResponse(makePRListResponse([
+        {
+          number: 1247,
+          headRefOid: 'newSha',
+          statusCheckRollup: [
+            { __typename: 'CheckRun', name: 'test', status: 'COMPLETED', conclusion: 'SUCCESS' },
+            { __typename: 'CheckRun', name: 'preview', status: 'COMPLETED', conclusion: 'FAILURE' },
+          ],
+        },
+      ]));
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'newSha', 'feature-x');
+
+      expect(result).not.toBeNull();
+      expect(result!.allCompleted).toBe(false);
+    });
+
+    it('suppresses event when webhook commit SHA differs from PR head (older commit)', async () => {
+      // Same PR, but webhook fired for an older commit. Suppress regardless of
+      // rollup contents — the rollup belongs to a different commit now.
+      enqueueSpawnResponse(makePRListResponse([
+        {
+          number: 1247,
+          headRefOid: 'newSha',
+          statusCheckRollup: [
+            { __typename: 'CheckRun', name: 'test', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          ],
+        },
+      ]));
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'oldSha', 'feature-x');
+
+      expect(result).not.toBeNull();
+      expect(result!.allCompleted).toBe(false);
+    });
+
+    it('reports allCompleted true with workflowNames when all rollup entries succeed', async () => {
+      enqueueSpawnResponse(makePRListResponse([
+        {
+          number: 100,
+          headRefOid: 'sha-head',
+          statusCheckRollup: [
+            { __typename: 'CheckRun', name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+            { __typename: 'CheckRun', name: 'test', status: 'COMPLETED', conclusion: 'SUCCESS' },
+            { __typename: 'CheckRun', name: 'build', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          ],
+        },
+      ]));
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'sha-head', 'feature-x');
+
+      expect(result).not.toBeNull();
+      expect(result!.allCompleted).toBe(true);
+      expect(result!.totalWorkflows).toBe(3);
+      expect(result!.successCount).toBe(3);
+      expect(result!.workflowNames).toEqual(['lint', 'test', 'build']);
+    });
+
+    it('handles mixed CheckRun + StatusContext rollup, all success', async () => {
+      enqueueSpawnResponse(makePRListResponse([
+        {
+          number: 100,
+          headRefOid: 'sha-head',
+          statusCheckRollup: [
+            { __typename: 'CheckRun', name: 'gha-test', status: 'COMPLETED', conclusion: 'SUCCESS' },
+            { __typename: 'StatusContext', context: 'ci/legacy', state: 'SUCCESS' },
+          ],
+        },
+      ]));
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'sha-head', 'feature-x');
+
+      expect(result).not.toBeNull();
+      expect(result!.allCompleted).toBe(true);
+      expect(result!.workflowNames).toEqual(['gha-test', 'ci/legacy']);
+    });
+
+    it('suppresses when any rollup entry is still pending (CheckRun without conclusion)', async () => {
+      enqueueSpawnResponse(makePRListResponse([
+        {
+          number: 100,
+          headRefOid: 'sha-head',
+          statusCheckRollup: [
+            { __typename: 'CheckRun', name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+            { __typename: 'CheckRun', name: 'test', status: 'IN_PROGRESS', conclusion: null },
+          ],
+        },
+      ]));
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'sha-head', 'feature-x');
+
+      expect(result).not.toBeNull();
+      expect(result!.allCompleted).toBe(false);
+    });
+
+    it('suppresses when StatusContext is PENDING', async () => {
+      enqueueSpawnResponse(makePRListResponse([
+        {
+          number: 100,
+          headRefOid: 'sha-head',
+          statusCheckRollup: [
+            { __typename: 'StatusContext', context: 'ci/legacy', state: 'PENDING' },
+          ],
+        },
+      ]));
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'sha-head', 'feature-x');
+
+      expect(result).not.toBeNull();
+      expect(result!.allCompleted).toBe(false);
+    });
+
+    it('treats SKIPPED and NEUTRAL CheckRun conclusions as success', async () => {
+      enqueueSpawnResponse(makePRListResponse([
+        {
+          number: 100,
+          headRefOid: 'sha-head',
+          statusCheckRollup: [
+            { __typename: 'CheckRun', name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+            { __typename: 'CheckRun', name: 'optional', status: 'COMPLETED', conclusion: 'SKIPPED' },
+            { __typename: 'CheckRun', name: 'advisory', status: 'COMPLETED', conclusion: 'NEUTRAL' },
+          ],
+        },
+      ]));
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'sha-head', 'feature-x');
+
+      expect(result).not.toBeNull();
+      expect(result!.allCompleted).toBe(true);
+      expect(result!.workflowNames).toEqual(['lint', 'optional', 'advisory']);
+    });
+
+    it('falls back to workflow-runs path when no PR is found for the branch', async () => {
+      // First call: gh pr list returns []
+      enqueueSpawnResponse(makePRListResponse([]));
+      // Second call: gh api workflow runs returns all-success
+      enqueueSpawnResponse(makeWorkflowRunsResponse([
+        { workflow_id: 1, name: 'lint', status: 'completed', conclusion: 'success', run_number: 1 },
+        { workflow_id: 2, name: 'test', status: 'completed', conclusion: 'success', run_number: 1 },
+      ]));
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'sha-orphan', 'no-pr-branch');
+
+      expect(result).not.toBeNull();
+      expect(result!.allCompleted).toBe(true);
+      expect(result!.totalWorkflows).toBe(2);
+      // Verify both spawn calls were made in the right order
+      expect(spawnCalls).toHaveLength(2);
+      expect(spawnCalls[0].args[0]).toBe('gh');
+      expect(spawnCalls[0].args[1]).toBe('pr');
+      expect(spawnCalls[0].args[2]).toBe('list');
+      expect(spawnCalls[1].args[0]).toBe('gh');
+      expect(spawnCalls[1].args[1]).toBe('api');
+    });
+
+    it('returns null (fail-open) when gh pr list fails with non-zero exit', async () => {
+      enqueueSpawnResponse('', 1, 'gh: not authenticated');
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'sha-head', 'feature-x');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null (fail-open) when gh pr list output is malformed', async () => {
+      enqueueSpawnResponse('not valid json');
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'sha-head', 'feature-x');
+
+      expect(result).toBeNull();
+    });
+
+    it('uses workflow-runs path only when branch argument is omitted (legacy path)', async () => {
+      setSpawnResponse(makeWorkflowRunsResponse([
+        { workflow_id: 1, name: 'ci', status: 'completed', conclusion: 'success', run_number: 1 },
+      ]));
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'sha-head');
+
+      expect(result).not.toBeNull();
+      expect(result!.allCompleted).toBe(true);
+      // Only the workflow-runs call was made; no PR-list call
+      expect(spawnCalls).toHaveLength(1);
+      expect(spawnCalls[0].args[1]).toBe('api');
+    });
   });
 });

--- a/packages/server/src/services/__tests__/inbound-job-handler.test.ts
+++ b/packages/server/src/services/__tests__/inbound-job-handler.test.ts
@@ -462,6 +462,64 @@ describe('createInboundEventJobHandler', () => {
     expect(handlerMock).toHaveBeenCalledTimes(1);
   });
 
+  it('ci:completed forwards event.metadata.branch to ciCompletionChecker', async () => {
+    // Verifies that the job-handler passes `branch` as the third argument to
+    // the checker, enabling the PR-rollup-based check that resolves #699.
+    const checkerCalls: Array<[string, string, string | undefined]> = [];
+    const mockChecker: CICompletionChecker = async (repo, sha, branch) => {
+      checkerCalls.push([repo, sha, branch]);
+      return {
+        allCompleted: true,
+        totalWorkflows: 1,
+        successCount: 1,
+        workflowNames: ['test'],
+      };
+    };
+
+    const handlerMock = mock<InboundEventHandler['handle']>(async () => true);
+    const handler: InboundEventHandler = {
+      handlerId: 'test-handler',
+      supportedEvents: ['ci:completed'],
+      handle: handlerMock,
+    };
+
+    const parser: ServiceParser = {
+      serviceId: 'github',
+      authenticate: async () => true,
+      parse: async () => ({
+        type: 'ci:completed',
+        source: 'github',
+        timestamp: '2024-01-01T00:00:00Z',
+        metadata: {
+          repositoryName: 'owner/repo',
+          commitSha: 'abc123',
+          branch: 'feature-x',
+        },
+        payload: { ok: true },
+        summary: 'CI success',
+      }),
+    };
+
+    const jobHandler = createInboundEventJobHandler({
+      getServiceParser: () => parser,
+      resolveTargets: async () => [{ sessionId: 'session-1' }],
+      handlers: [handler],
+      notificationRepository,
+      ciCompletionChecker: mockChecker,
+    });
+
+    await jobHandler({
+      jobId: 'job-1',
+      service: 'github',
+      rawPayload: '{}',
+      headers: {},
+      receivedAt: '2024-01-01T00:00:00Z',
+    });
+
+    expect(checkerCalls).toEqual([['owner/repo', 'abc123', 'feature-x']]);
+    expect(handlerMock).toHaveBeenCalledTimes(1);
+  });
+
   it('ci:completed without commitSha skips the check', async () => {
     const mockChecker = mock<CICompletionChecker>(async () => ({
       allCompleted: false,

--- a/packages/server/src/services/inbound/__tests__/ci-completion-checker.test.ts
+++ b/packages/server/src/services/inbound/__tests__/ci-completion-checker.test.ts
@@ -79,7 +79,7 @@ describe('ci-completion-checker', () => {
   });
 
   async function getModule() {
-    return import(`../inbound/ci-completion-checker.js?v=${++importCounter}`);
+    return import(`../ci-completion-checker.js?v=${++importCounter}`);
   }
 
   it('returns allCompleted true when all workflows completed successfully', async () => {

--- a/packages/server/src/services/inbound/__tests__/ci-completion-checker.test.ts
+++ b/packages/server/src/services/inbound/__tests__/ci-completion-checker.test.ts
@@ -424,6 +424,24 @@ describe('ci-completion-checker', () => {
       expect(result!.workflowNames).toEqual(['lint', 'optional', 'advisory']);
     });
 
+    it('returns null (fail-open) when PR exists but statusCheckRollup is empty', async () => {
+      // CodeRabbit catch (PR #704 review): empty rollup must NOT vacuously
+      // report "all passed". Fail-open so the original event proceeds.
+      enqueueSpawnResponse(makePRListResponse([
+        {
+          number: 100,
+          headRefOid: 'sha-head',
+          statusCheckRollup: [],
+        },
+      ]));
+
+      const { createCICompletionChecker } = await getModule();
+      const checker = createCICompletionChecker();
+      const result = await checker('owner/repo', 'sha-head', 'feature-x');
+
+      expect(result).toBeNull();
+    });
+
     it('falls back to workflow-runs path when no PR is found for the branch', async () => {
       // First call: gh pr list returns []
       enqueueSpawnResponse(makePRListResponse([]));

--- a/packages/server/src/services/inbound/__tests__/job-handler.test.ts
+++ b/packages/server/src/services/inbound/__tests__/job-handler.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, mock, beforeEach } from 'bun:test';
-import type { ServiceParser } from '../inbound/service-parser.js';
-import type { InboundEventHandler } from '../inbound/handlers.js';
-import type { InboundEventNotification, NewInboundEventNotification } from '../../database/schema.js';
-import { createInboundEventJobHandler } from '../inbound/job-handler.js';
-import type { CICompletionChecker } from '../inbound/ci-completion-checker.js';
+import type { ServiceParser } from '../service-parser.js';
+import type { InboundEventHandler } from '../handlers.js';
+import type { InboundEventNotification, NewInboundEventNotification } from '../../../database/schema.js';
+import { createInboundEventJobHandler } from '../job-handler.js';
+import type { CICompletionChecker } from '../ci-completion-checker.js';
 
 // Mock functions with proper return types
 const mockFindInboundEventNotification = mock<() => Promise<InboundEventNotification | null>>(

--- a/packages/server/src/services/inbound/ci-completion-checker.ts
+++ b/packages/server/src/services/inbound/ci-completion-checker.ts
@@ -268,6 +268,7 @@ async function checkByPullRequestRollup(
     '--repo', repositoryName,
     '--head', branch,
     '--state', 'open',
+    '--limit', '1',
     '--json', 'number,headRefOid,statusCheckRollup',
   ];
   const responseText = await runGhCommand(args, { repositoryName, branch, webhookCommitSha });
@@ -325,6 +326,18 @@ async function checkByPullRequestRollup(
   }
 
   const rollup = pr.statusCheckRollup;
+  if (rollup.length === 0) {
+    // PR exists with matching head, but no checks have been registered yet.
+    // Treat as "cannot determine" and fail-open — the empty.every() vacuous
+    // truth would otherwise emit "all passed" with zero workflows, which is
+    // worse than the original per-run event.
+    logger.warn(
+      { repositoryName, branch, prNumber: pr.number, webhookCommitSha },
+      'PR statusCheckRollup is empty; falling open'
+    );
+    return { matched: true, result: null };
+  }
+
   const classifications = rollup.map(classifyRollupEntry);
   const workflowNames = rollup.map(rollupEntryName);
   const successCount = classifications.filter((status) => status === 'success').length;

--- a/packages/server/src/services/inbound/ci-completion-checker.ts
+++ b/packages/server/src/services/inbound/ci-completion-checker.ts
@@ -1,3 +1,4 @@
+import * as v from 'valibot';
 import { createLogger } from '../../lib/logger.js';
 
 const logger = createLogger('ci-completion-checker');
@@ -16,8 +17,16 @@ export interface CICompletionCheckResult {
 }
 
 /**
- * Check whether all GitHub Actions workflows for a given commit SHA
- * have completed successfully.
+ * Check whether the CI for a given commit SHA has completed successfully.
+ *
+ * When `branch` is provided, the checker first looks up the open PR for that
+ * branch and evaluates the PR HEAD's `statusCheckRollup`. This avoids the
+ * stale-event false positive where a webhook for an older commit reports
+ * "all passed" while the latest commit on the PR is still failing (#699).
+ *
+ * Falls back to the per-commit workflow-runs query when no PR is found
+ * (push to a branch with no PR, push to main, etc.) or when `branch` is
+ * omitted (legacy callers).
  *
  * Returns null if the check cannot be performed (gh not installed,
  * API error, timeout, etc). Callers should treat null as "pass through"
@@ -25,7 +34,8 @@ export interface CICompletionCheckResult {
  */
 export type CICompletionChecker = (
   repositoryName: string,
-  headSha: string
+  headSha: string,
+  branch?: string
 ) => Promise<CICompletionCheckResult | null>;
 
 interface WorkflowRun {
@@ -39,6 +49,63 @@ interface WorkflowRun {
 interface WorkflowRunsResponse {
   total_count: number;
   workflow_runs: WorkflowRun[];
+}
+
+const CheckRunSchema = v.object({
+  __typename: v.literal('CheckRun'),
+  name: v.string(),
+  status: v.string(),
+  conclusion: v.nullish(v.string()),
+});
+
+const StatusContextSchema = v.object({
+  __typename: v.literal('StatusContext'),
+  context: v.string(),
+  state: v.string(),
+});
+
+const RollupEntrySchema = v.union([CheckRunSchema, StatusContextSchema]);
+
+const PullRequestSchema = v.object({
+  number: v.number(),
+  headRefOid: v.string(),
+  statusCheckRollup: v.array(RollupEntrySchema),
+});
+
+const PullRequestListSchema = v.array(PullRequestSchema);
+
+type RollupEntry = v.InferOutput<typeof RollupEntrySchema>;
+
+/** Conclusions that GitHub treats as non-blocking on PR merge. */
+const SUCCESS_CHECKRUN_CONCLUSIONS = new Set(['SUCCESS', 'SKIPPED', 'NEUTRAL']);
+
+/** Per-entry status: terminal-success / terminal-failure / non-terminal. */
+type EntryStatus = 'success' | 'failure' | 'pending';
+
+function classifyRollupEntry(entry: RollupEntry): EntryStatus {
+  if (entry.__typename === 'CheckRun') {
+    if (entry.status !== 'COMPLETED') {
+      return 'pending';
+    }
+    if (entry.conclusion == null) {
+      return 'pending';
+    }
+    return SUCCESS_CHECKRUN_CONCLUSIONS.has(entry.conclusion) ? 'success' : 'failure';
+  }
+  // StatusContext
+  switch (entry.state) {
+    case 'SUCCESS':
+      return 'success';
+    case 'PENDING':
+      return 'pending';
+    default:
+      // FAILURE, ERROR, anything unexpected — treat as failure
+      return 'failure';
+  }
+}
+
+function rollupEntryName(entry: RollupEntry): string {
+  return entry.__typename === 'CheckRun' ? entry.name : entry.context;
 }
 
 function createTimeoutPromise(timeoutMs: number): { promise: Promise<never>; cleanup: () => void } {
@@ -57,6 +124,58 @@ function createTimeoutPromise(timeoutMs: number): { promise: Promise<never>; cle
   };
 
   return { promise, cleanup };
+}
+
+/**
+ * Run a `gh` command and return stdout, or null on any failure (timeout,
+ * non-zero exit, spawn error). Logs warnings for diagnostic purposes.
+ */
+async function runGhCommand(
+  args: string[],
+  context: Record<string, unknown>
+): Promise<string | null> {
+  try {
+    const proc = Bun.spawn(args, { stdout: 'pipe', stderr: 'pipe' });
+    const { promise: timeoutPromise, cleanup } = createTimeoutPromise(CI_CHECK_TIMEOUT_MS);
+
+    try {
+      const result = await Promise.race([
+        (async () => {
+          const exitCode = await proc.exited;
+          if (exitCode !== 0) {
+            const stderr = await new Response(proc.stderr).text();
+            return { ok: false as const, exitCode, stderr };
+          }
+          const stdout = await new Response(proc.stdout).text();
+          return { ok: true as const, stdout };
+        })(),
+        timeoutPromise,
+      ]);
+
+      if (!result.ok) {
+        logger.warn(
+          { ...context, exitCode: result.exitCode, stderr: result.stderr.trim() },
+          'gh command returned non-zero exit code'
+        );
+        return null;
+      }
+      return result.stdout;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('timed out')) {
+        try {
+          proc.kill();
+        } catch {
+          // Ignore kill errors (process may have already exited)
+        }
+      }
+      throw error;
+    } finally {
+      cleanup();
+    }
+  } catch (error) {
+    logger.warn({ ...context, err: error }, 'gh command failed');
+    return null;
+  }
 }
 
 function deduplicateByLatestRun(runs: WorkflowRun[]): WorkflowRun[] {
@@ -86,71 +205,160 @@ function checkCompletion(latestRuns: WorkflowRun[]): CICompletionCheckResult {
   };
 }
 
+/**
+ * Per-commit workflow-runs check (legacy semantics).
+ *
+ * Used when no PR exists for the branch (push to main, branch without PR)
+ * or when the caller does not have branch metadata. Subject to the #699
+ * stale-event bug when used for branches with open PRs — callers should
+ * prefer `checkByPullRequestRollup` and only fall back here.
+ */
+async function checkByCommitWorkflowRuns(
+  repositoryName: string,
+  headSha: string
+): Promise<CICompletionCheckResult | null> {
+  const endpoint = `repos/${repositoryName}/actions/runs?head_sha=${headSha}`;
+  const responseText = await runGhCommand(
+    ['gh', 'api', '--paginate', '--slurp', endpoint],
+    { repositoryName, headSha }
+  );
+  if (responseText === null) {
+    return null;
+  }
+
+  let allWorkflowRuns: WorkflowRun[];
+  try {
+    const pages = JSON.parse(responseText) as WorkflowRunsResponse[];
+    allWorkflowRuns = pages.flatMap((page) => page.workflow_runs ?? []);
+  } catch {
+    logger.warn({ repositoryName, headSha }, 'Failed to parse gh api response as JSON');
+    return null;
+  }
+
+  if (allWorkflowRuns.length === 0) {
+    logger.warn({ repositoryName, headSha }, 'No workflow runs found for commit');
+    return null;
+  }
+
+  const latestRuns = deduplicateByLatestRun(allWorkflowRuns);
+  return checkCompletion(latestRuns);
+}
+
+/**
+ * Look up the open PR for a branch and evaluate its statusCheckRollup.
+ *
+ * Returns:
+ * - `{ matched: true, result }` — PR was found and evaluated. Result reflects
+ *   PR HEAD's rollup. If `result === null`, PR lookup or parsing failed
+ *   (fail-open).
+ * - `{ matched: false }` — no open PR for the branch. Caller should fall back
+ *   to the per-commit workflow-runs path.
+ *
+ * When the webhook commit SHA does not match the PR's headRefOid, the event
+ * is suppressed (allCompleted: false) — the rollup belongs to a different
+ * commit and reporting "all passed" would be a false positive (#699).
+ */
+async function checkByPullRequestRollup(
+  repositoryName: string,
+  webhookCommitSha: string,
+  branch: string
+): Promise<{ matched: true; result: CICompletionCheckResult | null } | { matched: false }> {
+  const args = [
+    'gh', 'pr', 'list',
+    '--repo', repositoryName,
+    '--head', branch,
+    '--state', 'open',
+    '--json', 'number,headRefOid,statusCheckRollup',
+  ];
+  const responseText = await runGhCommand(args, { repositoryName, branch, webhookCommitSha });
+  if (responseText === null) {
+    // gh failed — fail-open
+    return { matched: true, result: null };
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(responseText);
+  } catch {
+    logger.warn({ repositoryName, branch }, 'Failed to parse gh pr list response as JSON');
+    return { matched: true, result: null };
+  }
+
+  const parsed = v.safeParse(PullRequestListSchema, parsedJson);
+  if (!parsed.success) {
+    logger.warn(
+      { repositoryName, branch, issues: parsed.issues },
+      'gh pr list output did not match expected schema'
+    );
+    return { matched: true, result: null };
+  }
+
+  const prs = parsed.output;
+  if (prs.length === 0) {
+    return { matched: false };
+  }
+
+  // Branch should resolve to at most one open PR, but if multiple are
+  // returned (e.g., across forks), pick the first deterministically.
+  const pr = prs[0];
+
+  if (pr.headRefOid !== webhookCommitSha) {
+    logger.info(
+      {
+        repositoryName,
+        branch,
+        prNumber: pr.number,
+        webhookCommitSha,
+        prHeadSha: pr.headRefOid,
+      },
+      'CI completion suppressed: webhook commit SHA does not match PR head SHA'
+    );
+    return {
+      matched: true,
+      result: {
+        allCompleted: false,
+        totalWorkflows: pr.statusCheckRollup.length,
+        successCount: 0,
+        workflowNames: [],
+      },
+    };
+  }
+
+  const rollup = pr.statusCheckRollup;
+  const classifications = rollup.map(classifyRollupEntry);
+  const workflowNames = rollup.map(rollupEntryName);
+  const successCount = classifications.filter((status) => status === 'success').length;
+  const allTerminal = classifications.every((status) => status !== 'pending');
+  const allSuccess = allTerminal && classifications.every((status) => status === 'success');
+
+  return {
+    matched: true,
+    result: {
+      allCompleted: allSuccess,
+      totalWorkflows: rollup.length,
+      successCount,
+      workflowNames,
+    },
+  };
+}
+
 export function createCICompletionChecker(): CICompletionChecker {
-  return async (repositoryName: string, headSha: string): Promise<CICompletionCheckResult | null> => {
+  return async (
+    repositoryName: string,
+    headSha: string,
+    branch?: string
+  ): Promise<CICompletionCheckResult | null> => {
     try {
-      const endpoint = `repos/${repositoryName}/actions/runs?head_sha=${headSha}`;
-      const proc = Bun.spawn(['gh', 'api', '--paginate', '--slurp', endpoint], {
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
-
-      const { promise: timeoutPromise, cleanup } = createTimeoutPromise(CI_CHECK_TIMEOUT_MS);
-
-      let responseText: string;
-      try {
-        const result = await Promise.race([
-          (async () => {
-            const exitCode = await proc.exited;
-            if (exitCode !== 0) {
-              const stderr = await new Response(proc.stderr).text();
-              return { ok: false as const, exitCode, stderr };
-            }
-            const stdout = await new Response(proc.stdout).text();
-            return { ok: true as const, stdout };
-          })(),
-          timeoutPromise,
-        ]);
-
-        if (!result.ok) {
-          logger.warn(
-            { exitCode: result.exitCode, stderr: result.stderr.trim(), repositoryName, headSha },
-            'gh api returned non-zero exit code'
-          );
-          return null;
+      if (branch) {
+        const prCheck = await checkByPullRequestRollup(repositoryName, headSha, branch);
+        if (prCheck.matched) {
+          return prCheck.result;
         }
-        responseText = result.stdout;
-      } catch (error) {
-        if (error instanceof Error && error.message.includes('timed out')) {
-          try {
-            proc.kill();
-          } catch {
-            // Ignore kill errors (process may have already exited)
-          }
-        }
-        throw error;
-      } finally {
-        cleanup();
+        // No PR found for branch — fall through to per-commit workflow-runs path
       }
-
-      let allWorkflowRuns: WorkflowRun[];
-      try {
-        const pages = JSON.parse(responseText) as WorkflowRunsResponse[];
-        allWorkflowRuns = pages.flatMap((page) => page.workflow_runs ?? []);
-      } catch {
-        logger.warn({ repositoryName, headSha }, 'Failed to parse gh api response as JSON');
-        return null;
-      }
-
-      if (allWorkflowRuns.length === 0) {
-        logger.warn({ repositoryName, headSha }, 'No workflow runs found for commit');
-        return null;
-      }
-
-      const latestRuns = deduplicateByLatestRun(allWorkflowRuns);
-      return checkCompletion(latestRuns);
+      return await checkByCommitWorkflowRuns(repositoryName, headSha);
     } catch (error) {
-      logger.warn({ err: error, repositoryName, headSha }, 'CI completion check failed');
+      logger.warn({ err: error, repositoryName, headSha, branch }, 'CI completion check failed');
       return null;
     }
   };

--- a/packages/server/src/services/inbound/job-handler.ts
+++ b/packages/server/src/services/inbound/job-handler.ts
@@ -101,9 +101,9 @@ export function createInboundEventJobHandler(deps: InboundEventJobDependencies) 
 
     // --- CI completion aggregation gate ---
     if (event.type === 'ci:completed' && deps.ciCompletionChecker) {
-      const { repositoryName, commitSha } = event.metadata;
+      const { repositoryName, commitSha, branch } = event.metadata;
       if (repositoryName && commitSha) {
-        const result = await deps.ciCompletionChecker(repositoryName, commitSha);
+        const result = await deps.ciCompletionChecker(repositoryName, commitSha, branch);
         if (result !== null) {
           if (!result.allCompleted) {
             logger.info(
@@ -111,6 +111,7 @@ export function createInboundEventJobHandler(deps: InboundEventJobDependencies) 
                 eventType: event.type,
                 repositoryName,
                 commitSha,
+                branch,
                 successCount: result.successCount,
                 totalWorkflows: result.totalWorkflows,
               },


### PR DESCRIPTION
## Summary

**Decision: Option A** — replace `ciCompletionChecker` semantics so the gate evaluates the PR HEAD's `statusCheckRollup` rather than per-commit workflow runs.

**Reason:** Option A keeps existing event consumers (Orchestrator skill, agent prompts) unchanged — they just become accurate. Option B would require migrating every consumer for low marginal benefit, since consumers always wanted PR-wide status anyway.

## Bug

Previously, the `[inbound:ci:completed]` MCP event was gated by checking workflow runs for the webhook's `head_sha`. When a PR had multiple commits and a `workflow_run` completed for an OLDER commit while the LATEST commit on the PR had a failing workflow, the event still reported "all passed" — a false positive that caused "CI green → merge" decisions on stale info (Sprint 16 PR #1247 in the conteditor project).

## Implementation

**`packages/server/src/services/inbound/ci-completion-checker.ts`** — split into two paths:

- `checkByPullRequestRollup(repo, webhookCommitSha, branch)` — new. Calls `gh pr list --repo R --head BRANCH --state open --json number,headRefOid,statusCheckRollup`, validates with Valibot, and:
  - If no PR → returns `{ matched: false }` so the caller falls back.
  - If `pr.headRefOid !== webhookCommitSha` → suppress (logged at info with both SHAs).
  - Otherwise classifies each rollup entry. CheckRun is success when `status === COMPLETED && conclusion ∈ {SUCCESS, SKIPPED, NEUTRAL}`. StatusContext is success when `state === SUCCESS`. PENDING / IN_PROGRESS / no-conclusion are non-terminal → suppress (next webhook will retry). Any FAILURE / ERROR / etc. → `allCompleted: false`.
- `checkByCommitWorkflowRuns(repo, headSha)` — existing logic lifted out unchanged.
- `createCICompletionChecker()` returned function: when `branch` is provided, try PR rollup first; on no-PR-found, fall back to workflow-runs. When `branch` is omitted, only the workflow-runs path runs (backwards-compat).
- All `gh` invocations go through a shared `runGhCommand()` helper that preserves the existing 10s timeout + fail-open semantics.

**`packages/server/src/services/inbound/job-handler.ts`** — pass `event.metadata.branch` as the third argument to the checker.

## Tests

`packages/server/src/services/__tests__/ci-completion-checker.test.ts` — extended the spawn harness with a queue (`enqueueSpawnResponse`) so a single test can mock both `gh pr list` and a follow-up `gh api workflow runs` call. Added a `describe('PR statusCheckRollup mode')` block with 10 tests:

1. **Main bug test** — PR latest commit has a failing CheckRun → `allCompleted: false`.
2. Webhook commit SHA differs from PR head (older commit) → suppress.
3. All rollup entries SUCCESS → `allCompleted: true`, `workflowNames` populated in PR-list order.
4. Mixed CheckRun + StatusContext, both SUCCESS → success.
5. Pending CheckRun (status `IN_PROGRESS`, conclusion null) → suppress.
6. Pending StatusContext (state `PENDING`) → suppress.
7. CheckRun conclusions `SKIPPED` and `NEUTRAL` treated as success.
8. No PR found → fall back to workflow-runs path; both spawn calls verified in order.
9. `gh pr list` non-zero exit → fail-open (null).
10. Malformed `gh pr list` JSON → fail-open (null) via Valibot rejection.

Plus: legacy path test confirming that omitting `branch` skips the PR-list call entirely.

`packages/server/src/services/__tests__/inbound-job-handler.test.ts` — added one integration test verifying the job-handler forwards `event.metadata.branch` as the third argument to the checker.

## Workflow rule audit

The Issue's AC item ("Workflow rule 'Verify PR status independently before merge' is removable / updatable once the event is reliable") and its citation of PR #695 was checked. **No such rule was actually added** — `gh pr view 695 --json files` shows PR #695 changed `.claude/rules/workflow.md`, `.claude/skills/orchestrator/core-responsibilities.md`, and `packages/client/package.json`, but `grep -ri 'verify.*PR.*status\|independent.*verif'` across `.claude/` returns nothing matching that rule name. AC is vacuously satisfied — there is no rule to remove or update.

## Glossary check

Not triggered. `statusCheckRollup` is a GitHub API field name, not a project-domain concept. No new domain term is introduced. Per `.claude/rules/glossary-maintenance.md` triggers, no glossary update is required.

## Pre-PR Gap-Scan (Q1-Q5)

1. **Similar mechanism exists?** Yes — `ciCompletionChecker` already exists. This PR is a behavior change to the existing mechanism (not a new mechanism), so the existing call site in `job-handler.ts` and the existing wiring in `services/inbound/index.ts` are reused. No duplicate.
2. **Invocation documented in canonical procedure?** N/A — no new invocation surface. The `[inbound:ci:completed]` event consumers continue to receive the same shape; only its accuracy changes.
3. **Failure paths tested?** Yes — `gh pr list` non-zero exit and malformed-JSON paths both covered (tests 9 and 10). Pending and stale-SHA suppression also covered (tests 2, 5, 6).
4. **New file type or directory?** No.
5. **Rule clarity pass?** N/A — this PR does not modify rule text.

## Acceptance Criteria

- [x] Option chosen + reason documented (Option A — see Summary)
- [x] Event payload reflects PR's statusCheckRollup for the latest commit
- [x] Multi-run / multi-commit test scenario added (test #1)
- [x] Workflow rule audit completed (no such rule was added; nothing to remove)

## Verification

- `bun run test`: 2427 server pass, 1361 client pass (+2 skip), 307 shared pass, 27 integration pass — `TEST_EXIT: 0`
- `bun run typecheck`: `TYPECHECK_EXIT: 0`
- `coderabbit review --agent --base main`: 7 findings, all on files NOT touched by this PR (`conditional-wakeup-manager.ts`, `conditional-wakeup.ts`, `app-context.ts`, `conditional-wakeup-manager.test.ts` — pre-existing issues from PR #703). Zero findings on this PR's changes.

Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note on CodeRabbit
CodeRabbit local CLI completed for the first push (zero findings on this PR's changes). After the second push (c5bcc2c — addressing the GitHub-side bot's actionable feedback on empty statusCheckRollup vacuous-truth + nitpicks), the GitHub-side bot was rate-limited and posted a walkthrough only. The bot will re-review automatically when the rate limit window clears. Pre-merge checks are 4/5 passed (the only failure is the repo-wide 'Docstring Coverage' warning at 0%, which is a pre-existing organization-wide setting, not specific to this PR).
