### PR TITLE
docs: add Inter-Session Messaging glossary entry

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -119,16 +119,16 @@ A registered shell-condition + interval that the server polls silently and notif
 - **Contrast:** [Timer](#timer) (fires on interval regardless of state)
 
 ### Inter-Session Messaging
-File-based message delivery channel between sessions. Used by the `send_session_message` MCP tool for explicit cross-session consultations and by `outputMode: "message"` of `run_process` to route long-form script stdout and `write_process_response` content to the calling session/worker without flooding the recipient PTY.
+File-based message delivery channel between sessions. Used by the `send_session_message` MCP tool for explicit cross-session consultations and by `outputMode: "message"` of `run_process` to route long-form script stdout and `write_process_response` content to the receiving session/worker without flooding its PTY.
 - **Aliases:** inter-session messaging, inter-session message files, inter-session message service, InterSessionMessageService, inter-session-message-service
-- **See:** [Inter-Session Messaging design](design/inter-session-messaging.md), implementation `packages/server/src/services/inter-session-message-service.ts`, MCP tool `send_session_message`, [outputMode](#outputmode)
+- **See:** [Inter-Session Messaging design](design/inter-session-messaging.md), implementation [`packages/server/src/services/inter-session-message-service.ts`](../packages/server/src/services/inter-session-message-service.ts), MCP tool `send_session_message`, [outputMode](#outputmode)
 
 ### outputMode
 Parameter on the `run_process` MCP tool that selects how the script's stdout and `write_process_response` content are delivered to the calling agent. Two modes:
 - `"pty"` (default): the script's stdout is delivered as a `[internal:process]` PTY notification carrying the full content; `write_process_response` echoes content directly to the worker PTY. Existing behavior, backward-compatible with all prior `run_process` callers.
 - `"message"`: the script's stdout is captured and routed through [Inter-Session Messaging](#inter-session-messaging) to the calling session/worker; `write_process_response` content is delivered through the same channel after stdin write succeeds. PTY receives only a brief `[stdout via message] path=… bytes=…` / `[response via message] …` notification per chunk so the owner retains progress visibility without the conversation being flooded by long-form Q&A. Designed for long interactive scripts (e.g., `.claude/skills/orchestrator/acceptance-check.js`, `sprint-retro.js`).
 - **Aliases:** output mode, run_process outputMode
-- **See:** Issue [#664](https://github.com/ms2sato/agent-console/issues/664), router (`packages/server/src/services/process-output-router.ts`)
+- **See:** Issue [#664](https://github.com/ms2sato/agent-console/issues/664), router [`packages/server/src/services/process-output-router.ts`](../packages/server/src/services/process-output-router.ts)
 
 ### SystemEvent
 The top-level event format representing meaningful occurrences in the system.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -118,10 +118,15 @@ A registered shell-condition + interval that the server polls silently and notif
 - **See:** Issue [#700](https://github.com/ms2sato/agent-console/issues/700), MCP tools `create_conditional_wakeup` / `delete_conditional_wakeup`
 - **Contrast:** [Timer](#timer) (fires on interval regardless of state)
 
+### Inter-Session Messaging
+File-based message delivery channel between sessions. Used by the `send_session_message` MCP tool for explicit cross-session consultations and by `outputMode: "message"` of `run_process` to route long-form script stdout and `write_process_response` content to the calling session/worker without flooding the recipient PTY.
+- **Aliases:** inter-session messaging, inter-session message files, inter-session message service, InterSessionMessageService, inter-session-message-service
+- **See:** [Inter-Session Messaging design](design/inter-session-messaging.md), implementation `packages/server/src/services/inter-session-message-service.ts`, MCP tool `send_session_message`, [outputMode](#outputmode)
+
 ### outputMode
 Parameter on the `run_process` MCP tool that selects how the script's stdout and `write_process_response` content are delivered to the calling agent. Two modes:
 - `"pty"` (default): the script's stdout is delivered as a `[internal:process]` PTY notification carrying the full content; `write_process_response` echoes content directly to the worker PTY. Existing behavior, backward-compatible with all prior `run_process` callers.
-- `"message"`: the script's stdout is captured and routed through `InterSessionMessageService` (file-based, see `packages/server/src/services/inter-session-message-service.ts`) to the calling session/worker; `write_process_response` content is delivered through the same channel after stdin write succeeds. PTY receives only a brief `[stdout via message] path=… bytes=…` / `[response via message] …` notification per chunk so the owner retains progress visibility without the conversation being flooded by long-form Q&A. Designed for long interactive scripts (e.g., `.claude/skills/orchestrator/acceptance-check.js`, `sprint-retro.js`).
+- `"message"`: the script's stdout is captured and routed through [Inter-Session Messaging](#inter-session-messaging) to the calling session/worker; `write_process_response` content is delivered through the same channel after stdin write succeeds. PTY receives only a brief `[stdout via message] path=… bytes=…` / `[response via message] …` notification per chunk so the owner retains progress visibility without the conversation being flooded by long-form Q&A. Designed for long interactive scripts (e.g., `.claude/skills/orchestrator/acceptance-check.js`, `sprint-retro.js`).
 - **Aliases:** output mode, run_process outputMode
 - **See:** Issue [#664](https://github.com/ms2sato/agent-console/issues/664), router (`packages/server/src/services/process-output-router.ts`)
 


### PR DESCRIPTION
## Summary
- Add `### Inter-Session Messaging` entry under `Events & Communication` in `docs/glossary.md`, with the alias surface forms collected from a repository audit (`grep -irn "inter-session\|InterSessionMessage" docs/ packages/ .claude/`).
- Cleanup: the existing `outputMode` entry's `"message"` mode previously linked directly to the implementation file (`inter-session-message-service.ts`). It now links to the new `Inter-Session Messaging` glossary entry, which keeps the implementation reference at one canonical hop.

## Audit findings (descriptive only, no renames)
Surface forms used across the repo, all kept as documented aliases:
- `Inter-Session Messaging` (design doc title, narrative refs)
- `inter-session messaging`, `inter-session message files`, `inter-session message service` (prose / comments)
- `inter-session-message-service` (file/module name, logger name)
- `InterSessionMessageService` / `interSessionMessageService` (class / property)

## Test plan
- [x] `bun run check:lang` exit 0
- [x] `coderabbit review --agent --base main` — 0 findings
- [ ] CI rollup green

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)