### PR TITLE
[AI] closed #746 chore: migrate orphan test files into __tests__/ directory convention (B1)

### DIFF
--- a/.claude/rules/test-trigger.md
+++ b/.claude/rules/test-trigger.md
@@ -24,6 +24,10 @@ When modifying production files matching these patterns, corresponding test file
 | `packages/client/src/components/**/*.tsx` | `.../__tests__/*.test.tsx` or sibling `*.test.tsx` |
 | `packages/shared/src/**/*.ts` | `.../__tests__/*.test.ts` or sibling `*.test.ts` |
 
+## Exceptions
+
+- **`packages/integration/src/`** uses a flat sibling layout (no `__tests__/` directory). This is deliberate: the package contains no production code — its entire `src/` is test infrastructure (`setup.ts`, `test-utils.ts`) and boundary tests (`*-boundary.test.ts(x)`). Do not move these files into a `__tests__/` subdirectory.
+
 ## Before Creating a PR
 
 Run the coverage check to verify all production files have corresponding tests:

--- a/.claude/skills/orchestrator/__tests__/brew-invariants.test.js
+++ b/.claude/skills/orchestrator/__tests__/brew-invariants.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { truncate, extractLinkedIssueNumber } from './brew-invariants.js';
+import { truncate, extractLinkedIssueNumber } from '../brew-invariants.js';
 
 describe('truncate', () => {
   test('returns input unchanged when under the line limit', () => {

--- a/.claude/skills/orchestrator/__tests__/delegation-prompt.test.js
+++ b/.claude/skills/orchestrator/__tests__/delegation-prompt.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { extractAcceptanceCriteria } from './delegation-prompt.js';
+import { extractAcceptanceCriteria } from '../delegation-prompt.js';
 
 describe('extractAcceptanceCriteria', () => {
   test('extracts checkbox items from issue body', () => {


### PR DESCRIPTION
## Summary

- Move two orchestrator-skill test files (`brew-invariants.test.js`, `delegation-prompt.test.js`) from `.claude/skills/orchestrator/` into the sibling `__tests__/` directory to match the convention documented in `testing.md`. Relative imports updated (`./foo.js` → `../foo.js`).
- Document the deliberate flat layout of `packages/integration/src/` as an explicit exception in `.claude/rules/test-trigger.md` so future contributors do not move the boundary tests there.

Per Issue #746, owner selected option **B1** (migrate Group A only — orchestrator-skill orphans — and document the integration package as an exception). The 8 boundary tests under `packages/integration/src/` remain in their flat layout because the package contains no production code; its entire `src/` is test infrastructure and boundary tests.

Closes #746

## Test plan

- [x] `bun test ./.claude/skills/orchestrator/__tests__/brew-invariants.test.js ./.claude/skills/orchestrator/__tests__/delegation-prompt.test.js` — 14 pass / 0 fail (the moved tests still resolve their imports correctly)
- [x] `bun run typecheck` — exit 0
- [x] `bun run test` (full suite) — exit 0
- [x] `bun run check:lang` — clean
- [x] `node .claude/skills/orchestrator/preflight-check.js` — no production-file gaps; rule/skill duplication clean; language clean
- [x] grep for old test paths confirmed no other callers reference them

## Note on CodeRabbit
Local CodeRabbit CLI rate-limited during this sprint. Relying on GitHub-side CodeRabbit bot review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)