### PR TITLE
feat: commit-msg hook for language check (closes #719)

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -246,14 +246,15 @@ This rule does not apply to design docs under `docs/design/` where architectural
 
 `scripts/check-public-artifacts-language.mjs` is the canonical check. It scans `CLAUDE.md`, `docs/**/*.md`, `.claude/rules/**/*.md`, `.claude/skills/**/*.md`, and `.claude/agents/**/*.md` for any Letter character (`\p{L}`) that is not in the Latin / Greek / Cyrillic scripts. The detection is language-agnostic: it does not hard-code Japanese or any other writing system, so adding a new public artifact in any other script (Han, Hangul, Arabic, Hebrew, Devanagari, Thai, ...) fails the same way.
 
-The check runs at four points:
+The check runs at five points:
 
 1. **Local (any time):** `bun run check:lang` — quick ad-hoc verification.
-2. **Pre-PR preflight:** `node .claude/skills/orchestrator/preflight-check.js` — runs the language check alongside the test-coverage and rule-skill-duplication invariants. Non-zero exit blocks PR readiness.
-3. **CI:** `.github/workflows/language-lint.yml` — fires on changes under `docs/`, `.claude/`, and any `*.md`. Failure blocks merge.
-4. **Acceptance Q11:** `.claude/skills/orchestrator/acceptance-check.js` — auto-detects the verdict and asks the Orchestrator to confirm before merge.
+2. **Commit-msg git hook (recommended setup):** `bun run hooks:install` installs `scripts/git-hooks/commit-msg` into the repository's hooks directory (idempotent, symlink with copy fallback). The hook pipes the prepared commit message through the language check in stdin mode and rejects the commit on any violation. This is opt-in but strongly recommended — it surfaces commit-message violations at commit time, before push, while the CI / preflight gates only scan files. The hook resolves the script path via `git rev-parse --show-toplevel`, so it works correctly across linked worktrees once installed once at the common hooks dir.
+3. **Pre-PR preflight:** `node .claude/skills/orchestrator/preflight-check.js` — runs the language check alongside the test-coverage and rule-skill-duplication invariants. Non-zero exit blocks PR readiness.
+4. **CI:** `.github/workflows/language-lint.yml` — fires on changes under `docs/`, `.claude/`, and any `*.md`. Failure blocks merge.
+5. **Acceptance Q11:** `.claude/skills/orchestrator/acceptance-check.js` — auto-detects the verdict and asks the Orchestrator to confirm before merge.
 
-Output format is consistent across all four entry points: `file:LINE:COL CHAR U+CODEPOINT`, one line per violation.
+Output format is consistent across all entry points: `file:LINE:COL CHAR U+CODEPOINT`, one line per violation. The commit-msg hook reports violations under the virtual filename `<stdin>`.
 
 ## Claude Code on the Web (Remote Environment)
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:scripts": "bun test scripts/",
     "test:coverage": "bun run --filter '*' test:coverage",
     "check:lang": "bun scripts/check-public-artifacts-language.mjs",
+    "hooks:install": "bun scripts/install-hooks.mjs",
     "lint": "bun run lint:structure",
     "lint:structure": "bun run lint:deps && bun run lint:cycles && bun run lint:unused",
     "lint:deps": "depcruise --config .dependency-cruiser.cjs --ignore-known .dependency-cruiser-known-violations.json packages",

--- a/scripts/__tests__/check-public-artifacts-language.test.mjs
+++ b/scripts/__tests__/check-public-artifacts-language.test.mjs
@@ -1,14 +1,22 @@
 import { describe, it, expect } from 'bun:test';
+import { spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
+  checkStdinText,
   findViolationsInText,
   findDefaultFiles,
   findViolationsInFile,
   formatFileViolations,
   runCheck,
 } from '../check-public-artifacts-language.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const SCRIPT_PATH = resolve(REPO_ROOT, 'scripts/check-public-artifacts-language.mjs');
+const HOOK_PATH = resolve(REPO_ROOT, 'scripts/git-hooks/commit-msg');
 
 describe('findViolationsInText — allowed cases', () => {
   it('returns no violations for empty string', () => {
@@ -280,5 +288,149 @@ describe('findDefaultFiles + runCheck (integration with a temp tree)', () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe('checkStdinText (pure function — stdin-mode core)', () => {
+  it('returns no violations for empty input (vacuous truth boundary)', () => {
+    const result = checkStdinText('');
+    expect(result.violations).toEqual([]);
+    expect(result.lines).toEqual([]);
+  });
+
+  it('returns no violations for pure ASCII single-line commit-msg', () => {
+    const result = checkStdinText('feat: add commit-msg hook for language check\n');
+    expect(result.violations).toEqual([]);
+    expect(result.lines).toEqual([]);
+  });
+
+  it('flags a single non-Latin character with the <stdin> label', () => {
+    const result = checkStdinText('日');
+    expect(result.lines).toEqual(['<stdin>:1:1 日 U+65E5']);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].file).toBe('<stdin>');
+  });
+
+  it('flags multiple non-Latin characters across lines', () => {
+    const result = checkStdinText('feat: 機能 add\nfix bug 修正\n');
+    expect(result.lines).toEqual([
+      '<stdin>:1:7 機 U+6A5F',
+      '<stdin>:1:8 能 U+80FD',
+      '<stdin>:2:9 修 U+4FEE',
+      '<stdin>:2:10 正 U+6B63',
+    ]);
+  });
+
+  it('honors a custom label override', () => {
+    const result = checkStdinText('日', { label: '<commit-msg>' });
+    expect(result.lines).toEqual(['<commit-msg>:1:1 日 U+65E5']);
+  });
+});
+
+function runScriptStdin(input) {
+  return spawnSync('bun', [SCRIPT_PATH, '--stdin'], {
+    input,
+    encoding: 'utf8',
+    cwd: REPO_ROOT,
+  });
+}
+
+describe('check-public-artifacts-language.mjs --stdin (subprocess)', () => {
+  it('exit 0 with no output for empty stdin', () => {
+    const result = runScriptStdin('');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('exit 0 for pure ASCII single-line commit-msg', () => {
+    const result = runScriptStdin('feat: add commit-msg hook for language check\n');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('exit 1 with one violation line for a single non-Latin character', () => {
+    const result = runScriptStdin('日');
+    expect(result.status).toBe(1);
+    expect(result.stdout.trim()).toBe('<stdin>:1:1 日 U+65E5');
+    expect(result.stderr).toContain('FAIL');
+  });
+
+  it('exit 1 listing all violations across multiple lines', () => {
+    const result = runScriptStdin('feat: 機能 add\nfix bug 修正\n');
+    expect(result.status).toBe(1);
+    const lines = result.stdout.trim().split('\n');
+    expect(lines).toEqual([
+      '<stdin>:1:7 機 U+6A5F',
+      '<stdin>:1:8 能 U+80FD',
+      '<stdin>:2:9 修 U+4FEE',
+      '<stdin>:2:10 正 U+6B63',
+    ]);
+  });
+
+  it('regression — file-mode behavior is unchanged when --stdin is absent', () => {
+    const root = mkdtempSync(join(tmpdir(), 'lang-check-stdin-regression-'));
+    try {
+      writeFileSync(join(root, 'docs.md'), 'feat: 日本\n');
+      const result = spawnSync('bun', [SCRIPT_PATH, 'docs.md'], {
+        encoding: 'utf8',
+        cwd: root,
+      });
+      expect(result.status).toBe(1);
+      const lines = result.stdout.trim().split('\n');
+      expect(lines).toEqual([
+        'docs.md:1:7 日 U+65E5',
+        'docs.md:1:8 本 U+672C',
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function runHookWithFile(input) {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'commit-msg-hook-'));
+  const msgPath = join(tmpDir, 'COMMIT_EDITMSG');
+  writeFileSync(msgPath, input);
+  try {
+    return spawnSync(HOOK_PATH, [msgPath], {
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+    });
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe('scripts/git-hooks/commit-msg (shell hook)', () => {
+  it('exit 0 for empty commit-msg file', () => {
+    const result = runHookWithFile('');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('exit 0 for pure ASCII commit-msg', () => {
+    const result = runHookWithFile('feat: add commit-msg hook for language check\n');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('exit 1 with violation line for non-Latin commit-msg', () => {
+    const result = runHookWithFile('feat: 日本語のメッセージ\n');
+    expect(result.status).toBe(1);
+    const stdoutLines = result.stdout.trim().split('\n');
+    expect(stdoutLines[0]).toMatch(/^<stdin>:1:7 . U\+[0-9A-F]+$/);
+    expect(stdoutLines.length).toBeGreaterThan(1);
+  });
+
+  it('exit 1 listing all violations across multiple lines', () => {
+    const result = runHookWithFile('feat: 機能 add\nfix bug 修正\n');
+    expect(result.status).toBe(1);
+    const lines = result.stdout.trim().split('\n');
+    expect(lines).toEqual([
+      '<stdin>:1:7 機 U+6A5F',
+      '<stdin>:1:8 能 U+80FD',
+      '<stdin>:2:9 修 U+4FEE',
+      '<stdin>:2:10 正 U+6B63',
+    ]);
   });
 });

--- a/scripts/__tests__/install-hooks.test.mjs
+++ b/scripts/__tests__/install-hooks.test.mjs
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  copyFileSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const INSTALL_SCRIPT = resolve(REPO_ROOT, 'scripts/install-hooks.mjs');
+const SOURCE_HOOK = resolve(REPO_ROOT, 'scripts/git-hooks/commit-msg');
+
+/**
+ * Run install-hooks.mjs in a sandbox repo so the test never touches the
+ * real .git/hooks directory. We bootstrap a minimal Git repo, copy our
+ * source hook into a fixture path, and override GIT_DIR so that
+ * `git rev-parse --git-path hooks` resolves inside the sandbox.
+ */
+function runInstaller(sandboxRoot, hookSource) {
+  return spawnSync('bun', [INSTALL_SCRIPT], {
+    encoding: 'utf8',
+    cwd: sandboxRoot,
+    env: {
+      ...process.env,
+      GIT_DIR: join(sandboxRoot, '.git'),
+    },
+  });
+}
+
+describe('scripts/install-hooks.mjs', () => {
+  let sandbox;
+  let hooksDir;
+
+  beforeEach(() => {
+    sandbox = mkdtempSync(join(tmpdir(), 'install-hooks-'));
+    // Make the sandbox look like a worktree of an existing repo: scripts/
+    // dir with the hook source, and a .git directory we control.
+    mkdirSync(join(sandbox, 'scripts/git-hooks'), { recursive: true });
+    copyFileSync(SOURCE_HOOK, join(sandbox, 'scripts/git-hooks/commit-msg'));
+    chmodSync(join(sandbox, 'scripts/git-hooks/commit-msg'), 0o755);
+    spawnSync('git', ['init', '-q', '-b', 'main'], { cwd: sandbox });
+    hooksDir = join(sandbox, '.git', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('fresh install creates a symlink to the source hook', () => {
+    const result = runInstaller(sandbox);
+    expect(result.status).toBe(0);
+    const target = join(hooksDir, 'commit-msg');
+    const stat = lstatSync(target);
+    expect(stat.isSymbolicLink()).toBe(true);
+    const link = readlinkSync(target);
+    // realpath both sides because tmpdir() can resolve through /var → /private/var
+    // on macOS while the script's `resolve()` keeps the unresolved form.
+    expect(realpathSync(resolve(hooksDir, link))).toBe(
+      realpathSync(resolve(sandbox, 'scripts/git-hooks/commit-msg')),
+    );
+  });
+
+  it('re-running on a correct symlink is idempotent', () => {
+    runInstaller(sandbox);
+    const result = runInstaller(sandbox);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('already installed (symlink)');
+  });
+
+  it('refuses to overwrite a symlink pointing elsewhere', () => {
+    const target = join(hooksDir, 'commit-msg');
+    const otherFile = join(sandbox, 'somewhere-else');
+    writeFileSync(otherFile, '#!/bin/sh\nexit 0\n');
+    symlinkSync(otherFile, target);
+    const result = runInstaller(sandbox);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('is a symlink to');
+  });
+
+  it('treats a same-content copy as already installed and normalizes mode (Major: CodeRabbit #725)', () => {
+    // Pre-populate the hooks dir with a copy of our source content but at
+    // mode 0644 — simulating a hand-edited install or a chmod -x mishap.
+    const target = join(hooksDir, 'commit-msg');
+    copyFileSync(join(sandbox, 'scripts/git-hooks/commit-msg'), target);
+    chmodSync(target, 0o644);
+    expect(lstatSync(target).mode & 0o111).toBe(0);
+
+    const result = runInstaller(sandbox);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('already installed (copy)');
+
+    // Mode must be normalized to executable so Git will run the hook.
+    expect(lstatSync(target).mode & 0o100).not.toBe(0);
+  });
+
+  it('refuses to overwrite a regular file with different content', () => {
+    const target = join(hooksDir, 'commit-msg');
+    writeFileSync(target, '#!/bin/sh\necho different\n');
+    chmodSync(target, 0o755);
+    const result = runInstaller(sandbox);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('exists with different content');
+  });
+
+  it('errors with a clear message when the source hook is missing', () => {
+    rmSync(join(sandbox, 'scripts/git-hooks/commit-msg'));
+    const result = runInstaller(sandbox);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('source missing');
+  });
+});

--- a/scripts/check-public-artifacts-language.mjs
+++ b/scripts/check-public-artifacts-language.mjs
@@ -22,6 +22,11 @@
  * Usage:
  *   bun scripts/check-public-artifacts-language.mjs
  *   bun scripts/check-public-artifacts-language.mjs path/to/file.md ...
+ *   bun scripts/check-public-artifacts-language.mjs --stdin < file.txt
+ *
+ * In --stdin mode, the input is treated as a single virtual file named
+ * `<stdin>` and reported using the same `<filename>:LINE:COL CHAR U+CODEPOINT`
+ * format. This mode powers the commit-msg git hook (see scripts/git-hooks/).
  */
 
 import { Glob } from 'bun';
@@ -146,8 +151,61 @@ export async function runCheck({ cwd = process.cwd(), files } = {}) {
   };
 }
 
+/**
+ * Read all of process.stdin as a UTF-8 string.
+ *
+ * @param {NodeJS.ReadableStream} [stream]
+ * @returns {Promise<string>}
+ */
+export async function readStreamAsText(stream = process.stdin) {
+  const chunks = [];
+  for await (const chunk of stream) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/**
+ * Scan a single text blob (typically a commit-msg file piped via stdin) and
+ * return per-line formatted violation lines plus a summary.
+ *
+ * Pure function — no I/O — so tests can exercise it directly without spawning
+ * a subprocess to feed stdin. The CLI wrapper layers I/O on top.
+ *
+ * @param {string} text
+ * @param {object} [options]
+ * @param {string} [options.label] virtual filename used in the output prefix (default: `<stdin>`)
+ * @returns {{ violations: Array<{file: string, line: number, col: number, char: string, codepoint: string}>, lines: string[] }}
+ */
+export function checkStdinText(text, { label = '<stdin>' } = {}) {
+  const found = findViolationsInText(text);
+  const violations = found.map((v) => ({ file: label, ...v }));
+  const lines = formatFileViolations(label, found);
+  return { violations, lines };
+}
+
+async function runStdinMode() {
+  const text = await readStreamAsText();
+  const { violations, lines } = checkStdinText(text);
+  if (violations.length === 0) return 0;
+  for (const line of lines) console.log(line);
+  console.error('');
+  console.error(
+    `FAIL — ${violations.length} violation${violations.length === 1 ? '' : 's'} in commit message / stdin input.`,
+  );
+  console.error(
+    'Commit messages and other public artifacts must be written in English. ' +
+      'See .claude/rules/workflow.md "Language Policy".',
+  );
+  return 1;
+}
+
 async function main(argv) {
-  const explicit = argv.slice(2).filter((a) => !a.startsWith('-'));
+  const args = argv.slice(2);
+  const useStdin = args.includes('--stdin');
+  if (useStdin) return runStdinMode();
+
+  const explicit = args.filter((a) => !a.startsWith('-'));
   const result = await runCheck({
     files: explicit.length > 0 ? explicit : undefined,
   });

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,0 +1,13 @@
+#!/bin/sh
+# commit-msg hook — language check for commit messages.
+#
+# Installed by `bun run hooks:install`. Pipes the prepared commit message
+# (path passed as $1) into scripts/check-public-artifacts-language.mjs in
+# stdin mode and rejects the commit on any violation.
+#
+# See .claude/rules/workflow.md "Language Policy" and Issue #719.
+
+set -e
+
+TOPLEVEL=$(git rev-parse --show-toplevel)
+exec bun "$TOPLEVEL/scripts/check-public-artifacts-language.mjs" --stdin <"$1"

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -69,6 +69,11 @@ function installOne({ name, source }, hooksDir) {
       const sourceContent = readFileSync(sourceAbs, 'utf8');
       const targetContent = readFileSync(target, 'utf8');
       if (sourceContent === targetContent) {
+        // Normalize the executable bit. Git ignores hooks that are not
+        // executable (e.g., the file was edited and re-saved with mode
+        // 0644), and the same-content shortcut would otherwise leave that
+        // broken state in place.
+        chmodSync(target, 0o755);
         console.log(`hooks:install — already installed (copy): ${target}`);
         return;
       }

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+
+/**
+ * Install Git hooks defined under scripts/git-hooks/ into the repository's
+ * hooks directory. Currently installs only `commit-msg` (the language check).
+ *
+ * Idempotent — safe to re-run. Resolves the hooks directory via
+ * `git rev-parse --git-path hooks` so it works correctly inside linked
+ * worktrees (which share the common dir's hooks/).
+ *
+ * Installation strategy: symlink first, copy on failure (per Issue #719).
+ * If the target already exists and matches our source (symlink target
+ * identical, or file content identical), the script reports "already
+ * installed" and exits 0. If it exists with different content, the script
+ * refuses to overwrite and asks the user to remove it explicitly.
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  symlinkSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const HOOKS = [{ name: 'commit-msg', source: 'scripts/git-hooks/commit-msg' }];
+
+function resolveHooksDir() {
+  const result = spawnSync('git', ['rev-parse', '--git-path', 'hooks'], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    console.error('hooks:install — `git rev-parse --git-path hooks` failed:');
+    console.error(result.stderr || '(no stderr)');
+    process.exit(1);
+  }
+  return resolve(result.stdout.trim());
+}
+
+function installOne({ name, source }, hooksDir) {
+  const sourceAbs = resolve(source);
+  if (!existsSync(sourceAbs)) {
+    console.error(`hooks:install — source missing: ${sourceAbs}`);
+    process.exit(1);
+  }
+  const target = join(hooksDir, name);
+  const stat = lstatSync(target, { throwIfNoEntry: false });
+
+  if (stat) {
+    if (stat.isSymbolicLink()) {
+      const link = readlinkSync(target);
+      const linkAbs = resolve(hooksDir, link);
+      if (linkAbs === sourceAbs) {
+        console.log(`hooks:install — already installed (symlink): ${target}`);
+        return;
+      }
+      console.error(
+        `hooks:install — ${target} is a symlink to ${linkAbs}, not ${sourceAbs}.`,
+      );
+      console.error(`Remove it manually and re-run: rm "${target}"`);
+      process.exit(1);
+    }
+    if (stat.isFile()) {
+      const sourceContent = readFileSync(sourceAbs, 'utf8');
+      const targetContent = readFileSync(target, 'utf8');
+      if (sourceContent === targetContent) {
+        console.log(`hooks:install — already installed (copy): ${target}`);
+        return;
+      }
+      console.error(
+        `hooks:install — ${target} exists with different content.`,
+      );
+      console.error(`Remove it manually and re-run: rm "${target}"`);
+      process.exit(1);
+    }
+    console.error(
+      `hooks:install — ${target} exists and is neither a symlink nor a regular file.`,
+    );
+    process.exit(1);
+  }
+
+  try {
+    symlinkSync(sourceAbs, target);
+    console.log(`hooks:install — symlinked ${target} -> ${sourceAbs}`);
+    return;
+  } catch (err) {
+    console.warn(
+      `hooks:install — symlink failed (${err?.code || err?.message || 'unknown'}), falling back to copy.`,
+    );
+  }
+  copyFileSync(sourceAbs, target);
+  chmodSync(target, 0o755);
+  console.log(`hooks:install — copied ${source} -> ${target}`);
+}
+
+function main() {
+  const hooksDir = resolveHooksDir();
+  mkdirSync(hooksDir, { recursive: true });
+  for (const hook of HOOKS) installOne(hook, hooksDir);
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds a `commit-msg` Git hook that rejects commits whose messages contain non-Latin/Greek/Cyrillic Letter characters. Closes the gap surfaced in Sprint 2026-04-28 #715 retrospective: file-based scans (CI / preflight / acceptance) cannot scan commit messages because they live outside the file system at scan time.

- New `--stdin` mode in `scripts/check-public-artifacts-language.mjs` reports violations under the virtual filename `<stdin>`.
- `scripts/git-hooks/commit-msg` (shell, executable) pipes `$1` through the script in stdin mode. Resolves the worktree via `git rev-parse --show-toplevel`, so a single install at the common hooks dir works across linked worktrees.
- `bun run hooks:install` (`scripts/install-hooks.mjs`) installs the hook idempotently — symlink first, copy on failure. Refuses to overwrite foreign content.
- `.claude/rules/workflow.md` Language Policy section now documents the hook as the recommended local setup (5th gate added to the existing 4-layer check).

## Design notes

- **Opt-in nudge gate, not a hard gate.** Hard gates remain: local `bun run check:lang`, preflight, CI, acceptance Q11. The hook only surfaces violations earlier (at commit time) for developers who install it.
- **Comment lines are not stripped.** Default `git commit` editor templates are pure ASCII English, so this does not generate false positives in practice. Localized templates are an unlikely edge case; if it surfaces, comment-stripping is a follow-up.
- **Worktree-aware.** Git's hooks dir is shared across linked worktrees. The hook is intentionally short and self-contained — its only path resolution is `git rev-parse --show-toplevel`, which returns the *current* worktree's root at commit time. So one installation works across all worktrees of the repo.

## Test plan

- [x] `bun run typecheck && bun run test` exit 0 (47 new + existing all pass; client 1361, shared 309, integration 29, server 2463, scripts 47)
- [x] `bun run check:lang` exit 0
- [x] `bun run hooks:install` — fresh install succeeds (symlink), re-run is idempotent
- [x] AC verification: `printf "feat: add hook\n" | scripts/git-hooks/commit-msg /dev/stdin` exit 0; `printf "test\n日本語\n" | scripts/git-hooks/commit-msg /dev/stdin` exit 1 with violations listed
- [x] This PR's own commit was authored with the freshly-installed hook engaged (real-device verification)
- [x] Boundary set covered by tests: empty stdin (vacuous truth), pure ASCII single-line, single non-Latin char, multi-line non-Latin, file-mode regression

## Note on CodeRabbit

Local CodeRabbit CLI rate-limited during this sprint. Relying on GitHub-side CodeRabbit bot review.

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)