### PR TITLE
[AI] closed #733 process: integrate .claude/hooks/__tests__/ into preflight coverage-check

### DIFF
--- a/.claude/rules/test-trigger.md
+++ b/.claude/rules/test-trigger.md
@@ -5,8 +5,10 @@ globs:
   - "packages/client/src/hooks/**/*.ts"
   - "packages/client/src/components/**/*.tsx"
   - "packages/shared/src/**/*.ts"
+  - ".claude/hooks/**/*.sh"
   - "!**/*.test.ts"
   - "!**/*.test.tsx"
+  - "!**/*.test.mjs"
   - "!**/__tests__/**"
 ---
 
@@ -23,6 +25,7 @@ When modifying production files matching these patterns, corresponding test file
 | `packages/client/src/hooks/**/*.ts` | `.../__tests__/*.test.ts(x)` or sibling `*.test.ts(x)` |
 | `packages/client/src/components/**/*.tsx` | `.../__tests__/*.test.tsx` or sibling `*.test.tsx` |
 | `packages/shared/src/**/*.ts` | `.../__tests__/*.test.ts` or sibling `*.test.ts` |
+| `.claude/hooks/**/*.sh` | `.claude/hooks/__tests__/*.test.mjs` or sibling `*.test.mjs` |
 
 ## Before Creating a PR
 

--- a/.claude/skills/orchestrator/__tests__/check-utils.test.js
+++ b/.claude/skills/orchestrator/__tests__/check-utils.test.js
@@ -6,6 +6,7 @@ import {
   isReExportOnlyContent,
   requiresTestCoverage,
   runLanguageCheck,
+  findTestFiles,
 } from '../check-utils.js';
 
 describe('isReExportOnlyContent', () => {
@@ -157,6 +158,105 @@ describe('preflight-check parity fix verification', () => {
     // 4. Added documentation about parity guarantee
 
     expect(true).toBe(true); // Always pass - this is documentation
+  });
+});
+
+describe('hook shell-script coverage (Issue #733)', () => {
+  describe('requiresTestCoverage', () => {
+    it('flags a hook shell script as requiring coverage', () => {
+      // Real fixture on disk: this file exists and is not re-export-only.
+      expect(requiresTestCoverage('.claude/hooks/enforce-permissions.sh')).toBe(true);
+    });
+
+    it('does not flag a hook test file as requiring coverage (test files are excluded)', () => {
+      expect(requiresTestCoverage('.claude/hooks/__tests__/enforce-permissions.test.mjs')).toBe(false);
+    });
+
+    it('does not flag shell scripts outside .claude/hooks/ (e.g., scripts/*.sh)', () => {
+      expect(requiresTestCoverage('scripts/upload-qa-screenshots.sh')).toBe(false);
+    });
+
+    it('does not flag the hooks README (non-shell file)', () => {
+      expect(requiresTestCoverage('.claude/hooks/README.md')).toBe(false);
+    });
+  });
+
+  describe('findTestFiles for hook shell-script + .mjs test pairings', () => {
+    it('reports a coverage gap when only a hook .sh changes (positive)', () => {
+      const { testCoverage } = findTestFiles(['.claude/hooks/enforce-permissions.sh']);
+      expect(testCoverage).toHaveLength(1);
+      const entry = testCoverage[0];
+      expect(entry.file).toBe('.claude/hooks/enforce-permissions.sh');
+      expect(entry.needsCoverage).toBe(true);
+      expect(entry.hasTest).toBe(false);
+      expect(entry.expectedTestPath).toBe('.claude/hooks/__tests__/enforce-permissions.test.mjs');
+    });
+
+    it('reports no gap when both .sh and matching __tests__ .test.mjs change (negative)', () => {
+      const { testCoverage } = findTestFiles([
+        '.claude/hooks/enforce-permissions.sh',
+        '.claude/hooks/__tests__/enforce-permissions.test.mjs',
+      ]);
+      expect(testCoverage).toHaveLength(1);
+      expect(testCoverage[0].hasTest).toBe(true);
+      expect(testCoverage[0].needsCoverage).toBe(true);
+    });
+
+    it('reports no gap when .sh changes alongside a sibling .test.mjs in the same dir', () => {
+      // Sibling-placement variant: `foo.sh` + `foo.test.mjs` in the same dir,
+      // mirroring the table's "or sibling `*.test.mjs`" allowance.
+      const { testCoverage } = findTestFiles([
+        '.claude/hooks/enforce-permissions.sh',
+        '.claude/hooks/enforce-permissions.test.mjs',
+      ]);
+      expect(testCoverage).toHaveLength(1);
+      expect(testCoverage[0].hasTest).toBe(true);
+    });
+
+    it('does not flag anything when only the test file changes (boundary: no false positive)', () => {
+      const { testCoverage } = findTestFiles([
+        '.claude/hooks/__tests__/enforce-permissions.test.mjs',
+      ]);
+      // The .test.mjs file is classified as a test file, not a production file,
+      // so testCoverage is empty — preflight must not invent a phantom gap.
+      expect(testCoverage).toHaveLength(0);
+    });
+
+    it('flags the missing one when multiple hook .sh files change but only some have tests', () => {
+      const { testCoverage } = findTestFiles([
+        '.claude/hooks/enforce-permissions.sh',
+        '.claude/hooks/__tests__/enforce-permissions.test.mjs',
+        '.claude/hooks/check-prerequisites.sh',
+        // intentionally no test for check-prerequisites in this diff
+      ]);
+      expect(testCoverage).toHaveLength(2);
+      const enforce = testCoverage.find(c => c.file.endsWith('enforce-permissions.sh'));
+      const check = testCoverage.find(c => c.file.endsWith('check-prerequisites.sh'));
+      expect(enforce.hasTest).toBe(true);
+      expect(check.hasTest).toBe(false);
+      expect(check.expectedTestPath).toBe('.claude/hooks/__tests__/check-prerequisites.test.mjs');
+    });
+
+    it('returns an empty testCoverage on an empty diff (boundary: vacuous truth)', () => {
+      const { testCoverage, productionFiles, testFiles } = findTestFiles([]);
+      expect(testCoverage).toEqual([]);
+      expect(productionFiles).toEqual([]);
+      expect(testFiles).toEqual([]);
+    });
+
+    it('returns an empty testCoverage when only doc files change (boundary)', () => {
+      const { testCoverage } = findTestFiles(['docs/glossary.md', 'CLAUDE.md']);
+      expect(testCoverage).toEqual([]);
+    });
+
+    it('does not flag a non-hooks .sh as needing coverage even though it is recognised as source', () => {
+      // `scripts/foo.sh` becomes a productionFiles entry but needsCoverage is
+      // false because it is not in COVERAGE_PATTERNS. The display logic in
+      // preflight-check.js filters by `needsCoverage`.
+      const { testCoverage } = findTestFiles(['scripts/upload-qa-screenshots.sh']);
+      expect(testCoverage).toHaveLength(1);
+      expect(testCoverage[0].needsCoverage).toBe(false);
+    });
   });
 });
 

--- a/.claude/skills/orchestrator/check-utils.js
+++ b/.claude/skills/orchestrator/check-utils.js
@@ -82,7 +82,24 @@ export const COVERAGE_PATTERNS = [
   /^packages\/client\/src\/hooks\/.+\.ts$/,
   /^packages\/client\/src\/components\/.+\.tsx$/,
   /^packages\/shared\/src\/.+\.ts$/,
+  /^\.claude\/hooks\/.+\.sh$/,
 ];
+
+// Source-file extensions considered for coverage analysis. `.sh` is included
+// because `.claude/hooks/**/*.sh` participates in COVERAGE_PATTERNS; the
+// matching test extension is `.mjs` (see expectedTestExt below).
+const SOURCE_EXT_RE = /\.(ts|tsx|js|jsx|sh)$/;
+
+// Test-file naming pattern. `.mjs` is recognised so hook tests
+// (e.g. `enforce-permissions.test.mjs`) are matched against their
+// `.sh` source.
+const TEST_NAME_RE = /\.(test|spec)\.(ts|tsx|js|jsx|mjs)$/;
+
+function expectedTestExt(sourceExt) {
+  if (sourceExt === '.tsx') return '.tsx';
+  if (sourceExt === '.sh') return '.mjs';
+  return '.ts';
+}
 
 // Files excluded from coverage requirements (no runtime logic to test)
 const COVERAGE_EXCLUSIONS = [
@@ -169,30 +186,29 @@ export function findTestFiles(changedFiles) {
   for (const file of changedFiles) {
     if (isTestFile(file)) {
       testFiles.push(file);
-    } else if (file.match(/\.(ts|tsx|js|jsx)$/)) {
+    } else if (SOURCE_EXT_RE.test(file)) {
       productionFiles.push(file);
     }
   }
 
   const testCoverage = [];
   for (const prodFile of productionFiles) {
-    const ext = prodFile.match(/\.(ts|tsx|js|jsx)$/)[0];
-    const baseName = prodFile.replace(/\.(ts|tsx|js|jsx)$/, '');
+    const ext = prodFile.match(SOURCE_EXT_RE)[0];
+    const baseName = prodFile.replace(SOURCE_EXT_RE, '');
     const dir = baseName.substring(0, baseName.lastIndexOf('/'));
     const fileName = baseName.substring(baseName.lastIndexOf('/') + 1);
 
-    const testPattern = new RegExp(`\\.(test|spec)\\.(ts|tsx|js|jsx)$`);
     const hasTest = testFiles.some(tf => {
-      if (!testPattern.test(tf)) return false;
+      if (!TEST_NAME_RE.test(tf)) return false;
       const tfDir = tf.substring(0, tf.lastIndexOf('/'));
       const tfFileName = tf.substring(tf.lastIndexOf('/') + 1);
-      const tfBaseName = tfFileName.replace(/\.(test|spec)\.(ts|tsx|js|jsx)$/, '');
+      const tfBaseName = tfFileName.replace(TEST_NAME_RE, '');
       if (tfBaseName !== fileName) return false;
       return tfDir === dir || tfDir === dir + '/__tests__';
     });
 
     const needsCoverage = requiresTestCoverage(prodFile);
-    const expectedTestPath = dir + '/__tests__/' + fileName + '.test' + (ext === '.tsx' ? '.tsx' : '.ts');
+    const expectedTestPath = dir + '/__tests__/' + fileName + '.test' + expectedTestExt(ext);
     testCoverage.push({ file: prodFile, hasTest, expectedTestPath, needsCoverage });
   }
 


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/**/*.sh` to `COVERAGE_PATTERNS` in `.claude/skills/orchestrator/check-utils.js` so changes to a hook shell script require an accompanying `.test.mjs`.
- Extends `findTestFiles` to recognise `.sh` source files (mapped to `.mjs` test extension via the new `expectedTestExt` helper) and `.mjs` test files in the matching loop. The matching path-pair convention (`__tests__/<name>.test.mjs` or sibling `<name>.test.mjs`) is the same one already used by `.claude/hooks/__tests__/`.
- Updates the mirror in `.claude/rules/test-trigger.md` (table row + YAML `globs:` + `!**/*.test.mjs` exclusion) so the human-readable rule and the executable check stay aligned.
- Regression tests in `.claude/skills/orchestrator/__tests__/check-utils.test.js` cover positive (gap), negative (covered), boundary (test-only diff, empty diff, doc-only diff), and exclusion (non-hooks `.sh`) cases.

Closes #733

## Architectural-invariants walk

- **I-2 Single Writer for Derived Values.** `COVERAGE_PATTERNS` remains the single canonical writer; this PR extends it rather than introducing a parallel array. The mirror in `test-trigger.md` is documentation-side and is kept manually in sync; flagged in retro as a structural concern (no CI sync today).
- **I-7 Enumeration Exhaustiveness.** Source-extension shape gains `.sh`; test-extension shape gains `.mjs`. Each shape is exercised by at least one regression test row (positive gap, negative covered, sibling placement, `__tests__/` placement, multi-file with mixed coverage, test-only-changed, empty diff, doc-only diff, non-hooks `.sh`). No silent default branch.

## Self-test

```
$ node .claude/skills/orchestrator/preflight-check.js
## Test Coverage Check
No production files matching coverage patterns were changed.
✅ No rule paragraphs found verbatim in any skill file.
✅ All public artifacts use Latin / Greek / Cyrillic scripts only.
```

(This PR's own diff touches `.claude/skills/orchestrator/**/*.js` and `__tests__/*.test.js`, neither of which is in `COVERAGE_PATTERNS`, plus a doc — so preflight reports "no production files matching coverage patterns were changed". Expected.)

## Test plan

- [x] `bun run test` (full suite) — TEST_EXIT 0; client 1361 / shared 309 / integration 29 / server 2463 / scripts+hooks 121 all pass.
- [x] `bun run typecheck` — covered by `bun run test` (script chains typecheck before test:only).
- [x] Regression tests (8 new cases under `hook shell-script coverage (Issue #733)`) — all pass.
- [x] `node .claude/skills/orchestrator/preflight-check.js` against this branch — clean.

## Note on CodeRabbit

Local CodeRabbit CLI rate-limited during this sprint. Relying on GitHub-side CodeRabbit bot review.

## Concurrent PR notice

PR #746 (separate worktree) also touches `.claude/rules/test-trigger.md` with a different exception note. Different rows; will rebase from `origin/main` if conflict at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)