### PR TITLE
feat: delegation message templates (closes #707)

### DIFF
--- a/.claude/skills/orchestrator/core-responsibilities.md
+++ b/.claude/skills/orchestrator/core-responsibilities.md
@@ -45,6 +45,7 @@
   4. Update the Issue if criteria need to be added or corrected
   5. You must be able to explain each criterion in your own words before delegating
 - **Generate delegation messages**: Run `node .claude/skills/orchestrator/delegation-prompt.js <Issue number>` to generate a delegation prompt template. The Issue is the source of truth — the prompt references the Issue URL and provides a placeholder for supplementary notes only. Customize the "Key Implementation Notes" section with constraints or context not already in the Issue before sending.
+- **Reusable delegation templates**: Hand-written delegation boilerplate (retrospective callback, Definition of Done reminders, test placement, CI rollup verification) can be registered once per Orchestrator session via `register_delegation_template({ sessionId, name, content })` and applied per-call via `delegate_to_worktree({ ..., useTemplates: ["retrospective-callback", "test-placement"] })`. Templates are appended to the prompt in the order listed before callback instructions. Use `list_delegation_templates({ sessionId })` to inspect, `delete_delegation_template({ sessionId, name })` to remove. Templates are scoped to the registering session and cleaned up when that session is deleted.
 - **Available specialist agents for delegation**:
   - `frontend-specialist` — for changes in `packages/client`
   - `backend-specialist` — for changes in `packages/server`

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -118,6 +118,11 @@ A registered shell-condition + interval that the server polls silently and notif
 - **See:** Issue [#700](https://github.com/ms2sato/agent-console/issues/700), MCP tools `create_conditional_wakeup` / `delete_conditional_wakeup`
 - **Contrast:** [Timer](#timer) (fires on interval regardless of state)
 
+### Delegation Template
+A named text fragment registered to a session via `register_delegation_template` and applied by `delegate_to_worktree`'s [useTemplates](#usetemplates) parameter to append reusable boilerplate (retrospective callback, Definition of Done, test placement, CI rollup verification, etc.) to delegated agent prompts. Scoped to the registering session and removed when that session is deleted.
+- **Aliases:** delegation message template, named template
+- **See:** Issue [#707](https://github.com/ms2sato/agent-console/issues/707), MCP tools `register_delegation_template` / `list_delegation_templates` / `delete_delegation_template`
+
 ### SystemEvent
 The top-level event format representing meaningful occurrences in the system.
 - **Aliases:** System-wide event
@@ -132,6 +137,10 @@ A periodic, fixed-interval notification mechanism for sessions. Fires on every i
 Real-time bidirectional communication channel between client and server.
 - **Types:** App Connection (`/ws/app`), Worker Connection (`/ws/session/:id/worker/:id`)
 - **See:** [WebSocket protocol in websocket-protocol.md](design/websocket-protocol.md)
+
+### useTemplates
+The `delegate_to_worktree` MCP-tool parameter that lists [Delegation Template](#delegation-template) names whose bodies are appended to the delegated agent's prompt (in the order listed) before any callback instructions. Requires `parentSessionId` (the registry to look up belongs to the parent session). Missing names cause an atomic error — no partial appending.
+- **See:** [Delegation Template](#delegation-template), Issue [#707](https://github.com/ms2sato/agent-console/issues/707)
 
 ## Maintenance
 

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -63,6 +63,7 @@ import { AnnotationService as AnnotationServiceClass } from './services/annotati
 import { InterSessionMessageService as InterSessionMessageServiceClass } from './services/inter-session-message-service.js';
 import { WorkerOutputFileManager } from './lib/worker-output-file.js';
 import { MemoService } from './services/memo-service.js';
+import { DelegationTemplateService } from './services/delegation-template-service.js';
 import { BranchWatcherService } from './services/branch-watcher-service.js';
 import { suggestSessionMetadata } from './services/session-metadata-suggester.js';
 import { fetchPullRequestUrl, findOpenPullRequest } from './services/github-pr-service.js';
@@ -205,6 +206,7 @@ export async function createAppContext(
   const annotationService = new AnnotationServiceClass();
   const interSessionMessageService = new InterSessionMessageServiceClass();
   const memoService = new MemoService();
+  const delegationTemplateService = new DelegationTemplateService();
 
   // 4. Create agent manager (needed by SessionManager)
   const agentRepository = new SqliteAgentRepository(db);
@@ -241,6 +243,7 @@ export async function createAppContext(
     workerOutputFileManager,
     interSessionMessageService,
     memoService,
+    delegationTemplateService,
     repositoryLookup: {
       getRepositorySlug: (id) => repositoryManager.getRepositorySlug(id),
     },
@@ -489,6 +492,7 @@ export async function createTestContext(
   const annotationService = new AnnotationServiceClass();
   const interSessionMessageService = new InterSessionMessageServiceClass();
   const memoService = new MemoService();
+  const delegationTemplateService = new DelegationTemplateService();
 
   // Create agent manager (needed by SessionManager)
   const agentRepository = new SqliteAgentRepository(db);
@@ -527,6 +531,7 @@ export async function createTestContext(
     workerOutputFileManager,
     interSessionMessageService,
     memoService,
+    delegationTemplateService,
     repositoryLookup: {
       getRepositorySlug: (id) => repositoryManager.getRepositorySlug(id),
     },

--- a/packages/server/src/lib/session-data-path-resolver.ts
+++ b/packages/server/src/lib/session-data-path-resolver.ts
@@ -28,4 +28,12 @@ export class SessionDataPathResolver {
   getOutputFilePath(sessionId: string, workerId: string): string {
     return path.join(this.getOutputsDir(), sessionId, `${workerId}.log`);
   }
+
+  getDelegationTemplatesDir(): string {
+    return path.join(this.baseDir, 'delegation-templates');
+  }
+
+  getDelegationTemplatesPath(sessionId: string): string {
+    return path.join(this.getDelegationTemplatesDir(), `${sessionId}.json`);
+  }
 }

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -2227,6 +2227,447 @@ describe('MCP Server Tools', () => {
   });
 
   // ===========================================================================
+  // delegation template tools
+  // ===========================================================================
+
+  describe('delegation template tools', () => {
+    /**
+     * Create a quick session that owns the template registry.
+     * Returns the session id so tests can address it.
+     */
+    async function makeOwnerSession(): Promise<string> {
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      return session.id;
+    }
+
+    describe('register_delegation_template', () => {
+      it('should register a template and return the file path', async () => {
+        const sessionId = await makeOwnerSession();
+
+        const response = await callTool(app, mcpSessionId, 'register_delegation_template', {
+          sessionId,
+          name: 'callback',
+          content: 'CALLBACK BODY',
+        }, nextId++);
+
+        expect(response.result?.isError).toBeUndefined();
+        const data = parseToolResult(response) as {
+          success: boolean;
+          sessionId: string;
+          name: string;
+          filePath: string;
+        };
+        expect(data.success).toBe(true);
+        expect(data.sessionId).toBe(sessionId);
+        expect(data.name).toBe('callback');
+        expect(data.filePath).toContain('delegation-templates');
+        expect(data.filePath.endsWith(`${sessionId}.json`)).toBe(true);
+      });
+
+      it('should reject names that violate the regex', async () => {
+        const sessionId = await makeOwnerSession();
+
+        const response = await callTool(app, mcpSessionId, 'register_delegation_template', {
+          sessionId,
+          name: 'has space',
+          content: 'body',
+        }, nextId++);
+
+        // Zod schema rejection may arrive as JSON-RPC error or tool isError
+        if (response.error) {
+          expect(response.error).toBeDefined();
+        } else {
+          expect(response.result?.isError).toBe(true);
+        }
+      });
+
+      it('should reject names longer than 64 characters', async () => {
+        const sessionId = await makeOwnerSession();
+        const longName = 'a'.repeat(65);
+
+        const response = await callTool(app, mcpSessionId, 'register_delegation_template', {
+          sessionId,
+          name: longName,
+          content: 'body',
+        }, nextId++);
+
+        if (response.error) {
+          expect(response.error).toBeDefined();
+        } else {
+          expect(response.result?.isError).toBe(true);
+        }
+      });
+
+      it('should reject content over 256KB', async () => {
+        const sessionId = await makeOwnerSession();
+        const oversized = 'x'.repeat(256 * 1024 + 1);
+
+        const response = await callTool(app, mcpSessionId, 'register_delegation_template', {
+          sessionId,
+          name: 'big',
+          content: oversized,
+        }, nextId++);
+
+        if (response.error) {
+          expect(response.error).toBeDefined();
+        } else {
+          expect(response.result?.isError).toBe(true);
+        }
+      });
+
+      it('should return error when session is not found', async () => {
+        const response = await callTool(app, mcpSessionId, 'register_delegation_template', {
+          sessionId: 'non-existent',
+          name: 'callback',
+          content: 'body',
+        }, nextId++);
+
+        expect(response.result?.isError).toBe(true);
+        const data = parseToolResult(response) as { error: string };
+        expect(data.error).toContain('Session not found');
+      });
+    });
+
+    describe('list_delegation_templates', () => {
+      it('should return the registered templates', async () => {
+        const sessionId = await makeOwnerSession();
+
+        await callTool(app, mcpSessionId, 'register_delegation_template', {
+          sessionId,
+          name: 'foo',
+          content: 'F',
+        }, nextId++);
+
+        const response = await callTool(app, mcpSessionId, 'list_delegation_templates', {
+          sessionId,
+        }, nextId++);
+
+        expect(response.result?.isError).toBeUndefined();
+        const data = parseToolResult(response) as {
+          sessionId: string;
+          templates: Array<{ name: string; content: string }>;
+        };
+        expect(data.sessionId).toBe(sessionId);
+        expect(data.templates).toEqual([{ name: 'foo', content: 'F' }]);
+      });
+
+      it('should return an empty array for a session with no templates', async () => {
+        const sessionId = await makeOwnerSession();
+
+        const response = await callTool(app, mcpSessionId, 'list_delegation_templates', {
+          sessionId,
+        }, nextId++);
+
+        expect(response.result?.isError).toBeUndefined();
+        const data = parseToolResult(response) as {
+          templates: Array<{ name: string; content: string }>;
+        };
+        expect(data.templates).toEqual([]);
+      });
+    });
+
+    describe('delete_delegation_template', () => {
+      it('should remove the template; subsequent list returns empty', async () => {
+        const sessionId = await makeOwnerSession();
+
+        await callTool(app, mcpSessionId, 'register_delegation_template', {
+          sessionId,
+          name: 'foo',
+          content: 'F',
+        }, nextId++);
+
+        const deleteResponse = await callTool(app, mcpSessionId, 'delete_delegation_template', {
+          sessionId,
+          name: 'foo',
+        }, nextId++);
+
+        expect(deleteResponse.result?.isError).toBeUndefined();
+        const deleteData = parseToolResult(deleteResponse) as {
+          success: boolean;
+          deleted: boolean;
+        };
+        expect(deleteData.success).toBe(true);
+        expect(deleteData.deleted).toBe(true);
+
+        const listResponse = await callTool(app, mcpSessionId, 'list_delegation_templates', {
+          sessionId,
+        }, nextId++);
+        const listData = parseToolResult(listResponse) as {
+          templates: Array<{ name: string; content: string }>;
+        };
+        expect(listData.templates).toEqual([]);
+      });
+
+      it('should be idempotent for missing names (deleted=false)', async () => {
+        const sessionId = await makeOwnerSession();
+
+        const response = await callTool(app, mcpSessionId, 'delete_delegation_template', {
+          sessionId,
+          name: 'never-registered',
+        }, nextId++);
+
+        expect(response.result?.isError).toBeUndefined();
+        const data = parseToolResult(response) as { success: boolean; deleted: boolean };
+        expect(data.success).toBe(true);
+        expect(data.deleted).toBe(false);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // delegate_to_worktree useTemplates integration
+  // ===========================================================================
+
+  describe('delegate_to_worktree useTemplates', () => {
+    // Reuses the helper functions defined inside the delegate_to_worktree
+    // describe block above. We cannot reach those nested helpers from here,
+    // so we duplicate the minimal setup needed for these tests.
+
+    async function setupDelegateRepo(): Promise<void> {
+      const db = getDatabase();
+      const sqliteRepoRepo = new SqliteRepositoryRepository(db);
+      await sqliteRepoRepo.save({
+        id: 'test-repo',
+        name: 'test',
+        path: TEST_REPO_PATH,
+        createdAt: new Date().toISOString(),
+      });
+      repositoryManager = await RepositoryManager.create({
+        jobQueue: testJobQueue,
+        repository: sqliteRepoRepo,
+      });
+      await remountMcpApp();
+    }
+
+    async function setupDelegateEnvironmentForUseTemplates(branchName: string): Promise<void> {
+      setupMemfs({
+        [`${TEST_CONFIG_DIR}/.keep`]: '',
+        [`${TEST_REPO_PATH}/.git/HEAD`]: 'ref: refs/heads/main',
+      });
+      process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+
+      mockGit.getRemoteUrl.mockImplementation(async () => 'git@github.com:owner/repo.git');
+      mockGit.getDefaultBranch.mockImplementation(async () => 'main');
+      let capturedWorktreePath = '';
+      mockGit.createWorktree.mockImplementation(async (...args: unknown[]) => {
+        capturedWorktreePath = args[0] as string;
+      });
+      mockGit.listWorktrees.mockImplementation(async () => {
+        if (capturedWorktreePath) {
+          return `worktree ${TEST_REPO_PATH}\nHEAD abc123\nbranch refs/heads/main\n\nworktree ${capturedWorktreePath}\nHEAD def456\nbranch refs/heads/${branchName}\n`;
+        }
+        return `worktree ${TEST_REPO_PATH}\nHEAD abc123\nbranch refs/heads/main\n`;
+      });
+
+      await setupDelegateRepo();
+    }
+
+    function getAgentPromptForSession(sessionId: string): string {
+      const calls = ptyFactory.spawn.mock.calls as unknown as Array<[string, string[], PtySpawnOptions]>;
+      const matchingCall = calls.find((call) =>
+        call[2]?.env?.AGENT_CONSOLE_SESSION_ID === sessionId,
+      );
+      expect(matchingCall).toBeDefined();
+      const agentPrompt = matchingCall![2].env!.__AGENT_PROMPT__;
+      expect(agentPrompt).toBeDefined();
+      return agentPrompt!;
+    }
+
+    async function makeParentSession(): Promise<string> {
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      return session.id;
+    }
+
+    it('should leave the prompt unchanged when useTemplates is omitted', async () => {
+      await setupDelegateEnvironmentForUseTemplates('feat/no-templates');
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Plain prompt with no templates',
+        branch: 'feat/no-templates',
+      }, nextId++);
+
+      expect(response.result?.isError).toBeUndefined();
+      const data = parseToolResult(response) as { sessionId: string };
+      const agentPrompt = getAgentPromptForSession(data.sessionId);
+      expect(agentPrompt).toBe('Plain prompt with no templates');
+    });
+
+    it('should leave the prompt unchanged when useTemplates is an empty array', async () => {
+      await setupDelegateEnvironmentForUseTemplates('feat/empty-templates');
+      const parentSessionId = await makeParentSession();
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Plain prompt',
+        branch: 'feat/empty-templates',
+        parentSessionId,
+        parentWorkerId: 'parent-worker-id',
+        useTemplates: [],
+        skipMessageCallbackPrompt: true,
+      }, nextId++);
+
+      expect(response.result?.isError).toBeUndefined();
+      const data = parseToolResult(response) as { sessionId: string };
+      const agentPrompt = getAgentPromptForSession(data.sessionId);
+      expect(agentPrompt).toBe('Plain prompt');
+    });
+
+    it('should append a single template body before callback instructions', async () => {
+      await setupDelegateEnvironmentForUseTemplates('feat/single-template');
+      const parentSessionId = await makeParentSession();
+
+      await callTool(app, mcpSessionId, 'register_delegation_template', {
+        sessionId: parentSessionId,
+        name: 'retro',
+        content: 'RETRO_BODY',
+      }, nextId++);
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'USER_PROMPT',
+        branch: 'feat/single-template',
+        parentSessionId,
+        parentWorkerId: 'parent-worker-id',
+        useTemplates: ['retro'],
+      }, nextId++);
+
+      expect(response.result?.isError).toBeUndefined();
+      const data = parseToolResult(response) as { sessionId: string };
+      const agentPrompt = getAgentPromptForSession(data.sessionId);
+
+      // user prompt, template body, then callback (separated by --- block)
+      expect(agentPrompt).toContain('USER_PROMPT\n\nRETRO_BODY');
+      const userIdx = agentPrompt.indexOf('USER_PROMPT');
+      const retroIdx = agentPrompt.indexOf('RETRO_BODY');
+      const callbackIdx = agentPrompt.indexOf('[Message Callback Instructions]');
+      expect(userIdx).toBeLessThan(retroIdx);
+      expect(retroIdx).toBeLessThan(callbackIdx);
+    });
+
+    it('should append multiple template bodies in the order requested', async () => {
+      await setupDelegateEnvironmentForUseTemplates('feat/multi-template');
+      const parentSessionId = await makeParentSession();
+
+      await callTool(app, mcpSessionId, 'register_delegation_template', {
+        sessionId: parentSessionId,
+        name: 'AAA',
+        content: 'AAA_BODY',
+      }, nextId++);
+      await callTool(app, mcpSessionId, 'register_delegation_template', {
+        sessionId: parentSessionId,
+        name: 'BBB',
+        content: 'BBB_BODY',
+      }, nextId++);
+      await callTool(app, mcpSessionId, 'register_delegation_template', {
+        sessionId: parentSessionId,
+        name: 'CCC',
+        content: 'CCC_BODY',
+      }, nextId++);
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'USER_PROMPT',
+        branch: 'feat/multi-template',
+        parentSessionId,
+        parentWorkerId: 'parent-worker-id',
+        useTemplates: ['CCC', 'AAA', 'BBB'],
+        skipMessageCallbackPrompt: true,
+      }, nextId++);
+
+      expect(response.result?.isError).toBeUndefined();
+      const data = parseToolResult(response) as { sessionId: string };
+      const agentPrompt = getAgentPromptForSession(data.sessionId);
+
+      expect(agentPrompt).toBe('USER_PROMPT\n\nCCC_BODY\n\nAAA_BODY\n\nBBB_BODY');
+    });
+
+    it('should return error and not create a worktree when a template name is missing', async () => {
+      await setupDelegateEnvironmentForUseTemplates('feat/missing-template');
+      const parentSessionId = await makeParentSession();
+
+      await callTool(app, mcpSessionId, 'register_delegation_template', {
+        sessionId: parentSessionId,
+        name: 'present',
+        content: 'P',
+      }, nextId++);
+
+      mockGit.createWorktree.mockClear();
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'USER_PROMPT',
+        branch: 'feat/missing-template',
+        parentSessionId,
+        parentWorkerId: 'parent-worker-id',
+        useTemplates: ['present', 'absent-1', 'absent-2'],
+      }, nextId++);
+
+      expect(response.result?.isError).toBe(true);
+      const data = parseToolResult(response) as { error: string };
+      expect(data.error).toContain('Delegation templates not found');
+      expect(data.error).toContain('absent-1');
+      expect(data.error).toContain('absent-2');
+      // No worktree was created
+      expect(mockGit.createWorktree).not.toHaveBeenCalled();
+    });
+
+    it('should return error when useTemplates is non-empty without parentSessionId', async () => {
+      await setupDelegateEnvironmentForUseTemplates('feat/no-parent');
+
+      mockGit.createWorktree.mockClear();
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'USER_PROMPT',
+        branch: 'feat/no-parent',
+        useTemplates: ['retro'],
+        // parentSessionId intentionally omitted
+      }, nextId++);
+
+      expect(response.result?.isError).toBe(true);
+      const data = parseToolResult(response) as { error: string };
+      expect(data.error).toContain('useTemplates requires parentSessionId');
+      expect(mockGit.createWorktree).not.toHaveBeenCalled();
+    });
+
+    it('should be cross-session isolated (templates from session A not visible to session B)', async () => {
+      await setupDelegateEnvironmentForUseTemplates('feat/cross-session');
+      const sessionA = await makeParentSession();
+      const sessionB = await makeParentSession();
+
+      await callTool(app, mcpSessionId, 'register_delegation_template', {
+        sessionId: sessionA,
+        name: 'shared-name',
+        content: 'A_BODY',
+      }, nextId++);
+
+      // Use sessionB as the parent — its registry is empty
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'USER_PROMPT',
+        branch: 'feat/cross-session',
+        parentSessionId: sessionB,
+        parentWorkerId: 'parent-worker-id',
+        useTemplates: ['shared-name'],
+      }, nextId++);
+
+      expect(response.result?.isError).toBe(true);
+      const data = parseToolResult(response) as { error: string };
+      expect(data.error).toContain('Delegation templates not found');
+      expect(data.error).toContain('shared-name');
+    });
+  });
+
+  // ===========================================================================
   // remove_worktree
   // ===========================================================================
 

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -110,6 +110,16 @@ function errorResult(message: string) {
 }
 
 /**
+ * Build the body that includes the user prompt followed by template bodies
+ * (in the order requested). The result is suitable for further composition
+ * with optional callback instructions.
+ */
+function buildPromptWithTemplates(prompt: string, templateBodies: string[]): string {
+  if (templateBodies.length === 0) return prompt;
+  return [prompt, ...templateBodies].join('\n\n');
+}
+
+/**
  * Build a prompt that includes callback instructions telling the delegated agent
  * to report results back to the parent session via send_session_message.
  */
@@ -471,7 +481,8 @@ export function createMcpApp(deps: McpDependencies): Hono {
       'Use this to delegate work to a new agent running in an isolated worktree. ' +
       'Note: once started, the worktree and session persist on the server even if the MCP client disconnects. ' +
       'To delegate to a repository other than your own, use list_repositories to discover available repositories. ' +
-      'Optionally pass parentSessionId and parentWorkerId to have the delegated agent report results back via send_session_message.',
+      'Optionally pass parentSessionId and parentWorkerId to have the delegated agent report results back via send_session_message. ' +
+      'Optionally pass useTemplates to append registered template bodies (see register_delegation_template).',
     {
       repositoryId: z.string().describe(
         'The repository ID. The calling agent can get this from the AGENT_CONSOLE_REPOSITORY_ID environment variable. ' +
@@ -549,6 +560,14 @@ export function createMcpApp(deps: McpDependencies): Hono {
           'Custom template variable overrides. Keys are variable names (e.g., "model"), values are the replacement strings. ' +
             'These override default values defined in the agent command template (e.g., {{model:claude-opus-4-6}}).',
         ),
+      useTemplates: z
+        .array(z.string().min(1))
+        .optional()
+        .describe(
+          'List of named templates registered with register_delegation_template (in the parent session) ' +
+            'whose bodies will be appended to the prompt in the order listed, before any callback instructions. ' +
+            'Requires parentSessionId. Missing names cause an error (no partial appending).',
+        ),
     },
     async ({
       repositoryId,
@@ -563,6 +582,7 @@ export function createMcpApp(deps: McpDependencies): Hono {
       parentWorkerId,
       skipMessageCallbackPrompt,
       templateVars,
+      useTemplates,
     }) => {
       try {
         // Validate parent IDs: both must be provided together
@@ -570,11 +590,43 @@ export function createMcpApp(deps: McpDependencies): Hono {
           return errorResult('parentSessionId and parentWorkerId must be provided together');
         }
 
-        // Build effective prompt with optional callback instructions
+        // Resolve useTemplates: requires parentSessionId; missing names abort.
+        const requestedTemplateNames = useTemplates ?? [];
+        let templateBodies: string[] = [];
+        if (requestedTemplateNames.length > 0) {
+          if (!parentSessionId) {
+            return errorResult(
+              'useTemplates requires parentSessionId to identify the registry to look up',
+            );
+          }
+          const parentSession = sessionManager.getSession(parentSessionId);
+          if (!parentSession) {
+            return errorResult(`Parent session not found: ${parentSessionId}`);
+          }
+          let lookup;
+          try {
+            lookup = await sessionManager.lookupDelegationTemplates(
+              parentSessionId,
+              requestedTemplateNames,
+            );
+          } catch (err) {
+            const message = err instanceof Error ? err.message : 'Unknown error';
+            return errorResult(`Failed to look up delegation templates: ${message}`);
+          }
+          if (lookup.missing.length > 0) {
+            return errorResult(
+              `Delegation templates not found in parent session ${parentSessionId}: ${lookup.missing.join(', ')}`,
+            );
+          }
+          templateBodies = lookup.found.map((t) => t.content);
+        }
+
+        // Compose the final prompt: user prompt + template bodies, then optional callback.
+        const promptWithTemplates = buildPromptWithTemplates(prompt, templateBodies);
         const effectivePrompt =
           parentSessionId && parentWorkerId && !skipMessageCallbackPrompt
-            ? buildMessageCallbackPrompt(prompt, parentSessionId, parentWorkerId)
-            : prompt;
+            ? buildMessageCallbackPrompt(promptWithTemplates, parentSessionId, parentWorkerId)
+            : promptWithTemplates;
 
         // Validate repository
         const repo = repositoryManager.getRepository(repositoryId);
@@ -773,6 +825,107 @@ export function createMcpApp(deps: McpDependencies): Hono {
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         logger.error({ err, sessionId }, 'write_memo failed');
+        return errorResult(message);
+      }
+    },
+  );
+
+  // ---------- Tool: register_delegation_template ----------
+
+  mcpServer.tool(
+    'register_delegation_template',
+    'Register (or overwrite) a named template body for the current session. ' +
+      'Templates are reusable boilerplate fragments (retrospective callback, Definition of Done reminders, ' +
+      'test placement, CI rollup verification) that can be appended to delegate_to_worktree prompts ' +
+      'via the useTemplates parameter. Re-registering the same name overwrites the previous body. ' +
+      'Templates are scoped to the registering session and cleaned up when that session is deleted.',
+    {
+      sessionId: z
+        .string()
+        .describe(
+          'The session that owns the template registry. Get from AGENT_CONSOLE_SESSION_ID.',
+        ),
+      name: z
+        .string()
+        .min(1, 'name is required')
+        .max(64, 'name must be 64 characters or less')
+        .regex(/^[a-zA-Z0-9_-]+$/, 'name must be alphanumeric, hyphen, or underscore')
+        .describe('Template name. Use kebab-case. Re-registering the same name overwrites.'),
+      content: z
+        .string()
+        .refine(
+          (s) => Buffer.byteLength(s, 'utf-8') <= 256 * 1024,
+          { message: 'Template content must not exceed 256KB' },
+        )
+        .describe('Template body — plain text appended verbatim to delegate_to_worktree prompts.'),
+    },
+    async ({ sessionId, name, content }) => {
+      try {
+        const session = sessionManager.getSession(sessionId);
+        if (!session) {
+          return errorResult(`Session not found: ${sessionId}`);
+        }
+        const result = await sessionManager.registerDelegationTemplate(sessionId, name, content);
+        logger.info({ sessionId, name }, 'Delegation template registered via MCP');
+        return textResult({ success: true, sessionId, name: result.name, filePath: result.filePath });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        logger.error({ err, sessionId, name }, 'register_delegation_template failed');
+        return errorResult(message);
+      }
+    },
+  );
+
+  // ---------- Tool: list_delegation_templates ----------
+
+  mcpServer.tool(
+    'list_delegation_templates',
+    'List all delegation templates registered for the current session. Returns templates sorted by name. ' +
+      'Use this to inspect templates before applying them via delegate_to_worktree useTemplates.',
+    {
+      sessionId: z.string().describe('The session whose templates to list.'),
+    },
+    async ({ sessionId }) => {
+      try {
+        const session = sessionManager.getSession(sessionId);
+        if (!session) {
+          return errorResult(`Session not found: ${sessionId}`);
+        }
+        const templates = await sessionManager.listDelegationTemplates(sessionId);
+        return textResult({ sessionId, templates });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        logger.error({ err, sessionId }, 'list_delegation_templates failed');
+        return errorResult(message);
+      }
+    },
+  );
+
+  // ---------- Tool: delete_delegation_template ----------
+
+  mcpServer.tool(
+    'delete_delegation_template',
+    'Delete a delegation template by name. Idempotent: returns deleted=false if the name was not registered. ' +
+      'Use this to remove templates that are no longer needed.',
+    {
+      sessionId: z.string().describe('The session that owns the template.'),
+      name: z
+        .string()
+        .min(1)
+        .describe('Template name to delete. Idempotent — no error if not found.'),
+    },
+    async ({ sessionId, name }) => {
+      try {
+        const session = sessionManager.getSession(sessionId);
+        if (!session) {
+          return errorResult(`Session not found: ${sessionId}`);
+        }
+        const result = await sessionManager.deleteDelegationTemplate(sessionId, name);
+        logger.info({ sessionId, name, deleted: result.deleted }, 'delete_delegation_template completed');
+        return textResult({ success: result.success, sessionId, name, deleted: result.deleted });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        logger.error({ err, sessionId, name }, 'delete_delegation_template failed');
         return errorResult(message);
       }
     },

--- a/packages/server/src/services/__tests__/delegation-template-service.test.ts
+++ b/packages/server/src/services/__tests__/delegation-template-service.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { vol } from 'memfs';
+import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
+import { DelegationTemplateService } from '../delegation-template-service.js';
+import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
+
+const TEST_CONFIG_DIR = '/test/config';
+const ORIGINAL_AGENT_CONSOLE_HOME = process.env.AGENT_CONSOLE_HOME;
+const quickResolver = new SessionDataPathResolver(`${TEST_CONFIG_DIR}/_quick`);
+
+const TEMPLATES_DIR = `${TEST_CONFIG_DIR}/_quick/delegation-templates`;
+const fileFor = (sessionId: string) => `${TEMPLATES_DIR}/${sessionId}.json`;
+
+describe('DelegationTemplateService', () => {
+  let service: DelegationTemplateService;
+
+  beforeEach(() => {
+    setupMemfs({ [`${TEST_CONFIG_DIR}/.keep`]: '' });
+    process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+    service = new DelegationTemplateService();
+  });
+
+  afterEach(() => {
+    cleanupMemfs();
+    if (ORIGINAL_AGENT_CONSOLE_HOME === undefined) {
+      delete process.env.AGENT_CONSOLE_HOME;
+    } else {
+      process.env.AGENT_CONSOLE_HOME = ORIGINAL_AGENT_CONSOLE_HOME;
+    }
+  });
+
+  describe('registerTemplate', () => {
+    it('should create the directory and write the registry file', async () => {
+      const filePath = await service.registerTemplate('session-1', 'callback', 'body-A', quickResolver);
+
+      expect(filePath).toBe(fileFor('session-1'));
+      expect(vol.existsSync(TEMPLATES_DIR)).toBe(true);
+
+      const raw = vol.readFileSync(filePath, 'utf-8') as string;
+      expect(JSON.parse(raw)).toEqual({ callback: 'body-A' });
+    });
+
+    it('should overwrite an existing name within the same session', async () => {
+      await service.registerTemplate('session-1', 'callback', 'first', quickResolver);
+      await service.registerTemplate('session-1', 'callback', 'second', quickResolver);
+
+      const raw = vol.readFileSync(fileFor('session-1'), 'utf-8') as string;
+      expect(JSON.parse(raw)).toEqual({ callback: 'second' });
+    });
+
+    it('should preserve other names when overwriting one', async () => {
+      await service.registerTemplate('session-1', 'foo', 'F-old', quickResolver);
+      await service.registerTemplate('session-1', 'bar', 'B', quickResolver);
+      await service.registerTemplate('session-1', 'foo', 'F-new', quickResolver);
+
+      const raw = vol.readFileSync(fileFor('session-1'), 'utf-8') as string;
+      expect(JSON.parse(raw)).toEqual({ foo: 'F-new', bar: 'B' });
+    });
+
+    it('should reject content exceeding 256KB', async () => {
+      const oversized = 'x'.repeat(256 * 1024 + 1);
+      await expect(
+        service.registerTemplate('session-1', 'big', oversized, quickResolver),
+      ).rejects.toThrow(/exceeds maximum size/);
+    });
+
+    it('should reject sessionId with path traversal (..)', async () => {
+      await expect(
+        service.registerTemplate('../etc/passwd', 'name', 'body', quickResolver),
+      ).rejects.toThrow(/Invalid sessionId/);
+    });
+
+    it('should reject sessionId with slashes', async () => {
+      await expect(
+        service.registerTemplate('foo/bar', 'name', 'body', quickResolver),
+      ).rejects.toThrow(/Invalid sessionId/);
+    });
+
+    it('should reject invalid template names', async () => {
+      await expect(
+        service.registerTemplate('session-1', 'has space', 'body', quickResolver),
+      ).rejects.toThrow(/Invalid template name/);
+      await expect(
+        service.registerTemplate('session-1', '../etc', 'body', quickResolver),
+      ).rejects.toThrow(/Invalid template name/);
+      await expect(
+        service.registerTemplate('session-1', '', 'body', quickResolver),
+      ).rejects.toThrow(/Invalid template name/);
+      const longName = 'a'.repeat(65);
+      await expect(
+        service.registerTemplate('session-1', longName, 'body', quickResolver),
+      ).rejects.toThrow(/Invalid template name/);
+    });
+
+    it('should accept names with hyphens, underscores, and digits', async () => {
+      await service.registerTemplate('session-1', 'retro-callback_2', 'body', quickResolver);
+      const raw = vol.readFileSync(fileFor('session-1'), 'utf-8') as string;
+      expect(JSON.parse(raw)).toEqual({ 'retro-callback_2': 'body' });
+    });
+  });
+
+  describe('listTemplates', () => {
+    it('should return an empty array when no file exists', async () => {
+      const list = await service.listTemplates('session-x', quickResolver);
+      expect(list).toEqual([]);
+    });
+
+    it('should return a single registered template', async () => {
+      await service.registerTemplate('session-1', 'foo', 'F', quickResolver);
+
+      const list = await service.listTemplates('session-1', quickResolver);
+      expect(list).toEqual([{ name: 'foo', content: 'F' }]);
+    });
+
+    it('should return multiple templates sorted by name', async () => {
+      await service.registerTemplate('session-1', 'zeta', 'Z', quickResolver);
+      await service.registerTemplate('session-1', 'alpha', 'A', quickResolver);
+      await service.registerTemplate('session-1', 'mike', 'M', quickResolver);
+
+      const list = await service.listTemplates('session-1', quickResolver);
+      expect(list).toEqual([
+        { name: 'alpha', content: 'A' },
+        { name: 'mike', content: 'M' },
+        { name: 'zeta', content: 'Z' },
+      ]);
+    });
+  });
+
+  describe('deleteTemplate', () => {
+    it('should remove the named entry and leave others intact', async () => {
+      await service.registerTemplate('session-1', 'a', 'A', quickResolver);
+      await service.registerTemplate('session-1', 'b', 'B', quickResolver);
+
+      const result = await service.deleteTemplate('session-1', 'a', quickResolver);
+      expect(result).toEqual({ deleted: true });
+
+      const list = await service.listTemplates('session-1', quickResolver);
+      expect(list).toEqual([{ name: 'b', content: 'B' }]);
+    });
+
+    it('should be idempotent when name does not exist (returns deleted=false, no throw)', async () => {
+      await service.registerTemplate('session-1', 'a', 'A', quickResolver);
+
+      const result = await service.deleteTemplate('session-1', 'missing', quickResolver);
+      expect(result).toEqual({ deleted: false });
+
+      // Other entries remain intact
+      const list = await service.listTemplates('session-1', quickResolver);
+      expect(list).toEqual([{ name: 'a', content: 'A' }]);
+    });
+
+    it('should leave an empty {} file when last template is deleted', async () => {
+      await service.registerTemplate('session-1', 'only', 'X', quickResolver);
+      const result = await service.deleteTemplate('session-1', 'only', quickResolver);
+
+      expect(result).toEqual({ deleted: true });
+      // File still exists with an empty object — atomicity simplicity, no special-case
+      const raw = vol.readFileSync(fileFor('session-1'), 'utf-8') as string;
+      expect(JSON.parse(raw)).toEqual({});
+      const list = await service.listTemplates('session-1', quickResolver);
+      expect(list).toEqual([]);
+    });
+
+    it('should be a no-op (deleted=false) when no registry file exists', async () => {
+      const result = await service.deleteTemplate('session-x', 'anything', quickResolver);
+      expect(result).toEqual({ deleted: false });
+    });
+  });
+
+  describe('lookupTemplates', () => {
+    it('should return empty arrays for empty names input (no-op boundary)', async () => {
+      await service.registerTemplate('session-1', 'a', 'A', quickResolver);
+
+      const result = await service.lookupTemplates('session-1', [], quickResolver);
+      expect(result).toEqual({ found: [], missing: [] });
+    });
+
+    it('should return a single found template', async () => {
+      await service.registerTemplate('session-1', 'a', 'AAA', quickResolver);
+
+      const result = await service.lookupTemplates('session-1', ['a'], quickResolver);
+      expect(result).toEqual({ found: [{ name: 'a', content: 'AAA' }], missing: [] });
+    });
+
+    it('should report a single missing name', async () => {
+      const result = await service.lookupTemplates('session-1', ['nope'], quickResolver);
+      expect(result).toEqual({ found: [], missing: ['nope'] });
+    });
+
+    it('should return found and missing arrays for mixed input', async () => {
+      await service.registerTemplate('session-1', 'a', 'AAA', quickResolver);
+      await service.registerTemplate('session-1', 'b', 'BBB', quickResolver);
+
+      const result = await service.lookupTemplates('session-1', ['a', 'missing', 'b'], quickResolver);
+      expect(result).toEqual({
+        found: [
+          { name: 'a', content: 'AAA' },
+          { name: 'b', content: 'BBB' },
+        ],
+        missing: ['missing'],
+      });
+    });
+
+    it('should preserve input order in the found array', async () => {
+      await service.registerTemplate('session-1', 'a', 'AAA', quickResolver);
+      await service.registerTemplate('session-1', 'b', 'BBB', quickResolver);
+      await service.registerTemplate('session-1', 'c', 'CCC', quickResolver);
+
+      const result = await service.lookupTemplates('session-1', ['c', 'a', 'b'], quickResolver);
+      expect(result.found.map((t) => t.name)).toEqual(['c', 'a', 'b']);
+      expect(result.missing).toEqual([]);
+    });
+  });
+
+  describe('deleteAllForSession', () => {
+    it('should remove the per-session registry file', async () => {
+      await service.registerTemplate('session-1', 'a', 'A', quickResolver);
+      expect(vol.existsSync(fileFor('session-1'))).toBe(true);
+
+      await service.deleteAllForSession('session-1', quickResolver);
+      expect(vol.existsSync(fileFor('session-1'))).toBe(false);
+    });
+
+    it('should be a no-op when the file does not exist', async () => {
+      // Ensure parent dir exists so rm doesn't fail on missing parent
+      vol.mkdirSync(TEMPLATES_DIR, { recursive: true });
+
+      await expect(
+        service.deleteAllForSession('nonexistent', quickResolver),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('cross-session isolation', () => {
+    it('should not surface session A templates when listing session B', async () => {
+      await service.registerTemplate('session-A', 'foo', 'A-foo', quickResolver);
+
+      const list = await service.listTemplates('session-B', quickResolver);
+      expect(list).toEqual([]);
+    });
+
+    it('should not surface session A templates when looking up via session B', async () => {
+      await service.registerTemplate('session-A', 'foo', 'A-foo', quickResolver);
+
+      const result = await service.lookupTemplates('session-B', ['foo'], quickResolver);
+      expect(result).toEqual({ found: [], missing: ['foo'] });
+    });
+  });
+});

--- a/packages/server/src/services/__tests__/session-deletion-service.test.ts
+++ b/packages/server/src/services/__tests__/session-deletion-service.test.ts
@@ -46,6 +46,9 @@ function createMockDeps(overrides?: Partial<SessionDeletionDeps>): SessionDeleti
     memoService: {
       deleteMemo: mock(async () => {}),
     } as unknown as SessionDeletionDeps['memoService'],
+    delegationTemplateService: {
+      deleteAllForSession: mock(async () => {}),
+    } as unknown as SessionDeletionDeps['delegationTemplateService'],
     getPathResolverForSession: () => new SessionDataPathResolver('/test/config/repositories/test-repo'),
     getPathResolverForPersistedSession: () => new SessionDataPathResolver('/test/config/repositories/test-repo'),
     getSessionScope: () => ({ scope: 'repository', slug: 'test-repo' }),
@@ -147,6 +150,8 @@ describe('SessionDeletionService', () => {
       expect(deps.interSessionMessageService.deleteSessionMessages).toHaveBeenCalledTimes(1);
       // Memo cleanup
       expect(deps.memoService.deleteMemo).toHaveBeenCalledTimes(1);
+      // Delegation templates cleanup
+      expect(deps.delegationTemplateService.deleteAllForSession).toHaveBeenCalledTimes(1);
       // Persistence deletion
       expect(deps.sessionRepository.delete).toHaveBeenCalledWith('session-1');
       // Lifecycle callback
@@ -270,6 +275,21 @@ describe('SessionDeletionService', () => {
       expect(result).toBe(true);
     });
 
+    it('should not fail if delegation templates cleanup throws', async () => {
+      const session = buildInternalWorktreeSession();
+
+      const deps = createMockDeps({
+        getSession: () => session,
+        delegationTemplateService: {
+          deleteAllForSession: mock(async () => { throw new Error('templates error'); }),
+        } as unknown as SessionDeletionDeps['delegationTemplateService'],
+      });
+      const service = new SessionDeletionService(deps);
+
+      const result = await service.deleteSession('session-1');
+      expect(result).toBe(true);
+    });
+
     it('should skip enqueueing cleanup job when getSessionScope returns null (orphaned)', async () => {
       // Simulate an orphaned session whose (scope, slug) cannot be resolved.
       // The service must still delete the DB row and complete successfully,
@@ -334,6 +354,7 @@ describe('SessionDeletionService', () => {
       expect(deps.sessionRepository.delete).toHaveBeenCalledWith('orphan-1');
       expect(deps.jobQueue!.enqueue).toHaveBeenCalledTimes(1);
       expect(deps.memoService.deleteMemo).toHaveBeenCalledTimes(1);
+      expect(deps.delegationTemplateService.deleteAllForSession).toHaveBeenCalledTimes(1);
       expect(onSessionDeleted).toHaveBeenCalledWith('orphan-1');
     });
 

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -3848,4 +3848,80 @@ describe('SessionManager', () => {
       expect(secondCallback).toHaveBeenCalledWith(session.id);
     });
   });
+
+  describe('delegation templates', () => {
+    it('should register, list, lookup, and delete a template via SessionManager wrappers', async () => {
+      const manager = await getSessionManager();
+
+      const session = await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+
+      // register
+      const register = await manager.registerDelegationTemplate(session.id, 'callback', 'BODY');
+      expect(register.name).toBe('callback');
+      expect(register.filePath).toContain('delegation-templates');
+
+      // list
+      const list = await manager.listDelegationTemplates(session.id);
+      expect(list).toEqual([{ name: 'callback', content: 'BODY' }]);
+
+      // lookup found + missing
+      const lookup = await manager.lookupDelegationTemplates(session.id, ['callback', 'nope']);
+      expect(lookup.found).toEqual([{ name: 'callback', content: 'BODY' }]);
+      expect(lookup.missing).toEqual(['nope']);
+
+      // delete
+      const del = await manager.deleteDelegationTemplate(session.id, 'callback');
+      expect(del).toEqual({ success: true, deleted: true });
+      const listAfter = await manager.listDelegationTemplates(session.id);
+      expect(listAfter).toEqual([]);
+    });
+
+    it('should throw when the session does not exist', async () => {
+      const manager = await getSessionManager();
+      await expect(
+        manager.registerDelegationTemplate('non-existent', 'callback', 'BODY'),
+      ).rejects.toThrow(/Session not found/);
+      await expect(manager.listDelegationTemplates('non-existent')).rejects.toThrow(/Session not found/);
+      await expect(
+        manager.deleteDelegationTemplate('non-existent', 'callback'),
+      ).rejects.toThrow(/Session not found/);
+      await expect(
+        manager.lookupDelegationTemplates('non-existent', ['callback']),
+      ).rejects.toThrow(/Session not found/);
+    });
+
+    it('should treat empty lookup names as a no-op (no registry read needed)', async () => {
+      const manager = await getSessionManager();
+      const session = await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+
+      const result = await manager.lookupDelegationTemplates(session.id, []);
+      expect(result).toEqual({ found: [], missing: [] });
+    });
+
+    it('should clean up template registry when the session is deleted', async () => {
+      const manager = await getSessionManager();
+      const session = await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+
+      const register = await manager.registerDelegationTemplate(session.id, 'callback', 'BODY');
+      // Sanity: the file exists
+      expect(fs.existsSync(register.filePath)).toBe(true);
+
+      await manager.deleteSession(session.id);
+
+      // The registry file is removed during session deletion
+      expect(fs.existsSync(register.filePath)).toBe(false);
+    });
+  });
 });

--- a/packages/server/src/services/delegation-template-service.ts
+++ b/packages/server/src/services/delegation-template-service.ts
@@ -1,0 +1,222 @@
+/**
+ * DelegationTemplateService — file-based named-template registry per session.
+ *
+ * Each session owns a single JSON file mapping template name -> template body.
+ * Templates are appended to delegate_to_worktree prompts via the `useTemplates`
+ * parameter, replacing hand-written delegation boilerplate.
+ *
+ * Storage path: {baseDir}/delegation-templates/{sessionId}.json
+ * File schema:  Record<templateName, templateContent>
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import type { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
+import { createLogger } from '../lib/logger.js';
+
+const logger = createLogger('delegation-template-service');
+
+/** Maximum size of a single template body. Matches MemoService. */
+const MAX_TEMPLATE_CONTENT_BYTES = 256 * 1024;
+
+/** Allowed template names: alphanumeric, hyphen, underscore. 1–64 chars. */
+const TEMPLATE_NAME_REGEX = /^[a-zA-Z0-9_-]{1,64}$/;
+
+export interface DelegationTemplate {
+  name: string;
+  content: string;
+}
+
+export interface DelegationTemplateLookupResult {
+  /** Templates that were found, in the order requested. */
+  found: DelegationTemplate[];
+  /** Names that were not present in the registry (preserves request order). */
+  missing: string[];
+}
+
+export class DelegationTemplateService {
+  private validateSessionId(sessionId: string): void {
+    const safe = path.basename(sessionId);
+    if (safe !== sessionId || sessionId.includes('..') || sessionId.includes('/')) {
+      throw new Error(`Invalid sessionId: ${sessionId}`);
+    }
+  }
+
+  private validateName(name: string): void {
+    if (!TEMPLATE_NAME_REGEX.test(name)) {
+      throw new Error(
+        `Invalid template name: ${JSON.stringify(name)} (must be 1–64 chars, alphanumeric/hyphen/underscore)`,
+      );
+    }
+  }
+
+  private validateContent(content: string): void {
+    const size = Buffer.byteLength(content, 'utf-8');
+    if (size > MAX_TEMPLATE_CONTENT_BYTES) {
+      throw new Error(`Template content exceeds maximum size of ${MAX_TEMPLATE_CONTENT_BYTES} bytes (got ${size})`);
+    }
+  }
+
+  /**
+   * Read the per-session registry from disk. Returns an empty map if no file
+   * exists. Throws if the file exists but is unreadable or has invalid shape.
+   */
+  private async readRegistry(
+    sessionId: string,
+    resolver: SessionDataPathResolver,
+  ): Promise<Record<string, string>> {
+    const filePath = resolver.getDelegationTemplatesPath(sessionId);
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, 'utf-8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return {};
+      }
+      throw err;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`Failed to parse delegation templates file ${filePath}: ${(err as Error).message}`);
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`Delegation templates file ${filePath} has invalid shape (expected object)`);
+    }
+    const map: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v !== 'string') {
+        throw new Error(`Delegation templates file ${filePath} has non-string value for key ${JSON.stringify(k)}`);
+      }
+      map[k] = v;
+    }
+    return map;
+  }
+
+  /**
+   * Write the per-session registry to disk atomically (write tmp + rename).
+   */
+  private async writeRegistry(
+    sessionId: string,
+    resolver: SessionDataPathResolver,
+    registry: Record<string, string>,
+  ): Promise<string> {
+    const dir = resolver.getDelegationTemplatesDir();
+    await fs.mkdir(dir, { recursive: true });
+
+    const filePath = path.join(dir, `${sessionId}.json`);
+    const tmpPath = path.join(dir, `.tmp-${sessionId}.json`);
+    const body = JSON.stringify(registry, null, 2);
+
+    await fs.writeFile(tmpPath, body, 'utf-8');
+    try {
+      await fs.rename(tmpPath, filePath);
+    } catch (err) {
+      await fs.rm(tmpPath, { force: true }).catch(() => {});
+      throw err;
+    }
+    return filePath;
+  }
+
+  /**
+   * Register (or overwrite) a template. Returns the absolute file path of the
+   * registry file after the write.
+   */
+  async registerTemplate(
+    sessionId: string,
+    name: string,
+    content: string,
+    resolver: SessionDataPathResolver,
+  ): Promise<string> {
+    this.validateSessionId(sessionId);
+    this.validateName(name);
+    this.validateContent(content);
+
+    const registry = await this.readRegistry(sessionId, resolver);
+    registry[name] = content;
+    const filePath = await this.writeRegistry(sessionId, resolver, registry);
+    logger.debug({ sessionId, name, filePath }, 'Delegation template registered');
+    return filePath;
+  }
+
+  /**
+   * List all templates registered for a session, sorted by name.
+   * Returns an empty array if no registry file exists.
+   */
+  async listTemplates(
+    sessionId: string,
+    resolver: SessionDataPathResolver,
+  ): Promise<DelegationTemplate[]> {
+    this.validateSessionId(sessionId);
+    const registry = await this.readRegistry(sessionId, resolver);
+    return Object.keys(registry)
+      .sort()
+      .map((name) => ({ name, content: registry[name] }));
+  }
+
+  /**
+   * Delete a template by name. Idempotent: if the name does not exist, returns
+   * `{ deleted: false }` without throwing.
+   */
+  async deleteTemplate(
+    sessionId: string,
+    name: string,
+    resolver: SessionDataPathResolver,
+  ): Promise<{ deleted: boolean }> {
+    this.validateSessionId(sessionId);
+    this.validateName(name);
+
+    const registry = await this.readRegistry(sessionId, resolver);
+    if (!(name in registry)) {
+      return { deleted: false };
+    }
+    delete registry[name];
+    await this.writeRegistry(sessionId, resolver, registry);
+    logger.debug({ sessionId, name }, 'Delegation template deleted');
+    return { deleted: true };
+  }
+
+  /**
+   * Resolve a list of template names for use by `delegate_to_worktree`.
+   * Preserves the input order in the `found` array.
+   *
+   * Empty `names` returns `{ found: [], missing: [] }` (boundary: no-op).
+   */
+  async lookupTemplates(
+    sessionId: string,
+    names: string[],
+    resolver: SessionDataPathResolver,
+  ): Promise<DelegationTemplateLookupResult> {
+    this.validateSessionId(sessionId);
+    if (names.length === 0) {
+      return { found: [], missing: [] };
+    }
+
+    const registry = await this.readRegistry(sessionId, resolver);
+    const found: DelegationTemplate[] = [];
+    const missing: string[] = [];
+    for (const name of names) {
+      if (name in registry) {
+        found.push({ name, content: registry[name] });
+      } else {
+        missing.push(name);
+      }
+    }
+    return { found, missing };
+  }
+
+  /**
+   * Delete the per-session registry file entirely. Used on session deletion.
+   * Does not throw if the file does not exist.
+   */
+  async deleteAllForSession(
+    sessionId: string,
+    resolver: SessionDataPathResolver,
+  ): Promise<void> {
+    this.validateSessionId(sessionId);
+    const filePath = resolver.getDelegationTemplatesPath(sessionId);
+    await fs.rm(filePath, { force: true });
+    logger.debug({ sessionId }, 'Delegation templates cleared for session');
+  }
+}

--- a/packages/server/src/services/session-deletion-service.ts
+++ b/packages/server/src/services/session-deletion-service.ts
@@ -6,6 +6,7 @@ import type { NotificationManager } from './notifications/notification-manager.j
 import type { MessageService } from './message-service.js';
 import type { InterSessionMessageService } from './inter-session-message-service.js';
 import type { MemoService } from './memo-service.js';
+import type { DelegationTemplateService } from './delegation-template-service.js';
 import type { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
 import type { SessionLifecycleCallbacks } from './session-lifecycle-types.js';
 import type { JobQueue } from '../jobs/index.js';
@@ -25,6 +26,7 @@ export interface SessionDeletionDeps {
   messageService: MessageService;
   interSessionMessageService: InterSessionMessageService;
   memoService: MemoService;
+  delegationTemplateService: DelegationTemplateService;
   getPathResolverForSession: (session: InternalSession) => SessionDataPathResolver;
   getPathResolverForPersistedSession: (persisted: PersistedSession) => SessionDataPathResolver;
   /** Return the (scope, slug) pair for an in-memory session, or null if orphaned. */
@@ -164,6 +166,17 @@ export class SessionDeletionService {
         logger.warn({ sessionId: id }, 'No resolver; skipping memo cleanup');
       }
 
+      // 2e. Clean up delegation templates registry
+      if (resolver) {
+        try {
+          await this.deps.delegationTemplateService.deleteAllForSession(id, resolver);
+        } catch (err) {
+          logger.warn({ sessionId: id, err }, 'Failed to clean delegation templates file');
+        }
+      } else {
+        logger.warn({ sessionId: id }, 'No resolver; skipping delegation templates cleanup');
+      }
+
       // 3. Remove from in-memory map
       this.deps.deleteSessionFromMemory(id);
 
@@ -237,6 +250,16 @@ export class SessionDeletionService {
         }
       } else {
         logger.warn({ sessionId: id, method: 'forceDeleteSession' }, 'No resolver; skipping memo cleanup');
+      }
+      // Clean up delegation templates registry
+      if (resolver) {
+        try {
+          await this.deps.delegationTemplateService.deleteAllForSession(id, resolver);
+        } catch (err) {
+          logger.warn({ sessionId: id, err }, 'Failed to clean delegation templates file');
+        }
+      } else {
+        logger.warn({ sessionId: id, method: 'forceDeleteSession' }, 'No resolver; skipping delegation templates cleanup');
       }
       // Broadcast deletion to connected clients
       this.deps.getSessionLifecycleCallbacks()?.onSessionDeleted?.(id);

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -46,6 +46,7 @@ import { MessageService } from './message-service.js';
 import { InterSessionMessageService } from './inter-session-message-service.js';
 import { AnnotationService } from './annotation-service.js';
 import { MemoService } from './memo-service.js';
+import { DelegationTemplateService, type DelegationTemplate, type DelegationTemplateLookupResult } from './delegation-template-service.js';
 import { PtyMessageInjectionService } from './pty-message-injection-service.js';
 import { SessionMetadataService } from './session-metadata-service.js';
 import { createLogger } from '../lib/logger.js';
@@ -111,6 +112,8 @@ interface SessionManagerOptions {
   interSessionMessageService?: InterSessionMessageService;
   /** Memo file management. Defaults to a fresh instance if not provided. */
   memoService?: MemoService;
+  /** Delegation template registry. Defaults to a fresh instance if not provided. */
+  delegationTemplateService?: DelegationTemplateService;
   /** PTY message injection service. Defaults to a new instance wired to this manager. */
   ptyMessageInjectionService?: PtyMessageInjectionService;
   /**
@@ -142,6 +145,7 @@ export class SessionManager {
   private workerOutputFileManager: WorkerOutputFileManager;
   private interSessionMessageService: InterSessionMessageService;
   private memoService: MemoService;
+  private delegationTemplateService: DelegationTemplateService;
   private ptyMessageInjectionService: PtyMessageInjectionService;
   private sessionMetadataService: SessionMetadataService;
   private sessionInitializationService: SessionInitializationService;
@@ -182,6 +186,7 @@ export class SessionManager {
     this.workerOutputFileManager = workerOutputFileManager;
     this.interSessionMessageService = options.interSessionMessageService ?? new InterSessionMessageService();
     this.memoService = options.memoService ?? new MemoService();
+    this.delegationTemplateService = options.delegationTemplateService ?? new DelegationTemplateService();
     this.workerManager = new WorkerManager(userMode, agentManager, workerOutputFileManager);
     this.pathExists = options?.pathExists ?? defaultPathExists;
     this.sessionRepository = options?.sessionRepository ??
@@ -270,6 +275,7 @@ export class SessionManager {
       messageService: this.messageService,
       interSessionMessageService: this.interSessionMessageService,
       memoService: this.memoService,
+      delegationTemplateService: this.delegationTemplateService,
       getPathResolverForSession: (session) => this.getPathResolverForSession(session),
       getPathResolverForPersistedSession: (persisted) => this.getPathResolverForPersistedSession(persisted),
       getSessionScope: (session) => this.getSessionScopeForCleanup(session),
@@ -833,6 +839,75 @@ export class SessionManager {
     }
     const resolver = this.getPathResolverForSession(session);
     return this.memoService.readMemo(sessionId, resolver);
+  }
+
+  /**
+   * Register (or overwrite) a delegation template for a session.
+   * Returns the file path of the persisted registry and the template name.
+   */
+  async registerDelegationTemplate(
+    sessionId: string,
+    name: string,
+    content: string,
+  ): Promise<{ filePath: string; name: string }> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    const resolver = this.getPathResolverForSession(session);
+    const filePath = await this.delegationTemplateService.registerTemplate(
+      sessionId,
+      name,
+      content,
+      resolver,
+    );
+    return { filePath, name };
+  }
+
+  /**
+   * List all delegation templates registered for a session.
+   */
+  async listDelegationTemplates(sessionId: string): Promise<DelegationTemplate[]> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    const resolver = this.getPathResolverForSession(session);
+    return this.delegationTemplateService.listTemplates(sessionId, resolver);
+  }
+
+  /**
+   * Delete a delegation template by name. Idempotent: `deleted=false` if the
+   * name was not present.
+   */
+  async deleteDelegationTemplate(
+    sessionId: string,
+    name: string,
+  ): Promise<{ success: boolean; deleted: boolean }> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    const resolver = this.getPathResolverForSession(session);
+    const result = await this.delegationTemplateService.deleteTemplate(sessionId, name, resolver);
+    return { success: true, deleted: result.deleted };
+  }
+
+  /**
+   * Look up a list of template names registered to a session. Used by
+   * `delegate_to_worktree` to resolve `useTemplates`. Preserves the input order
+   * in `found`. Empty `names` returns `{ found: [], missing: [] }`.
+   */
+  async lookupDelegationTemplates(
+    sessionId: string,
+    names: string[],
+  ): Promise<DelegationTemplateLookupResult> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    const resolver = this.getPathResolverForSession(session);
+    return this.delegationTemplateService.lookupTemplates(sessionId, names, resolver);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds 3 MCP tools (`register_delegation_template`, `list_delegation_templates`, `delete_delegation_template`) that let the Orchestrator register reusable delegation boilerplate once per session.
- Extends `delegate_to_worktree` with `useTemplates: string[]`, which appends the named template bodies (in the order listed) before any callback instructions. Requires `parentSessionId`; missing names cause an atomic error so partial appending never happens.
- Storage is a single JSON file per parent session at `{baseDir}/delegation-templates/{sessionId}.json` (flat name→content map). Atomic writes, sessionId path-traversal guard, name regex `/^[a-zA-Z0-9_-]{1,64}$/`, 256KB content limit (matches MemoService).
- Cleanup is wired into both `deleteSession` and `forceDeleteSession` paths in `SessionDeletionService`.

## Boundary coverage

- 24 unit tests for `DelegationTemplateService` (memfs): empty / single / many; lookup all-found / all-missing / mixed; preserves input order; cross-session isolation; idempotent delete; over-size and invalid-name rejection.
- 16 MCP tool tests: register / list / delete / cross-session, plus delegation extension cases (no useTemplates, empty array, single, multi, missing-name aborts before worktree creation, useTemplates without parentSessionId aborts).
- Updated `session-deletion-service` tests to assert templates cleanup is invoked and survives cleanup-path errors.

## Out of scope

Per the Issue, this PR does not migrate hardcoded boilerplate (`delegation-prompt.js`, `buildMessageCallbackPrompt`, etc.) to template form, does not add cross-session sharing or `{{var}}` placeholders. Those remain follow-ups.

## Note on CodeRabbit

Local CodeRabbit CLI rate-limited during this sprint. Relying on GitHub-side CodeRabbit bot review.

## Test plan

- [x] `bun run typecheck` exits 0 across all packages
- [x] `bun run test` exits 0 (server: 2469 pass, client: 1361 pass, shared: 307 pass, integration: 27 pass; TEST_EXIT: 0)
- [x] Glossary entries added for `Delegation Template` and `useTemplates` (per `glossary-maintenance.md` triggers #2 / #4)
- [x] `core-responsibilities.md` §3 bullet documents the register-then-use canonical pattern
- [ ] CI rollup green (`gh pr view <N> --json statusCheckRollup`)
- [ ] CodeRabbit GitHub-side bot review APPROVED

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)