### PR TITLE
chore: include orchestrator skill __tests__/ in test:scripts (closes #753)

### DIFF
--- a/.claude/skills/orchestrator/suggest-criteria.js
+++ b/.claude/skills/orchestrator/suggest-criteria.js
@@ -160,6 +160,54 @@ export const MATCHING_RULES = {
     relevance:
       'value crossing a trust boundary — must be schema-validated before use',
   },
+  'I-7': {
+    keywords: [
+      'shape',
+      'shapes',
+      'variant',
+      'variants',
+      'enumeration',
+      'exhaustive',
+      'exhaustiveness',
+      'discriminated union',
+      'default branch',
+      'default case',
+      'fallback',
+      'optional prefix',
+      'org/repo',
+      'protocol-relative',
+      'either',
+    ],
+    pathFragments: [],
+    relevance:
+      'value has multiple valid shapes — every code path and test must cover all shapes; no silent fallback to a single default',
+  },
+  'I-8': {
+    keywords: [
+      'install',
+      'installer',
+      'postinstall',
+      'symlink',
+      'git hook',
+      'commit-msg',
+      'pre-commit',
+      'daemon',
+      'systemd',
+      'launchd',
+      'package metadata',
+      'embedded reference',
+      'embedded path',
+      'dangling',
+      'cwd-anchored',
+      'worktree-anchored',
+      'artifact lifetime',
+      'shared resource',
+      'git-common-dir',
+    ],
+    pathFragments: ['scripts/install', 'hooks/', 'git-hooks/'],
+    relevance:
+      'artifact written to a shared / persistent location — embedded references must resolve via globally-stable anchors, not cwd or per-worktree paths',
+  },
 };
 
 function usage() {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck": "bun run --filter '*' typecheck",
     "test": "bun run typecheck && bun run test:only",
     "test:only": "bun run --filter '*' test && bun run test:scripts",
-    "test:scripts": "bun test scripts/ ./.claude/hooks/__tests__/",
+    "test:scripts": "bun test scripts/ ./.claude/hooks/__tests__/ ./.claude/skills/*/__tests__/",
     "test:coverage": "bun run --filter '*' test:coverage",
     "check:lang": "bun scripts/check-public-artifacts-language.mjs",
     "hooks:install": "bun scripts/install-hooks.mjs",


### PR DESCRIPTION
## Summary

Extends the `test:scripts` glob in `package.json` to include `.claude/skills/*/__tests__/` so orchestrator-skill tests run as part of `bun run test` / CI. Previously the glob only covered `scripts/` and `.claude/hooks/__tests__/`, silently excluding six orchestrator-skill test files.

## Pre-existing failure surfaced

After expanding the glob, `MATCHING_RULES` sanity test in `.claude/skills/orchestrator/__tests__/suggest-criteria.test.js` failed:

```
✗ MATCHING_RULES > has a rule for every shipped invariant that has a template
  expect(MATCHING_RULES[entry.id]).toBeDefined() — Received: undefined
```

**Diagnosis: production bug** (not test bug). The `architectural-invariants/SKILL.md` catalog was extended with `I-7` (PR #650, Enumeration Exhaustiveness) and `I-8` (PR #751, Shared-Resource Artifact Lifetime), but `MATCHING_RULES` in `suggest-criteria.js` was never updated. `git log --follow .claude/skills/orchestrator/suggest-criteria.js` confirms the file has not been touched since its initial introduction in PR #643.

Fix: add `MATCHING_RULES` entries for `I-7` and `I-8` with keywords / pathFragments / relevance descriptions matching the existing pattern.

## Other orchestrator __tests__/ files

All five other test files (`acceptance-check`, `brew-invariants`, `check-utils`, `delegation-prompt`, `sprint-retro`) pass under the new glob with no other dormant failures detected.

## Verification

```
$ bun run typecheck && bun run test
... (full suite)
TEST_EXIT: 0

$ bun run test:scripts
343 pass / 0 fail / 856 expect() calls / 10 files
```

CI chain confirmed: `.github/workflows/ci.yml` → `bun run test` → `bun run test:only` → `bun run test:scripts`. The new glob therefore runs in CI on every PR / push that triggers `ci.yml`.

## Note on CodeRabbit CLI

Local `coderabbit review --agent --base main` returned `rate_limit` (9 min wait). Skipped per coderabbit-ops fallback policy; relying on GitHub-side bot review.

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)