### PR TITLE
[AI] closed #735 feat: auto-run hooks:install via package.json postinstall + document setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,28 @@ Monorepo with Bun workspaces:
 - `packages/server` - Bun backend with Hono framework and native WebSocket
 - `packages/shared` - Shared types and utilities
 
+## Initial setup
+
+```bash
+bun install
+```
+
+`bun install` runs a `postinstall` step that installs the repository's git hooks (currently the `commit-msg` language check) into `.git/hooks/`. The step fails soft when `.git` is not present (e.g., Docker images, non-git checkouts) so it never breaks `bun install` itself.
+
+If the postinstall was skipped or you want to re-run it manually:
+
+```bash
+bun run hooks:install
+```
+
+Verify the hook is in place:
+
+```bash
+ls -la "$(git rev-parse --git-path hooks)/commit-msg"
+```
+
+Hook policy details and the rationale for the symlink-first / copy-fallback strategy are documented in [`.claude/hooks/README.md`](.claude/hooks/README.md).
+
 ## Core Concepts
 
 - **Session**: A working context tied to a worktree or arbitrary directory. Each session can have multiple workers.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:coverage": "bun run --filter '*' test:coverage",
     "check:lang": "bun scripts/check-public-artifacts-language.mjs",
     "hooks:install": "bun scripts/install-hooks.mjs",
+    "postinstall": "bun scripts/install-hooks.mjs || echo 'hooks:install skipped (likely no git or non-interactive env)'",
     "lint": "bun run lint:structure",
     "lint:structure": "bun run lint:deps && bun run lint:cycles && bun run lint:unused",
     "lint:deps": "depcruise --config .dependency-cruiser.cjs --ignore-known .dependency-cruiser-known-violations.json packages",

--- a/scripts/__tests__/install-hooks.test.mjs
+++ b/scripts/__tests__/install-hooks.test.mjs
@@ -186,3 +186,104 @@ describe('scripts/install-hooks.mjs', () => {
     }
   });
 });
+
+describe('scripts/install-hooks.mjs in a non-git environment (Issue #735)', () => {
+  let nonGitSandbox;
+
+  beforeEach(() => {
+    nonGitSandbox = mkdtempSync(join(tmpdir(), 'install-hooks-nogit-'));
+    // Mirror the repo's scripts/ tree so the postinstall command's
+    // cwd-relative path `bun scripts/install-hooks.mjs` resolves inside
+    // the sandbox the same way `bun install` would resolve it at the
+    // repo root.
+    mkdirSync(join(nonGitSandbox, 'scripts/git-hooks'), { recursive: true });
+    copyFileSync(
+      INSTALL_SCRIPT,
+      join(nonGitSandbox, 'scripts/install-hooks.mjs'),
+    );
+    copyFileSync(
+      SOURCE_HOOK,
+      join(nonGitSandbox, 'scripts/git-hooks/commit-msg'),
+    );
+    chmodSync(join(nonGitSandbox, 'scripts/git-hooks/commit-msg'), 0o755);
+  });
+
+  afterEach(() => {
+    rmSync(nonGitSandbox, { recursive: true, force: true });
+  });
+
+  // GIT_CEILING_DIRECTORIES stops git from walking up past the sandbox to
+  // discover the real repo's .git that contains this test file. Without
+  // it, `git rev-parse` succeeds on dev machines and the no-git scenario
+  // is unreachable.
+  function envWithCeiling() {
+    return { ...process.env, GIT_CEILING_DIRECTORIES: nonGitSandbox };
+  }
+
+  it('install-hooks.mjs exits non-zero when no .git is reachable', () => {
+    const result = spawnSync(
+      'bun',
+      [join(nonGitSandbox, 'scripts/install-hooks.mjs')],
+      { encoding: 'utf8', cwd: nonGitSandbox, env: envWithCeiling() },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('git rev-parse');
+  });
+
+  it('package.json#scripts.postinstall fails soft (exit 0) when no .git is reachable', () => {
+    const pkg = JSON.parse(
+      readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
+    );
+    const postinstallCmd = pkg.scripts.postinstall;
+    expect(postinstallCmd).toContain('bun scripts/install-hooks.mjs');
+    expect(postinstallCmd).toContain('||');
+
+    const result = spawnSync('sh', ['-c', postinstallCmd], {
+      encoding: 'utf8',
+      cwd: nonGitSandbox,
+      env: envWithCeiling(),
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('skipped');
+  });
+});
+
+describe('scripts/install-hooks.mjs invoked via package.json#postinstall in a git repo (Issue #735)', () => {
+  let sandbox;
+  let hooksDir;
+
+  beforeEach(() => {
+    sandbox = mkdtempSync(join(tmpdir(), 'install-hooks-postinstall-'));
+    mkdirSync(join(sandbox, 'scripts/git-hooks'), { recursive: true });
+    copyFileSync(INSTALL_SCRIPT, join(sandbox, 'scripts/install-hooks.mjs'));
+    copyFileSync(SOURCE_HOOK, join(sandbox, 'scripts/git-hooks/commit-msg'));
+    chmodSync(join(sandbox, 'scripts/git-hooks/commit-msg'), 0o755);
+    spawnSync('git', ['init', '-q', '-b', 'main'], { cwd: sandbox });
+    hooksDir = join(sandbox, '.git', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('running the postinstall command string installs the symlink (mirrors `bun install` behavior)', () => {
+    const pkg = JSON.parse(
+      readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
+    );
+    const postinstallCmd = pkg.scripts.postinstall;
+
+    const result = spawnSync('sh', ['-c', postinstallCmd], {
+      encoding: 'utf8',
+      cwd: sandbox,
+      env: { ...process.env, GIT_DIR: join(sandbox, '.git') },
+    });
+    expect(result.status).toBe(0);
+    const target = join(hooksDir, 'commit-msg');
+    const stat = lstatSync(target);
+    expect(stat.isSymbolicLink()).toBe(true);
+    expect(realpathSync(resolve(hooksDir, readlinkSync(target)))).toBe(
+      realpathSync(resolve(sandbox, 'scripts/git-hooks/commit-msg')),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `postinstall` script to root `package.json` so `bun install` runs `bun scripts/install-hooks.mjs` for every contributor and CI env. Closes the bootstrap gap left out of scope by PR #729 (Issue #728).
- Fail-soft form: `bun scripts/install-hooks.mjs || echo 'hooks:install skipped (likely no git or non-interactive env)'`. Chosen over `test -d .git && ...` because linked worktrees have `.git` as a *file* — a `test -d` gate would skip installation in worktrees.
- Document the install-time flow in `CLAUDE.md` (`Initial setup` section): `bun install`, manual `bun run hooks:install` fallback, verification one-liner. Cross-link to `.claude/hooks/README.md` for hook policy details (no duplication).
- Extend `scripts/__tests__/install-hooks.test.mjs` with boundary tests for the no-git case and for the postinstall command string itself.

Closes #735

## Test plan

- [x] `bun run typecheck` — exit 0
- [x] `bun run test` — full suite, 4262 pass / 0 fail / 3 skip — exit 0
- [x] `bun run check:lang` — exit 0
- [x] `node .claude/skills/orchestrator/preflight-check.js` — exit 0
- [x] `coderabbit review --agent --base main` — 0 findings
- [x] End-to-end smoke: `bun install` from this worktree triggered the postinstall, which correctly resolved `.git/hooks/commit-msg` to the main worktree's hook (anchoring preserved per PR #729).
- [x] New tests cover: (a) `install-hooks.mjs` exits 1 in no-git env, (b) postinstall command string fails soft in no-git env, (c) postinstall command string installs the symlink in a git repo. `GIT_CEILING_DIRECTORIES` makes the no-git scenario reproducible on dev machines.

## Architectural invariants

- **I-7 Enumeration Exhaustiveness** — install-context shapes (main worktree / linked worktree / no-git env / already-installed symlink / already-installed copy / different-content) each have a test. Existing tests covered the first five; this PR adds the no-git boundary.
- **Shared-Resource Artifact Lifetime (memory candidate)** — postinstall is a thin wrapper over `install-hooks.mjs`. The wrapper introduces no new path resolution; the existing linked-worktree regression test (`Issue #728`) continues to guard the artifact lifetime invariant. Smoke run from this worktree confirmed the symlink resolves to the main worktree's source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)