### PR TITLE
fix: branch watcher survives git atomic HEAD rename (closes #708)

### DIFF
--- a/packages/server/src/services/__tests__/branch-watcher-rename-bug.test.ts
+++ b/packages/server/src/services/__tests__/branch-watcher-rename-bug.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Reproduction test for Issue #708 — fs.watch becomes stale after git's
+ * atomic rename pattern (HEAD.lock → HEAD).
+ *
+ * Git updates HEAD via:
+ *   1. Write HEAD.lock with new content
+ *   2. rename(HEAD.lock, HEAD)  ← atomic, replaces inode
+ *
+ * Watching the HEAD file by path attaches the watcher to the original
+ * inode. After the rename, that inode is gone — the watcher fires once
+ * (or on some platforms not at all for the next change) and never sees
+ * subsequent updates to the new HEAD inode.
+ *
+ * This test uses real `fs.watch` (no mock) to demonstrate the failure
+ * mode. With the directory-watch fix in branch-watcher-service.ts,
+ * subsequent renames continue to fire the callback.
+ *
+ * Note: This test only runs when `node:fs` is NOT mocked by memfs. When run
+ * as part of the full server suite, other tests import `mock-fs-helper.ts`
+ * which calls `mock.module('node:fs', ...)` — and bun:test's `mock.module`
+ * is process-global and unforgettable. The boundary cases (filename
+ * filtering, null filename, HEAD.lock ignore) are covered by injected-mock
+ * tests in `branch-watcher-service.test.ts`. This file additionally
+ * verifies the real fs.watch behavior end-to-end and is intended to be run
+ * directly: `bun test packages/server/src/services/__tests__/branch-watcher-rename-bug.test.ts`.
+ */
+import { describe, it, expect } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { BranchWatcherService } from '../branch-watcher-service.js';
+
+/**
+ * Detect whether `node:fs` has been replaced by memfs (via mock.module in
+ * mock-fs-helper.ts). memfs operates on an in-memory volume that does not
+ * see files written through Bun.write to the real OS tmpdir, so a
+ * round-trip write+stat probe disambiguates real fs from memfs.
+ */
+function isRealFsActive(): boolean {
+  const probePath = path.join(
+    os.tmpdir(),
+    `branch-watcher-fs-probe-${crypto.randomUUID().slice(0, 8)}`,
+  );
+  try {
+    Bun.spawnSync(['sh', '-c', `printf x > ${probePath}`]);
+    fs.statSync(probePath);
+    Bun.spawnSync(['rm', '-f', probePath]);
+    return true;
+  } catch {
+    Bun.spawnSync(['rm', '-f', probePath]);
+    return false;
+  }
+}
+
+const REAL_FS = isRealFsActive();
+
+async function createTempDir(prefix: string): Promise<string> {
+  const tmpDir = path.join(os.tmpdir(), `${prefix}${crypto.randomUUID().slice(0, 8)}`);
+  await Bun.spawn(['mkdir', '-p', tmpDir]).exited;
+  return tmpDir;
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+  await Bun.spawn(['rm', '-rf', dir]).exited;
+}
+
+async function createDir(dir: string): Promise<void> {
+  await Bun.spawn(['mkdir', '-p', dir]).exited;
+}
+
+/**
+ * Simulate git's atomic HEAD update: write HEAD.lock, then rename to HEAD.
+ * This replaces the HEAD file's inode atomically.
+ */
+async function atomicGitHeadUpdate(headFilePath: string, content: string): Promise<void> {
+  const lockPath = `${headFilePath}.lock`;
+  await Bun.write(lockPath, content);
+  // Use mv to perform atomic rename (simulates git's behavior)
+  await Bun.spawn(['mv', lockPath, headFilePath]).exited;
+}
+
+describe('BranchWatcherService — fs.watch rename robustness (Issue #708)', () => {
+  if (!REAL_FS) {
+    it.skip('SKIPPED: node:fs is mocked by memfs in this process (run this file directly to exercise real fs.watch)', () => {});
+    return;
+  }
+
+  it('detects branch changes across multiple atomic renames (real fs.watch)', async () => {
+    const tmpDir = await createTempDir('branch-watcher-rename-bug-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      const headPath = path.join(gitDir, 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/main\n');
+
+      const observed: string[] = [];
+      const onBranchChanged = async (_sid: string, branch: string) => {
+        observed.push(branch);
+      };
+
+      // Use real fs.watch (no mock parameter)
+      const service = new BranchWatcherService(onBranchChanged);
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      // First atomic rename — branch change to feature-a
+      await atomicGitHeadUpdate(headPath, 'ref: refs/heads/feature-a\n');
+      // Wait for fs.watch event + debounce + handler
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      // Second atomic rename — branch change to feature-b
+      await atomicGitHeadUpdate(headPath, 'ref: refs/heads/feature-b\n');
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      // Third atomic rename — branch change to feature-c
+      await atomicGitHeadUpdate(headPath, 'ref: refs/heads/feature-c\n');
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      service.stopAll();
+
+      // BUG: With file-level fs.watch, only the first rename is observed,
+      // because the watcher's inode is detached after the first rename.
+      // After the fix (directory-level watch), all three renames fire.
+      expect(observed).toContain('feature-a');
+      expect(observed).toContain('feature-b');
+      expect(observed).toContain('feature-c');
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('detects branch change after rename (single rename, real fs.watch)', async () => {
+    const tmpDir = await createTempDir('branch-watcher-rename-bug-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      const headPath = path.join(gitDir, 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/main\n');
+
+      const observed: string[] = [];
+      const onBranchChanged = async (_sid: string, branch: string) => {
+        observed.push(branch);
+      };
+
+      const service = new BranchWatcherService(onBranchChanged);
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      // Single atomic rename
+      await atomicGitHeadUpdate(headPath, 'ref: refs/heads/feature-x\n');
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      service.stopAll();
+      expect(observed).toContain('feature-x');
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+});

--- a/packages/server/src/services/__tests__/branch-watcher-rename-bug.test.ts
+++ b/packages/server/src/services/__tests__/branch-watcher-rename-bug.test.ts
@@ -42,12 +42,12 @@ function isRealFsActive(): boolean {
     `branch-watcher-fs-probe-${crypto.randomUUID().slice(0, 8)}`,
   );
   try {
-    Bun.spawnSync(['sh', '-c', `printf x > ${probePath}`]);
+    fs.writeFileSync(probePath, 'x');
     fs.statSync(probePath);
-    Bun.spawnSync(['rm', '-f', probePath]);
+    fs.unlinkSync(probePath);
     return true;
   } catch {
-    Bun.spawnSync(['rm', '-f', probePath]);
+    try { fs.unlinkSync(probePath); } catch { /* probe may not have been created */ }
     return false;
   }
 }
@@ -79,6 +79,25 @@ async function atomicGitHeadUpdate(headFilePath: string, content: string): Promi
   await Bun.spawn(['mv', lockPath, headFilePath]).exited;
 }
 
+/**
+ * Poll a predicate until it becomes true or the timeout elapses.
+ * Used to reduce flake risk on slow CI: a fixed setTimeout can race with
+ * fs.watch + debounce + handler scheduling, while polling a known
+ * post-condition (e.g., `observed.includes('feature-a')`) waits exactly
+ * as long as needed.
+ */
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 2000,
+  stepMs = 25,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) return;
+    await new Promise((resolve) => setTimeout(resolve, stepMs));
+  }
+}
+
 describe('BranchWatcherService — fs.watch rename robustness (Issue #708)', () => {
   if (!REAL_FS) {
     it.skip('SKIPPED: node:fs is mocked by memfs in this process (run this file directly to exercise real fs.watch)', () => {});
@@ -102,18 +121,20 @@ describe('BranchWatcherService — fs.watch rename robustness (Issue #708)', () 
       const service = new BranchWatcherService(onBranchChanged);
       await service.startWatching('session-1', tmpDir, 'main');
 
-      // First atomic rename — branch change to feature-a
+      // First atomic rename — branch change to feature-a.
+      // Poll until observed contains the expected branch, with a generous
+      // timeout to absorb fs.watch + debounce + handler scheduling jitter
+      // on slow CI without race-prone fixed-duration sleeps.
       await atomicGitHeadUpdate(headPath, 'ref: refs/heads/feature-a\n');
-      // Wait for fs.watch event + debounce + handler
-      await new Promise((resolve) => setTimeout(resolve, 600));
+      await waitFor(() => observed.includes('feature-a'));
 
       // Second atomic rename — branch change to feature-b
       await atomicGitHeadUpdate(headPath, 'ref: refs/heads/feature-b\n');
-      await new Promise((resolve) => setTimeout(resolve, 600));
+      await waitFor(() => observed.includes('feature-b'));
 
       // Third atomic rename — branch change to feature-c
       await atomicGitHeadUpdate(headPath, 'ref: refs/heads/feature-c\n');
-      await new Promise((resolve) => setTimeout(resolve, 600));
+      await waitFor(() => observed.includes('feature-c'));
 
       service.stopAll();
 
@@ -146,7 +167,7 @@ describe('BranchWatcherService — fs.watch rename robustness (Issue #708)', () 
 
       // Single atomic rename
       await atomicGitHeadUpdate(headPath, 'ref: refs/heads/feature-x\n');
-      await new Promise((resolve) => setTimeout(resolve, 600));
+      await waitFor(() => observed.includes('feature-x'));
 
       service.stopAll();
       expect(observed).toContain('feature-x');

--- a/packages/server/src/services/__tests__/branch-watcher-service.test.ts
+++ b/packages/server/src/services/__tests__/branch-watcher-service.test.ts
@@ -152,9 +152,11 @@ describe('BranchWatcherService', () => {
       const service = new BranchWatcherService(onBranchChanged, mockWatch);
       await service.startWatching('session-1', tmpDir, 'main');
 
-      // Simulate file change: write new content then trigger watcher
+      // Simulate file change: write new content then trigger watcher.
+      // The watcher is registered on the parent directory (gitDir), and the
+      // filename argument identifies the changed file within that directory.
       await Bun.write(headPath, 'ref: refs/heads/feature-branch\n');
-      const callback = mockWatchCallbacks.get(headPath);
+      const callback = mockWatchCallbacks.get(gitDir);
       callback?.('change', 'HEAD');
 
       // Wait for debounce
@@ -182,7 +184,7 @@ describe('BranchWatcherService', () => {
       await service.startWatching('session-1', tmpDir, 'main');
 
       // Trigger watcher without changing content
-      const callback = mockWatchCallbacks.get(headPath);
+      const callback = mockWatchCallbacks.get(gitDir);
       callback?.('change', 'HEAD');
 
       await new Promise(resolve => setTimeout(resolve, 300));
@@ -210,7 +212,7 @@ describe('BranchWatcherService', () => {
 
       // Simulate detached HEAD
       await Bun.write(headPath, '4b825dc642cb6eb9a060e54bf899d69f82563773\n');
-      mockWatchCallbacks.get(headPath)?.('change', 'HEAD');
+      mockWatchCallbacks.get(gitDir)?.('change', 'HEAD');
 
       await new Promise(resolve => setTimeout(resolve, 300));
 
@@ -235,7 +237,7 @@ describe('BranchWatcherService', () => {
       const service = new BranchWatcherService(onBranchChanged, mockWatch);
       await service.startWatching('session-1', tmpDir, 'main');
 
-      const callback = mockWatchCallbacks.get(headPath)!;
+      const callback = mockWatchCallbacks.get(gitDir)!;
 
       // Rapid triggers — only the last write should be read
       await Bun.write(headPath, 'ref: refs/heads/branch-a\n');
@@ -382,20 +384,107 @@ describe('BranchWatcherService', () => {
 
       // First change: succeeds
       await Bun.write(headPath, 'ref: refs/heads/branch-a\n');
-      mockWatchCallbacks.get(headPath)?.('change', 'HEAD');
+      mockWatchCallbacks.get(gitDir)?.('change', 'HEAD');
       await new Promise(resolve => setTimeout(resolve, 300));
       expect(onBranchChanged).toHaveBeenCalledWith('session-1', 'branch-a');
 
       // Second change: fails — currentBranch should NOT advance
       await Bun.write(headPath, 'ref: refs/heads/branch-b\n');
-      mockWatchCallbacks.get(headPath)?.('change', 'HEAD');
+      mockWatchCallbacks.get(gitDir)?.('change', 'HEAD');
       await new Promise(resolve => setTimeout(resolve, 300));
 
       // Third change: should still detect from branch-a (not branch-b)
       await Bun.write(headPath, 'ref: refs/heads/branch-c\n');
-      mockWatchCallbacks.get(headPath)?.('change', 'HEAD');
+      mockWatchCallbacks.get(gitDir)?.('change', 'HEAD');
       await new Promise(resolve => setTimeout(resolve, 300));
       expect(onBranchChanged).toHaveBeenCalledWith('session-1', 'branch-c');
+
+      service.stopAll();
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should ignore directory events for HEAD.lock', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      const headPath = path.join(gitDir, 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/main\n');
+
+      const onBranchChanged = mock(async () => {});
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(onBranchChanged, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      // Even if we change HEAD's content, a HEAD.lock-only event must not
+      // trigger the callback. (Git writes HEAD.lock first, then renames it
+      // to HEAD; the rename event will be filename === 'HEAD'.)
+      await Bun.write(headPath, 'ref: refs/heads/feature-branch\n');
+      mockWatchCallbacks.get(gitDir)?.('rename', 'HEAD.lock');
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      expect(onBranchChanged).not.toHaveBeenCalled();
+
+      service.stopAll();
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should ignore directory events for unrelated files (e.g., index)', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      const headPath = path.join(gitDir, 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/main\n');
+
+      const onBranchChanged = mock(async () => {});
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(onBranchChanged, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      // Stage changes / git commands write to other files in .git/.
+      // Those events must not trigger the branch callback.
+      await Bun.write(headPath, 'ref: refs/heads/feature-branch\n');
+      mockWatchCallbacks.get(gitDir)?.('change', 'index');
+      mockWatchCallbacks.get(gitDir)?.('change', 'ORIG_HEAD');
+      mockWatchCallbacks.get(gitDir)?.('change', 'config');
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      expect(onBranchChanged).not.toHaveBeenCalled();
+
+      service.stopAll();
+    } finally {
+      await removeTempDir(tmpDir);
+    }
+  });
+
+  it('should ignore directory events with null filename', async () => {
+    const tmpDir = await createTempDir('branch-watcher-svc-');
+    try {
+      const gitDir = path.join(tmpDir, '.git');
+      await createDir(gitDir);
+      const headPath = path.join(gitDir, 'HEAD');
+      await Bun.write(headPath, 'ref: refs/heads/main\n');
+
+      const onBranchChanged = mock(async () => {});
+      const mockWatch = createMockWatch();
+      const service = new BranchWatcherService(onBranchChanged, mockWatch);
+      await service.startWatching('session-1', tmpDir, 'main');
+
+      // Some platforms / encodings can pass null as filename. Without a
+      // filename we cannot disambiguate, so we must safely ignore.
+      await Bun.write(headPath, 'ref: refs/heads/feature-branch\n');
+      mockWatchCallbacks.get(gitDir)?.('change', null);
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      expect(onBranchChanged).not.toHaveBeenCalled();
 
       service.stopAll();
     } finally {

--- a/packages/server/src/services/branch-watcher-service.ts
+++ b/packages/server/src/services/branch-watcher-service.ts
@@ -145,8 +145,21 @@ export class BranchWatcherService {
       pendingRecheck: false,
     };
 
+    // Watch the parent directory rather than the HEAD file directly.
+    // Git updates HEAD via atomic rename (HEAD.lock -> HEAD), which detaches
+    // the original inode. fs.watch on a file is bound to the inode, so it
+    // would miss updates after the first rename. Directory watchers persist
+    // across file replacements. (Issue #708)
+    const headDir = path.dirname(headFilePath);
+    const headBasename = path.basename(headFilePath);
+
     try {
-      const fsWatcher = this.watchFn(headFilePath, (_eventType) => {
+      const fsWatcher = this.watchFn(headDir, (_eventType, filename) => {
+        // Filter: only react to events for the HEAD file itself.
+        // Directory watcher also fires for HEAD.lock, index, ORIG_HEAD, etc.
+        // Some platforms pass null filename — ignore those (cannot disambiguate).
+        if (filename !== headBasename) return;
+
         // Debounce: git may write HEAD multiple times during a single operation
         if (entry.debounceTimer) {
           clearTimeout(entry.debounceTimer);
@@ -158,15 +171,15 @@ export class BranchWatcherService {
       });
 
       fsWatcher.on('error', (error) => {
-        logger.error({ sessionId, headFilePath, err: error }, 'HEAD file watcher error');
+        logger.error({ sessionId, headDir, err: error }, 'HEAD file watcher error');
       });
 
       entry.watcher = fsWatcher;
       this.watchers.set(sessionId, entry);
 
-      logger.info({ sessionId, headFilePath, currentBranch: actualBranch }, 'Started watching HEAD file');
+      logger.info({ sessionId, headFilePath, headDir, currentBranch: actualBranch }, 'Started watching HEAD file');
     } catch (error) {
-      logger.error({ sessionId, headFilePath, err: error }, 'Failed to start HEAD file watcher');
+      logger.error({ sessionId, headDir, err: error }, 'Failed to start HEAD file watcher');
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #708.

`BranchWatcherService` attached `fs.watch` to the HEAD file by path. Git updates HEAD via atomic rename (`HEAD.lock` → `HEAD`), which detaches the original inode. `fs.watch` on a file binds to that inode on both kqueue (macOS) and inotify (Linux), so subsequent updates went to a new inode the watcher never observed — branch changes after the first checkout were silently missed.

This PR switches the watcher to the parent directory with a `filename === 'HEAD'` filter. Directory watchers persist across file replacements, so all subsequent renames continue to fire.

## Root cause

1. `git checkout` updates HEAD via the standard ref-update path: write `HEAD.lock` with the new content, then `rename(HEAD.lock, HEAD)`. This is atomic and replaces the HEAD inode.
2. Node-style `fs.watch(filePath, …)` opens an inode-bound watch:
   - macOS: kqueue's `EVFILT_VNODE` is associated with the open file descriptor, which references the original inode.
   - Linux: `inotify_add_watch` on a file path resolves to an inode at watch-add time; `IN_MOVE_SELF` / `IN_DELETE_SELF` then mark the watch invalid.
3. After the first atomic rename, the watcher's inode is detached. Subsequent `git checkout` operations write to a new inode the watcher does not observe. The `'rename'` event may fire once, but no further events arrive.
4. Symptom: after the first branch switch, the UI never reflects further branch changes for that worktree session — exactly the behaviour reported in #708.

## Fix

`BranchWatcherService.startWatching` (`packages/server/src/services/branch-watcher-service.ts`) now watches `path.dirname(headFilePath)` rather than the HEAD file itself, and filters incoming events by `filename === path.basename(headFilePath)`. Directory watchers are not bound to a specific child inode, so they survive `rename(HEAD.lock, HEAD)` and continue firing for every subsequent rename.

The public API of `BranchWatcherService` (`startWatching`, `stopWatching`, `stopAll`, `isWatching`, constructor) is unchanged. No other service was touched. Production diff is ~13 net lines.

```ts
// Before
const fsWatcher = this.watchFn(headFilePath, (_eventType) => { /* … */ });

// After
const headDir = path.dirname(headFilePath);
const headBasename = path.basename(headFilePath);
const fsWatcher = this.watchFn(headDir, (_eventType, filename) => {
  if (filename !== headBasename) return; // ignore HEAD.lock, index, ORIG_HEAD, …
  /* … debounce + serializedHeadChange unchanged … */
});
```

The HEAD file content is still read via `Bun.file(headFilePath).text()` in `handleHeadChange` — only the watch target changes.

## Test evidence

### TDD reproduction (real `fs.watch`)

`packages/server/src/services/__tests__/branch-watcher-rename-bug.test.ts` uses real `fs.watch` (no mocks) and simulates git's pattern (`Bun.write(HEAD.lock)` + `mv HEAD.lock HEAD`).

- **Before the fix:** 3 successive atomic renames → only the first (`feature-a`) is observed; `feature-b`, `feature-c` are silently dropped.
- **After the fix:** all 3 atomic renames fire the callback (`feature-a`, `feature-b`, `feature-c` all observed).

The test self-detects when `node:fs` has been replaced by `mock-fs-helper.ts`'s memfs (a process-global `mock.module` from sibling tests) and skips with an explanatory message in that case. Run it directly to exercise real `fs.watch`:

```bash
bun test packages/server/src/services/__tests__/branch-watcher-rename-bug.test.ts
```

Result: `2 pass, 0 fail` (real fs).

### Boundary cases (injected-mock unit tests)

Three new tests in `branch-watcher-service.test.ts` cover the directory-watch filter:

- `should ignore directory events for HEAD.lock` — git's intermediate lock file does not trigger the callback.
- `should ignore directory events for unrelated files (e.g., index)` — `index`, `ORIG_HEAD`, `config` updates from other git operations are filtered out.
- `should ignore directory events with null filename` — some platforms / encodings can pass `null`; safely ignored (cannot disambiguate).

The pre-existing 405-line test suite remains green; mock keys were updated from `headPath` to `gitDir` to match the new watch target.

### Full suite

```
output=$(bun run test 2>&1); exitcode=$?; echo "$output" | tail -100; echo "TEST_EXIT: $exitcode"
```

Last lines:
```
@agent-console/client    1361 pass  2 skip  0 fail   2526 expect()  Ran 1363 tests across 83 files  [16.22s]
@agent-console/shared     307 pass  0 skip  0 fail    466 expect()  Ran 307 tests across 10 files   [36.00ms]
@agent-console/integration 27 pass  0 skip  0 fail    131 expect()  Ran 27 tests across 8 files     [1.19s]
@agent-console/server    2431 pass  1 skip  0 fail   6674 expect()  Ran 2432 tests across 117 files [54.06s]
TEST_EXIT: 0
```

The single server skip is the deliberate memfs-active branch in `branch-watcher-rename-bug.test.ts` (covered by injected-mock boundary tests when memfs is active).

`bun run typecheck` — green for client / server / shared.

## Boundary cases coverage

- HEAD.lock event ignored — covered (filename filter, new test)
- Unrelated `.git/` file events ignored — covered (filename filter, new test)
- `null` filename event ignored — covered (filename filter, new test)
- Detached HEAD transition (raw commit hash → `'(detached)'`) — covered by pre-existing test
- Rapid switch (3+ near-simultaneous renames) — covered by pre-existing debounce test, and by the real-fs reproduction (final state observed)
- Multiple atomic renames across one watcher — covered by the real-fs reproduction (this is the bug the PR fixes)
- Worktree path resolution (`gitdir:` indirection) — covered by pre-existing `resolveHeadFilePath` tests

## Hypotheses considered

The Issue body listed four hypotheses. The investigation:

- **Hypothesis 3 — `fs.watch` rename behaviour:** confirmed by the real-fs TDD reproduction. Root cause. Fixed by this PR.
- **Hypothesis 1 — server startup auto-resume not invoking `startWatching`:** confirmed correctly wired by code inspection. `SessionManager.create()` runs `initialize()` (which auto-resumes worktree sessions into memory) and the subsequent `setBranchWatcherCallbacks` (`session-manager.ts:466`) backfills watchers for every in-memory worktree session. Not the bug.
- **Hypothesis 2 — `.claude/worktrees/<name>` path resolution edge case:** unaffected; `resolveHeadFilePath` is unchanged and its existing tests cover both the `.git`-file and `.git`-directory cases.
- **Hypothesis 4 — WebSocket / UI broadcast defect:** code path unchanged. `syncBranchFromGit` → `onSessionUpdated` → `broadcastToApp({ type: 'session-updated', session })` is exercised by the existing rename flow (`updateSessionMetadata`, which uses the same broadcast). With the watcher firing correctly the existing pipeline carries the update.

## Manual verification — transparency note

Per `workflow.md` §"Real-device verification for bug fixes", the standard expectation is browser-QA via Chrome DevTools MCP. Two environment-specific blockers in this delegated worktree precluded a `bun run dev` start:

1. The owner's production-ish server is currently running on the same host (`bun` PID listening on `:6340`); a second dev server risked port / resource contention with the live session that delegated this task.
2. The agent could not read `.env` directly to confirm this worktree's port allocation (`Read` and `Bash cat .env` were both denied), so port deconfliction could not be verified before launch.

Per `workflow.md` "environment-specific blocker → baseline comparison + transparency note" guidance, the verification was redirected:

- **OS-level fix verification** is provided by `branch-watcher-rename-bug.test.ts` using real `fs.watch` against a real OS tmpdir with real `mv` (atomic rename). This deterministically reproduces the user-reported symptom and proves the fix.
- **WebSocket → React → UI path** is unchanged by this PR; existing tests for `syncBranchFromGit`, `onSessionUpdated`, and the `/ws/app` `session-updated` broadcast continue to cover that edge of the pipeline.
- **End-to-end UI verification** is intended to be performed by the owner via the running orchestrator session (this PR's worktree is itself the dogfooded reproduction): merge → restart server → `git checkout` in a worktree session → confirm UI updates within ~5s.

If the dogfood verification surfaces a residual symptom not covered by Hypothesis 3, that is a separate Issue (the watcher-fire path is now deterministically correct).

## Test plan

- [x] `bun run typecheck` green
- [x] `bun run test` green (TEST_EXIT 0; 4126 pass / 3 skip / 0 fail) — re-verified after nitpick fix in 6e10d55
- [x] CodeRabbit CLI: initial review on b9d3afa returned `0 findings`. Re-run on 6e10d55 was rate-limited locally (~48 min wait); relying on the GitHub-side bot review for re-verification per `workflow.md` rate-limit fallback.
- [x] Real-fs reproduction test passes standalone (3-rename scenario; runtime ~1.0s after polling refactor)
- [ ] Owner dogfood verification: `git checkout` in a worktree session reflects in UI within ~5s after server restart

## Note on CodeRabbit

CodeRabbit GitHub bot APPROVED commit b9d3afa with two nitpicks (no CRITICAL/HIGH/MEDIUM); both addressed in commit 6e10d55. Local CLI re-run hit a 48-minute rate-limit; relying on the GitHub-side CodeRabbit bot re-review of 6e10d55. Confirm `reviewDecision` remains `APPROVED` (or empty) before merge.
