### PR TITLE
docs: codify Browser QA skip threshold (closes #659)

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -34,7 +34,14 @@ Before completing any code changes, always verify:
 
    "CodeRabbit clean" requires all three. Pre-merge checks alone are insufficient. (Sprint 2026-04-25 PR #694 — agent declared "clean" based on pre-merge 5/5 while review state was `CHANGES_REQUESTED` with 3 actionable issues.)
 4. **Review test quality:** When tests are added or modified, evaluate adequacy and coverage
-5. **Manual verification (UI changes only):** When modifying UI components and Chrome DevTools MCP is available, perform manual testing through the browser
+5. **Manual verification (UI changes only):** When modifying UI components and Chrome DevTools MCP is available, perform manual testing through the browser.
+
+   **Skip threshold.** Browser QA may be omitted when **all** of the following conditions hold:
+   - The change is a pure behavior subtraction — removing a conditional branch, a field, or a side-effect with no user-visible rendering.
+   - The corresponding server-side contract is covered by existing server or integration tests.
+   - The client-side behavior change is fully covered by unit tests.
+
+   When skipping, document the three justifications in the PR body and request owner dogfood verification post-merge. The Orchestrator's acceptance check still performs Browser QA as final gate. (Lesson: Sprint 2026-04-17b PR #655 — frontend-specialist correctly skipped for a pure cache-restore subtraction; absent threshold caused unnecessary anxiety. See `frontend-standards.md` "Browser Verification for UI Changes" for the worked example.)
 6. **Duplication check:** When adding or modifying logic, grep the repository for the core processing part (method chains, regex patterns, transformation expressions) with variable names removed. For example, search for `.replace(/\r?\n/g, '\r')` rather than `content.replace(...)`. If hits are found, review whether they represent the same concern and should be consolidated into a shared function.
 7. **Shell script execution test:** When adding or modifying shell scripts (`scripts/*.sh`), execute them locally on macOS before committing. CI does not cover shell scripts. Watch for BSD/GNU incompatibilities (e.g., `sed -E` with non-greedy `+?` is not portable). (Lesson: Sprint 2026-04-05c — `upload-qa-screenshots.sh` had 2 bugs only caught at runtime.)
 

--- a/.claude/skills/frontend-standards/frontend-standards.md
+++ b/.claude/skills/frontend-standards/frontend-standards.md
@@ -149,3 +149,11 @@ Reason: without `minLength(1)`, the `regex` check on an empty string produces th
 - New UI elements or dialogs
 - Responsive behavior
 - Form interactions (tab through fields, submit button reachable)
+
+### When skip is justified
+
+The skip threshold is defined in `.claude/rules/workflow.md` Verification Checklist Step 5. Reproduced here for skill-level reference: skip is permitted only when **all three** of pure behavior subtraction, server-side contract test coverage, and client-side unit test coverage hold simultaneously. If any condition does not hold, run Browser QA.
+
+**Worked example — Sprint 2026-04-17b PR #655 (Issue #648).** The fix removed a stale-cache-on-restart code path. The change introduced no new UI state and produced no new visual element; the post-fix behavior was indistinguishable from the pre-fix one except for not wiping cache. The new server-side truncation-detection contract was already covered by server tests, and the corresponding client-side cache decision was covered by unit tests. The delegated worktree had no running backend and no seeded session data — spinning up a seeded environment purely to observe a sub-second cache restore vs a 20-second full render would have been high setup cost for a low blast radius. The frontend-specialist agent skipped Browser QA, documented the three justifications in the PR body, and retrospectively reported feeling some anxiety about making the skip judgment unilaterally without a written threshold to point to. The skip turned out correct. This threshold codifies that judgment so future agents skip with explicit grounding rather than guesswork.
+
+When skipping, write a short "Browser QA skip justification" subsection in the PR body that names the three conditions and how each is satisfied for this change. Owner dogfood verification post-merge serves as the safety net; the Orchestrator's acceptance check remains the formal final gate.


### PR DESCRIPTION
## Summary

- Adds an explicit Browser QA skip threshold to `.claude/rules/workflow.md` Verification Checklist Step 5
- Adds a worked example to `.claude/skills/frontend-standards/frontend-standards.md`
- Three conditions required for skip: pure behavior subtraction, server-side contract test coverage, client-side unit test coverage

## Source incident

Sprint 2026-04-17b PR #655 (Issue #648) — frontend-specialist correctly skipped Browser QA for a pure cache-restore subtraction, but retrospectively reported feeling anxious about making the skip judgment unilaterally without a written threshold to point to. This change codifies the threshold so future agents skip with explicit grounding rather than guesswork.

## Test plan

- [ ] Read both modified files end-to-end and confirm rule wording is mechanical (a fresh reader can apply the threshold without further context)
- [ ] Confirm the worked example matches the actual PR #655 / Issue #648 history
- [ ] No CI required — this is a `[skip ci]` doc-only change

## Closes

Closes #659

Generated with [Claude Code](https://claude.com/claude-code)