### PR TITLE
fix: install-hooks symlink target uses main worktree root, not cwd (closes #728)

### DIFF
--- a/scripts/__tests__/install-hooks.test.mjs
+++ b/scripts/__tests__/install-hooks.test.mjs
@@ -121,4 +121,68 @@ describe('scripts/install-hooks.mjs', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('source missing');
   });
+
+  it('binds the symlink target to the main worktree, not cwd, when run from a linked worktree (Issue #728)', () => {
+    // Reproduces the original bug: install was run from a linked worktree, so
+    // `path.resolve(source)` (cwd-bound) embedded the worktree path into the
+    // symlink target. Removing the worktree silently disabled the hook.
+    const add = spawnSync('git', ['add', '.'], { cwd: sandbox, encoding: 'utf8' });
+    expect(add.status).toBe(0);
+    const commit = spawnSync(
+      'git',
+      [
+        '-c',
+        'user.email=test@example.com',
+        '-c',
+        'user.name=test',
+        'commit',
+        '-q',
+        '-m',
+        'init',
+      ],
+      { cwd: sandbox, encoding: 'utf8' },
+    );
+    expect(commit.status).toBe(0);
+
+    // git worktree add wants the destination to not exist yet.
+    const linkedWorktree = join(
+      tmpdir(),
+      `install-hooks-linked-${process.pid}-${Date.now()}`,
+    );
+    const addResult = spawnSync(
+      'git',
+      ['worktree', 'add', '-q', '-b', 'wt-test-728', linkedWorktree],
+      { cwd: sandbox, encoding: 'utf8' },
+    );
+    expect(addResult.status).toBe(0);
+
+    try {
+      // No GIT_DIR override — let git auto-detect via the linked worktree's
+      // .git pointer file, exactly as in the real bug scenario.
+      const result = spawnSync('bun', [INSTALL_SCRIPT], {
+        encoding: 'utf8',
+        cwd: linkedWorktree,
+      });
+      expect(result.status).toBe(0);
+
+      // Hooks dir is the shared common dir at <sandbox>/.git/hooks.
+      const target = join(hooksDir, 'commit-msg');
+      expect(lstatSync(target).isSymbolicLink()).toBe(true);
+      const link = readlinkSync(target);
+
+      // The symlink target must NOT mention the linked worktree path —
+      // that was the bug and the regression we are guarding against.
+      expect(link).not.toContain(linkedWorktree);
+
+      // Resolved, the symlink points to the main worktree's source.
+      expect(realpathSync(resolve(hooksDir, link))).toBe(
+        realpathSync(resolve(sandbox, 'scripts/git-hooks/commit-msg')),
+      );
+    } finally {
+      spawnSync('git', ['worktree', 'remove', '--force', linkedWorktree], {
+        cwd: sandbox,
+      });
+      rmSync(linkedWorktree, { recursive: true, force: true });
+    }
+  });
 });

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -26,9 +26,27 @@ import {
   readlinkSync,
   symlinkSync,
 } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 const HOOKS = [{ name: 'commit-msg', source: 'scripts/git-hooks/commit-msg' }];
+
+function resolveRepoRoot() {
+  const result = spawnSync('git', ['rev-parse', '--git-common-dir'], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    console.error(
+      'hooks:install — `git rev-parse --git-common-dir` failed:',
+    );
+    console.error(result.stderr || '(no stderr)');
+    process.exit(1);
+  }
+  // `.git` (relative) when run from the main worktree, absolute path to the
+  // shared `.git` when run from a linked worktree. Either way the parent
+  // directory is the main worktree root, which is the stable location that
+  // owns scripts/git-hooks/.
+  return dirname(resolve(result.stdout.trim()));
+}
 
 function resolveHooksDir() {
   const result = spawnSync('git', ['rev-parse', '--git-path', 'hooks'], {
@@ -42,8 +60,12 @@ function resolveHooksDir() {
   return resolve(result.stdout.trim());
 }
 
-function installOne({ name, source }, hooksDir) {
-  const sourceAbs = resolve(source);
+function installOne({ name, source }, hooksDir, repoRoot) {
+  // Resolve the source against the main worktree root rather than cwd.
+  // Issue #728: `resolve(source)` was cwd-bound, so running from a linked
+  // worktree embedded that ephemeral worktree's path into the symlink
+  // target, silently disabling the hook once the worktree was removed.
+  const sourceAbs = join(repoRoot, source);
   if (!existsSync(sourceAbs)) {
     console.error(`hooks:install — source missing: ${sourceAbs}`);
     process.exit(1);
@@ -104,9 +126,10 @@ function installOne({ name, source }, hooksDir) {
 }
 
 function main() {
+  const repoRoot = resolveRepoRoot();
   const hooksDir = resolveHooksDir();
   mkdirSync(hooksDir, { recursive: true });
-  for (const hook of HOOKS) installOne(hook, hooksDir);
+  for (const hook of HOOKS) installOne(hook, hooksDir, repoRoot);
 }
 
 main();


### PR DESCRIPTION
## Summary

Closes #728

`scripts/install-hooks.mjs` resolved the source path with `path.resolve(source)`, which is cwd-bound. Running the installer from a linked worktree (the normal #725 agent workflow) embedded that ephemeral worktree's path into the symlink target. After the worktree was removed the symlink dangled, and **git silently skips broken hooks** — disabling the language gate without any error.

This blocked cleanup of the #725 agent's worktree (`wt-006-ulve`).

## Fix — option (a) chosen

Resolve the source against the main worktree root via `git rev-parse --git-common-dir` (parent of that directory is the main worktree). Symlink target is now an absolute path bound to the main worktree regardless of where install was invoked.

**Why (a) over (b):** minimal diff (only `sourceAbs` computation changes; idempotency check `linkAbs === sourceAbs` works unchanged), and the absolute target is self-explanatory in `ls -la .git/hooks/` output for users debugging hook issues. The repo-relocation scenario where a relative symlink would shine is rare and trivially recovered by re-running `bun run hooks:install`.

## Verification

### TDD reproduction

The new regression test creates a real linked worktree (`git worktree add`), runs the installer from inside it, and asserts the resulting symlink target does not contain the linked-worktree path. Verified that the test **fails on the pre-fix code** with the exact bug pattern:

```
Expected to not contain: "/var/folders/.../install-hooks-linked-..."
Received: "/private/var/folders/.../install-hooks-linked-.../scripts/git-hooks/commit-msg"
```

After the fix, the symlink resolves to the main (sandbox) worktree's source — the test passes.

### Test paste (last 100 lines)

```
<truncated header — full output below was bun run test from project root>
@agent-console/client test  $ bun test --preload ./src/test/setup.ts src/
 1361 pass
  2 skip
 0 fail
 2526 expect() calls
Ran 1363 tests across 83 files. [16.92s]
└─ Done in 16.94 s

@agent-console/shared test  $ bun test src/
 309 pass
 0 fail
 470 expect() calls
Ran 309 tests across 10 files. [70.00ms]
└─ Done in 78 ms

@agent-console/integration test  $ bun test --preload ./src/setup.ts src/
 29 pass
 0 fail
 137 expect() calls
Ran 29 tests across 8 files. [2.02s]
└─ Done in 2.03 s

@agent-console/server test  $ bun test src/
 2463 pass
  1 skip
 0 fail
 6772 expect() calls
Ran 2464 tests across 118 files. [55.59s]
└─ Done in 55.61 s

$ bun test scripts/
bun test v1.3.8 (b64edcb4)

 54 pass
 0 fail
 123 expect() calls
Ran 54 tests across 2 files. [1264.00ms]
TEST_EXIT: 0
```

`bun run typecheck` exit 0 (TYPECHECK_EXIT: 0).

### CodeRabbit local CLI

1 minor finding (missing `expect(add.status).toBe(0)` on the `git add` call in the new test) — addressed before this push. No CRITICAL / HIGH / MEDIUM.

### Preflight

```
Test Coverage Check: ✅ No production files matching coverage patterns were changed.
Rule/Skill Duplication Check: ✅
Language Check: ✅
```

## Concerns Surfaced

**Existing broken installs (upgrade path).** Users who installed the hook from a worktree before this fix have a `.git/hooks/commit-msg` symlink pointing to a (possibly removed) worktree path. After this PR lands, re-running `bun run hooks:install` will detect the mismatch and exit with:

```
hooks:install — .git/hooks/commit-msg is a symlink to <old worktree path>, not <main worktree path>.
Remove it manually and re-run: rm "<.git/hooks/commit-msg>"
```

That is the correct behavior — surface, do not silently overwrite — but it does mean the install is a 2-step recovery for affected users (`rm` then `bun run hooks:install`). The script's existing error message already tells users exactly what to do, so no further action is needed; just flagging.

## Test plan

- [x] New test in `scripts/__tests__/install-hooks.test.mjs` reproducing Issue #728 via real `git worktree add`
- [x] All 7 install-hooks tests pass
- [x] Full `bun run test` suite green (TEST_EXIT: 0)
- [x] `bun run typecheck` green
- [x] CodeRabbit local CLI: 1 minor finding addressed
- [ ] Manual verification post-merge: re-run `bun run hooks:install` from the main worktree, then create + remove a linked worktree and confirm `.git/hooks/commit-msg` still resolves

## Out of scope (separate Issue per delegation brief)

- `package.json` `postinstall` integration so `bun install` auto-runs `hooks:install`
- README / CLAUDE.md install documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)