### PR TITLE
chore: detect mirror drift between executable rule and markdown (closes #752)

### DIFF
--- a/.claude/rules/test-trigger.md
+++ b/.claude/rules/test-trigger.md
@@ -44,3 +44,15 @@ node .claude/skills/orchestrator/preflight-check.js
 ```
 
 If any gaps are detected (non-zero exit code), add the missing tests before proceeding.
+
+## Mirror Maintenance
+
+The patterns above are a **markdown mirror** of the executable single-writer `COVERAGE_PATTERNS` in `.claude/skills/orchestrator/check-utils.js` (the source of truth used by `preflight-check.js`). When updating one, update the other in the same PR.
+
+Drift between the two is detected mechanically by `.claude/skills/orchestrator/check-mirror-drift.js` (CI workflow: `.github/workflows/check-mirror-drift.yml`). To verify locally:
+
+```bash
+node .claude/skills/orchestrator/check-mirror-drift.js
+```
+
+The check normalizes the regex `^DIR\/.+\.EXT$` shape to its glob `DIR/**/*.EXT` equivalent and compares against both the markdown table above and the YAML `globs:` frontmatter. Negation entries in the YAML (`!**/*.test.ts`, `!**/__tests__/**`) mirror the `isTestFile()` helper rather than `COVERAGE_PATTERNS`, and are excluded from the comparison. (Issue #752)

--- a/.claude/skills/orchestrator/__tests__/check-mirror-drift.test.js
+++ b/.claude/skills/orchestrator/__tests__/check-mirror-drift.test.js
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  regexSourceToGlob,
+  parseFrontmatterGlobs,
+  parseMarkdownTablePatterns,
+  detectDrift,
+  formatReport,
+} from '../check-mirror-drift.js';
+
+describe('regexSourceToGlob', () => {
+  it('converts the canonical "^DIR\\/.+\\.EXT$" shape to a glob', () => {
+    expect(regexSourceToGlob('^packages\\/server\\/src\\/routes\\/.+\\.ts$')).toBe(
+      'packages/server/src/routes/**/*.ts',
+    );
+    expect(regexSourceToGlob('^packages\\/client\\/src\\/components\\/.+\\.tsx$')).toBe(
+      'packages/client/src/components/**/*.tsx',
+    );
+    expect(regexSourceToGlob('^\\.claude\\/hooks\\/.+\\.sh$')).toBe('.claude/hooks/**/*.sh');
+  });
+
+  it('returns null for regex shapes outside the canonical form', () => {
+    expect(regexSourceToGlob('^packages\\/server\\/src\\/routes\\/foo\\.ts$')).toBeNull();
+    expect(regexSourceToGlob('^packages\\/(client|server)\\/.+\\.ts$')).toBeNull();
+    expect(regexSourceToGlob('not-a-regex-source')).toBeNull();
+  });
+});
+
+describe('parseFrontmatterGlobs', () => {
+  it('returns positive globs only and skips negation entries', () => {
+    const md = [
+      '---',
+      'globs:',
+      '  - "packages/server/src/routes/**/*.ts"',
+      '  - "packages/shared/src/**/*.ts"',
+      '  - "!**/*.test.ts"',
+      '  - "!**/__tests__/**"',
+      '---',
+      '',
+      '# body',
+    ].join('\n');
+    expect(parseFrontmatterGlobs(md)).toEqual([
+      'packages/server/src/routes/**/*.ts',
+      'packages/shared/src/**/*.ts',
+    ]);
+  });
+
+  it('returns [] when the frontmatter has no globs key', () => {
+    const md = '---\nname: foo\n---\n# body\n';
+    expect(parseFrontmatterGlobs(md)).toEqual([]);
+  });
+
+  it('returns [] when there is no frontmatter at all', () => {
+    expect(parseFrontmatterGlobs('# just markdown\n\nbody\n')).toEqual([]);
+  });
+
+  it('handles unquoted YAML list items', () => {
+    const md = [
+      '---',
+      'globs:',
+      '  - packages/shared/src/**/*.ts',
+      '---',
+      '',
+    ].join('\n');
+    expect(parseFrontmatterGlobs(md)).toEqual(['packages/shared/src/**/*.ts']);
+  });
+
+  it('stops collecting at a sibling top-level key', () => {
+    const md = [
+      '---',
+      'globs:',
+      '  - "packages/server/src/routes/**/*.ts"',
+      'name: foo',
+      '---',
+      '',
+    ].join('\n');
+    expect(parseFrontmatterGlobs(md)).toEqual(['packages/server/src/routes/**/*.ts']);
+  });
+});
+
+describe('parseMarkdownTablePatterns', () => {
+  it('extracts backtick-quoted patterns from the first column, skipping header / separator', () => {
+    const md = [
+      '# Heading',
+      '',
+      '| File Pattern | Expected Test Location |',
+      '|-------------|------------------------|',
+      '| `packages/server/src/routes/**/*.ts` | `.../__tests__/*.test.ts` |',
+      '| `packages/shared/src/**/*.ts` | `.../__tests__/*.test.ts` |',
+      '',
+      '## Another Section',
+    ].join('\n');
+    expect(parseMarkdownTablePatterns(md)).toEqual([
+      'packages/server/src/routes/**/*.ts',
+      'packages/shared/src/**/*.ts',
+    ]);
+  });
+
+  it('returns [] when there is no table', () => {
+    expect(parseMarkdownTablePatterns('# heading only\n\nbody\n')).toEqual([]);
+  });
+});
+
+describe('detectDrift', () => {
+  const mkMarkdown = ({ globs, table }) => {
+    const fm = ['---', 'globs:'];
+    for (const g of globs) fm.push(`  - "${g}"`);
+    fm.push('---', '', '# heading', '', '| File Pattern | Expected Test Location |');
+    fm.push('|-------------|------------------------|');
+    for (const t of table) fm.push(`| \`${t}\` | \`...test...\` |`);
+    return fm.join('\n');
+  };
+
+  it('happy path: matching code / table / yaml → no drift', () => {
+    const result = detectDrift({
+      coveragePatterns: [/^packages\/server\/src\/routes\/.+\.ts$/, /^packages\/shared\/src\/.+\.ts$/],
+      markdown: mkMarkdown({
+        globs: ['packages/server/src/routes/**/*.ts', 'packages/shared/src/**/*.ts'],
+        table: ['packages/server/src/routes/**/*.ts', 'packages/shared/src/**/*.ts'],
+      }),
+    });
+    expect(result.hasDrift).toBe(false);
+    expect(result.unconvertible).toEqual([]);
+    expect(result.diffs.codeMissingFromTable).toEqual([]);
+    expect(result.diffs.tableMissingFromCode).toEqual([]);
+    expect(result.diffs.codeMissingFromYaml).toEqual([]);
+    expect(result.diffs.yamlMissingFromCode).toEqual([]);
+  });
+
+  it('detects pattern present in code but missing from markdown table and YAML', () => {
+    const result = detectDrift({
+      coveragePatterns: [
+        /^packages\/server\/src\/routes\/.+\.ts$/,
+        /^\.claude\/hooks\/.+\.sh$/,
+      ],
+      markdown: mkMarkdown({
+        globs: ['packages/server/src/routes/**/*.ts'],
+        table: ['packages/server/src/routes/**/*.ts'],
+      }),
+    });
+    expect(result.hasDrift).toBe(true);
+    expect(result.diffs.codeMissingFromTable).toEqual(['.claude/hooks/**/*.sh']);
+    expect(result.diffs.codeMissingFromYaml).toEqual(['.claude/hooks/**/*.sh']);
+  });
+
+  it('detects pattern present in markdown but missing from code', () => {
+    const result = detectDrift({
+      coveragePatterns: [/^packages\/server\/src\/routes\/.+\.ts$/],
+      markdown: mkMarkdown({
+        globs: ['packages/server/src/routes/**/*.ts', 'packages/server/src/services/**/*.ts'],
+        table: ['packages/server/src/routes/**/*.ts', 'packages/server/src/services/**/*.ts'],
+      }),
+    });
+    expect(result.hasDrift).toBe(true);
+    expect(result.diffs.tableMissingFromCode).toEqual(['packages/server/src/services/**/*.ts']);
+    expect(result.diffs.yamlMissingFromCode).toEqual(['packages/server/src/services/**/*.ts']);
+  });
+
+  it('reports an unconvertible regex as drift (fails closed)', () => {
+    const result = detectDrift({
+      coveragePatterns: [/^packages\/server\/(routes|services)\/.+\.ts$/],
+      markdown: mkMarkdown({ globs: [], table: [] }),
+    });
+    expect(result.hasDrift).toBe(true);
+    expect(result.unconvertible).toHaveLength(1);
+  });
+
+  it('boundary: empty COVERAGE_PATTERNS + empty markdown mirror → no drift', () => {
+    const result = detectDrift({
+      coveragePatterns: [],
+      markdown: mkMarkdown({ globs: [], table: [] }),
+    });
+    expect(result.hasDrift).toBe(false);
+  });
+
+  it('boundary: empty COVERAGE_PATTERNS but populated markdown → drift on mirror side', () => {
+    const result = detectDrift({
+      coveragePatterns: [],
+      markdown: mkMarkdown({
+        globs: ['packages/server/src/routes/**/*.ts'],
+        table: ['packages/server/src/routes/**/*.ts'],
+      }),
+    });
+    expect(result.hasDrift).toBe(true);
+    expect(result.diffs.tableMissingFromCode).toEqual(['packages/server/src/routes/**/*.ts']);
+    expect(result.diffs.yamlMissingFromCode).toEqual(['packages/server/src/routes/**/*.ts']);
+  });
+
+  it('YAML negation entries do not contribute to drift', () => {
+    const md = [
+      '---',
+      'globs:',
+      '  - "packages/server/src/routes/**/*.ts"',
+      '  - "!**/*.test.ts"',
+      '  - "!**/__tests__/**"',
+      '---',
+      '',
+      '| File Pattern | Expected |',
+      '|---|---|',
+      '| `packages/server/src/routes/**/*.ts` | `.test.ts` |',
+    ].join('\n');
+    const result = detectDrift({
+      coveragePatterns: [/^packages\/server\/src\/routes\/.+\.ts$/],
+      markdown: md,
+    });
+    expect(result.hasDrift).toBe(false);
+  });
+});
+
+describe('formatReport', () => {
+  it('returns a green-check message when there is no drift', () => {
+    const text = formatReport({
+      hasDrift: false,
+      unconvertible: [],
+      codeGlobs: new Set(),
+      tableGlobs: new Set(),
+      yamlGlobs: new Set(),
+      diffs: {
+        codeMissingFromTable: [],
+        tableMissingFromCode: [],
+        codeMissingFromYaml: [],
+        yamlMissingFromCode: [],
+      },
+    });
+    expect(text).toContain('in sync');
+  });
+
+  it('renders sections for each non-empty diff bucket', () => {
+    const text = formatReport({
+      hasDrift: true,
+      unconvertible: ['^weird\\/regex$'],
+      codeGlobs: new Set(),
+      tableGlobs: new Set(),
+      yamlGlobs: new Set(),
+      diffs: {
+        codeMissingFromTable: ['a/**/*.ts'],
+        tableMissingFromCode: ['b/**/*.ts'],
+        codeMissingFromYaml: ['c/**/*.ts'],
+        yamlMissingFromCode: ['d/**/*.ts'],
+      },
+    });
+    expect(text).toContain('Mirror drift detected');
+    expect(text).toContain('Unconvertible regex patterns');
+    expect(text).toContain('+ a/**/*.ts');
+    expect(text).toContain('- b/**/*.ts');
+    expect(text).toContain('+ c/**/*.ts');
+    expect(text).toContain('- d/**/*.ts');
+  });
+});
+
+describe('integration with current repo state', () => {
+  it('the actual COVERAGE_PATTERNS and test-trigger.md are in sync', async () => {
+    const { COVERAGE_PATTERNS } = await import('../check-utils.js');
+    const { TEST_TRIGGER_MD } = await import('../check-mirror-drift.js');
+    const { readFileSync } = await import('node:fs');
+    const md = readFileSync(TEST_TRIGGER_MD, 'utf-8');
+    const result = detectDrift({ coveragePatterns: COVERAGE_PATTERNS, markdown: md });
+    if (result.hasDrift) {
+      throw new Error(formatReport(result));
+    }
+    expect(result.hasDrift).toBe(false);
+  });
+});

--- a/.claude/skills/orchestrator/check-mirror-drift.js
+++ b/.claude/skills/orchestrator/check-mirror-drift.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+/**
+ * Mirror Drift Check — COVERAGE_PATTERNS ↔ test-trigger.md
+ *
+ * The executable single-writer is `COVERAGE_PATTERNS` in `check-utils.js`
+ * (consumed by `preflight-check.js`). Its markdown mirror lives in
+ * `.claude/rules/test-trigger.md` (auto-loaded rule consumed by agents).
+ *
+ * The mirror has two encodings inside the same file:
+ *   - YAML frontmatter `globs:` list (glob form)
+ *   - Markdown table "File Pattern" column (glob form, in backticks)
+ *
+ * This check normalizes all three sources to a common glob form and
+ * asserts set equality. Drift exits non-zero with a per-side report.
+ *
+ * Normalization rule: every pattern is canonicalized to its glob form.
+ *   regex `^DIR\/.+\.EXT$` ↔ glob `DIR/**\/*.EXT`
+ * Patterns that do not fit this canonical shape are reported as
+ * "unconvertible" so the check fails closed rather than silently passing.
+ *
+ * Negation entries in the YAML frontmatter (e.g., `!**\/*.test.ts`) are
+ * intentionally excluded from comparison: they mirror the `isTestFile()`
+ * helper in check-utils.js, not COVERAGE_PATTERNS.
+ *
+ * Issue: https://github.com/ms2sato/agent-console/issues/752
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+import { COVERAGE_PATTERNS } from './check-utils.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../..');
+const TEST_TRIGGER_MD = resolve(REPO_ROOT, '.claude/rules/test-trigger.md');
+
+// --- Conversion ---
+
+/**
+ * Convert a regex `source` string of the canonical shape
+ *   ^DIR\/.+\.EXT$
+ * to its equivalent glob:
+ *   DIR/**\/*.EXT
+ *
+ * Returns null if the regex does not fit this shape, signalling that the
+ * caller cannot mechanically compare it against the markdown mirror.
+ */
+export function regexSourceToGlob(source) {
+  // The dir portion may only contain word chars, hyphens, escaped slashes,
+  // or escaped dots. This rejects regex constructs like `(a|b)` so an
+  // alternation regex falls through to the "unconvertible" bucket.
+  const m = source.match(/^\^((?:[\w-]|\\\/|\\\.)+)\\\/\.\+\\(\.\w+)\$$/);
+  if (!m) return null;
+  const dir = m[1].replace(/\\\//g, '/').replace(/\\\./g, '.');
+  return `${dir}/**/*${m[2]}`;
+}
+
+// --- Markdown parsing ---
+
+/**
+ * Extract positive (non-negated) globs from the YAML `globs:` frontmatter.
+ * Negation entries (lines beginning with `!`) are excluded — they mirror
+ * `isTestFile()` rather than COVERAGE_PATTERNS.
+ */
+export function parseFrontmatterGlobs(markdown) {
+  const fmMatch = markdown.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return [];
+  const frontmatter = fmMatch[1];
+  // Find the `globs:` block: lines under it until a sibling key or EOF.
+  const lines = frontmatter.split('\n');
+  const out = [];
+  let inGlobs = false;
+  for (const line of lines) {
+    if (/^globs\s*:\s*$/.test(line)) {
+      inGlobs = true;
+      continue;
+    }
+    if (inGlobs) {
+      // Sibling top-level key (no leading whitespace, contains colon) ends the block.
+      if (/^[A-Za-z_][\w-]*\s*:/.test(line)) {
+        inGlobs = false;
+        continue;
+      }
+      const itemMatch = line.match(/^\s*-\s*['"]?([^'"\s]+)['"]?\s*$/);
+      if (itemMatch && !itemMatch[1].startsWith('!')) {
+        out.push(itemMatch[1]);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract the first column ("File Pattern") of the markdown table that
+ * lives under the "Expected Test File Locations" section. Each cell is
+ * expected to be a single backtick-quoted glob.
+ */
+export function parseMarkdownTablePatterns(markdown) {
+  const lines = markdown.split('\n');
+  const tableLines = lines.filter((l) => /^\|/.test(l));
+  if (tableLines.length === 0) return [];
+  // Drop header row and any separator rows (---).
+  const dataRows = tableLines.filter((l) => !/^\|[\s|:-]+\|\s*$/.test(l)).slice(1);
+  const out = [];
+  for (const row of dataRows) {
+    const cells = row.split('|').slice(1, -1).map((c) => c.trim());
+    if (cells.length === 0) continue;
+    const m = cells[0].match(/^`([^`]+)`$/);
+    if (m) out.push(m[1]);
+  }
+  return out;
+}
+
+// --- Drift detection ---
+
+function setDiff(a, b) {
+  return [...a].filter((x) => !b.has(x)).sort();
+}
+
+/**
+ * Compare COVERAGE_PATTERNS to the markdown mirror's two encodings.
+ * Pure function: takes the inputs, returns a structured result.
+ */
+export function detectDrift({ coveragePatterns, markdown }) {
+  const converted = coveragePatterns.map((p) => ({ source: p.source, glob: regexSourceToGlob(p.source) }));
+  const unconvertible = converted.filter((p) => p.glob === null).map((p) => p.source);
+  const codeGlobs = new Set(converted.filter((p) => p.glob !== null).map((p) => p.glob));
+  const tableGlobs = new Set(parseMarkdownTablePatterns(markdown));
+  const yamlGlobs = new Set(parseFrontmatterGlobs(markdown));
+
+  const diffs = {
+    codeMissingFromTable: setDiff(codeGlobs, tableGlobs),
+    tableMissingFromCode: setDiff(tableGlobs, codeGlobs),
+    codeMissingFromYaml: setDiff(codeGlobs, yamlGlobs),
+    yamlMissingFromCode: setDiff(yamlGlobs, codeGlobs),
+  };
+
+  const hasDrift =
+    unconvertible.length > 0 ||
+    diffs.codeMissingFromTable.length > 0 ||
+    diffs.tableMissingFromCode.length > 0 ||
+    diffs.codeMissingFromYaml.length > 0 ||
+    diffs.yamlMissingFromCode.length > 0;
+
+  return { hasDrift, unconvertible, codeGlobs, tableGlobs, yamlGlobs, diffs };
+}
+
+/**
+ * Render the result as a unified diff-style report. Lines prefixed with
+ * `+` are present in the executable side and missing from the mirror;
+ * `-` are present in the mirror and missing from the executable side.
+ */
+export function formatReport(result) {
+  if (!result.hasDrift) {
+    return '✅ COVERAGE_PATTERNS and test-trigger.md are in sync.';
+  }
+  const out = [];
+  out.push('❌ Mirror drift detected between COVERAGE_PATTERNS and test-trigger.md');
+  out.push('');
+  if (result.unconvertible.length > 0) {
+    out.push('Unconvertible regex patterns (not in canonical "^DIR\\/.+\\.EXT$" form):');
+    for (const src of result.unconvertible) out.push(`  ! ${src}`);
+    out.push('');
+    out.push('  Either reshape the regex to the canonical form, or extend');
+    out.push('  regexSourceToGlob() in check-mirror-drift.js to handle the new shape.');
+    out.push('');
+  }
+  const sections = [
+    ['In COVERAGE_PATTERNS, missing from markdown table:', result.diffs.codeMissingFromTable, '+'],
+    ['In markdown table, missing from COVERAGE_PATTERNS:', result.diffs.tableMissingFromCode, '-'],
+    ['In COVERAGE_PATTERNS, missing from YAML globs:', result.diffs.codeMissingFromYaml, '+'],
+    ['In YAML globs, missing from COVERAGE_PATTERNS:', result.diffs.yamlMissingFromCode, '-'],
+  ];
+  for (const [title, list, sigil] of sections) {
+    if (list.length === 0) continue;
+    out.push(title);
+    for (const g of list) out.push(`  ${sigil} ${g}`);
+    out.push('');
+  }
+  out.push('Update test-trigger.md to mirror COVERAGE_PATTERNS, or vice versa.');
+  out.push('Canonical source: .claude/skills/orchestrator/check-utils.js (COVERAGE_PATTERNS).');
+  out.push('Mirror: .claude/rules/test-trigger.md (markdown table + YAML globs frontmatter).');
+  return out.join('\n');
+}
+
+// --- Entry point ---
+
+export function run() {
+  const markdown = readFileSync(TEST_TRIGGER_MD, 'utf-8');
+  const result = detectDrift({ coveragePatterns: COVERAGE_PATTERNS, markdown });
+  const report = formatReport(result);
+  if (result.hasDrift) {
+    console.error(report);
+    return 1;
+  }
+  console.log(report);
+  return 0;
+}
+
+const isMainModule =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('check-mirror-drift.js');
+if (isMainModule) {
+  process.exit(run());
+}
+
+export { TEST_TRIGGER_MD, REPO_ROOT };

--- a/.github/workflows/check-mirror-drift.yml
+++ b/.github/workflows/check-mirror-drift.yml
@@ -1,0 +1,43 @@
+name: Mirror Drift Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.claude/skills/orchestrator/check-utils.js'
+      - '.claude/skills/orchestrator/check-mirror-drift.js'
+      - '.claude/skills/orchestrator/__tests__/check-mirror-drift.test.js'
+      - '.claude/rules/test-trigger.md'
+      - '.github/workflows/check-mirror-drift.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.claude/skills/orchestrator/check-utils.js'
+      - '.claude/skills/orchestrator/check-mirror-drift.js'
+      - '.claude/skills/orchestrator/__tests__/check-mirror-drift.test.js'
+      - '.claude/rules/test-trigger.md'
+      - '.github/workflows/check-mirror-drift.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check-mirror-drift:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Bun is required to run the unit tests (`bun:test`). The drift check
+      # script itself runs under `node`, but keeping a single runtime here
+      # avoids the cross-runtime-spawn pitfall (Sprint 2026-04-28 lesson).
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.4"
+
+      - name: Run mirror drift check
+        run: node .claude/skills/orchestrator/check-mirror-drift.js
+
+      - name: Run mirror drift unit tests
+        run: bun test ./.claude/skills/orchestrator/__tests__/check-mirror-drift.test.js


### PR DESCRIPTION
## Summary

Implements **Approach 1** (sync test) from [Issue #752](https://github.com/ms2sato/agent-console/issues/752): a CI gate that fails when the executable single-writer (`COVERAGE_PATTERNS` in `.claude/skills/orchestrator/check-utils.js`) drifts from its markdown mirror (`.claude/rules/test-trigger.md`).

Closes #752

## How it works

- `check-mirror-drift.js` imports `COVERAGE_PATTERNS` directly (no eval / no regex extraction from source).
- Each regex is normalized to its glob equivalent: `^DIR\/.+\.EXT$` → `DIR/**/*.EXT`.
- The markdown mirror is parsed twice: from the YAML `globs:` frontmatter and from the "Expected Test File Locations" markdown table.
- All three sets must be equal; otherwise the script exits non-zero with a diff-style report.
- Regex shapes outside the canonical form are reported as "unconvertible" — the check fails closed rather than silently allowing them.
- YAML negation entries (`!**/*.test.ts`, `!**/__tests__/**`) are excluded from the comparison: they mirror `isTestFile()` rather than `COVERAGE_PATTERNS`.

## CI

New workflow `.github/workflows/check-mirror-drift.yml` triggers on changes to:
- `.claude/skills/orchestrator/check-utils.js`
- `.claude/skills/orchestrator/check-mirror-drift.js`
- `.claude/skills/orchestrator/__tests__/check-mirror-drift.test.js`
- `.claude/rules/test-trigger.md`
- `.github/workflows/check-mirror-drift.yml`

`setup-bun` is included so the unit tests can run via `bun:test` (Sprint 2026-04-28 cross-runtime spawn lesson).

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run test` — full suite green (1361 + 309 + 29 + 2463 + 153 pass / 0 fail)
- [x] `bun test ./.claude/skills/orchestrator/__tests__/check-mirror-drift.test.js` — 19 pass
- [x] `node .claude/skills/orchestrator/check-mirror-drift.js` — exits 0 on current state
- [x] `node .claude/skills/orchestrator/preflight-check.js` — exits 0
- [ ] `coderabbit review --agent --base main` — local CLI rate-limited; relying on GitHub-side bot

## Notes

- Approach 2 (generation step) was rejected for this slice: it couples the markdown to the build, and the markdown would no longer be hand-editable.
- Approach 3 (merge with #671) remains viable as a future refactor; this PR doesn't preclude it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)