### PR TITLE
[AI] closed #730 fix: enforce-permissions.sh deadlocks the agent when jq is missing

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -5,10 +5,31 @@ Each hook is a single executable invoked by the Claude Code runtime at a
 specific lifecycle event; the runtime pipes the event JSON to stdin and acts
 on the script's stdout / exit code.
 
+## Prerequisites
+
+`enforce-permissions.sh` (the `PreToolUse` hook) parses its event JSON with
+`jq`. If `jq` is not on `PATH`, the hook fail-closes on every
+`Bash|Read|Write|Edit` invocation and the agent deadlocks (see Issue #730).
+Install `jq` once per environment:
+
+```bash
+brew install jq        # macOS (Homebrew)
+apt-get install jq     # Debian/Ubuntu
+dnf install jq         # Fedora / RHEL 8+
+yum install jq         # RHEL 7 / older
+pacman -S jq           # Arch Linux
+```
+
+`check-prerequisites.sh` runs at `SessionStart` and verifies this — if `jq`
+is missing it prints the install one-liners above and exits non-zero, so the
+deadlock surfaces as an actionable error before the first tool call rather
+than as a silent string of denied operations.
+
 ## Hooks in this repository
 
 | Script                     | Event         | Matcher              | Purpose                                                           |
 | -------------------------- | ------------- | -------------------- | ----------------------------------------------------------------- |
+| `check-prerequisites.sh`   | `SessionStart`| (any)                | Verify external prerequisites (`jq`) are on PATH; fail fast otherwise |
 | `gh-setup.sh`              | `SessionStart`| (any)                | Install `gh` CLI on Claude Code on the Web                         |
 | `enforce-permissions.sh`   | `PreToolUse`  | `Bash\|Read\|Write\|Edit` | Reject catastrophic / credential-touching operations              |
 

--- a/.claude/hooks/__tests__/check-prerequisites.test.mjs
+++ b/.claude/hooks/__tests__/check-prerequisites.test.mjs
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOOK = resolve(__dirname, '..', 'check-prerequisites.sh');
+
+function runHook({ env } = {}) {
+  return spawnSync('/bin/bash', [HOOK], {
+    encoding: 'utf-8',
+    env: env ?? process.env,
+  });
+}
+
+describe('check-prerequisites: jq prerequisite (Issue #730)', () => {
+  it('exits 0 silently when jq is on PATH (happy path)', () => {
+    const r = runHook();
+    expect(r.status).toBe(0);
+    expect(r.stderr).toBe('');
+  });
+
+  it('exits non-zero with actionable diagnostic when jq is NOT on PATH', () => {
+    const r = runHook({ env: { PATH: '/nonexistent', HOME: process.env.HOME ?? '' } });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/jq/);
+    expect(r.stderr).toMatch(/enforce-permissions\.sh/);
+    expect(r.stderr).toMatch(/brew install jq/);
+    expect(r.stderr).toMatch(/apt-get install jq/);
+  });
+
+  it('exits non-zero with diagnostic when PATH is empty', () => {
+    const r = runHook({ env: { PATH: '', HOME: process.env.HOME ?? '' } });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/jq/);
+  });
+});

--- a/.claude/hooks/__tests__/check-prerequisites.test.mjs
+++ b/.claude/hooks/__tests__/check-prerequisites.test.mjs
@@ -22,7 +22,7 @@ describe('check-prerequisites: jq prerequisite (Issue #730)', () => {
 
   it('exits non-zero with actionable diagnostic when jq is NOT on PATH', () => {
     const r = runHook({ env: { PATH: '/nonexistent', HOME: process.env.HOME ?? '' } });
-    expect(r.status).not.toBe(0);
+    expect(r.status).toBe(1);
     expect(r.stderr).toMatch(/jq/);
     expect(r.stderr).toMatch(/enforce-permissions\.sh/);
     expect(r.stderr).toMatch(/brew install jq/);
@@ -31,7 +31,7 @@ describe('check-prerequisites: jq prerequisite (Issue #730)', () => {
 
   it('exits non-zero with diagnostic when PATH is empty', () => {
     const r = runHook({ env: { PATH: '', HOME: process.env.HOME ?? '' } });
-    expect(r.status).not.toBe(0);
+    expect(r.status).toBe(1);
     expect(r.stderr).toMatch(/jq/);
   });
 });

--- a/.claude/hooks/check-prerequisites.sh
+++ b/.claude/hooks/check-prerequisites.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# SessionStart hook: verify external prerequisites before the agent enters
+# its main loop.
+#
+# Why this exists: PreToolUse hooks (e.g. enforce-permissions.sh) hard-block
+# the agent when a runtime dependency is missing. If jq is absent, the
+# fail-closed branch fires on EVERY Bash/Read/Write/Edit and the agent
+# cannot self-recover (it cannot run `which jq`, cannot read docs, cannot
+# call any tool). Surfacing the diagnostic at SessionStart turns a silent
+# deadlock into an actionable error before the first tool call.
+#
+# Behaviour:
+#   - jq present: exit 0 silently
+#   - jq absent : exit 1, print actionable diagnostic to stderr (binary
+#                 name, dependent script, install one-liners per platform)
+#
+# Implementation note: the diagnostic uses `printf` (a bash builtin) rather
+# than `cat <<EOF`, so the message is still emitted when PATH is empty or
+# does not contain coreutils — exactly the deadlock scenario this hook
+# exists to surface.
+
+set -u
+
+if command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+printf '%s\n' \
+  'check-prerequisites: jq is required by .claude/hooks/enforce-permissions.sh but was not found on PATH.' \
+  'Without jq, the PreToolUse hook fail-closes on every Bash/Read/Write/Edit and the agent cannot run.' \
+  '' \
+  'Install jq:' \
+  '  brew install jq        # macOS (Homebrew)' \
+  '  apt-get install jq     # Debian/Ubuntu' \
+  '  dnf install jq         # Fedora / RHEL 8+' \
+  '  yum install jq         # RHEL 7 / older' \
+  '  pacman -S jq           # Arch Linux' \
+  '' \
+  'Then start a new session.' >&2
+
+exit 1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "./.claude/hooks/check-prerequisites.sh"
+          },
+          {
+            "type": "command",
             "command": "./.claude/hooks/gh-setup.sh"
           }
         ]


### PR DESCRIPTION
## Summary

- Adds a `SessionStart` hook (`.claude/hooks/check-prerequisites.sh`) that verifies `jq` is on `PATH` and prints actionable install one-liners to stderr when missing.
- Without this hook, a missing `jq` causes `enforce-permissions.sh` (`PreToolUse`) to fail-closed on every `Bash|Read|Write|Edit` — the agent loses every tool call and cannot self-recover.
- Documents the prerequisite + install one-liners in `.claude/hooks/README.md`.

Closes #730

## Implementation notes

- The diagnostic uses `printf` (a bash builtin) rather than `cat <<EOF` so the message is still emitted when `PATH` is empty / does not contain coreutils — exactly the deadlock scenario this hook exists to surface.
- Hook script lives at the same per-worktree path as the existing `gh-setup.sh` / `enforce-permissions.sh`. No shared-resource symlink dependency (Issue #728 / PR #729 territory) — each worktree has its own copy via the repo tree.

## Test plan

- [x] Tests at `.claude/hooks/__tests__/check-prerequisites.test.mjs` cover happy path (`jq` present), missing-from-PATH, and empty-PATH cases. The diagnostic-content assertions verify the binary name, dependent script reference, and both `brew install jq` / `apt-get install jq` install one-liners.
- [x] TDD polarity verified: tests written first, fail before script exists, pass after.
- [x] Manual reproduction: `env -i PATH=/nonexistent /bin/bash .claude/hooks/check-prerequisites.sh` → exit 1 with full diagnostic.
- [x] `bun run test` green (1361 client + 309 shared + 29 integration + 2463 server + 118 scripts/hooks; exit 0).
- [x] `bun run typecheck` green (exit 0).
- [x] `bun run check:lang` green.
- [x] `node .claude/skills/orchestrator/preflight-check.js` green.

## Architectural invariants walked

- **I-1 / I-2 (I/O addressing, single writer):** N/A — no persisted resource introduced.
- **I-3 (identity stability):** N/A.
- **I-4 (state persistence):** N/A — hook is a stateless prerequisite check.
- **I-5 (server as source of truth):** N/A.
- **I-6 (boundary validation):** SessionStart input is irrelevant; the hook's only check is `command -v jq` against `PATH` (a system trust boundary). Diagnostic messages contain no user-controlled content.
- **I-7 (enumeration exhaustiveness):** Two states only — `jq` present (exit 0) or absent (exit 1 with diagnostic). Tests cover both, plus the empty-PATH boundary as a sanity check that the diagnostic still emits when coreutils are unreachable.
- **Shared-resource lifetime (memory-tracked candidate invariant):** The hook script is committed at `.claude/hooks/check-prerequisites.sh` per worktree (same pattern as the existing `gh-setup.sh` / `enforce-permissions.sh`). Each worktree has its own copy in its own working tree — no install-time symlink dependency, so the lifetime of the hook artifact is bounded by the worktree, not by a shared external location. Differs structurally from Issue #728 (install-hooks symlink) which DID need shared-lifetime treatment.

## Out of scope

Per Issue #730: only the `jq` prerequisite gap. Other PR #727 follow-ups — bypass detection scope (#732), hook tests preflight wiring (#733), emergency bypass docs (#734) — are tracked separately and are not addressed here.

## Note on CodeRabbit

Local CodeRabbit CLI rate-limited during this sprint (60-min wait). Relying on GitHub-side CodeRabbit bot review per `workflow.md` Verification Checklist Step 3 rate-limit fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)