### PR TITLE
feat: PreToolUse hook to deny dangerous commands (closes #723)

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,122 @@
+# Claude Code hooks
+
+This directory contains hook scripts referenced by `.claude/settings.json`.
+Each hook is a single executable invoked by the Claude Code runtime at a
+specific lifecycle event; the runtime pipes the event JSON to stdin and acts
+on the script's stdout / exit code.
+
+## Hooks in this repository
+
+| Script                     | Event         | Matcher              | Purpose                                                           |
+| -------------------------- | ------------- | -------------------- | ----------------------------------------------------------------- |
+| `gh-setup.sh`              | `SessionStart`| (any)                | Install `gh` CLI on Claude Code on the Web                         |
+| `enforce-permissions.sh`   | `PreToolUse`  | `Bash\|Read\|Write\|Edit` | Reject catastrophic / credential-touching operations              |
+
+## `enforce-permissions.sh` policy
+
+The Claude Code runtime guarantees that **a `permissionDecision: "deny"`
+returned from a `PreToolUse` hook blocks the tool even in
+`--dangerously-skip-permissions` (bypassPermissions) mode**. We use this
+to mechanically block the small set of operations whose blast radius is
+catastrophic, while leaving everything else to the agent's normal
+confirmation flow.
+
+### Policy: deny strong, ask minimal
+
+This system spawns parallel Claude Code agents that routinely
+`git push` and `gh pr create`. Treating those as `ask` would defeat the
+parallelism the platform exists for. The hook therefore **never** returns
+an `ask` verdict — it either denies a known-dangerous pattern or stays
+out of the way.
+
+### Categories
+
+#### Article-aligned core (catastrophic verbs)
+
+| Pattern                                         | Why                          |
+| ----------------------------------------------- | ---------------------------- |
+| `rm -r{,f} / -f / --recursive / --force`        | Mass destruction             |
+| `sudo`                                          | Privilege escalation         |
+| `ssh <args>`                                    | Outbound shell to other host |
+| `dd if=… of=…`                                  | Block-level overwrite        |
+| `kill -9 / -KILL`                               | Forceful process kill        |
+
+#### Credential files (read AND write are denied)
+
+`.env`, `.env.<suffix>`, `.aws/`, `.ssh/`, `id_rsa*`, `*.pem`, `.gnupg/`.
+Reads are denied because exfiltration via `cat .env` is itself the
+attack; the hook treats any reference in a Bash command, or any
+Read/Write/Edit `file_path` matching the pattern, as deny.
+
+#### This-system specifics
+
+| Pattern                                         | Why                                                     |
+| ----------------------------------------------- | ------------------------------------------------------- |
+| `rm` / `find … -delete` inside `~/.agent-console/` | Production data directory of the platform               |
+| Direct write to `*.db`                          | SQLite production data file                             |
+| Direct edit to `.git/{refs,HEAD,hooks}`         | Bypasses git's own integrity guarantees                 |
+| `git push --force / -f / --force-with-lease`    | When the last token resolves to `main` or `master`      |
+| `git push origin :main` / `:master`             | Branch-deletion form                                    |
+
+### Bypass detection
+
+The hook normalises the command before pattern-matching:
+
+1. **Quote splitting** — strips single and double quotes so `'r''m' -rf`
+   collapses to `rm -rf` for detection. The actual command Claude Code is
+   about to run is unchanged.
+2. **`bash -c "<body>"` / `sh -c '<body>'`** — extracts the inner body
+   and includes it in the haystack so wrapped commands are also matched.
+3. **Pipe / xargs** — patterns are word-boundary-aware so
+   `echo /tmp/x | xargs rm -rf` is matched.
+
+The hook does **not** attempt to detect language-level bypass (e.g.
+`python -c "os.system('rm -rf /')"`). That class of evasion is out of
+scope; trying to cover it with regex produces false positives without
+meaningfully improving safety.
+
+### Fail-closed behaviour
+
+The script exits with code 2 (which Claude Code treats as a blocking
+error) when:
+
+- `jq` is not on `PATH`
+- stdin is empty
+- the JSON event cannot be parsed
+- `tool_name` is missing
+
+This means a misconfigured environment cannot silently allow dangerous
+operations. The trade-off is that you must keep `jq` installed; on
+macOS it ships with `brew install jq`, and on Claude Code on the Web it
+is pre-installed.
+
+### Tests
+
+Sibling tests live at
+`.claude/hooks/__tests__/enforce-permissions.test.mjs` and run as part
+of `bun run test` (via `test:scripts`). They pipe representative event
+JSON to the script and assert the verdict, including bypass-attempt
+cases and the fail-closed paths.
+
+## Adding a new hook
+
+1. Create the script under `.claude/hooks/<name>.sh`. Keep it
+   `set -u`-clean and `command -v <prereq> >/dev/null 2>&1 || exit 2`
+   for any external dependency (fail-closed).
+2. Add an executable bit (`chmod +x`).
+3. Register it in `.claude/settings.json` under the appropriate event
+   (`SessionStart` / `PreToolUse` / `PostToolUse` / `Stop` / `Notification`).
+4. Add sibling tests under `.claude/hooks/__tests__/` and verify they
+   are picked up by `bun run test:scripts`.
+5. Document the script in this README's "Hooks in this repository"
+   table.
+
+## Cross-project deployment
+
+This configuration is committed to the `agent-console` repository so
+every worktree spawned for development of this project (Orchestrator
+session and delegated agents alike) inherits the same denylist. To
+extend coverage to another repository, copy `.claude/settings.json`
+(its `PreToolUse` block) and `.claude/hooks/enforce-permissions.sh`
+into that repository's tree. Each repository's owner is responsible
+for tuning the denylist to their codebase.

--- a/.claude/hooks/__tests__/enforce-permissions.test.mjs
+++ b/.claude/hooks/__tests__/enforce-permissions.test.mjs
@@ -1,0 +1,251 @@
+import { describe, it, expect } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOOK = resolve(__dirname, '..', 'enforce-permissions.sh');
+
+function runHook(input, { env } = {}) {
+  const result = spawnSync('bash', [HOOK], {
+    input: typeof input === 'string' ? input : JSON.stringify(input),
+    encoding: 'utf-8',
+    env: { ...process.env, ...(env ?? {}) },
+  });
+  return {
+    exitCode: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function decision(stdout) {
+  if (!stdout.trim()) return null;
+  const parsed = JSON.parse(stdout);
+  return parsed?.hookSpecificOutput?.permissionDecision ?? null;
+}
+
+function reason(stdout) {
+  if (!stdout.trim()) return null;
+  const parsed = JSON.parse(stdout);
+  return parsed?.hookSpecificOutput?.permissionDecisionReason ?? null;
+}
+
+function bashEvent(command) {
+  return { tool_name: 'Bash', tool_input: { command } };
+}
+
+function fileEvent(tool_name, file_path) {
+  return { tool_name, tool_input: { file_path } };
+}
+
+describe('enforce-permissions: fail-closed', () => {
+  it('exits 2 on empty stdin', () => {
+    const r = runHook('');
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/empty stdin/);
+  });
+
+  it('exits 2 on malformed JSON', () => {
+    const r = runHook('not json {{');
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/parse failed/);
+  });
+
+  it('exits 2 when tool_name is missing', () => {
+    const r = runHook({ tool_input: { command: 'ls' } });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/tool_name missing/);
+  });
+});
+
+describe('enforce-permissions: allow path (no rules matched)', () => {
+  it.each([
+    ['Bash: ls', bashEvent('ls -la')],
+    ['Bash: git status', bashEvent('git status')],
+    ['Bash: git push feature branch', bashEvent('git push origin feature/foo')],
+    ['Bash: git push --force feature branch', bashEvent('git push --force origin feature/main-fix')],
+    ['Bash: bun run test', bashEvent('bun run test')],
+    ['Bash: gh pr create', bashEvent('gh pr create --title "feat: x" --body "..."')],
+    ['Read: source file', fileEvent('Read', '/repo/packages/server/src/foo.ts')],
+    ['Write: source file', fileEvent('Write', '/repo/packages/server/src/foo.ts')],
+    ['Edit: doc file', fileEvent('Edit', '/repo/docs/glossary.md')],
+    ['unknown tool', { tool_name: 'WebFetch', tool_input: {} }],
+  ])('%s → allow (exit 0, no decision)', (_label, event) => {
+    const r = runHook(event);
+    expect(r.exitCode).toBe(0);
+    expect(decision(r.stdout)).toBeNull();
+  });
+});
+
+describe('enforce-permissions: Bash deny — article-aligned core', () => {
+  it.each([
+    ['rm -rf /tmp/x', 'rm with recursive/force flag'],
+    ['rm -fr /tmp/x', 'rm with recursive/force flag'],
+    ['rm --recursive /tmp/x', 'rm with recursive/force flag'],
+    ['rm --force foo', 'rm with recursive/force flag'],
+    ['sudo whoami', 'sudo'],
+    ['ssh user@host', 'ssh'],
+    ['dd if=/dev/zero of=/tmp/x bs=1M', 'dd with if=/of='],
+    ['kill -9 1234', 'kill -9'],
+    ['kill -KILL 1234', 'kill -9'],
+  ])('denies: %s', (command, expectedReasonFragment) => {
+    const r = runHook(bashEvent(command));
+    expect(r.exitCode).toBe(0);
+    expect(decision(r.stdout)).toBe('deny');
+    expect(reason(r.stdout)).toContain(expectedReasonFragment);
+  });
+});
+
+describe('enforce-permissions: Bash deny — bypass detection', () => {
+  it("collapses single-quote splitting ('r''m' -rf → rm -rf)", () => {
+    const r = runHook(bashEvent("'r''m' -rf /tmp/x"));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('collapses double-quote splitting ("r""m" -rf → rm -rf)', () => {
+    const r = runHook(bashEvent('"r""m" -rf /tmp/x'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('catches xargs rm pipeline (echo /tmp/x | xargs rm -rf)', () => {
+    const r = runHook(bashEvent('echo /tmp/x | xargs rm -rf'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('catches bash -c "rm -rf ..." inner body', () => {
+    const r = runHook(bashEvent('bash -c "rm -rf /tmp/x"'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it("catches sh -c 'rm -rf ...' inner body", () => {
+    const r = runHook(bashEvent("sh -c 'rm -rf /tmp/x'"));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+});
+
+describe('enforce-permissions: Bash deny — credential files', () => {
+  it.each([
+    'cat .env',
+    'cat .env.production',
+    'cp .env /tmp/x',
+    'cat ~/.aws/credentials',
+    'ls ~/.ssh/',
+    'cat ~/.ssh/id_rsa',
+    'cat ~/.ssh/id_rsa_personal',
+    'cat /Users/foo/cert.pem',
+    'tar c ~/.gnupg/',
+  ])('denies credential reference: %s', (command) => {
+    const r = runHook(bashEvent(command));
+    expect(decision(r.stdout)).toBe('deny');
+    expect(reason(r.stdout)).toMatch(/credential/);
+  });
+});
+
+describe('enforce-permissions: Bash deny — this-system specifics', () => {
+  it('denies wiping ~/.agent-console/', () => {
+    const r = runHook(bashEvent('rm -rf ~/.agent-console/'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('denies find -delete inside ~/.agent-console/', () => {
+    const r = runHook(bashEvent('find ~/.agent-console -name "*.log" -delete'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('denies direct write to .git/HEAD', () => {
+    const r = runHook(bashEvent('echo "ref: refs/heads/x" > .git/HEAD'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('denies rm inside .git/refs', () => {
+    const r = runHook(bashEvent('rm .git/refs/heads/main'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('denies git push --force to main', () => {
+    const r = runHook(bashEvent('git push --force origin main'));
+    expect(decision(r.stdout)).toBe('deny');
+    expect(reason(r.stdout)).toMatch(/force.*main\/master/);
+  });
+
+  it('denies git push -f to master', () => {
+    const r = runHook(bashEvent('git push -f origin master'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('denies git push --force-with-lease to main', () => {
+    const r = runHook(bashEvent('git push --force-with-lease origin main'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('denies git push origin :main (branch deletion)', () => {
+    const r = runHook(bashEvent('git push origin :main'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('allows git push --force to feature/main-fix (last token differs)', () => {
+    const r = runHook(bashEvent('git push --force origin feature/main-fix'));
+    expect(decision(r.stdout)).toBeNull();
+  });
+});
+
+describe('enforce-permissions: Read/Write/Edit deny — credential paths', () => {
+  it.each([
+    ['Read', '/repo/.env'],
+    ['Read', '/repo/.env.local'],
+    ['Read', '/Users/foo/.aws/credentials'],
+    ['Read', '/Users/foo/.ssh/id_rsa'],
+    ['Read', '/Users/foo/.ssh/id_rsa.pub'],
+    ['Read', '/etc/cert.pem'],
+    ['Write', '/repo/.env'],
+    ['Edit', '/Users/foo/.ssh/config'],
+    ['Edit', '/Users/foo/.gnupg/pubring.kbx'],
+  ])('%s %s → deny', (toolName, filePath) => {
+    const r = runHook(fileEvent(toolName, filePath));
+    expect(decision(r.stdout)).toBe('deny');
+    expect(reason(r.stdout)).toMatch(/credential/);
+  });
+});
+
+describe('enforce-permissions: Read/Write/Edit deny — this-system specifics', () => {
+  it('denies Write to *.db', () => {
+    const r = runHook(fileEvent('Write', '/repo/data/agent-console.db'));
+    expect(decision(r.stdout)).toBe('deny');
+    expect(reason(r.stdout)).toMatch(/SQLite/);
+  });
+
+  it('allows Read of *.db', () => {
+    const r = runHook(fileEvent('Read', '/repo/data/agent-console.db'));
+    expect(decision(r.stdout)).toBeNull();
+  });
+
+  it('denies Write to .git/refs/heads/main', () => {
+    const r = runHook(fileEvent('Write', '/repo/.git/refs/heads/main'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('denies Edit to .git/HEAD', () => {
+    const r = runHook(fileEvent('Edit', '/repo/.git/HEAD'));
+    expect(decision(r.stdout)).toBe('deny');
+  });
+
+  it('allows Read of .git/HEAD (diagnostics)', () => {
+    const r = runHook(fileEvent('Read', '/repo/.git/HEAD'));
+    expect(decision(r.stdout)).toBeNull();
+  });
+});
+
+describe('enforce-permissions: Bash empty input handling', () => {
+  it('allows Bash with empty command (defensive — no command means nothing to run)', () => {
+    const r = runHook({ tool_name: 'Bash', tool_input: { command: '' } });
+    expect(r.exitCode).toBe(0);
+    expect(decision(r.stdout)).toBeNull();
+  });
+
+  it('allows Bash with missing tool_input', () => {
+    const r = runHook({ tool_name: 'Bash' });
+    expect(r.exitCode).toBe(0);
+    expect(decision(r.stdout)).toBeNull();
+  });
+});

--- a/.claude/hooks/enforce-permissions.sh
+++ b/.claude/hooks/enforce-permissions.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# PreToolUse hook for Claude Code. Even in --dangerously-skip-permissions
+# mode, a permissionDecision: "deny" returned by a PreToolUse hook blocks
+# the tool. We use this to mechanically reject catastrophic /
+# credential-touching operations regardless of the agent's interactive
+# confirmations.
+#
+# Policy: deny strong, ask minimal. This system spawns parallel agents that
+# routinely git push and gh pr create; ask-prompts on those would defeat
+# the platform's parallelism. Therefore the hook never returns "ask" — it
+# either denies a known-dangerous pattern or stays out of the way.
+#
+# I/O contract:
+#   stdin  : Claude Code PreToolUse JSON event
+#            (tool_name + tool_input)
+#   stdout : on deny, a single JSON object:
+#            {"hookSpecificOutput": {
+#               "hookEventName": "PreToolUse",
+#               "permissionDecision": "deny",
+#               "permissionDecisionReason": "<short reason>"}}
+#   stderr : on fail-closed, a single human-readable error line
+#   exit 0 : allow OR deny (deny is conveyed via stdout JSON)
+#   exit 2 : fail-closed (jq missing, empty input, parse failure)
+
+set -u
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+fail_closed() {
+  printf 'enforce-permissions: %s (fail-closed)\n' "$1" >&2
+  exit 2
+}
+
+# Emit deny verdict on stdout and exit 0 (Claude Code blocks the tool).
+deny() {
+  jq -nc --arg reason "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+}
+
+# Quote-stripping normalization so 'r''m' / "r""m" collapse to rm before
+# pattern matching. The normalized string is for *detection only*; the
+# actual command Claude Code is about to run is unchanged.
+normalize_quotes() {
+  printf '%s' "$1" | tr -d "'" | tr -d '"'
+}
+
+# Extract the body of the *first* `bash -c "<body>"` (or 'sh -c "<body>"`)
+# call so we can scan its inner command. If none, prints empty.
+extract_bash_c_body() {
+  printf '%s' "$1" | sed -nE "s/.*\\b(bash|sh)[[:space:]]+-c[[:space:]]+['\"]([^'\"]*)['\"].*/\\2/p"
+}
+
+# Produce the haystack we grep against: original + quote-stripped + bash -c
+# body. Doing all three lets a single pattern match cover quote-bypass and
+# bash -c wrapping.
+build_haystack() {
+  local cmd="$1"
+  local stripped
+  local inner
+  stripped=$(normalize_quotes "$cmd")
+  inner=$(extract_bash_c_body "$cmd")
+  printf '%s\n%s\n%s\n' "$cmd" "$stripped" "$inner"
+}
+
+# Last whitespace-separated token in a string (for `git push ... <ref>`).
+last_token() {
+  printf '%s' "$1" | awk '{print $NF}'
+}
+
+# -----------------------------------------------------------------------------
+# Fail-closed prerequisites
+# -----------------------------------------------------------------------------
+
+command -v jq >/dev/null 2>&1 || fail_closed "jq not found in PATH"
+
+INPUT=$(cat)
+[ -n "$INPUT" ] || fail_closed "empty stdin"
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) \
+  || fail_closed "JSON parse failed"
+[ -n "$TOOL_NAME" ] || fail_closed "tool_name missing in event"
+
+# -----------------------------------------------------------------------------
+# Bash: command-string inspection
+# -----------------------------------------------------------------------------
+
+if [ "$TOOL_NAME" = "Bash" ]; then
+  CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) \
+    || fail_closed "Bash command parse failed"
+
+  HAY=$(build_haystack "$CMD")
+  STRIPPED=$(normalize_quotes "$CMD")
+
+  # --- Article-aligned core: catastrophic Unix verbs ---
+  if printf '%s' "$HAY" | grep -qE '\brm[[:space:]]+(-[a-zA-Z]*[rRf]|--recursive|--force)'; then
+    deny "rm with recursive/force flag is denied (alert-fatigue guard)"
+  fi
+  if printf '%s' "$HAY" | grep -qE '\bsudo\b'; then
+    deny "sudo is denied"
+  fi
+  if printf '%s' "$HAY" | grep -qE '\bssh\b[[:space:]]'; then
+    deny "ssh is denied"
+  fi
+  if printf '%s' "$HAY" | grep -qE '\bdd[[:space:]]+(if|of)='; then
+    deny "dd with if=/of= is denied"
+  fi
+  if printf '%s' "$HAY" | grep -qE '\bkill[[:space:]]+(-9|-KILL)\b'; then
+    deny "kill -9 is denied"
+  fi
+
+  # --- Credential-file touching (read OR write — both are leak vectors) ---
+  # Note: \b is unreliable when the boundary is between two non-word chars
+  # (e.g., space-then-dot before `.env`). Use explicit
+  # (^|[^A-Za-z0-9_]) anchors so the pattern matches in real shells.
+  if printf '%s' "$HAY" | grep -qE '(^|[^A-Za-z0-9_])(\.env(\.[A-Za-z0-9_-]+)?|\.aws/|\.ssh/|id_rsa[A-Za-z0-9_.-]*|\.gnupg/)'; then
+    deny "operation references credential files (.env*, .aws/, .ssh/, id_rsa*, .gnupg/)"
+  fi
+  if printf '%s' "$HAY" | grep -qE '\.pem([^A-Za-z0-9_]|$)'; then
+    deny "operation references *.pem credential file"
+  fi
+
+  # --- ~/.agent-console/ subtree wipes ---
+  if printf '%s' "$HAY" | grep -qE '\b(rm|rmdir|find)\b[^|]*\.agent-console(/|\b)'; then
+    deny "modifying ~/.agent-console/ via rm/rmdir/find is denied (production data dir)"
+  fi
+
+  # --- .git/{refs,HEAD,hooks} direct edits ---
+  if printf '%s' "$HAY" | grep -qE '\.git/(refs|HEAD|hooks)([/[:space:]]|$)'; then
+    if printf '%s' "$HAY" | grep -qE '(\brm\b|>>?[[:space:]]*[^|]*\.git/|\btee\b[^|]*\.git/|\bcp\b[^|]*\.git/|\bmv\b[^|]*\.git/)'; then
+      deny "direct edits under .git/{refs,HEAD,hooks} are denied"
+    fi
+  fi
+
+  # --- git push --force to main/master (and branch deletion) ---
+  if printf '%s' "$STRIPPED" | grep -qE '^[[:space:]]*git[[:space:]]+push([[:space:]]|$)'; then
+    if printf '%s' "$STRIPPED" | grep -qE '(^|[[:space:]])(-f|--force|--force-[a-z-]+)([[:space:]]|$)'; then
+      LAST=$(last_token "$STRIPPED")
+      if printf '%s' "$LAST" | grep -qE '^([A-Za-z0-9._-]+/)?(main|master)$'; then
+        deny "git push --force to main/master is denied (per workflow.md gating)"
+      fi
+    fi
+    # branch deletion :main / :master
+    if printf '%s' "$STRIPPED" | grep -qE '(^|[[:space:]]):(main|master)([[:space:]]|$)'; then
+      deny "git push deleting main/master is denied"
+    fi
+  fi
+
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Read / Write / Edit: file_path inspection
+# -----------------------------------------------------------------------------
+
+if [ "$TOOL_NAME" = "Read" ] || [ "$TOOL_NAME" = "Write" ] || [ "$TOOL_NAME" = "Edit" ]; then
+  FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) \
+    || fail_closed "${TOOL_NAME} file_path parse failed"
+
+  # Credential-file paths (deny on any of Read/Write/Edit).
+  if printf '%s' "$FILE_PATH" | grep -qE '(/|^)(\.env(\.[A-Za-z0-9_-]+)?|\.aws/|\.ssh/|\.gnupg/)|id_rsa[A-Za-z0-9_.-]*|\.pem$'; then
+    deny "access to credential files is denied"
+  fi
+
+  # *.db direct write (Read is fine for diagnostics).
+  if [ "$TOOL_NAME" != "Read" ] && printf '%s' "$FILE_PATH" | grep -qE '\.db$'; then
+    deny "direct write to *.db files is denied (SQLite production data)"
+  fi
+
+  # .git/{refs,HEAD,hooks} writes.
+  if [ "$TOOL_NAME" != "Read" ] && printf '%s' "$FILE_PATH" | grep -qE '(/|^)\.git/(refs|HEAD|hooks)(/|$)'; then
+    deny "direct edits under .git/{refs,HEAD,hooks} are denied"
+  fi
+
+  exit 0
+fi
+
+# Unknown tool — out of scope, allow.
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Read|Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/enforce-permissions.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck": "bun run --filter '*' typecheck",
     "test": "bun run typecheck && bun run test:only",
     "test:only": "bun run --filter '*' test && bun run test:scripts",
-    "test:scripts": "bun test scripts/",
+    "test:scripts": "bun test scripts/ ./.claude/hooks/__tests__/",
     "test:coverage": "bun run --filter '*' test:coverage",
     "check:lang": "bun scripts/check-public-artifacts-language.mjs",
     "lint": "bun run lint:structure",


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/enforce-permissions.sh`, a `PreToolUse` hook registered for `Bash|Read|Write|Edit`. Per the official Claude Code spec, a `permissionDecision: "deny"` returned from a `PreToolUse` hook blocks the tool **even in `--dangerously-skip-permissions` (bypassPermissions) mode** — exactly the layer this repository needs because it spawns parallel Claude Code agents that run in that mode.
- Approach borrowed from https://zenn.dev/spectee/articles/0a1bd9cb320d31 (yamazaki / Spectee, 2026-04-27).
- Policy: **deny strong, ask minimal** — never returns `ask`, since the platform's premise is parallel agents that routinely `git push` / `gh pr create`. `ask` would defeat the parallelism.
- Tests live next to the script at `.claude/hooks/__tests__/enforce-permissions.test.mjs`. `package.json` `test:scripts` is extended to pick up the new directory; running `bun run test` exercises 61 hook-specific cases (94 total `scripts/` + hooks tests).

## Deny categories

| Category | Examples |
|---|---|
| **Article-aligned core** (catastrophic verbs) | `rm -r/-f/--recursive/--force`, `sudo`, `ssh <args>`, `dd if=…of=…`, `kill -9` |
| **Credential files** (read AND write are denied) | `.env*`, `.aws/`, `.ssh/`, `id_rsa*`, `*.pem`, `.gnupg/` |
| **This-system specifics** | subtree wipes of `~/.agent-console/`, direct write to `*.db` (SQLite), direct edits under `.git/{refs,HEAD,hooks}`, `git push --force` / `-f` / `--force-with-lease` / `origin :main` targeting `main` or `master` |

## Bypass detection

- Quote splitting: `'r''m' -rf` and `"r""m" -rf` are stripped so the underlying `rm -rf` is detected.
- `bash -c "<body>"` / `sh -c '<body>'` — inner body is extracted and added to the haystack.
- Pipe / `xargs`: `echo /tmp/x | xargs rm -rf` matches the `rm` pattern via word-boundary regex.

Out of scope: language-level evasion such as `python -c "os.system('rm -rf /')"`. Trying to cover that with regex produces false positives without meaningfully improving safety; documented in `.claude/hooks/README.md`.

## Fail-closed

The hook exits 2 (blocking error in Claude Code's contract) when:

- `jq` is not on `PATH`
- stdin is empty
- the JSON event cannot be parsed
- `tool_name` is missing

This means a misconfigured environment cannot silently allow dangerous operations.

## Boundary coverage (per `.claude/rules/design-principles.md`)

The hook script is a contract / classifier, so the test set explicitly covers:

- empty stdin, malformed JSON, missing `tool_name` → fail-closed (exit 2)
- empty Bash command, missing `tool_input` → allow (no command to run)
- happy-path allow: `ls`, `git status`, `bun run test`, `gh pr create`, source-file Read/Write/Edit, unknown tool name (`WebFetch`)
- every deny pattern in positive + bypass-attempt variants
- `git push --force origin feature/main-fix` → allow (last token differs from `main`/`master` even though `main` substring is present)
- Read of `*.db` and `.git/HEAD` → allow (diagnostics); Write/Edit of the same → deny

## Test plan

- [x] `bun run typecheck && bun run test` → exit 0 (TEST_EXIT: 0; client 1361 / shared 309 / integration 29 / server 2463 / scripts+hooks 94)
- [x] `bun run check:lang` exit 0
- [x] Hook-script local execution test on macOS (`scripts/git-hooks/commit-msg`-style spawn from the test file)
- [ ] CI rollup green (`gh pr view <PR> --json statusCheckRollup`)
- [ ] CodeRabbit GitHub-side bot review APPROVED

## Note on CodeRabbit

Local CodeRabbit CLI rate-limited during this sprint. Relying on GitHub-side CodeRabbit bot review per `.claude/rules/workflow.md` rate-limit fallback.

## Out of scope

- Forcing this hook into worktrees of other repositories the platform manages — each repository owner is responsible for their own `.claude/settings.json`.
- Cross-project distribution. Once this has run for a sprint and is stable, a follow-up PR will copy the configuration into the CTO Room repository (`conteditor`).

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)