### PR TITLE
refactor: rename coverage-check workflow to preflight

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -59,7 +59,7 @@ Before completing any code changes, always verify:
 A task or PR is "done" only when ALL of the following hold. Reporting "ready for merge" or "implementation complete" without all eight causes Orchestrator hand-hold cycles and erodes trust in completion reports.
 
 1. **Production code is implemented** — the feature / fix exists in the source tree.
-2. **Corresponding tests are added** — placed in the sibling `__tests__/` directory per `testing.md` "Test File Naming Convention" (production `path/to/foo.ts` → test `path/to/__tests__/foo.test.ts`). Parent-directory `__tests__/` placement does not satisfy `coverage-check`.
+2. **Corresponding tests are added** — placed in the sibling `__tests__/` directory per `testing.md` "Test File Naming Convention" (production `path/to/foo.ts` → test `path/to/__tests__/foo.test.ts`). Parent-directory `__tests__/` placement does not satisfy `preflight`.
 3. **Local verification passes** — `bun run typecheck && bun run test` exit 0, full suite paste per the Verification Checklist (Step 1 / Step 2 above).
 4. **Changes are committed** with conventional commit format (`type: description`) — see Commit Standards below.
 5. **Branch is pushed to origin**.
@@ -79,7 +79,7 @@ gh run view <run_id> --log-failed | tail -80
 
 Diagnostic steps:
 
-1. **Read the failure step** — typecheck, test, build, coverage-check, lint each have distinct failure shapes.
+1. **Read the failure step** — typecheck, test, build, preflight, lint each have distinct failure shapes.
 2. **Correlate with your changes** — does the failing file appear in your diff? Is the error message tied to a symbol you renamed / added / removed?
 3. **Compare to previous CI run on the same branch** — if the previous run passed, only your last commits could have caused the failure.
 4. **If the cause is genuinely opaque after the above**, ask the Orchestrator before pushing speculative fixes. Speculative pushes that only adjust adjacent code without identifying the root cause cycle CI for nothing.
@@ -87,7 +87,7 @@ Diagnostic steps:
 Common categories that look like "infra" but are actually code:
 
 - TypeScript error in a file the agent didn't realize they touched (e.g., a shared type rename propagated unexpectedly)
-- Missing test for a newly-added production file (preflight `coverage-check` failure with explicit "expected: …" path)
+- Missing test for a newly-added production file (`preflight` failure with explicit "expected: …" path)
 - Test fixture state divergence between local and CI (look for tests that pass locally but fail CI — usually local fixture leakage from a previous run)
 
 (Lesson: Sprint 2026-04-27 PR #703 — agent diagnosed a `TS2353 'getConditionalWakeupCleanupCallback' does not exist in type 'SessionDeletionDeps'` error as an "infra problem" and asked the Orchestrator how to investigate, when the type-definition file was in their own diff three lines away from the error site.)

--- a/.claude/skills/orchestrator/delegation-prompt.js
+++ b/.claude/skills/orchestrator/delegation-prompt.js
@@ -107,7 +107,7 @@ Quick reference (full details in the skill file):
 - **I-6 Boundary Validation** — external values validated with a schema before use.
 
 ## Test Placement (mandatory)
-For every production file you change or add, the corresponding test file **must** be placed in a sibling \`__tests__/\` directory at the same level — \`path/to/foo.ts\` → \`path/to/__tests__/foo.test.ts\`. Parent-directory placement (e.g., a test for \`services/inbound/foo.ts\` placed at \`services/__tests__/foo.test.ts\`) does **not** satisfy the \`coverage-check\` rule and will fail CI on first push. See \`testing.md\` "Test File Naming Convention".
+For every production file you change or add, the corresponding test file **must** be placed in a sibling \`__tests__/\` directory at the same level — \`path/to/foo.ts\` → \`path/to/__tests__/foo.test.ts\`. Parent-directory placement (e.g., a test for \`services/inbound/foo.ts\` placed at \`services/__tests__/foo.test.ts\`) does **not** satisfy the \`preflight\` rule and will fail CI on first push. See \`testing.md\` "Test File Naming Convention".
 
 ## Boundary Values (mandatory in tests)
 Per \`design-principles.md\` "Specify boundary values in design briefs", initial test sets must cover boundary inputs, not just the happy path. For each contract you implement (predicate, validator, classifier, aggregator, splitter, transformer), write tests for: empty input (\`length === 0\`), single element, all-success, all-failure, mixed terminal / non-terminal. **Vacuous truth** (\`[].every() === true\`, \`[].some() === false\`) is a recurring blind-spot.

--- a/.github/workflows/preflight-check.yml
+++ b/.github/workflows/preflight-check.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      # preflight-check.js spawns `bun` internally for the language-check helper.
+      # Required even though the script itself is invoked via `node`.
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/preflight-check.yml
+++ b/.github/workflows/preflight-check.yml
@@ -1,11 +1,11 @@
-name: Test Coverage Check
+name: Preflight Check
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
-  coverage-check:
+  preflight:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -27,16 +27,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          node .claude/skills/orchestrator/preflight-check.js ${{ github.event.pull_request.number }} > coverage-result.txt 2>&1 || true
-          cat coverage-result.txt
+          node .claude/skills/orchestrator/preflight-check.js ${{ github.event.pull_request.number }} > preflight-result.txt 2>&1 || true
+          cat preflight-result.txt
 
       - name: Post PR comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          header: test-coverage-check
-          path: coverage-result.txt
+          header: preflight-check
+          path: preflight-result.txt
 
-      - name: Fail if gaps detected
+      - name: Run preflight invariants
         env:
           GH_TOKEN: ${{ github.token }}
         run: node .claude/skills/orchestrator/preflight-check.js ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- `git mv .github/workflows/test-coverage-check.yml` → `preflight-check.yml`
- Workflow display name `Test Coverage Check` → `Preflight Check`; job `coverage-check` → `preflight`; step `Fail if gaps detected` → `Run preflight invariants`; artifact `coverage-result.txt` → `preflight-result.txt`; sticky-comment header `test-coverage-check` → `preflight-check`
- Updated active references in `.claude/rules/workflow.md` and `.claude/skills/orchestrator/delegation-prompt.js`. Sprint 2026-04-28 PR #716 historical narrative entries (referencing the old name in past-tense lesson context) intentionally preserved per task scope.

## Why
The script `preflight-check.js` invoked by this workflow now performs three invariants — test coverage + rule/skill duplication + public-artifacts language — so the workflow filename / job name `coverage-check` no longer reflect actual scope.

## Owner action required (branch protection)
**Branch protection rule update is admin-only.** After merge, please update the required-status-check rule on `main`: remove `coverage-check / coverage-check` (or whatever the previous required check is named) and add `preflight-check / preflight`. Otherwise, post-merge PRs will be missing the required check.

## Verification
- `bun run typecheck` exit 0
- `bun run test` exit 0 (client 1361 pass / shared 309 pass / integration 29 pass / server 2463 pass / scripts 33 pass — total ~4195 pass, 0 fail)
- `bun run check:lang` exit 0
- `coderabbit review --agent --base main` 1 minor finding (false positive — `setup-bun` is required because `preflight-check.js` spawns `bun` internally for the language-check helper, with explicit error messaging at `preflight-check.js:38`. Below MEDIUM threshold so does not block PR.)

## Test plan
- [ ] CI rollup green (`gh pr view <PR> --json statusCheckRollup`)
- [ ] Renamed workflow runs (`gh run list -R ms2sato/agent-console -w preflight-check.yml`)
- [ ] Owner updates branch-protection required-check name

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)