### PR TITLE
feat: run_process outputMode "pty" | "message" routes script I/O via messages

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -118,6 +118,13 @@ A registered shell-condition + interval that the server polls silently and notif
 - **See:** Issue [#700](https://github.com/ms2sato/agent-console/issues/700), MCP tools `create_conditional_wakeup` / `delete_conditional_wakeup`
 - **Contrast:** [Timer](#timer) (fires on interval regardless of state)
 
+### outputMode
+Parameter on the `run_process` MCP tool that selects how the script's stdout and `write_process_response` content are delivered to the calling agent. Two modes:
+- `"pty"` (default): the script's stdout is delivered as a `[internal:process]` PTY notification carrying the full content; `write_process_response` echoes content directly to the worker PTY. Existing behavior, backward-compatible with all prior `run_process` callers.
+- `"message"`: the script's stdout is captured and routed through `InterSessionMessageService` (file-based, see `packages/server/src/services/inter-session-message-service.ts`) to the calling session/worker; `write_process_response` content is delivered through the same channel after stdin write succeeds. PTY receives only a brief `[stdout via message] path=… bytes=…` / `[response via message] …` notification per chunk so the owner retains progress visibility without the conversation being flooded by long-form Q&A. Designed for long interactive scripts (e.g., `.claude/skills/orchestrator/acceptance-check.js`, `sprint-retro.js`).
+- **Aliases:** output mode, run_process outputMode
+- **See:** Issue [#664](https://github.com/ms2sato/agent-console/issues/664), router (`packages/server/src/services/process-output-router.ts`)
+
 ### SystemEvent
 The top-level event format representing meaningful occurrences in the system.
 - **Aliases:** System-wide event

--- a/packages/integration/src/interactive-process-boundary.test.ts
+++ b/packages/integration/src/interactive-process-boundary.test.ts
@@ -201,6 +201,46 @@ describe('Interactive Process MCP boundary: shared type contract', () => {
     expect(data.workerId).toBe(workerId);
     expect(typeof data.command).toBe('string');
     expect(data.command).toBe('sleep 30');
+    // outputMode defaults to 'pty' when omitted (Issue #664)
+    expect(data.outputMode).toBe('pty');
+  });
+
+  it('run_process accepts outputMode "message" and surfaces it in the response', async () => {
+    const session = await sessionManager.createSession({
+      type: 'quick',
+      locationPath: '/test/path',
+      agentId: 'claude-code',
+    });
+
+    const response = await callTool(app, mcpSessionId, 'run_process', {
+      command: 'sleep 30',
+      sessionId: session.id,
+      workerId: session.workers[0].id,
+      outputMode: 'message',
+    }, nextId++);
+
+    expect(response.result?.isError).toBeUndefined();
+
+    const data = parseToolResult(response) as Record<string, unknown>;
+    expect(data.outputMode).toBe('message');
+  });
+
+  it('run_process rejects an invalid outputMode value', async () => {
+    const session = await sessionManager.createSession({
+      type: 'quick',
+      locationPath: '/test/path',
+      agentId: 'claude-code',
+    });
+
+    const response = await callTool(app, mcpSessionId, 'run_process', {
+      command: 'sleep 30',
+      sessionId: session.id,
+      workerId: session.workers[0].id,
+      outputMode: 'invalid-mode',
+    }, nextId++);
+
+    // zod enum rejection surfaces as an MCP-level error, not as isError on a successful tool call
+    expect(response.error ?? response.result?.isError).toBeTruthy();
   });
 
   it('list_processes returns items matching InteractiveProcessInfo shape', async () => {

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -337,9 +337,11 @@ export async function createAppContext(
 
   const interactiveProcessManager = new InteractiveProcessManagerClass(
     (process, output) => {
-      // onOutput is a synchronous callback; route asynchronously and log
-      // failures via the router itself (it never rejects). The .catch is a
-      // safety net in case the router is changed later.
+      // onOutput is fired from a synchronous debounce flush; the manager has
+      // no caller awaiting its result, so failures are logged structurally
+      // and discarded rather than propagated. (`writeResponse` is the
+      // direction where caller-visible failure matters — see onResponse
+      // below.)
       void routeProcessContent(processRouterDeps, {
         process,
         content: output,
@@ -347,7 +349,7 @@ export async function createAppContext(
       }).catch((err) => {
         logger.warn(
           { processId: process.id, sessionId: process.sessionId, err },
-          'Unexpected error from process output router (stdout)',
+          'Process output routing failed (stdout)',
         );
       });
     },
@@ -379,22 +381,19 @@ export async function createAppContext(
     // path as MessagePanel) when outputMode === 'pty'. The manager itself
     // skips the echo for outputMode === 'message'.
     sessionManager,
-    // onResponse: route the response via the same helper. In `pty` mode the
-    // brief notification is no-op (writeResponse already echoed content +
-    // the subsequent stdout flush carries the [internal:process] notif).
+    // onResponse: in `pty` mode there is nothing to do (writeResponse
+    // already echoed content; the subsequent stdout flush carries the
+    // [internal:process] notif). In `message` mode, return the router's
+    // promise so writeResponse awaits message-file delivery and can report
+    // failure via a `false` result instead of silently lying about success.
     (process, content) => {
       if (process.outputMode === 'pty') {
         return;
       }
-      void routeProcessContent(processRouterDeps, {
+      return routeProcessContent(processRouterDeps, {
         process,
         content,
         direction: 'response',
-      }).catch((err) => {
-        logger.warn(
-          { processId: process.id, sessionId: process.sessionId, err },
-          'Unexpected error from process output router (response)',
-        );
       });
     },
   );

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -56,6 +56,7 @@ import { createLogger } from './lib/logger.js';
 import { TimerManager as TimerManagerClass } from './services/timer-manager.js';
 import { ConditionalWakeupManager as ConditionalWakeupManagerClass } from './services/conditional-wakeup-manager.js';
 import { InteractiveProcessManager as InteractiveProcessManagerClass } from './services/interactive-process-manager.js';
+import { routeProcessContent } from './services/process-output-router.js';
 import { writePtyNotification } from './lib/pty-notification.js';
 import { WorktreeService as WorktreeServiceClass } from './services/worktree-service.js';
 import { RepositorySlackIntegrationService as RepositorySlackIntegrationServiceClass } from './services/notifications/repository-slack-integration-service.js';
@@ -321,31 +322,38 @@ export async function createAppContext(
     conditionalWakeupManager.deleteWakeupsBySession(sessionId);
   });
 
-  // 6.7. Create interactive process manager (in-memory, volatile)
+  // 6.7. Create interactive process manager (in-memory, volatile).
+  // Stdout and response routing both go through the shared
+  // `routeProcessContent` helper so `outputMode` ('pty' vs 'message') is
+  // handled uniformly.
+  const processRouterDeps = {
+    getResolver: (sessionId: string) =>
+      sessionManager.getPathResolverForSessionId(sessionId),
+    writeInput: (sessionId: string, workerId: string, data: string) => {
+      sessionManager.writeWorkerInput(sessionId, workerId, data);
+    },
+    sendMessage: interSessionMessageService.sendMessage.bind(interSessionMessageService),
+  };
+
   const interactiveProcessManager = new InteractiveProcessManagerClass(
     (process, output) => {
-      try {
-        const writeInput = (data: string) =>
-          sessionManager.writeWorkerInput(process.sessionId, process.workerId, data);
-        writePtyNotification({
-          kind: 'internal-process',
-          tag: 'internal:process',
-          fields: {
-            processId: process.id,
-            command: process.command,
-            message: output,
-          },
-          intent: 'triage',
-          writeInput,
-        });
-      } catch (err) {
+      // onOutput is a synchronous callback; route asynchronously and log
+      // failures via the router itself (it never rejects). The .catch is a
+      // safety net in case the router is changed later.
+      void routeProcessContent(processRouterDeps, {
+        process,
+        content: output,
+        direction: 'stdout',
+      }).catch((err) => {
         logger.warn(
           { processId: process.id, sessionId: process.sessionId, err },
-          'Failed to deliver process output notification',
+          'Unexpected error from process output router (stdout)',
         );
-      }
+      });
     },
     (process) => {
+      // Exit notifications stay on the PTY in both modes — they are short
+      // and message routing is unnecessary.
       try {
         const writeInput = (data: string) =>
           sessionManager.writeWorkerInput(process.sessionId, process.workerId, data);
@@ -367,8 +375,28 @@ export async function createAppContext(
         );
       }
     },
-    // PTY message injector: echo process response to the worker's PTY (same path as MessagePanel)
+    // PTY message injector: echo process response to the worker's PTY (same
+    // path as MessagePanel) when outputMode === 'pty'. The manager itself
+    // skips the echo for outputMode === 'message'.
     sessionManager,
+    // onResponse: route the response via the same helper. In `pty` mode the
+    // brief notification is no-op (writeResponse already echoed content +
+    // the subsequent stdout flush carries the [internal:process] notif).
+    (process, content) => {
+      if (process.outputMode === 'pty') {
+        return;
+      }
+      void routeProcessContent(processRouterDeps, {
+        process,
+        content,
+        direction: 'response',
+      }).catch((err) => {
+        logger.warn(
+          { processId: process.id, sessionId: process.sessionId, err },
+          'Unexpected error from process output router (response)',
+        );
+      });
+    },
   );
 
   // 6.8. Wire process cleanup into session lifecycle

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -2804,6 +2804,72 @@ describe('MCP Server Tools', () => {
         expect(response.result?.isError).toBe(true);
         expect(data.error).toContain('Worker non-existent-worker not found');
       });
+
+      it('should default outputMode to "pty" when omitted', async () => {
+        const { sessionId, workerId } = await createSessionWithWorker();
+
+        const response = await callTool(app, mcpSessionId, 'run_process', {
+          command: 'echo hello',
+          sessionId,
+          workerId,
+        }, nextId++);
+
+        const data = parseToolResult(response) as { outputMode: string };
+
+        expect(response.result?.isError).toBeUndefined();
+        expect(data.outputMode).toBe('pty');
+      });
+
+      it('should accept and propagate outputMode "pty"', async () => {
+        const { sessionId, workerId } = await createSessionWithWorker();
+
+        const response = await callTool(app, mcpSessionId, 'run_process', {
+          command: 'echo hello',
+          sessionId,
+          workerId,
+          outputMode: 'pty',
+        }, nextId++);
+
+        const data = parseToolResult(response) as { outputMode: string };
+
+        expect(response.result?.isError).toBeUndefined();
+        expect(data.outputMode).toBe('pty');
+      });
+
+      it('should accept and propagate outputMode "message"', async () => {
+        const { sessionId, workerId } = await createSessionWithWorker();
+
+        const response = await callTool(app, mcpSessionId, 'run_process', {
+          command: 'echo hello',
+          sessionId,
+          workerId,
+          outputMode: 'message',
+        }, nextId++);
+
+        const data = parseToolResult(response) as { outputMode: string };
+
+        expect(response.result?.isError).toBeUndefined();
+        expect(data.outputMode).toBe('message');
+      });
+
+      it('should reject invalid outputMode values via zod enum validation', async () => {
+        const { sessionId, workerId } = await createSessionWithWorker();
+
+        const response = await callTool(app, mcpSessionId, 'run_process', {
+          command: 'echo hello',
+          sessionId,
+          workerId,
+          outputMode: 'invalid-mode',
+        }, nextId++);
+
+        // MCP returns either a JSON-RPC error or an isError result with a
+        // schema violation message. Either path signals failure.
+        if (response.error) {
+          expect(response.error).toBeDefined();
+        } else {
+          expect(response.result?.isError).toBe(true);
+        }
+      });
     });
 
     describe('list_processes', () => {

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -1065,8 +1065,8 @@ export function createMcpApp(deps: McpDependencies): Hono {
   mcpServer.tool(
     'run_process',
     'Start an interactive script connected to a session. ' +
-      'The script drives workflow via STDOUT (sent as [internal:process] PTY notifications), ' +
-      'and blocks on STDIN waiting for responses via write_process_response. ' +
+      'The script drives workflow via STDOUT and blocks on STDIN waiting for responses via write_process_response. ' +
+      'Set outputMode="message" to keep long-paragraph script I/O out of the calling agent\'s PTY conversation. ' +
       'Processes are volatile and will not survive server restarts.',
     {
       command: z
@@ -1087,8 +1087,19 @@ export function createMcpApp(deps: McpDependencies): Hono {
         .describe(
           'Working directory for the command. Defaults to server CWD if omitted.',
         ),
+      outputMode: z
+        .enum(['pty', 'message'])
+        .optional()
+        .describe(
+          'Routing mode for script I/O. ' +
+            '"pty" (default): script stdout is delivered as [internal:process] PTY notifications with full content. ' +
+            '"message": script stdout and write_process_response content are routed via inter-session message files ' +
+            '(toSessionId/toWorkerId match this run_process call); the PTY receives only a brief notification with ' +
+            'the message file path and byte count. ' +
+            'Use "message" for long-paragraph interactive scripts (e.g., acceptance-check.js, sprint-retro.js) to keep the conversation clean.',
+        ),
     },
-    async ({ command, sessionId, workerId, cwd }) => {
+    async ({ command, sessionId, workerId, cwd, outputMode }) => {
       try {
         const session = sessionManager.getSession(sessionId);
         if (!session) {
@@ -1109,6 +1120,7 @@ export function createMcpApp(deps: McpDependencies): Hono {
           workerId,
           command,
           cwd,
+          outputMode,
         });
 
         return textResult({
@@ -1116,6 +1128,7 @@ export function createMcpApp(deps: McpDependencies): Hono {
           sessionId: process.sessionId,
           workerId: process.workerId,
           command: process.command,
+          outputMode: process.outputMode,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';

--- a/packages/server/src/services/__tests__/interactive-process-manager.test.ts
+++ b/packages/server/src/services/__tests__/interactive-process-manager.test.ts
@@ -616,7 +616,9 @@ describe('InteractiveProcessManager', () => {
       expect(onResponse).not.toHaveBeenCalled();
     });
 
-    it('should still return true when onResponse callback throws (stdin write succeeded)', async () => {
+    it('should return false when onResponse callback throws synchronously', async () => {
+      // Synchronously-thrown callback failures surface as a `false` result
+      // so the MCP caller cannot mistake a routing failure for success.
       const throwingOnResponse = mock(() => {
         throw new Error('onResponse callback error');
       });
@@ -634,20 +636,101 @@ describe('InteractiveProcessManager', () => {
       });
 
       const deadline = Date.now() + 5000;
+      let attempted = false;
+      let result = true;
+      while (Date.now() < deadline) {
+        const info = isolatedManager.getProcess(process.id);
+        if (info?.status === 'running') {
+          result = await isolatedManager.writeResponse(process.id, 'hello');
+          attempted = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      expect(attempted).toBe(true);
+      expect(result).toBe(false);
+      expect(throwingOnResponse).toHaveBeenCalled();
+
+      isolatedManager.disposeAll();
+    });
+
+    it('should return false when onResponse callback rejects asynchronously', async () => {
+      // Async routing failures (e.g., disk write, resolver miss) must
+      // propagate to the caller as a `false` result.
+      const rejectingOnResponse = mock(async () => {
+        throw new Error('async routing failure');
+      });
+      const isolatedManager = new InteractiveProcessManager(
+        onOutput,
+        onExit,
+        { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+        rejectingOnResponse,
+      );
+
+      const process = await isolatedManager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'cat > /dev/null',
+        outputMode: 'message',
+      });
+
+      const deadline = Date.now() + 5000;
+      let attempted = false;
+      let result = true;
+      while (Date.now() < deadline) {
+        const info = isolatedManager.getProcess(process.id);
+        if (info?.status === 'running') {
+          result = await isolatedManager.writeResponse(process.id, 'hello');
+          attempted = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      expect(attempted).toBe(true);
+      expect(result).toBe(false);
+      expect(rejectingOnResponse).toHaveBeenCalled();
+
+      isolatedManager.disposeAll();
+    });
+
+    it('should await async onResponse before returning success', async () => {
+      // Verifies the contract: writeResponse only resolves true after the
+      // onResponse callback (which may write a message file) completes.
+      const order: string[] = [];
+      const slowOnResponse = mock(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        order.push('onResponse-completed');
+      });
+      const isolatedManager = new InteractiveProcessManager(
+        onOutput,
+        onExit,
+        { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+        slowOnResponse,
+      );
+
+      const process = await isolatedManager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'cat > /dev/null',
+        outputMode: 'message',
+      });
+
+      const deadline = Date.now() + 5000;
       let result = false;
       while (Date.now() < deadline) {
         const info = isolatedManager.getProcess(process.id);
         if (info?.status === 'running') {
           result = await isolatedManager.writeResponse(process.id, 'hello');
+          if (result) order.push('writeResponse-resolved');
           if (result) break;
         }
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
 
-      // The stdin write succeeded; the callback's exception must not flip
-      // the writeResponse result.
       expect(result).toBe(true);
-      expect(throwingOnResponse).toHaveBeenCalled();
+      expect(order).toEqual(['onResponse-completed', 'writeResponse-resolved']);
 
       isolatedManager.disposeAll();
     });

--- a/packages/server/src/services/__tests__/interactive-process-manager.test.ts
+++ b/packages/server/src/services/__tests__/interactive-process-manager.test.ts
@@ -8,18 +8,25 @@ describe('InteractiveProcessManager', () => {
   let manager: InteractiveProcessManager;
   let onOutput: ReturnType<typeof mock>;
   let onExit: ReturnType<typeof mock>;
+  let onResponse: ReturnType<typeof mock>;
   let mockInjectPtyMessage: ReturnType<typeof mock>;
   let mockWritePtyData: ReturnType<typeof mock>;
 
   beforeEach(() => {
     onOutput = mock(() => {});
     onExit = mock(() => {});
+    onResponse = mock(() => {});
     mockInjectPtyMessage = mock(() => true);
     mockWritePtyData = mock(() => true);
-    manager = new InteractiveProcessManager(onOutput, onExit, {
-      injectPtyMessage: mockInjectPtyMessage,
-      writePtyData: mockWritePtyData,
-    });
+    manager = new InteractiveProcessManager(
+      onOutput,
+      onExit,
+      {
+        injectPtyMessage: mockInjectPtyMessage,
+        writePtyData: mockWritePtyData,
+      },
+      onResponse,
+    );
   });
 
   afterEach(() => {
@@ -41,6 +48,51 @@ describe('InteractiveProcessManager', () => {
       expect(process.command).toBe('echo hello');
       expect(process.status).toBe('running');
       expect(process.startedAt).toBeString();
+    });
+
+    it('should default outputMode to "pty" when omitted', async () => {
+      const process = await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'echo hello',
+      });
+
+      expect(process.outputMode).toBe('pty');
+    });
+
+    it('should propagate explicit outputMode "pty"', async () => {
+      const process = await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'echo hello',
+        outputMode: 'pty',
+      });
+
+      expect(process.outputMode).toBe('pty');
+    });
+
+    it('should propagate explicit outputMode "message"', async () => {
+      const process = await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'echo hello',
+        outputMode: 'message',
+      });
+
+      expect(process.outputMode).toBe('message');
+    });
+
+    it('should expose outputMode on subsequent getProcess and listProcesses queries', async () => {
+      const created = await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'sleep 60',
+        outputMode: 'message',
+      });
+
+      expect(manager.getProcess(created.id)?.outputMode).toBe('message');
+      const listed = manager.listProcesses('session-1');
+      expect(listed[0]?.outputMode).toBe('message');
     });
 
     it('should throw when session reaches the per-session process limit', async () => {
@@ -460,6 +512,144 @@ describe('InteractiveProcessManager', () => {
       expect(result).toBe(true);
       expect(mockWritePtyData).not.toHaveBeenCalled();
       managerNoPty.disposeAll();
+    });
+
+    it('should skip PTY echo via writePtyData when outputMode is "message"', async () => {
+      const process = await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'cat > /dev/null',
+        outputMode: 'message',
+      });
+
+      const deadline = Date.now() + 5000;
+      let result = false;
+      while (Date.now() < deadline) {
+        const info = manager.getProcess(process.id);
+        if (info?.status === 'running') {
+          result = await manager.writeResponse(process.id, 'hello');
+          if (result) break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      expect(result).toBe(true);
+      // PTY echo must be skipped in message mode — the brief notification is
+      // the consumer's responsibility via onResponse.
+      expect(mockWritePtyData).not.toHaveBeenCalled();
+    });
+
+    it('should call onResponse with content after stdin write succeeds (pty mode)', async () => {
+      const process = await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'cat > /dev/null',
+      });
+
+      const deadline = Date.now() + 5000;
+      let result = false;
+      while (Date.now() < deadline) {
+        const info = manager.getProcess(process.id);
+        if (info?.status === 'running') {
+          result = await manager.writeResponse(process.id, 'hello');
+          if (result) break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      expect(result).toBe(true);
+      expect(onResponse).toHaveBeenCalledTimes(1);
+      const [respInfo, respContent] = onResponse.mock.calls[0] as [
+        { id: string; outputMode: string },
+        string,
+      ];
+      expect(respInfo.id).toBe(process.id);
+      expect(respInfo.outputMode).toBe('pty');
+      expect(respContent).toBe('hello');
+    });
+
+    it('should call onResponse with content after stdin write succeeds (message mode)', async () => {
+      const process = await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'cat > /dev/null',
+        outputMode: 'message',
+      });
+
+      const deadline = Date.now() + 5000;
+      let result = false;
+      while (Date.now() < deadline) {
+        const info = manager.getProcess(process.id);
+        if (info?.status === 'running') {
+          result = await manager.writeResponse(process.id, 'hello');
+          if (result) break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      expect(result).toBe(true);
+      expect(onResponse).toHaveBeenCalledTimes(1);
+      const [respInfo, respContent] = onResponse.mock.calls[0] as [
+        { outputMode: string },
+        string,
+      ];
+      expect(respInfo.outputMode).toBe('message');
+      expect(respContent).toBe('hello');
+    });
+
+    it('should not call onResponse when writeResponse returns false (process missing)', async () => {
+      const result = await manager.writeResponse('non-existent', 'hello');
+      expect(result).toBe(false);
+      expect(onResponse).not.toHaveBeenCalled();
+    });
+
+    it('should not call onResponse when writeResponse returns false (process killed)', async () => {
+      const process = await manager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'sleep 60',
+      });
+      manager.killProcess(process.id);
+
+      const result = await manager.writeResponse(process.id, 'hello');
+      expect(result).toBe(false);
+      expect(onResponse).not.toHaveBeenCalled();
+    });
+
+    it('should still return true when onResponse callback throws (stdin write succeeded)', async () => {
+      const throwingOnResponse = mock(() => {
+        throw new Error('onResponse callback error');
+      });
+      const isolatedManager = new InteractiveProcessManager(
+        onOutput,
+        onExit,
+        { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+        throwingOnResponse,
+      );
+
+      const process = await isolatedManager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'cat > /dev/null',
+      });
+
+      const deadline = Date.now() + 5000;
+      let result = false;
+      while (Date.now() < deadline) {
+        const info = isolatedManager.getProcess(process.id);
+        if (info?.status === 'running') {
+          result = await isolatedManager.writeResponse(process.id, 'hello');
+          if (result) break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      // The stdin write succeeded; the callback's exception must not flip
+      // the writeResponse result.
+      expect(result).toBe(true);
+      expect(throwingOnResponse).toHaveBeenCalled();
+
+      isolatedManager.disposeAll();
     });
   });
 

--- a/packages/server/src/services/__tests__/process-output-router.test.ts
+++ b/packages/server/src/services/__tests__/process-output-router.test.ts
@@ -31,18 +31,23 @@ function makeDeps(
   sendMessage: ReturnType<typeof mock>;
   getResolver: ReturnType<typeof mock>;
 } {
-  const writeInput = mock(() => {});
+  const writeInput = mock((_sessionId: string, _workerId: string, _data: string) => {});
   const sendMessage = mock(async (params: { content: string }) => ({
     messageId: `msg-${Math.random().toString(16).slice(2, 10)}.json`,
     path: `/tmp/messages/${params.content.slice(0, 4)}.json`,
   }));
   const resolver = new SessionDataPathResolver('/tmp/test-base');
-  const getResolver = mock(() => resolver);
+  const getResolver = mock((_sessionId: string) => resolver as SessionDataPathResolver | null);
 
   const deps: ProcessOutputRouterDeps = {
-    getResolver: overrides.getResolver ?? (getResolver as unknown as ProcessOutputRouterDeps['getResolver']),
-    writeInput: overrides.writeInput ?? (writeInput as unknown as ProcessOutputRouterDeps['writeInput']),
-    sendMessage: overrides.sendMessage ?? (sendMessage as unknown as ProcessOutputRouterDeps['sendMessage']),
+    getResolver:
+      overrides.getResolver ?? ((sessionId) => getResolver(sessionId)),
+    writeInput:
+      overrides.writeInput ??
+      ((sessionId, workerId, data) => {
+        writeInput(sessionId, workerId, data);
+      }),
+    sendMessage: overrides.sendMessage ?? ((params) => sendMessage(params)),
   };
   return { deps, writeInput, sendMessage, getResolver };
 }
@@ -87,6 +92,51 @@ describe('splitContentIntoChunks', () => {
     const chunks = splitContentIntoChunks(content, 1000);
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.join('')).toBe(content);
+  });
+
+  it('throws RangeError when targetBytes is zero or negative', () => {
+    expect(() => splitContentIntoChunks('hello', 0)).toThrow(RangeError);
+    expect(() => splitContentIntoChunks('hello', -1)).toThrow(RangeError);
+  });
+
+  it('throws RangeError when targetBytes is not an integer', () => {
+    expect(() => splitContentIntoChunks('hello', 1.5)).toThrow(RangeError);
+    expect(() => splitContentIntoChunks('hello', NaN)).toThrow(RangeError);
+    expect(() => splitContentIntoChunks('hello', Number.POSITIVE_INFINITY)).toThrow(
+      RangeError,
+    );
+  });
+
+  it('does not split a UTF-16 surrogate pair across chunks (emoji boundary)', () => {
+    // Build content where a hard byte cut would land between the high and
+    // low surrogate of an emoji. Each emoji 😀 is 4 bytes UTF-8 / 2 chars
+    // UTF-16. Target 5 bytes forces a cut after the first emoji's first byte
+    // would be illegal — the splitter must move the cut to a code-point
+    // boundary instead.
+    const content = '😀😀😀'; // 12 bytes UTF-8, 6 chars UTF-16
+    const chunks = splitContentIntoChunks(content, 5);
+    // Reassembly is lossless and each chunk is decodable as valid UTF-8.
+    expect(chunks.join('')).toBe(content);
+    for (const chunk of chunks) {
+      // A surrogate pair never spans the chunk boundary if every emoji
+      // appears whole in the chunk that contains its code point. Verify
+      // that decoding chunk to UTF-8 round-trips back to the same string.
+      expect(Buffer.from(chunk, 'utf-8').toString('utf-8')).toBe(chunk);
+      // No lone high surrogate at the end of any chunk.
+      const lastChar = chunk.charCodeAt(chunk.length - 1);
+      expect(lastChar >= 0xd800 && lastChar <= 0xdbff).toBe(false);
+    }
+  });
+
+  it('preserves emoji integrity in mixed text crossing chunk boundaries', () => {
+    // Mixed ASCII + emoji content larger than the target byte budget.
+    const text = 'aaaaa😀bbbbb😀ccccc😀ddddd😀eeeee';
+    const chunks = splitContentIntoChunks(text, 8);
+    expect(chunks.join('')).toBe(text);
+    // Every emoji should appear exactly 4 times across the chunks
+    // (no halves dropped or duplicated).
+    expect(text.match(/😀/g)?.length).toBe(4);
+    expect(chunks.join('').match(/😀/g)?.length).toBe(4);
   });
 });
 
@@ -195,53 +245,42 @@ describe('routeProcessContent (message mode)', () => {
     expect(writeInput.mock.calls.length).toBeGreaterThanOrEqual(sendMessage.mock.calls.length);
   });
 
-  it('skips routing when getResolver returns null and emits no PTY notification', async () => {
-    const { deps, sendMessage, writeInput, getResolver } = makeDeps({
+  it('rejects when getResolver returns null so callers can detect the failure', async () => {
+    const { deps, sendMessage, writeInput } = makeDeps({
       getResolver: () => null,
     });
-    void getResolver;
     const process = makeProcess({ outputMode: 'message' });
 
-    await routeProcessContent(deps, {
-      process,
-      content: 'unreachable',
-      direction: 'stdout',
-    });
+    await expect(
+      routeProcessContent(deps, {
+        process,
+        content: 'unreachable',
+        direction: 'stdout',
+      }),
+    ).rejects.toThrow(/Cannot resolve data path/);
 
     expect(sendMessage).not.toHaveBeenCalled();
     expect(writeInput).not.toHaveBeenCalled();
   });
 
-  it('continues with subsequent chunks when sendMessage fails for one chunk', async () => {
-    let callCount = 0;
-    const failingSend = mock(async (_params: { content: string }) => {
-      callCount += 1;
-      if (callCount === 1) {
-        throw new Error('disk full');
-      }
-      return {
-        messageId: 'msg.json',
-        path: `/tmp/messages/ok-${callCount}.json`,
-      };
+  it('rejects when sendMessage fails so callers can report write failure', async () => {
+    const failingSend = mock(async (_params: unknown): Promise<{ messageId: string; path: string }> => {
+      throw new Error('disk full');
     });
     const { deps, writeInput } = makeDeps({
-      sendMessage: failingSend as unknown as ProcessOutputRouterDeps['sendMessage'],
+      sendMessage: (params) => failingSend(params),
     });
     const process = makeProcess({ outputMode: 'message' });
 
-    const blockBytes = MESSAGE_CHUNK_TARGET_BYTES + 256;
-    const content = 'x'.repeat(blockBytes) + '\n' + 'y'.repeat(blockBytes);
+    await expect(
+      routeProcessContent(deps, {
+        process,
+        content: 'a single chunk',
+        direction: 'response',
+      }),
+    ).rejects.toThrow(/disk full/);
 
-    await routeProcessContent(deps, { process, content, direction: 'stdout' });
-
-    // Multiple chunks were attempted (>= 2) — failure on the first did not
-    // abort the loop.
-    expect(failingSend.mock.calls.length).toBeGreaterThanOrEqual(2);
-    // PTY notification suppressed for the failed chunk; emitted for each
-    // successful chunk (>= 1).
-    expect(writeInput.mock.calls.length).toBeGreaterThanOrEqual(1);
-    // The number of PTY notifications equals successful sendMessage calls
-    // (total - failed = total - 1).
-    expect(writeInput.mock.calls.length).toBe(failingSend.mock.calls.length - 1);
+    // PTY notification was not emitted for the failed chunk.
+    expect(writeInput).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/services/__tests__/process-output-router.test.ts
+++ b/packages/server/src/services/__tests__/process-output-router.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, mock } from 'bun:test';
+import type { InteractiveProcessInfo } from '@agent-console/shared';
+import {
+  routeProcessContent,
+  splitContentIntoChunks,
+  MESSAGE_CHUNK_TARGET_BYTES,
+  type ProcessOutputRouterDeps,
+} from '../process-output-router.js';
+import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
+
+function makeProcess(
+  overrides: Partial<InteractiveProcessInfo> = {},
+): InteractiveProcessInfo {
+  return {
+    id: 'proc-1',
+    sessionId: 'session-1',
+    workerId: 'worker-1',
+    command: 'node script.js',
+    status: 'running',
+    startedAt: '2026-01-01T00:00:00Z',
+    outputMode: 'pty',
+    ...overrides,
+  };
+}
+
+function makeDeps(
+  overrides: Partial<ProcessOutputRouterDeps> = {},
+): {
+  deps: ProcessOutputRouterDeps;
+  writeInput: ReturnType<typeof mock>;
+  sendMessage: ReturnType<typeof mock>;
+  getResolver: ReturnType<typeof mock>;
+} {
+  const writeInput = mock(() => {});
+  const sendMessage = mock(async (params: { content: string }) => ({
+    messageId: `msg-${Math.random().toString(16).slice(2, 10)}.json`,
+    path: `/tmp/messages/${params.content.slice(0, 4)}.json`,
+  }));
+  const resolver = new SessionDataPathResolver('/tmp/test-base');
+  const getResolver = mock(() => resolver);
+
+  const deps: ProcessOutputRouterDeps = {
+    getResolver: overrides.getResolver ?? (getResolver as unknown as ProcessOutputRouterDeps['getResolver']),
+    writeInput: overrides.writeInput ?? (writeInput as unknown as ProcessOutputRouterDeps['writeInput']),
+    sendMessage: overrides.sendMessage ?? (sendMessage as unknown as ProcessOutputRouterDeps['sendMessage']),
+  };
+  return { deps, writeInput, sendMessage, getResolver };
+}
+
+describe('splitContentIntoChunks', () => {
+  it('returns an empty array for empty input', () => {
+    expect(splitContentIntoChunks('', 100)).toEqual([]);
+  });
+
+  it('returns a single chunk when content fits within targetBytes', () => {
+    expect(splitContentIntoChunks('hello world', 1024)).toEqual(['hello world']);
+  });
+
+  it('splits content larger than targetBytes into multiple chunks', () => {
+    const content = 'a'.repeat(2500);
+    const chunks = splitContentIntoChunks(content, 1000);
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+    // Reassembly is lossless.
+    expect(chunks.join('')).toBe(content);
+    // Each chunk respects the byte budget.
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, 'utf-8')).toBeLessThanOrEqual(1000);
+    }
+  });
+
+  it('prefers cutting at a newline boundary inside the candidate prefix', () => {
+    // 200 bytes total. With targetBytes=120, the first cut should land on the
+    // newline at index 100 (cut=101), not on a non-newline byte.
+    const line1 = 'a'.repeat(100);
+    const line2 = 'b'.repeat(99);
+    const content = `${line1}\n${line2}`;
+    const chunks = splitContentIntoChunks(content, 120);
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    // The first chunk should end exactly at the newline.
+    expect(chunks[0].endsWith('\n')).toBe(true);
+    expect(chunks[0]).toBe(`${line1}\n`);
+    expect(chunks.join('')).toBe(content);
+  });
+
+  it('falls back to a hard cut when no newline exists in the candidate prefix', () => {
+    const content = 'x'.repeat(3000);
+    const chunks = splitContentIntoChunks(content, 1000);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join('')).toBe(content);
+  });
+});
+
+describe('routeProcessContent (pty mode)', () => {
+  it('writes the full content as an [internal:process] PTY notification', async () => {
+    const { deps, writeInput, sendMessage } = makeDeps();
+    const process = makeProcess({ outputMode: 'pty' });
+
+    await routeProcessContent(deps, {
+      process,
+      content: 'full stdout content',
+      direction: 'stdout',
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    // writeInput is called twice: once with the notification text, once with \r
+    // (delayed via setTimeout 150ms — only the first call is observed
+    // synchronously after await).
+    expect(writeInput).toHaveBeenCalled();
+    const firstCall = writeInput.mock.calls[0] as [string, string, string];
+    expect(firstCall[0]).toBe('session-1');
+    expect(firstCall[1]).toBe('worker-1');
+    expect(firstCall[2]).toContain('[internal:process]');
+    expect(firstCall[2]).toContain('processId=proc-1');
+    expect(firstCall[2]).toContain('full stdout content');
+  });
+
+  it('does nothing for empty content', async () => {
+    const { deps, writeInput, sendMessage } = makeDeps();
+    const process = makeProcess({ outputMode: 'pty' });
+
+    await routeProcessContent(deps, { process, content: '', direction: 'stdout' });
+
+    expect(writeInput).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('routeProcessContent (message mode)', () => {
+  it('calls sendMessage with self-routing target ids and the original content', async () => {
+    const { deps, writeInput, sendMessage } = makeDeps();
+    const process = makeProcess({ outputMode: 'message' });
+
+    await routeProcessContent(deps, {
+      process,
+      content: 'hello from script',
+      direction: 'stdout',
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const sendArgs = sendMessage.mock.calls[0]?.[0] as {
+      toSessionId: string;
+      toWorkerId: string;
+      fromSessionId: string;
+      content: string;
+    };
+    expect(sendArgs.toSessionId).toBe('session-1');
+    expect(sendArgs.toWorkerId).toBe('worker-1');
+    expect(sendArgs.fromSessionId).toBe('session-1');
+    expect(sendArgs.content).toBe('hello from script');
+
+    // Brief PTY notification with file path and bytes.
+    expect(writeInput).toHaveBeenCalled();
+    const firstCall = writeInput.mock.calls[0] as [string, string, string];
+    expect(firstCall[2]).toContain('[internal:process]');
+    expect(firstCall[2]).toContain('stdout via message');
+    expect(firstCall[2]).toContain('bytes=');
+  });
+
+  it('uses [response via message] phrasing for direction=response', async () => {
+    const { deps, writeInput } = makeDeps();
+    const process = makeProcess({ outputMode: 'message' });
+
+    await routeProcessContent(deps, {
+      process,
+      content: 'response payload',
+      direction: 'response',
+    });
+
+    const firstCall = writeInput.mock.calls[0] as [string, string, string];
+    expect(firstCall[2]).toContain('response via message');
+  });
+
+  it('splits content larger than MESSAGE_CHUNK_TARGET_BYTES into multiple sendMessage calls', async () => {
+    const { deps, sendMessage, writeInput } = makeDeps();
+    const process = makeProcess({ outputMode: 'message' });
+
+    // Use a synthetic content >2 chunks. Target is ~60 KB; build ~150 KB.
+    const blockBytes = MESSAGE_CHUNK_TARGET_BYTES + 1024;
+    const content = 'a'.repeat(blockBytes) + '\n' + 'b'.repeat(blockBytes) + '\n' + 'c'.repeat(blockBytes);
+
+    await routeProcessContent(deps, {
+      process,
+      content,
+      direction: 'stdout',
+    });
+
+    expect(sendMessage.mock.calls.length).toBeGreaterThanOrEqual(3);
+    // Reassembling chunks must equal original content.
+    const reassembled = sendMessage.mock.calls
+      .map((c) => (c[0] as { content: string }).content)
+      .join('');
+    expect(reassembled).toBe(content);
+
+    // One brief PTY notification per chunk.
+    expect(writeInput.mock.calls.length).toBeGreaterThanOrEqual(sendMessage.mock.calls.length);
+  });
+
+  it('skips routing when getResolver returns null and emits no PTY notification', async () => {
+    const { deps, sendMessage, writeInput, getResolver } = makeDeps({
+      getResolver: () => null,
+    });
+    void getResolver;
+    const process = makeProcess({ outputMode: 'message' });
+
+    await routeProcessContent(deps, {
+      process,
+      content: 'unreachable',
+      direction: 'stdout',
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(writeInput).not.toHaveBeenCalled();
+  });
+
+  it('continues with subsequent chunks when sendMessage fails for one chunk', async () => {
+    let callCount = 0;
+    const failingSend = mock(async (_params: { content: string }) => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new Error('disk full');
+      }
+      return {
+        messageId: 'msg.json',
+        path: `/tmp/messages/ok-${callCount}.json`,
+      };
+    });
+    const { deps, writeInput } = makeDeps({
+      sendMessage: failingSend as unknown as ProcessOutputRouterDeps['sendMessage'],
+    });
+    const process = makeProcess({ outputMode: 'message' });
+
+    const blockBytes = MESSAGE_CHUNK_TARGET_BYTES + 256;
+    const content = 'x'.repeat(blockBytes) + '\n' + 'y'.repeat(blockBytes);
+
+    await routeProcessContent(deps, { process, content, direction: 'stdout' });
+
+    // Multiple chunks were attempted (>= 2) — failure on the first did not
+    // abort the loop.
+    expect(failingSend.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // PTY notification suppressed for the failed chunk; emitted for each
+    // successful chunk (>= 1).
+    expect(writeInput.mock.calls.length).toBeGreaterThanOrEqual(1);
+    // The number of PTY notifications equals successful sendMessage calls
+    // (total - failed = total - 1).
+    expect(writeInput.mock.calls.length).toBe(failingSend.mock.calls.length - 1);
+  });
+});

--- a/packages/server/src/services/interactive-process-manager.ts
+++ b/packages/server/src/services/interactive-process-manager.ts
@@ -26,9 +26,13 @@ export interface ProcessExitCallback {
  * Invoked after `writeResponse` successfully forwards content to the
  * subprocess stdin. Consumers route the content based on
  * `process.outputMode` (e.g., echo to PTY, or write a message file).
+ *
+ * May return a Promise — `writeResponse` awaits it before reporting
+ * success so failures in `"message"` mode routing surface to the caller
+ * instead of being silently swallowed.
  */
 export interface ProcessResponseCallback {
-  (process: InteractiveProcessInfo, content: string): void;
+  (process: InteractiveProcessInfo, content: string): void | Promise<void>;
 }
 
 /** Service that can inject content into a worker's PTY as submitted input. */
@@ -207,13 +211,15 @@ export class InteractiveProcessManager {
 
     // Notify the consumer that a response was forwarded. Routing per
     // outputMode (PTY echo vs message file) is the consumer's concern.
-    // Isolated from the stdin try/catch so a failing callback does not flip
-    // the writeResponse result reported to the caller.
+    // The callback is awaited so message-mode routing failures (e.g., disk
+    // write error, resolver miss) surface as a `false` return to the
+    // caller instead of being silently swallowed.
     if (this.onResponse) {
       try {
-        this.onResponse({ ...stored.info }, content);
+        await this.onResponse({ ...stored.info }, content);
       } catch (err) {
-        logger.warn({ processId, err }, 'onResponse callback threw');
+        logger.warn({ processId, err }, 'onResponse callback failed');
+        return false;
       }
     }
 

--- a/packages/server/src/services/interactive-process-manager.ts
+++ b/packages/server/src/services/interactive-process-manager.ts
@@ -1,4 +1,4 @@
-import type { InteractiveProcessInfo } from '@agent-console/shared';
+import type { InteractiveProcessInfo, InteractiveProcessOutputMode } from '@agent-console/shared';
 import type { Subprocess, FileSink } from 'bun';
 import { createLogger } from '../lib/logger.js';
 
@@ -22,6 +22,15 @@ export interface ProcessExitCallback {
   (process: InteractiveProcessInfo): void;
 }
 
+/**
+ * Invoked after `writeResponse` successfully forwards content to the
+ * subprocess stdin. Consumers route the content based on
+ * `process.outputMode` (e.g., echo to PTY, or write a message file).
+ */
+export interface ProcessResponseCallback {
+  (process: InteractiveProcessInfo, content: string): void;
+}
+
 /** Service that can inject content into a worker's PTY as submitted input. */
 export interface PtyMessageInjector {
   injectPtyMessage(sessionId: string, workerId: string, content: string): boolean;
@@ -43,11 +52,18 @@ export class InteractiveProcessManager {
   private onOutput: ProcessOutputCallback;
   private onExit: ProcessExitCallback;
   private ptyMessageInjector?: PtyMessageInjector;
+  private onResponse?: ProcessResponseCallback;
 
-  constructor(onOutput: ProcessOutputCallback, onExit: ProcessExitCallback, ptyMessageInjector?: PtyMessageInjector) {
+  constructor(
+    onOutput: ProcessOutputCallback,
+    onExit: ProcessExitCallback,
+    ptyMessageInjector?: PtyMessageInjector,
+    onResponse?: ProcessResponseCallback,
+  ) {
     this.onOutput = onOutput;
     this.onExit = onExit;
     this.ptyMessageInjector = ptyMessageInjector;
+    this.onResponse = onResponse;
   }
 
   async runProcess(params: {
@@ -55,8 +71,10 @@ export class InteractiveProcessManager {
     workerId: string;
     command: string;
     cwd?: string;
+    outputMode?: InteractiveProcessOutputMode;
   }): Promise<InteractiveProcessInfo> {
     const { sessionId, workerId, command, cwd } = params;
+    const outputMode: InteractiveProcessOutputMode = params.outputMode ?? 'pty';
 
     const sessionProcessCount = this.listProcesses(sessionId).filter(
       (p) => p.status === 'running',
@@ -75,6 +93,7 @@ export class InteractiveProcessManager {
       command,
       status: 'running',
       startedAt: new Date().toISOString(),
+      outputMode,
     };
 
     const subprocess = Bun.spawn(['sh', '-c', command], {
@@ -159,12 +178,14 @@ export class InteractiveProcessManager {
     }
 
     try {
-      // Echo response content to worker PTY (newlines normalized to LF so
-      // they remain soft newlines, no Enter yet). The Enter (\r) will be sent
-      // by writePtyNotification when process output settles and onOutput is
-      // called. See Issue #660 — converting \n to \r here previously caused
-      // multi-line responses to be submitted as multiple messages.
-      if (this.ptyMessageInjector) {
+      // In `pty` mode, echo response content to the worker PTY (newlines
+      // normalized to LF so they remain soft newlines, no Enter yet). The
+      // Enter (\r) will be sent by writePtyNotification when process output
+      // settles and onOutput is called. See Issue #660 — converting \n to
+      // \r here previously caused multi-line responses to be submitted as
+      // multiple messages. In `message` mode the brief PTY notification is
+      // emitted by the onResponse consumer, so PTY echo is skipped here.
+      if (this.ptyMessageInjector && stored.info.outputMode === 'pty') {
         this.ptyMessageInjector.writePtyData(
           stored.info.sessionId,
           stored.info.workerId,
@@ -179,11 +200,24 @@ export class InteractiveProcessManager {
       stored.stdin.flush();
 
       logger.debug({ processId, contentLength: content.length }, 'Wrote response to process');
-      return true;
     } catch (err) {
       logger.warn({ processId, err }, 'Failed to write to process stdin');
       return false;
     }
+
+    // Notify the consumer that a response was forwarded. Routing per
+    // outputMode (PTY echo vs message file) is the consumer's concern.
+    // Isolated from the stdin try/catch so a failing callback does not flip
+    // the writeResponse result reported to the caller.
+    if (this.onResponse) {
+      try {
+        this.onResponse({ ...stored.info }, content);
+      } catch (err) {
+        logger.warn({ processId, err }, 'onResponse callback threw');
+      }
+    }
+
+    return true;
   }
 
   killProcess(processId: string): boolean {

--- a/packages/server/src/services/process-output-router.ts
+++ b/packages/server/src/services/process-output-router.ts
@@ -1,0 +1,212 @@
+/**
+ * Routes interactive-process content (stdout chunks and response echoes) to
+ * either the worker PTY (full content) or to inter-session message files
+ * (chunked) with a brief PTY notification, based on the process's
+ * `outputMode`.
+ *
+ * The router is decoupled from `app-context` wiring so it can be tested in
+ * isolation without booting the full service graph.
+ */
+
+import type { InteractiveProcessInfo } from '@agent-console/shared';
+import type { SessionDataPathResolver } from '../lib/session-data-path-resolver.js';
+import { writePtyNotification } from '../lib/pty-notification.js';
+import { createLogger } from '../lib/logger.js';
+
+const logger = createLogger('process-output-router');
+
+/**
+ * Maximum bytes per message-file chunk. Slightly under the
+ * `MAX_MESSAGE_CONTENT_BYTES` (64 KB) limit enforced by
+ * {@link InterSessionMessageService.sendMessage} to leave headroom for any
+ * envelope overhead.
+ */
+export const MESSAGE_CHUNK_TARGET_BYTES = 60 * 1024;
+
+/** Direction of the routed content (used for logging and notification text). */
+export type ProcessOutputDirection = 'stdout' | 'response';
+
+export interface ProcessOutputRouterDeps {
+  /**
+   * Resolve the session-data path resolver for a given session id, or
+   * `null` when the session has no resolvable scope (e.g., already deleted).
+   */
+  getResolver: (sessionId: string) => SessionDataPathResolver | null;
+  /** Write data to the calling worker's PTY (used for the notification). */
+  writeInput: (sessionId: string, workerId: string, data: string) => void;
+  /** Send a message file via the inter-session message service. */
+  sendMessage: (params: {
+    toSessionId: string;
+    toWorkerId: string;
+    fromSessionId: string;
+    content: string;
+    resolver: SessionDataPathResolver;
+  }) => Promise<{ messageId: string; path: string }>;
+}
+
+export interface RouteProcessContentParams {
+  process: InteractiveProcessInfo;
+  content: string;
+  direction: ProcessOutputDirection;
+}
+
+/**
+ * Split a string into chunks no larger than `targetBytes` UTF-8 bytes,
+ * preferring to break on a line boundary (`\n`) within the chunk. The last
+ * chunk may be shorter than the target. Empty input yields an empty array.
+ *
+ * Exported for unit testing.
+ *
+ * @internal Exported for testing
+ */
+export function splitContentIntoChunks(content: string, targetBytes: number): string[] {
+  if (content.length === 0) {
+    return [];
+  }
+  if (Buffer.byteLength(content, 'utf-8') <= targetBytes) {
+    return [content];
+  }
+
+  const chunks: string[] = [];
+  let remaining = content;
+  while (remaining.length > 0) {
+    if (Buffer.byteLength(remaining, 'utf-8') <= targetBytes) {
+      chunks.push(remaining);
+      break;
+    }
+
+    // Find the largest prefix whose UTF-8 byte length fits in targetBytes.
+    let cutChar = remaining.length;
+    let cutBytes = Buffer.byteLength(remaining.slice(0, cutChar), 'utf-8');
+    while (cutBytes > targetBytes) {
+      cutChar = Math.floor(cutChar * (targetBytes / cutBytes));
+      if (cutChar < 1) cutChar = 1;
+      cutBytes = Buffer.byteLength(remaining.slice(0, cutChar), 'utf-8');
+      // Tighten if the heuristic over-shrank.
+      while (
+        cutChar < remaining.length &&
+        Buffer.byteLength(remaining.slice(0, cutChar + 1), 'utf-8') <= targetBytes
+      ) {
+        cutChar += 1;
+      }
+    }
+
+    // Prefer cutting at the last newline within the candidate prefix, when
+    // such a newline exists. This keeps log lines whole across chunks.
+    const candidate = remaining.slice(0, cutChar);
+    const newlineIdx = candidate.lastIndexOf('\n');
+    let cut: number;
+    if (newlineIdx > 0) {
+      cut = newlineIdx + 1;
+    } else {
+      cut = cutChar;
+    }
+
+    chunks.push(remaining.slice(0, cut));
+    remaining = remaining.slice(cut);
+  }
+  return chunks;
+}
+
+/**
+ * Route process content according to the process's outputMode.
+ *
+ * - `'pty'` — emit a single `[internal:process]` notification carrying the
+ *   full content (existing behavior).
+ * - `'message'` — split content into <= MESSAGE_CHUNK_TARGET_BYTES chunks,
+ *   write each chunk via `sendMessage`, and emit a brief PTY notification
+ *   carrying the file path and byte count for each chunk.
+ *
+ * The function is async because message writes are async; callers may
+ * await the returned promise or fire-and-track via `.catch` (the function
+ * never rejects — it logs failures and returns).
+ */
+export async function routeProcessContent(
+  deps: ProcessOutputRouterDeps,
+  params: RouteProcessContentParams,
+): Promise<void> {
+  const { process, content, direction } = params;
+  if (content.length === 0) {
+    return;
+  }
+
+  const writeInputForWorker = (data: string) =>
+    deps.writeInput(process.sessionId, process.workerId, data);
+
+  if (process.outputMode === 'pty') {
+    try {
+      writePtyNotification({
+        kind: 'internal-process',
+        tag: 'internal:process',
+        fields: {
+          processId: process.id,
+          command: process.command,
+          message: content,
+        },
+        intent: direction === 'stdout' ? 'triage' : 'inform',
+        writeInput: writeInputForWorker,
+      });
+    } catch (err) {
+      logger.warn(
+        { processId: process.id, sessionId: process.sessionId, direction, err },
+        'Failed to deliver process PTY notification',
+      );
+    }
+    return;
+  }
+
+  // outputMode === 'message'
+  const resolver = deps.getResolver(process.sessionId);
+  if (!resolver) {
+    logger.warn(
+      { processId: process.id, sessionId: process.sessionId, direction },
+      'Cannot resolve data path for message-mode process; skipping message routing',
+    );
+    return;
+  }
+
+  const chunks = splitContentIntoChunks(content, MESSAGE_CHUNK_TARGET_BYTES);
+  for (const chunk of chunks) {
+    let result: { path: string };
+    try {
+      result = await deps.sendMessage({
+        toSessionId: process.sessionId,
+        toWorkerId: process.workerId,
+        fromSessionId: process.sessionId,
+        content: chunk,
+        resolver,
+      });
+    } catch (err) {
+      logger.warn(
+        { processId: process.id, sessionId: process.sessionId, direction, err },
+        'Failed to write process content to message file',
+      );
+      continue;
+    }
+
+    const bytes = Buffer.byteLength(chunk, 'utf-8');
+    const summary =
+      direction === 'stdout'
+        ? `[stdout via message] path=${result.path} bytes=${bytes}`
+        : `[response via message] path=${result.path} bytes=${bytes}`;
+
+    try {
+      writePtyNotification({
+        kind: 'internal-process',
+        tag: 'internal:process',
+        fields: {
+          processId: process.id,
+          command: process.command,
+          message: summary,
+        },
+        intent: direction === 'stdout' ? 'triage' : 'inform',
+        writeInput: writeInputForWorker,
+      });
+    } catch (err) {
+      logger.warn(
+        { processId: process.id, sessionId: process.sessionId, direction, err },
+        'Failed to deliver brief process PTY notification (message file was written)',
+      );
+    }
+  }
+}

--- a/packages/server/src/services/process-output-router.ts
+++ b/packages/server/src/services/process-output-router.ts
@@ -52,14 +52,23 @@ export interface RouteProcessContentParams {
 
 /**
  * Split a string into chunks no larger than `targetBytes` UTF-8 bytes,
- * preferring to break on a line boundary (`\n`) within the chunk. The last
- * chunk may be shorter than the target. Empty input yields an empty array.
+ * preferring to break on a line boundary (`\n`) within the chunk and never
+ * splitting a UTF-16 surrogate pair. The last chunk may be shorter than the
+ * target. Empty input yields an empty array.
+ *
+ * Throws `RangeError` when `targetBytes` is not a positive integer — this
+ * is a defensive check to avoid the chunking loop failing to make progress.
  *
  * Exported for unit testing.
  *
  * @internal Exported for testing
  */
 export function splitContentIntoChunks(content: string, targetBytes: number): string[] {
+  if (!Number.isInteger(targetBytes) || targetBytes <= 0) {
+    throw new RangeError(
+      `targetBytes must be a positive integer, got ${targetBytes}`,
+    );
+  }
   if (content.length === 0) {
     return [];
   }
@@ -102,6 +111,20 @@ export function splitContentIntoChunks(content: string, targetBytes: number): st
       cut = cutChar;
     }
 
+    // Don't split a UTF-16 surrogate pair across chunks. Slicing between a
+    // high (0xD800-0xDBFF) and low (0xDC00-0xDFFF) surrogate would corrupt
+    // the represented code point (emoji, non-BMP CJK, etc.).
+    if (
+      cut > 0 &&
+      cut < remaining.length &&
+      remaining.charCodeAt(cut - 1) >= 0xd800 &&
+      remaining.charCodeAt(cut - 1) <= 0xdbff &&
+      remaining.charCodeAt(cut) >= 0xdc00 &&
+      remaining.charCodeAt(cut) <= 0xdfff
+    ) {
+      cut -= 1;
+    }
+
     chunks.push(remaining.slice(0, cut));
     remaining = remaining.slice(cut);
   }
@@ -112,14 +135,18 @@ export function splitContentIntoChunks(content: string, targetBytes: number): st
  * Route process content according to the process's outputMode.
  *
  * - `'pty'` — emit a single `[internal:process]` notification carrying the
- *   full content (existing behavior).
- * - `'message'` — split content into <= MESSAGE_CHUNK_TARGET_BYTES chunks,
- *   write each chunk via `sendMessage`, and emit a brief PTY notification
- *   carrying the file path and byte count for each chunk.
- *
- * The function is async because message writes are async; callers may
- * await the returned promise or fire-and-track via `.catch` (the function
- * never rejects — it logs failures and returns).
+ *   full content (existing behavior). Notification write errors are logged
+ *   as warnings and swallowed because they are cosmetic (the calling code
+ *   has nowhere to report a failed PTY notification to).
+ * - `'message'` — split content into <= `MESSAGE_CHUNK_TARGET_BYTES`
+ *   chunks, write each chunk via `sendMessage`, and emit a brief PTY
+ *   notification carrying the file path and byte count for each chunk.
+ *   **Routing failures (resolver miss or any chunk's `sendMessage` error)
+ *   throw**, so callers awaiting the returned promise can detect that
+ *   message-mode delivery did not happen and report a `false` success
+ *   to their own caller. Brief PTY notification write errors after a
+ *   successful chunk write are still cosmetic — they are logged as warnings
+ *   and do not throw.
  */
 export async function routeProcessContent(
   deps: ProcessOutputRouterDeps,
@@ -158,31 +185,20 @@ export async function routeProcessContent(
   // outputMode === 'message'
   const resolver = deps.getResolver(process.sessionId);
   if (!resolver) {
-    logger.warn(
-      { processId: process.id, sessionId: process.sessionId, direction },
-      'Cannot resolve data path for message-mode process; skipping message routing',
+    throw new Error(
+      `Cannot resolve data path for message-mode process ${process.id} (session ${process.sessionId})`,
     );
-    return;
   }
 
   const chunks = splitContentIntoChunks(content, MESSAGE_CHUNK_TARGET_BYTES);
   for (const chunk of chunks) {
-    let result: { path: string };
-    try {
-      result = await deps.sendMessage({
-        toSessionId: process.sessionId,
-        toWorkerId: process.workerId,
-        fromSessionId: process.sessionId,
-        content: chunk,
-        resolver,
-      });
-    } catch (err) {
-      logger.warn(
-        { processId: process.id, sessionId: process.sessionId, direction, err },
-        'Failed to write process content to message file',
-      );
-      continue;
-    }
+    const result = await deps.sendMessage({
+      toSessionId: process.sessionId,
+      toWorkerId: process.workerId,
+      fromSessionId: process.sessionId,
+      content: chunk,
+      resolver,
+    });
 
     const bytes = Buffer.byteLength(chunk, 'utf-8');
     const summary =

--- a/packages/shared/src/types/__tests__/interactive-process.test.ts
+++ b/packages/shared/src/types/__tests__/interactive-process.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'bun:test';
-import type { InteractiveProcessInfo, InteractiveProcessStatus } from '../interactive-process.js';
+import type {
+  InteractiveProcessInfo,
+  InteractiveProcessOutputMode,
+  InteractiveProcessStatus,
+} from '../interactive-process.js';
 
 describe('InteractiveProcess types', () => {
   it('should allow constructing a valid InteractiveProcessInfo', () => {
@@ -10,10 +14,12 @@ describe('InteractiveProcess types', () => {
       command: 'echo hello',
       status: 'running',
       startedAt: '2026-01-01T00:00:00Z',
+      outputMode: 'pty',
     };
 
     expect(info.id).toBe('proc-1');
     expect(info.status).toBe('running');
+    expect(info.outputMode).toBe('pty');
   });
 
   it('should allow exited status with exitCode', () => {
@@ -25,6 +31,7 @@ describe('InteractiveProcess types', () => {
       status: 'exited',
       startedAt: '2026-01-01T00:00:00Z',
       exitCode: 0,
+      outputMode: 'pty',
     };
 
     expect(info.status).toBe('exited');
@@ -37,5 +44,27 @@ describe('InteractiveProcess types', () => {
 
     expect(running).toBe('running');
     expect(exited).toBe('exited');
+  });
+
+  it('should export InteractiveProcessOutputMode with pty and message values', () => {
+    const pty: InteractiveProcessOutputMode = 'pty';
+    const message: InteractiveProcessOutputMode = 'message';
+
+    expect(pty).toBe('pty');
+    expect(message).toBe('message');
+  });
+
+  it('should allow constructing InteractiveProcessInfo with message output mode', () => {
+    const info: InteractiveProcessInfo = {
+      id: 'proc-3',
+      sessionId: 'session-1',
+      workerId: 'worker-1',
+      command: 'node acceptance-check.js',
+      status: 'running',
+      startedAt: '2026-01-01T00:00:00Z',
+      outputMode: 'message',
+    };
+
+    expect(info.outputMode).toBe('message');
   });
 });

--- a/packages/shared/src/types/interactive-process.ts
+++ b/packages/shared/src/types/interactive-process.ts
@@ -8,6 +8,22 @@
 
 export type InteractiveProcessStatus = 'running' | 'exited';
 
+/**
+ * Routing mode for interactive process I/O.
+ *
+ * - `'pty'` (default): script stdout is delivered as `[internal:process]` PTY
+ *   notifications containing the full output, and `write_process_response`
+ *   echoes the response content into the worker PTY.
+ * - `'message'`: script stdout and `write_process_response` content are
+ *   routed via inter-session message files to the calling agent
+ *   (toSessionId/toWorkerId match the run_process invocation). The PTY
+ *   receives only a brief notification with the message file path.
+ *
+ * Use `'message'` for long-paragraph interactive scripts to keep the
+ * calling agent's conversation clean.
+ */
+export type InteractiveProcessOutputMode = 'pty' | 'message';
+
 export interface InteractiveProcessInfo {
   id: string;
   sessionId: string;
@@ -16,4 +32,5 @@ export interface InteractiveProcessInfo {
   status: InteractiveProcessStatus;
   startedAt: string;
   exitCode?: number;
+  outputMode: InteractiveProcessOutputMode;
 }


### PR DESCRIPTION
## Summary

- Adds `outputMode: "pty" | "message"` (default `"pty"`) to the `run_process` MCP tool. `"message"` routes script stdout and `write_process_response` content through `InterSessionMessageService` (file-based) and emits only a brief `[internal:process]` PTY notification carrying the message file path and byte count.
- New `process-output-router.ts` encapsulates the mode-aware routing with line-break-preferring 60 KB UTF-8 chunking that does not split UTF-16 surrogate pairs. `app-context.ts` wires it in for both stdout (`onOutput`) and response (`onResponse`); the existing `pty` path is unchanged.
- `InteractiveProcessInfo.outputMode` is required at the type level (default applied at construction) so invalid states are unrepresentable.

Closes #664

## Why

`acceptance-check.js` and `sprint-retro.js` produce multi-paragraph prompts and accept multi-paragraph answers. Today both directions become full-content `[internal:process]` PTY notifications, which floods the calling agent's conversation panel. `"message"` mode keeps the dialogue in message files (which the agent reads on demand) while still surfacing brief progress notifications to the owner.

## Behavioral notes

- Exit notifications stay on the PTY in both modes — single line, no flooding concern.
- `outputMode` is opt-in. Every existing caller of `run_process` continues to receive `"pty"` semantics unchanged.
- In `"message"` mode, `writeResponse` skips the PTY echo and **awaits** the new `onResponse` callback so message-file write failures (disk error, resolver miss) surface as `false` to the MCP caller instead of being silently swallowed.
- Chunking guards against 64 KB `MAX_MESSAGE_CONTENT_BYTES`. The splitter prefers a `\n` boundary inside each candidate prefix, falls back to a hard byte cut when no newline is present, and never splits a UTF-16 surrogate pair so emoji and non-BMP code points survive chunk boundaries.
- `splitContentIntoChunks` validates `targetBytes` (positive integer) and throws `RangeError` on invalid input to avoid non-terminating loops.
- Resolver miss in `"message"` mode now throws (was previously logged-and-swallowed) so the failure propagates to the MCP caller.

## Test plan

- [x] `bun run typecheck` exit 0 across all workspaces
- [x] `bun run test` exit 0 — 4162 tests across 219 files (server: 2463 pass / 1 skip; client: 1361 pass / 2 skip; shared: 309 pass; integration: 29 pass)
- [x] New unit coverage:
  - `interactive-process-manager.test.ts` — `outputMode` defaulting, message-mode PTY-echo skip, `onResponse` invocation in both modes, async/sync callback failure → `writeResponse` returns `false`, ordering proof that `writeResponse` only resolves after `onResponse` completes
  - `process-output-router.test.ts` — `pty` notification, `message` chunking, resolver miss / sendMessage failure → `Promise.reject`, line-break-preferring split, UTF-16 surrogate pair guard, `targetBytes` validation
  - `mcp-server.test.ts` — schema default, explicit values, `zod` rejection of invalid mode, response payload includes `outputMode`
  - `interactive-process-boundary.test.ts` (integration) — cross-package contract for the new `outputMode` field on the MCP response
- [x] Manual verification (Plan A, e2e via curl) — see "Plan A e2e observation" below.

## Plan A e2e observation

Booted an isolated server (`PORT=3491`, `AGENT_CONSOLE_HOME=/tmp/agent-console-664-test-v2`) carrying this PR's code (commit `cc7855b`) and drove the MCP `run_process` + `write_process_response` flow via `curl --data-binary @file`. The script under test was a small Node program that prints `Q1: please answer with multi-line text`, reads stdin, prints `got: <input>`, and exits.

Observed:

| Stage | Action | Message file written | Bytes | Content |
|---|---|---|---|---|
| 1 | `run_process` with `outputMode: "message"` and the script | `…b6f04154.json` | 39 | `Q1: please answer with multi-line text\n` |
| 2 | `write_process_response` content `"line1\nline2\nline3 multi-line response"` | `…4329415c.json` | 37 | `line1\nline2\nline3 multi-line response` |
| 3 | Script's stdout echo of the response (`got: …`) | `…e888b9fd.json` | 43 | `got: line1\nline2\nline3 multi-line response\n` |

Each timestamp is monotone (`488913 < 489816 < 489820`), which is the e2e proof that `writeResponse`'s new `await onResponse` contract holds: the response message file (`489816`) is written **before** `writeResponse` returns success, and the script's stdout echo (`489820`) follows right after. The MCP response was `{"written":true,"processId":"…"}`. No long stdout / stdin content arrived as a `[internal:process] message="<full text>"` PTY notification.

The brief PTY notification text (`[stdout via message] path=… bytes=…`, `[response via message] path=… bytes=…`) is verified by unit tests in `process-output-router.test.ts`. Verifying it inside an actual MCP-client conversation panel — i.e., that the calling agent's session UI stays clean for a real `acceptance-check.js` run — requires an MCP client connected to a server that has loaded this PR's code, which the implementing agent's MCP client is not (it is bound to the existing production agent-console server). That step is therefore deferred to **post-merge dogfood by the owner** and is the only AC#6 sub-component not directly observed in this PR.

## CodeRabbit review

- 1st pass (local CLI): one minor finding — `onResponse` callback try/catch isolation — fixed in `cc7855b` ancestor `607430a`.
- 2nd pass (GitHub bot, commit `607430a`): four findings (Major × 2, Minor × 1, Nitpick × 1). All addressed in commit `cc7855b` with regression tests; ack reply chain at <https://github.com/ms2sato/agent-console/pull/711#issuecomment-4329047592>.
- Local CLI was rate-limited (≈48-min window) before the second pass; relying on the GitHub bot per `workflow.md` rate-limit fallback. Bot status check is currently SUCCESS.