### PR TITLE
docs: add Step 7 final memory sync to sprint-retro.js

### DIFF
--- a/.claude/skills/orchestrator/__tests__/sprint-retro.test.js
+++ b/.claude/skills/orchestrator/__tests__/sprint-retro.test.js
@@ -48,9 +48,9 @@ function createMockStdin(answers) {
 // --- Tests ---
 
 describe('getSteps', () => {
-  it('returns 7 steps', () => {
+  it('returns 8 steps', () => {
     const steps = getSteps();
-    expect(steps).toHaveLength(7);
+    expect(steps).toHaveLength(8);
   });
 
   it('returns steps with expected keys in order', () => {
@@ -64,7 +64,18 @@ describe('getSteps', () => {
       'apply_improvements',
       'memory_writeout',
       'cross_project',
+      'final_memory_sync',
     ]);
+  });
+
+  it('final_memory_sync step instructs post-merge update of 3 memory files', () => {
+    const steps = getSteps();
+    const finalSync = steps.find(s => s.key === 'final_memory_sync');
+    const text = finalSync.instructions.join('\n');
+    expect(text).toContain('project_sprint_status.md');
+    expect(text).toContain('MEMORY.md');
+    expect(text).toContain('project_pending_triage_list.md');
+    expect(text).toContain('After the retrospective PR is merged');
   });
 
   it('each step has title and instructions', () => {
@@ -199,7 +210,7 @@ describe('runRetro', () => {
     logSpy.mockRestore();
   });
 
-  it('runs through all 7 steps and prints summary', async () => {
+  it('runs through all 8 steps and prints summary', async () => {
     const answers = [
       'Removed old item from triage',
       'Cleaned wt-001',
@@ -208,6 +219,7 @@ describe('runRetro', () => {
       'Updated CLAUDE.md rule',
       'Deleted stale memory',
       'No other sessions',
+      'Task created, will sync after merge of PR #NNN',
     ];
     const stdin = createMockStdin(answers);
     await runRetro({ stdin, metricsRunner: async () => ({ proceed: true }) });
@@ -236,7 +248,7 @@ describe('runRetro', () => {
   });
 
   it('presents steps in correct order', async () => {
-    const answers = ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7'];
+    const answers = ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8'];
     const stdin = createMockStdin(answers);
     await runRetro({ stdin, metricsRunner: async () => ({ proceed: true }) });
     const output = logs.join('\n');
@@ -251,18 +263,18 @@ describe('runRetro', () => {
   });
 
   it('collects responses and maps them to step keys', async () => {
-    const answers = ['r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7'];
+    const answers = ['r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7', 'r8'];
     const stdin = createMockStdin(answers);
     await runRetro({ stdin, metricsRunner: async () => ({ proceed: true }) });
     const output = logs.join('\n');
 
     // Summary should contain all responses
     expect(output).toContain('r1');
-    expect(output).toContain('r7');
+    expect(output).toContain('r8');
   });
 
   it('handles empty responses gracefully', async () => {
-    const answers = ['', '', '', '', '', '', ''];
+    const answers = ['', '', '', '', '', '', '', ''];
     const stdin = createMockStdin(answers);
     await runRetro({ stdin, metricsRunner: async () => ({ proceed: true }) });
     const output = logs.join('\n');
@@ -276,7 +288,7 @@ describe('runRetro', () => {
   });
 
   it('aborts without running steps if metrics block returns proceed:false', async () => {
-    const answers = ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7'];
+    const answers = ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8'];
     const stdin = createMockStdin(answers);
     await runRetro({ stdin, metricsRunner: async () => ({ proceed: false }) });
     const output = logs.join('\n');

--- a/.claude/skills/orchestrator/sprint-lifecycle.md
+++ b/.claude/skills/orchestrator/sprint-lifecycle.md
@@ -93,6 +93,11 @@ Answer `Y` (default) at the `Continue to retro questions?` prompt to proceed to 
 - Use `EnterWorktree` when the first improvement is agreed upon; commit all subsequent improvements to the same worktree
 - Merge before the retrospective completes — the next Orchestrator needs the updated skills
 
+**Sprint closure spans the retro PR merge** (Step 7 of `sprint-retro.js`):
+- Steps 1–6 finish before the retrospective PR exists, so the retro PR's own merge state cannot be captured during script execution.
+- After the retro PR is merged, the Orchestrator MUST update `project_sprint_status.md`, `MEMORY.md`, and `project_pending_triage_list.md` to reflect the final merged state. Without this final pass, the sprint pointer drifts (status memo stays "merge-pending", MEMORY.md lags one sprint, triage misses the retro PR).
+- Step 7 of `sprint-retro.js` instructs the Orchestrator to create a TaskCreate task pinned to the retro PR number so the deferred sync is not lost between conversation compactions.
+
 ## Sprint End Proposal Conditions
 
 The Orchestrator can propose ending the sprint to the owner when any of the following apply:

--- a/.claude/skills/orchestrator/sprint-retro.js
+++ b/.claude/skills/orchestrator/sprint-retro.js
@@ -175,6 +175,33 @@ function getSteps() {
         'Report what was shared (or "no other sessions" / "skipped").',
       ],
     },
+    {
+      key: 'final_memory_sync',
+      title: 'Step 7: Final Memory Sync (post-merge)',
+      instructions: [
+        'This step closes the sprint memory state AFTER the retrospective PR is merged.',
+        'Step 5 (Memory Write-Out) ran before the retro PR existed, so the retro PR\'s',
+        'own merge cannot be captured at that point. Without this final pass, the sprint',
+        'pointer drifts: status memo says "owner-merge-pending" forever, MEMORY.md index',
+        'lags one sprint behind, the triage list misses the retro PR.',
+        '',
+        'After the retrospective PR is merged, update all three files:',
+        '  1. memory/project_sprint_status.md — flip retro PR row from "open" to merged,',
+        '     update front-matter description to reflect final state',
+        '  2. memory/MEMORY.md — update the Sprint status pointer line to the final',
+        '     sentence (e.g., "Sprint YYYY-MM-DD 完了 (PRs #A/#B/#R all merged: ...)")',
+        '  3. memory/project_pending_triage_list.md — add the retro PR to the sprint\'s',
+        '     Merged section (it was opened during retro, so it was not yet there in Step 1)',
+        '',
+        'Reliable execution pattern: create a TaskCreate task "final memory sync (post-merge)"',
+        'tagged with the retro PR number. Mark in_progress when the merge is observed,',
+        'completed after the 3 files are updated. Do not rely on memory of "I should sync",',
+        'rely on the task list.',
+        '',
+        'Report acknowledgement of the deferred action (e.g., "task created, will sync',
+        'after merge of PR #NNN").',
+      ],
+    },
   ];
 }
 


### PR DESCRIPTION
## Summary

- Adds Step 7 to `sprint-retro.js` that closes the sprint memory state AFTER the retrospective PR is merged
- Steps 1-6 finish before the retro PR exists, so the retro PR's own merge state cannot be captured during script execution
- Without this final pass, the sprint pointer drifts: `project_sprint_status.md` stays "merge-pending", `MEMORY.md` lags one sprint, `project_pending_triage_list.md` misses the retro PR (observed in Sprint 2026-04-30 closure)
- `sprint-lifecycle.md` gains a paragraph in the Sprint End section noting that sprint closure spans the retro PR merge

## Background

In Sprint 2026-04-30 the owner noticed the Orchestrator forgot to sync `project_sprint_status.md` from "owner-merge-pending" to "merged" after PR #740 landed, and noticed that the existing scripts had no instruction to do so post-merge. This PR closes the procedural gap.

The new Step 7 recommends creating a `TaskCreate` task pinned to the retro PR number so the deferred sync survives conversation compactions — the script cannot enforce post-merge work, but task tracking is the most reliable substitute.

## Test plan

- [x] `bun test ./.claude/skills/orchestrator/__tests__/sprint-retro.test.js` — 63 tests pass
- [x] `bun run check:lang` — clean
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean
- [ ] CI green
- [ ] CodeRabbit review clean

## Verification of Step 7 wording

After merge, the next sprint retrospective will exercise this step. The wording targets self-instruction reliability rather than mechanical enforcement.

## Note on CodeRabbit

If the local CodeRabbit CLI is rate-limited during this PR, relying on the GitHub-side bot review per `workflow.md` Rate-limit fallback policy.