### PR TITLE
docs: add summary + read_when frontmatter to founding narratives (ctx-saving Tier 1)

### DIFF
--- a/.claude/skills/orchestrator/sprint-lifecycle.md
+++ b/.claude/skills/orchestrator/sprint-lifecycle.md
@@ -32,7 +32,7 @@ Each sprint is labeled by the calendar date its retrospective runs (e.g., `2026-
    - **Propose a disposition** to the owner: resume (rebase + address feedback), close (obsoleted), or defer (keep open, revisit next sprint with a concrete trigger).
 
    **Why:** PRs silently rotting is a real failure mode. Sprint 2026-04-17 discovered PR #626 had sat 10 days with unaddressed CodeRabbit feedback; it turned out to still be valid and was merged after review. Without this step, it would have continued to rot. This step converts "discovered by accident" into "verified every sprint."
-6. **Read founding narratives.** Scan `docs/narratives/` for entries with `nature: founding` and `importance: high`. These are short essays on why key systems or habits exist. Reading them at Sprint Start primes judgment — you enter the sprint with the same "why" context as the orchestrator who built those systems. See [Narrative Memory System](#narrative-memory-system) below.
+6. **Pick founding-narrative frontmatter.** Scan `docs/narratives/` for entries with `nature: founding` and `importance: high`. **Read only the frontmatter** (date, nature, tags, `summary`, `read_when`) — not the body. The summary primes judgment with the lesson; the body is loaded on demand later when a `read_when` trigger matches the current task. (This is the ctx-saving design: founding narratives total ~600 lines / ~10K tokens; frontmatter-only pick saves ~95% of that at Sprint Start, with the full body still one Read away when needed.) See [Narrative Memory System](#narrative-memory-system) below.
 
 ## Sprint Execution
 - Task progression, acceptance checks, merges
@@ -130,10 +130,10 @@ When a rule feels arbitrary, walk the hierarchy: rule → feedback's "why" → n
 
 ### When to read narratives
 
-- **Sprint Start Step 6** — scan `nature: founding`, `importance: high` entries to prime judgment
+- **Sprint Start Step 6** — scan `nature: founding`, `importance: high` entries; pick **frontmatter only** (`summary` + `read_when`), not the body. Body is loaded later when a `read_when` trigger matches.
 - **When a rule feels arbitrary** — follow the `Read this if the rule feels arbitrary:` link from the rule
 - **After a near-miss or incident** — read the matching tag to see if the pattern recurred
-- **On demand** when exploring a topic — `grep tags:` in front matter
+- **On demand** when exploring a topic — `grep tags:` in front matter, then load the matching narrative's body if its `read_when` triggers apply
 
 ### When to write a narrative
 

--- a/docs/narratives/2026-04-17-founding-intent.md
+++ b/docs/narratives/2026-04-17-founding-intent.md
@@ -10,6 +10,13 @@ tags:
   - qualitative-knowledge
 related_rules: []
 related_issues: []
+summary: |
+  Owner's question "if you cannot pass on something qualitative, don't you
+  think you stop growing?" surfaced that rules preserve propositions but lose
+  the felt texture of incidents. Narratives directory created in response.
+read_when:
+  - Onboarding to the narrative system
+  - You wonder why narratives exist alongside rules
 ---
 
 # Why we start the narratives directory

--- a/docs/narratives/2026-04-17-rebase-during-local-review.md
+++ b/docs/narratives/2026-04-17-rebase-during-local-review.md
@@ -12,6 +12,14 @@ related_rules:
   - memory/feedback_no_unauthorized_rebase.md
   - memory/feedback_orchestrator_no_branch_edit.md
 related_issues: [#632, #638]
+summary: |
+  Orchestrator force-pushed `gh pr update-branch --rebase` on PRs while owner
+  was running local review; near-miss almost destroyed the agent's mid-review-
+  loop uncommitted work too. "Idle worktree" interpreted at face value missed
+  that owner's local checkout makes the branch active in a different sense.
+read_when:
+  - Considering rebase / force-push that affects another agent's branch or owner's local checkout
+  - `feedback_no_unauthorized_rebase.md` or `feedback_orchestrator_no_branch_edit.md` feels arbitrary
 ---
 
 # Rebase During Local Review

--- a/docs/narratives/2026-04-18-brewing-pilot-founding.md
+++ b/docs/narratives/2026-04-18-brewing-pilot-founding.md
@@ -16,6 +16,14 @@ related_rules:
 related_issues:
   - "#665"
   - "#654"
+summary: |
+  Brewing Pilot scope collapsed from "novel CTO device + Context Store" to
+  "rotting-prevention router reusing existing surfaces" after owner's single
+  question — `file-test-map.md` ≒ existing `test-trigger.md` — exposed the
+  proposal as un-grep-checked. No-LLM-call platform integrity preserved.
+read_when:
+  - Designing or modifying brewing or Context Store
+  - Tempted to propose a new infrastructure / artifact / directory before checking existing
 ---
 
 # How the brewing pilot ended up in this shape

--- a/docs/narratives/2026-04-18-strategic-position.md
+++ b/docs/narratives/2026-04-18-strategic-position.md
@@ -18,6 +18,14 @@ related_issues:
   - "#666"
   - "#625"
   - "#529"
+summary: |
+  agent-console articulated by owner as an LLM-agnostic PTY platform; provider
+  lock-in (Agent Team, hooks-as-product-surface, etc.) is "overreach" to be
+  avoided. Brewing's no-LLM-call shape is necessity, not coincidence. Issue
+  prioritization gains a strategic axis beyond "what's flagged next".
+read_when:
+  - Issue prioritization where business-impact / strategic-fit judgment matters
+  - Considering a feature that binds the platform to a specific LLM provider
 ---
 
 # The day agent-console's strategic position was articulated

--- a/docs/narratives/2026-04-21-orchestrator-as-skill.md
+++ b/docs/narratives/2026-04-21-orchestrator-as-skill.md
@@ -12,6 +12,14 @@ tags:
 related_rules: []
 related_issues:
   - "#678"
+summary: |
+  Shared Orchestrator reframed from first-class concept (dedicated lifecycle,
+  API key, server flag) to "any session running the orchestrator skill, owned
+  by a shared OS account". Design simplification deleted most of the prior
+  doc's frame; #678 implementation shape changed accordingly.
+read_when:
+  - Working on `#678` shared-account session implementation (Slices 2-6)
+  - Tempted to introduce a new first-class system concept when an existing extension would do
 ---
 
 # Orchestrator as Skill, Not System Concept

--- a/docs/narratives/2026-04-30-printf-empty-path-discovery.md
+++ b/docs/narratives/2026-04-30-printf-empty-path-discovery.md
@@ -14,6 +14,14 @@ related_rules:
 related_issues:
   - "#730"
   - "#737"
+summary: |
+  Empty-`PATH` boundary test caught `cat <<EOF` failing exactly where the
+  diagnostic was supposed to work (PATH-less environments). Boundary values
+  are not just inputs — they probe for invisible implementation-environment
+  dependencies. `printf` is a bash builtin; `cat` is not.
+read_when:
+  - Writing boundary-value tests for predicates / contracts / fail-fast diagnostics
+  - Implementing diagnostics that must run in minimal / degraded environments
 ---
 
 # The empty PATH boundary that found a structural defect

--- a/docs/narratives/README.md
+++ b/docs/narratives/README.md
@@ -35,10 +35,19 @@ tags:
 related_rules:
   - memory/feedback_xxx.md
 related_issues: [#123]
+summary: |
+  1-2 sentences distilling what was learned. Picked at Sprint Start in
+  place of the full body, so the next instance can decide whether to
+  read further.
+read_when:
+  - <trigger condition 1 — when a future instance should come back to read this in full>
+  - <trigger condition 2>
 ---
 ```
 
 Body sections are flexible but first-person present tense is encouraged — it carries more of the raw texture than third-person past.
+
+**`summary` and `read_when` are picked at Sprint Start.** Sprint Start Step 6 reads only frontmatter (including `summary` + `read_when`) for `nature: founding`, `importance: high` entries — the full body is loaded on demand when a `read_when` trigger matches the current task. Keep `summary` terse (no more than 4 lines) and `read_when` to 1-2 mechanically-checkable conditions; if more triggers seem applicable, the strongest two are usually enough — extras dilute the signal.
 
 **Language.** Write narratives entirely in English, including quoted speech. When a quote was originally spoken or written in another language, translate it into English — preserve semantic content and, where possible, tone — and do not retain the original-language text verbatim. (A term of art with no English equivalent is the rare exception.) A monolingual narrative stays readable for any future reader regardless of their native language and keeps search / grep uniform across the collection.
 


### PR DESCRIPTION
## Summary

Implements the **ctx-saving Tier 1** improvement proposed by the owner during Sprint 2026-05-03 handoff: extend `docs/narratives/` frontmatter with `summary` and `read_when` fields, and switch Sprint Start Step 6 to **frontmatter-only pick**.

### What changes

- All 6 existing narratives gain a `summary` (2-4 lines distilling the lesson) and `read_when` (2 mechanically-checkable trigger conditions) front-matter fields:
  - `2026-04-17-founding-intent.md` — narrative system founding
  - `2026-04-17-rebase-during-local-review.md` — force-push incident
  - `2026-04-18-brewing-pilot-founding.md` — brewing system founding
  - `2026-04-18-strategic-position.md` — strategic position articulation
  - `2026-04-21-orchestrator-as-skill.md` — shared-orchestrator design simplification
  - `2026-04-30-printf-empty-path-discovery.md` — boundary-value insight

- `docs/narratives/README.md` Format section documents the two new fields and the "terse summary, 1-2 trigger conditions" guidance.

- `.claude/skills/orchestrator/sprint-lifecycle.md` Step 6 instructs the Orchestrator to read **only the frontmatter** of `nature: founding`, `importance: high` entries — not the body. The body is loaded on demand later when a `read_when` trigger matches. The "Narrative Memory System / When to read narratives" subsection mirrors this.

### Why

Founding narratives total ~600 lines / ~10K tokens. Reading them all in full at every Sprint Start consumed ~4% of context for content that primes judgment but does not need to be present until a specific trigger matches. Frontmatter-only pick saves ~95% of that load while keeping the body one Read away.

### Constraints respected

- `summary` is descriptive (lesson distilled, neutral tone) — not so vivid that it short-circuits the body's emotion-textured reading when a trigger fires.
- `read_when` is limited to 2 conditions per narrative (per owner guidance) — extras dilute the mechanical-check signal.

## Test plan

- [x] `bun run check:lang` — pass (103 files, all Latin/Greek/Cyrillic).
- [x] `node .claude/skills/orchestrator/preflight-check.js` — pass (no production files changed; rule/skill duplication clean; language clean).
- [x] Diff scope verified: 8 files (`docs/narratives/*.md` + `.claude/skills/orchestrator/sprint-lifecycle.md`), 59 insertions, 3 deletions.

## Note on CodeRabbit

`[skip ci]` — pure documentation / skill-rule-text change. CodeRabbit GitHub-side bot still runs; CLI / additional review optional given the diff shape.