### PR TITLE
docs: add 'both review layers rate-limited simultaneously' disposition to workflow.md

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -48,7 +48,7 @@ Before completing any code changes, always verify:
    Both local CodeRabbit CLI and GitHub-side bot were rate-limited at this PR's review window. No CodeRabbit feedback obtainable from either source. Merging under existing PR Merge Authority (chore / docs → orchestrator merge / logic / config → owner approval).
    ```
 
-   The simultaneous-rate-limit case does not relax PR Merge Authority — it removes only the CodeRabbit safety net. Owner approval thresholds for production code remain unchanged. (Sprint 2026-05-01 — observed across PRs #747 / #748 / #749 / #750: all four hit simultaneous rate-limit; orchestrator merged the chore / docs / process PRs (#747 / #748 / #749) under PR Merge Authority, owner approved the logic PR (#750). No regressions surfaced post-merge.)
+   The simultaneous-rate-limit case does not relax PR Merge Authority — it removes only the CodeRabbit safety net. Owner approval thresholds for production code remain unchanged. (Sprint 2026-05-01 — observed across PRs #747 / #748 / #749 / #750: all four hit simultaneous rate-limit; orchestrator merged the docs PR (#747) and the chore PR (#748) under PR Merge Authority, owner approved the process PR (#749) and the logic PR (#750). No regressions surfaced post-merge.)
 
    **Pre-merge checks vs Review state — both required for "clean".** GitHub surfaces CodeRabbit info in two distinct layers that are easy to confuse:
    - **Pre-merge checks** (Title / Description / Docstring / Linked Issues / Out-of-Scope) — metadata validation, displayed as "5/5 passed" in the GitHub UI. **Not** code review.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -36,6 +36,20 @@ Before completing any code changes, always verify:
 
    **GitHub bot unresponsive — abandon the wait, do not over-engineer.** If the GitHub-side bot posts a rate-limit warning at PR open and a subsequent `@coderabbitai review` re-trigger does not produce a review submission within ~10-15 minutes, abandon the wait. CodeRabbit's "incremental review" policy can treat the rate-limit warning event as "already reviewed" and refuse to re-review the same commit. **Do not push trivial commits to force a re-trigger** — that bends the workflow around CodeRabbit's quirks at the cost of CI cycles and review log noise. Instead, when the local CodeRabbit CLI is clean (0 findings), add the rate-limit fallback note above to the PR body, treat that as the documented exception path, and proceed to merge after the rest of the "clean" 3-layer condition is satisfied. (Sprint 2026-04-30 PR #738 — bot unresponsive 60+ min after re-trigger while PR #737 in the same flow returned APPROVED in 3 min; owner guidance: do not bend the process for CodeRabbit, abandon the wait early.)
 
+   **Both review layers rate-limited simultaneously.** When the local CodeRabbit CLI and the GitHub-side bot are both rate-limited at the same time (no CodeRabbit feedback obtainable from either source), CodeRabbit's "clean" verdict is unavailable for that PR. Do not block the PR indefinitely. Disposition follows the existing PR Merge Authority (see Orchestrator's `core-responsibilities.md`):
+
+   - chore / docs / test-only / pure-refactor PRs → orchestrator may merge after CI is green and acceptance check passes
+   - logic / process / config-change PRs → owner approval required, as always
+
+   Add this rate-limit-fallback note to the PR body so the documented exception path is visible to anyone reviewing the merge:
+
+   ```markdown
+   ## Note on CodeRabbit
+   Both local CodeRabbit CLI and GitHub-side bot were rate-limited at this PR's review window. No CodeRabbit feedback obtainable from either source. Merging under existing PR Merge Authority (chore / docs → orchestrator merge / logic / config → owner approval).
+   ```
+
+   The simultaneous-rate-limit case does not relax PR Merge Authority — it removes only the CodeRabbit safety net. Owner approval thresholds for production code remain unchanged. (Sprint 2026-05-01 — observed across PRs #747 / #748 / #749 / #750: all four hit simultaneous rate-limit; orchestrator merged the chore / docs / process PRs (#747 / #748 / #749) under PR Merge Authority, owner approved the logic PR (#750). No regressions surfaced post-merge.)
+
    **Pre-merge checks vs Review state — both required for "clean".** GitHub surfaces CodeRabbit info in two distinct layers that are easy to confuse:
    - **Pre-merge checks** (Title / Description / Docstring / Linked Issues / Out-of-Scope) — metadata validation, displayed as "5/5 passed" in the GitHub UI. **Not** code review.
    - **Review state** (`gh pr view <N> --json reviewDecision`) — actual code-review verdict. Only `APPROVED` counts as a passing verdict. An empty `reviewDecision` means the bot has not yet reviewed and the PR is **not** yet clean — wait for the bot to submit, do not merge. (Exception: under the rate-limit fallback above, an empty state may persist; in that exception path, follow the fallback's verification steps before merge.)


### PR DESCRIPTION
## Summary

Adds a new paragraph to `.claude/rules/workflow.md` "Verification Checklist" Step 3 (Run CodeRabbit CLI review) covering the case where **both the local CodeRabbit CLI and the GitHub-side bot are rate-limited simultaneously** at the same PR's review window.

The existing rule covered:
- Local CLI rate-limited → use GitHub bot only
- GitHub bot unresponsive (rate-limit warning) → abandon the wait, proceed under fallback if local CLI is clean

The simultaneous case (both layers rate-limited at once) was not documented. Sprint 2026-05-01 hit this on all four merged PRs (#747 / #748 / #749 / #750); the orchestrator established the disposition empirically. This PR formalizes that disposition into the rule.

## Disposition (formalized)

When CodeRabbit feedback is unobtainable from either source, the existing PR Merge Authority continues to govern:

- chore / docs / test-only / pure-refactor PRs → orchestrator may merge after CI green + acceptance check
- logic / process / config-change PRs → owner approval required, as always

The simultaneous-rate-limit case removes the CodeRabbit safety net but does **not** relax PR Merge Authority. Owner approval thresholds for production code remain unchanged.

A standardized PR-body fallback note template is included so the exception path is visible at merge time.

## Why now

Filed in Sprint 2026-05-02 P1 (dev environment maintenance theme) following Sprint 2026-05-01 retro pending triage. Ungoverned simultaneous-rate-limit windows lead to either over-blocking (waiting indefinitely for a feedback path that will not materialize) or under-blocking (orchestrator proceeding without an explicit fallback), both of which erode trust in the rule.

## Test plan

- [x] `bun run check:lang` clean (101 files scanned)
- [x] `node .claude/skills/orchestrator/preflight-check.js` clean (no production files; rule/skill duplication clean; language clean)
- [x] `bun run typecheck` exit 0
- [x] `bun run test` 4315 pass + 3 skip + 0 fail (TEST_EXIT 0)

## Note on CodeRabbit

CodeRabbit GitHub bot reviewed the first push at 02:34:34 UTC and posted 1 Major finding: the example listed PR #749 (process category) under orchestrator-merged PRs, contradicting the rule that process / logic / config-change PRs require owner approval. The finding was addressed in commit `c6f1572` — the example now correctly reflects the empirical disposition recorded in Sprint 2026-05-01 retro memory: docs (#747) and chore (#748) → orchestrator merged; process (#749) and logic (#750) → owner approved.

After the fix push, CodeRabbit's GitHub bot is rate-limited (per the rate-limit warning posted at 02:32:04 UTC, before the original review even completed). Re-review on commit `c6f1572` will not run within this PR's natural merge window. Per `.claude/rules/workflow.md` "GitHub bot unresponsive — abandon the wait" guidance, applying the documented Rate-limit fallback exception path:

- Pre-merge checks: 5/5 GitHub Actions checks all SUCCESS
- `mergeStateStatus`: CLEAN
- The 1 Major finding has been addressed in code; no other inline comments outstanding
- Local CodeRabbit CLI not run (orchestrator session, not CLI-equipped)

This PR is itself a rule-text change (production-adjacent), so per its own newly-added rule, owner approval is required regardless of CodeRabbit state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
