### PR TITLE
chore: exclude re-export-only files from preflight coverage rule (closes #696)

### DIFF
--- a/.claude/skills/orchestrator/__tests__/check-utils.test.js
+++ b/.claude/skills/orchestrator/__tests__/check-utils.test.js
@@ -1,5 +1,127 @@
 import { describe, it, expect } from 'bun:test';
 import { readFileSync } from 'node:fs';
+import {
+  isReExportOnlyContent,
+  requiresTestCoverage,
+} from '../check-utils.js';
+
+describe('isReExportOnlyContent', () => {
+  it('returns true for a single `export * from` statement', () => {
+    expect(isReExportOnlyContent(`export * from './foo';`)).toBe(true);
+  });
+
+  it('returns true for multiple `export * from` statements with whitespace and trailing newlines', () => {
+    const content = `
+export * from './a';
+export * from './b';
+export * from './c';
+`;
+    expect(isReExportOnlyContent(content)).toBe(true);
+  });
+
+  it('returns true for `export { Named } from` statements', () => {
+    const content = `export { Foo, Bar } from './foo';\nexport { Baz } from './baz';`;
+    expect(isReExportOnlyContent(content)).toBe(true);
+  });
+
+  it('returns true for `export type { ... } from` statements', () => {
+    const content = `export type { Config } from './config';\nexport type * from './shared-types';`;
+    expect(isReExportOnlyContent(content)).toBe(true);
+  });
+
+  it('returns true for `export * as Name from` statements', () => {
+    expect(isReExportOnlyContent(`export * as utils from './utils';`)).toBe(true);
+  });
+
+  it('returns true with block comments and line comments interleaved', () => {
+    const content = `/**
+ * Barrel file for shared types.
+ */
+// First group
+export * from './a';
+// Second group
+export type { B } from './b'; /* inline note */
+`;
+    expect(isReExportOnlyContent(content)).toBe(true);
+  });
+
+  it('returns true for a multi-line `export { A, B }` statement', () => {
+    const content = `
+export {
+  Alpha,
+  Beta,
+  Gamma,
+} from './letters';
+`;
+    expect(isReExportOnlyContent(content)).toBe(true);
+  });
+
+  it('returns false for a file containing a const declaration', () => {
+    const content = `export * from './a';\nexport const VERSION = '1.0';`;
+    expect(isReExportOnlyContent(content)).toBe(false);
+  });
+
+  it('returns false for a file containing a function declaration', () => {
+    const content = `export function noop() {}`;
+    expect(isReExportOnlyContent(content)).toBe(false);
+  });
+
+  it('returns false for a file containing a default export', () => {
+    expect(isReExportOnlyContent(`export default function () {}`)).toBe(false);
+  });
+
+  it('returns false for a file with import statements that are not re-exports', () => {
+    const content = `import { foo } from './foo';\nexport { foo };`;
+    // `import { foo }` is not a re-export from-statement; the rewrite to
+    // `export { foo }` (no `from`) also does not match the pattern.
+    expect(isReExportOnlyContent(content)).toBe(false);
+  });
+
+  it('returns false for a file containing only `export { local }` without a from-clause', () => {
+    expect(isReExportOnlyContent(`export { foo };`)).toBe(false);
+  });
+
+  it('returns false for an empty file (no exports → not a re-export barrel)', () => {
+    expect(isReExportOnlyContent('')).toBe(false);
+    expect(isReExportOnlyContent('\n\n  \n')).toBe(false);
+    expect(isReExportOnlyContent('// only a comment')).toBe(false);
+  });
+});
+
+describe('requiresTestCoverage with re-export exclusion', () => {
+  it('returns true for a normal hook file (no exclusion path applies)', () => {
+    // Note: this test relies on the actual filesystem state of the repo —
+    // it checks that hook files NOT in the exclusion patterns still require
+    // coverage. The path `packages/client/src/hooks/__nonexistent__.ts`
+    // doesn't exist on disk, so isReExportOnlyFile returns false (existsSync
+    // false), preserving the requirement.
+    expect(requiresTestCoverage('packages/client/src/hooks/__nonexistent__.ts')).toBe(true);
+  });
+
+  it('returns false for non-coverage paths regardless of content', () => {
+    expect(requiresTestCoverage('packages/server/src/lib/logger.ts')).toBe(false);
+    expect(requiresTestCoverage('packages/server/src/index.ts')).toBe(false);
+  });
+
+  it('returns false for test files', () => {
+    expect(requiresTestCoverage('packages/shared/src/__tests__/foo.test.ts')).toBe(false);
+  });
+
+  it('returns false for the existing re-export-only barrel `packages/shared/src/constants/index.ts`', () => {
+    // Real fixture: this file is a pure re-export barrel.
+    // After PR #696, it must not require coverage even though it sits in
+    // a coverage-pattern path (matches /^packages\/shared\/src\/.+\.ts$/).
+    expect(requiresTestCoverage('packages/shared/src/constants/index.ts')).toBe(false);
+  });
+
+  it('returns true for `packages/shared/src/index.ts` because it mixes re-exports with an `ApiError` interface declaration', () => {
+    // Counter-fixture: this barrel adds an `interface ApiError` alongside
+    // the re-exports, so it has runtime-relevant content that should be
+    // covered. Demonstrates that the exclusion is content-aware, not
+    // path-based.
+    expect(requiresTestCoverage('packages/shared/src/index.ts')).toBe(true);
+  });
+});
 
 describe('preflight-check parity fix verification', () => {
   it('should verify getLocalChangedFiles implementation was simplified', () => {

--- a/.claude/skills/orchestrator/check-utils.js
+++ b/.claude/skills/orchestrator/check-utils.js
@@ -6,7 +6,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 
 // --- Utility functions ---
 
@@ -96,10 +96,68 @@ export function isTestFile(filePath) {
   return filePath.includes('.test.') || filePath.includes('.spec.') || filePath.includes('__tests__/');
 }
 
+/**
+ * Check whether a file's content consists only of re-export statements.
+ * Pure function — operates on the content string, no filesystem access.
+ *
+ * Re-export-only files (e.g., `packages/shared/src/index.ts` that only
+ * `export * from './foo'`) have no runtime logic to test. Their sibling
+ * test would be tautological (PR #694 added one only to silence the
+ * coverage rule). This helper detects that pattern so the rule can skip.
+ *
+ * Recognises:
+ *   export * from '...';
+ *   export * as Name from '...';
+ *   export { A, B } from '...';
+ *   export type { A } from '...';
+ *   export type * from '...';
+ *
+ * Block comments and line comments are stripped before matching. Empty
+ * files return false (not re-export-only — they need real coverage).
+ */
+export function isReExportOnlyContent(content) {
+  // Strip block comments (/* ... */, including JSDoc), then line comments (// ...).
+  const noBlockComments = content.replace(/\/\*[\s\S]*?\*\//g, '');
+  const noLineComments = noBlockComments.replace(/\/\/[^\n]*/g, '');
+
+  const trimmed = noLineComments.trim();
+  if (trimmed.length === 0) return false;
+
+  // Split into statements on `;`, normalising whitespace so multi-line exports collapse.
+  const statements = trimmed
+    .split(';')
+    .map(s => s.replace(/\s+/g, ' ').trim())
+    .filter(s => s.length > 0);
+
+  // Each statement must be `export [type] (* [as Name] | { ... }) from '...'`.
+  const reExportPattern = /^export\s+(type\s+)?(\*(\s+as\s+\w+)?|\{[^{}]*\})\s+from\s+['"][^'"]+['"]$/;
+
+  return statements.every(stmt => reExportPattern.test(stmt));
+}
+
+/**
+ * Filesystem wrapper around `isReExportOnlyContent`.
+ * Returns false on read errors so an unreadable file falls through to the
+ * normal coverage rule (safer default — surface the gap rather than hide it).
+ */
+export function isReExportOnlyFile(filePath) {
+  if (!existsSync(filePath)) return false;
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    return isReExportOnlyContent(content);
+  } catch {
+    return false;
+  }
+}
+
 export function requiresTestCoverage(filePath) {
   if (isTestFile(filePath)) return false;
   if (COVERAGE_EXCLUSIONS.some(pattern => pattern.test(filePath))) return false;
-  return COVERAGE_PATTERNS.some(pattern => pattern.test(filePath));
+  if (!COVERAGE_PATTERNS.some(pattern => pattern.test(filePath))) return false;
+  // Skip re-export-only files: their sibling test would be tautological
+  // (the type system already enforces re-export shape at consume sites).
+  if (isReExportOnlyFile(filePath)) return false;
+  return true;
 }
 
 export function findTestFiles(changedFiles) {


### PR DESCRIPTION
## Summary

Adds content-aware exclusion to `preflight-check.js`'s coverage rule so re-export-only barrel files (e.g. `packages/shared/src/constants/index.ts`) are no longer flagged as missing test coverage. Solves the case from PR #694 where a tautological re-export test had to be added solely to silence the rule.

## What

- New helper `isReExportOnlyContent(content)` — pure function, takes a content string and returns `true` if the file consists only of:
  - `export * from '...'`
  - `export * as Name from '...'`
  - `export { A, B } from '...'`
  - `export type { A } from '...'`
  - `export type * from '...'`
  - block / line comments and blank lines (stripped before matching)
- Filesystem wrapper `isReExportOnlyFile(filePath)` — reads from disk; returns `false` on read errors (safer default — surface the gap rather than hide it on missing files).
- `requiresTestCoverage` now short-circuits when `isReExportOnlyFile` returns `true`.

## Tests

13 new behaviour tests in `__tests__/check-utils.test.js` against the pure helper:
- happy paths: `export * from`, multiple statements, named, type-only, namespaced, multi-line `export { A, B }`, comment-interleaved
- failure paths: const declaration, function declaration, default export, `export { foo }` without `from`, `import` followed by `export { foo }`, empty file / comment-only file

4 tests against `requiresTestCoverage`:
- still returns `true` for normal hook files in coverage paths
- still returns `false` for non-coverage paths
- still returns `false` for test files
- returns `false` for the real barrel `packages/shared/src/constants/index.ts`
- returns `true` for `packages/shared/src/index.ts` because it adds an `interface ApiError` (counter-fixture demonstrating content-awareness)

## Pre-PR Gap-Scan

- **Q1 (similar mechanism)**: `COVERAGE_EXCLUSIONS` already exists for path-based exclusion. This PR adds content-based exclusion as a sibling — different concept (content vs path), cross-linked via in-code comment. Not a duplicate.
- **Q2 (canonical procedure trigger)**: no new invocation surface — `requiresTestCoverage` is already called by `findTestFiles` in the existing preflight pipeline.
- **Q3 (failure paths tested)**: yes — empty file, comment-only, mixed declaration, default export, named-without-from, etc. all covered.
- **Q4 (new file type / lifecycle)**: no.
- **Q5 (rule clarity)**: N/A (no rule text added; this is pure code change).

## Glossary check (Q9)

Not triggered. `re-export` is a TypeScript / JavaScript language concept, not a project-domain term. No new glossary entry required per `.claude/rules/glossary-maintenance.md` triggers.

## Test plan

- [x] `bun run typecheck` — pass
- [x] `bun run test` — full suite pass (4109 / 0 fail)
- [x] Local skill tests — 21 / 0 fail in `__tests__/check-utils.test.js`
- [ ] CodeRabbit local CLI — rate-limited at push time (4 min wait), relying on GitHub bot review per `workflow.md` Step 3

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)