### PR TITLE
fix: align worker outputOffset with file size on PTY activation (closes #769)

### DIFF
--- a/docs/design/websocket-protocol.md
+++ b/docs/design/websocket-protocol.md
@@ -81,6 +81,152 @@ Per-worker WebSocket for terminal I/O.
 | `activity` | `{ state: AgentActivityState }` | Agent activity state change (agent workers only) |
 | `error` | `{ message: string, code?: WorkerErrorCode }` | Error notification (e.g., worker not found) |
 
+### Output Offset Semantics
+
+All `offset` fields exchanged over the worker WebSocket — `output.offset`,
+`history.offset`, `output-truncated.newOffset`, and the client-cached
+`fromOffset` — represent **the absolute byte position from the start of the
+worker's persistent output file**. They are never cumulative since PTY
+activation, and never reset on hibernation / resume.
+
+The server keeps a single source of truth for this offset:
+`worker.outputOffset` is advanced per write by the byte length of the chunk
+being appended to the output file, and the file size on disk is the
+authoritative reference whenever the in-memory counter is reseeded.
+
+#### Lifecycle phase × offset table
+
+| Phase | `worker.outputOffset` (server) | `output.offset` (event) | `history.offset` (event) | `output-truncated.newOffset` |
+|---|---|---|---|---|
+| `createWorker` (fresh) | `0` (file size = 0) | file-absolute | file-absolute | — |
+| live output | advances by chunk byte length per write (= file size) | file-absolute | file-absolute | — |
+| PTY died (server restart / hibernation) | last value frozen, `pty = null` | — (no live output) | file-absolute (read from file) | — |
+| **Activation (revived)** | **seeded from `getCurrentOffset()` (file size) before PTY spawn** | file-absolute | file-absolute | — |
+| `restartWorker` | `0` (file truncated to 0 by `resetWorkerOutput`) | file-absolute | file-absolute | — |
+| Truncation (>10MB cap) | trimmed file size | file-absolute | file-absolute | trimmed file size |
+
+The "revived" row is the contract enforced by the
+`AgentActivationParams.revived` / `TerminalActivationParams.revived` flag
+(true for `restoreWorker`, `getAvailableWorker` activation, and pause/resume;
+false for `createWorker` and `restartWorker`). Without that seed, the
+counter restarts from `0` after every revival and silently drifts away from
+the file-absolute offset that the client's IndexedDB cache holds — see
+sequence (b) below.
+
+The client's `offsetRef` mirrors the same semantic: it stores whatever
+file-absolute value it most recently observed (from `history.offset` /
+`output.offset` / a cache hit) and only ever feeds that value back to the
+server via `request-history.fromOffset`.
+
+#### Sequence (a) — normal happy path (fresh worker, no race window)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant C as Client (Terminal.tsx)
+    participant Cache as IndexedDB
+    participant WS as WebSocket
+    participant S as Server (worker-manager)
+    participant F as Output file
+
+    Note over S,F: Fresh worker creation
+    S->>F: create file (size = 0)
+    S->>S: worker.outputOffset = 0
+
+    Note over U,C: Mount (1st visit)
+    U->>C: navigate
+    C->>Cache: loadTerminalState
+    Cache-->>C: null (cache miss)
+    C->>C: offsetRef = 0
+    C->>WS: request-history(fromOffset=0)
+    WS->>S: forward
+    S->>F: read from 0 (line-limit 5000)
+    F-->>S: data
+    S->>WS: history(data, offset=file_size)
+    WS->>C: forward
+    C->>C: offsetRef = file_size
+    C->>Cache: save(serialize, offset=file_size)
+
+    Note over S,F: Live output
+    S->>F: append chunk (file_size += chunk)
+    S->>S: outputOffset += chunk
+    Note right of S: outputOffset == file_size (fresh)
+    S->>WS: output(chunk, offset=outputOffset)
+    WS->>C: forward
+    C->>C: offsetRef = offset
+    C->>C: terminal.write(chunk)
+    C->>Cache: markDirty (idle save)
+
+    Note over U,C: Re-visit (cache hit)
+    U->>C: navigate back
+    C->>Cache: loadTerminalState
+    Cache-->>C: { data: serialize, offset: file_size }
+    C->>C: terminal.write(serialize) + offsetRef = file_size
+    C->>WS: request-history(fromOffset=file_size)
+    S->>F: read from file_size (incremental)
+    F-->>S: empty / small delta
+    S->>WS: history(delta, offset=new_size)
+    Note right of C: ideal incremental sync
+```
+
+#### Sequence (b) — restoration race window (Issue #762 root cause)
+
+This is the failure mode that exists when the activation path forgets to
+seed `worker.outputOffset` from the file size on revival. It is documented
+here as the rationale for the "revived" row in the table above.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant C as Client (Terminal.tsx)
+    participant Cache as IndexedDB
+    participant WS as WebSocket
+    participant S as Server (worker-manager)
+    participant F as Output file
+
+    Note over S,F: Server restart / hibernation
+    S->>S: PTY died, worker.pty = null
+    Note right of F: file persists (size = N)
+
+    Note over S: Activation (revived path)
+    Note over S: restoreWorker / getAvailableWorker / pause-resume
+    S->>S: spawn PTY
+    S->>S: outputOffset = 0  [BUG: should be N]
+
+    Note over U,C: Visit (cache hit from prev session)
+    U->>C: navigate
+    C->>Cache: loadTerminalState
+    Cache-->>C: { data, offset: N }
+    C->>C: offsetRef = N
+    C->>WS: request-history(fromOffset=N)
+    S->>F: read from N
+    F-->>S: empty
+    S->>WS: history(empty, offset=N)
+
+    Note over S,F: PTY live output (large burst at activation)
+    loop each chunk
+        S->>F: append (file_size = N + delta)
+        S->>S: outputOffset += chunk (small cumulative)
+        S->>WS: output(chunk, offset=outputOffset)
+        WS->>C: forward
+        C->>C: offsetRef = outputOffset  [overwrites N with small cumulative]
+    end
+    C->>Cache: idle save (offset = small cumulative)  [corrupted]
+
+    Note over U,C: Re-visit (cache hit, corrupted offset)
+    U->>C: navigate away & back
+    C->>Cache: loadTerminalState
+    Cache-->>C: { data, offset: small_cumulative }
+    C->>WS: request-history(fromOffset=small_cumulative)
+    Note right of S: fromOffset > 0, line-limit bypass
+    S->>F: read from small_cumulative (file_size = N + delta)
+    F-->>S: ~87% of file (huge tail)
+    S->>WS: history(1.55MB delta, ...)
+    Note right of C: disguised 100% reload
+```
+
 ### History Request Behavior
 
 When a Terminal component mounts, it requests terminal history to display previous output.

--- a/docs/design/websocket-protocol.md
+++ b/docs/design/websocket-protocol.md
@@ -79,6 +79,7 @@ Per-worker WebSocket for terminal I/O.
 | `exit` | `{ exitCode: number, signal: string \| null }` | Process exit |
 | `history` | `{ data: string, offset: number, timedOut?: boolean }` | Terminal output history with current offset. `timedOut: true` if history load timed out (client can continue without full history). |
 | `activity` | `{ state: AgentActivityState }` | Agent activity state change (agent workers only) |
+| `output-truncated` | `{ message: string, newOffset: number }` | Output file was truncated (size cap exceeded). `newOffset` is the new file-absolute byte position the client should use for any subsequent `request-history`. Client must invalidate / rebase its cached terminal state to this offset. |
 | `error` | `{ message: string, code?: WorkerErrorCode }` | Error notification (e.g., worker not found) |
 
 ### Output Offset Semantics

--- a/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
+++ b/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
@@ -38,8 +38,8 @@ function createMockDeps(overrides?: Partial<SessionPauseResumeDeps>): SessionPau
       killWorker: mock(async () => {}),
       restoreWorkersFromPersistence: mock((_workers: unknown[]) => new Map()),
       activateAgentWorkerPty: mock(async () => {}),
-      activateTerminalWorkerPty: mock(() => {}),
-    } as unknown as SessionPauseResumeDeps['workerManager'],
+      activateTerminalWorkerPty: mock(async () => {}),
+    } satisfies SessionPauseResumeDeps['workerManager'],
     pathExists: mock(async () => true),
     getRepositoryEnvVars: mock(async () => ({})),
     getPathResolverForSession: mock((_session: InternalSession) => new SessionDataPathResolver('/dummy')),
@@ -274,8 +274,8 @@ describe('SessionPauseResumeService', () => {
           killWorker: mock(async () => {}),
           restoreWorkersFromPersistence: mock(() => restoredWorkers),
           activateAgentWorkerPty: mock(async () => {}),
-          activateTerminalWorkerPty: mock(() => {}),
-        } as unknown as SessionPauseResumeDeps['workerManager'],
+          activateTerminalWorkerPty: mock(async () => {}),
+        } satisfies SessionPauseResumeDeps['workerManager'],
         toPublicSession: mock(() => mockPublicSession),
         getSessionLifecycleCallbacks: () => ({ onSessionResumed }),
       });
@@ -316,8 +316,8 @@ describe('SessionPauseResumeService', () => {
           killWorker: mock(async () => {}),
           restoreWorkersFromPersistence: mock(() => new Map()),
           activateAgentWorkerPty: mock(async () => {}),
-          activateTerminalWorkerPty: mock(() => {}),
-        } as unknown as SessionPauseResumeDeps['workerManager'],
+          activateTerminalWorkerPty: mock(async () => {}),
+        } satisfies SessionPauseResumeDeps['workerManager'],
       });
       const service = new SessionPauseResumeService(deps);
 
@@ -352,8 +352,8 @@ describe('SessionPauseResumeService', () => {
           killWorker: mock(async () => {}),
           restoreWorkersFromPersistence: mock(() => restoredWorkers),
           activateAgentWorkerPty: mock(async () => { throw new Error('PTY activation failed'); }),
-          activateTerminalWorkerPty: mock(() => {}),
-        } as unknown as SessionPauseResumeDeps['workerManager'],
+          activateTerminalWorkerPty: mock(async () => {}),
+        } satisfies SessionPauseResumeDeps['workerManager'],
       });
       const service = new SessionPauseResumeService(deps);
 
@@ -396,8 +396,8 @@ describe('SessionPauseResumeService', () => {
           killWorker: mock(async () => {}),
           restoreWorkersFromPersistence: mock(() => restoredWorkers),
           activateAgentWorkerPty: mock(async () => {}),
-          activateTerminalWorkerPty: mock(() => {}),
-        } as unknown as SessionPauseResumeDeps['workerManager'],
+          activateTerminalWorkerPty: mock(async () => {}),
+        } satisfies SessionPauseResumeDeps['workerManager'],
       });
       const service = new SessionPauseResumeService(deps);
 
@@ -443,7 +443,7 @@ describe('SessionPauseResumeService', () => {
           restoreWorkersFromPersistence: mock(() => restoredWorkers),
           activateAgentWorkerPty: activateAgentMock,
           activateTerminalWorkerPty: mock(async () => {}),
-        } as unknown as SessionPauseResumeDeps['workerManager'],
+        } satisfies SessionPauseResumeDeps['workerManager'],
       });
       const service = new SessionPauseResumeService(deps);
 
@@ -477,7 +477,7 @@ describe('SessionPauseResumeService', () => {
           restoreWorkersFromPersistence: mock(() => restoredWorkers),
           activateAgentWorkerPty: mock(async () => {}),
           activateTerminalWorkerPty: activateTerminalMock,
-        } as unknown as SessionPauseResumeDeps['workerManager'],
+        } satisfies SessionPauseResumeDeps['workerManager'],
       });
       const service = new SessionPauseResumeService(deps);
 
@@ -507,8 +507,8 @@ describe('SessionPauseResumeService', () => {
           killWorker: mock(async () => {}),
           restoreWorkersFromPersistence: mock(() => restoredWorkers),
           activateAgentWorkerPty: mock(async () => {}),
-          activateTerminalWorkerPty: mock(() => {}),
-        } as unknown as SessionPauseResumeDeps['workerManager'],
+          activateTerminalWorkerPty: mock(async () => {}),
+        } satisfies SessionPauseResumeDeps['workerManager'],
       });
       const service = new SessionPauseResumeService(deps);
 

--- a/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
+++ b/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
@@ -410,6 +410,83 @@ describe('SessionPauseResumeService', () => {
       expect(deps.deleteSession).toHaveBeenCalledWith('session-1');
     });
 
+    // Issue #769: paused-session resume is a "revived" PTY activation path,
+    // so the worker's outputOffset must be seeded from the persisted output
+    // file size. The contract is enforced by passing `revived: true` to the
+    // worker-manager activation methods, which then read the file size before
+    // spawning the PTY. See docs/design/websocket-protocol.md "Output offset
+    // semantics".
+    it('should pass revived: true when activating agent worker on resume', async () => {
+      const agentWorker = buildInternalAgentWorker({ id: 'w1' });
+      const restoredWorkers = new Map([['w1', agentWorker]]);
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-1',
+        serverPid: null,
+        pausedAt: '2026-01-01T00:00:00.000Z',
+        workers: [buildPersistedAgentWorker({ id: 'w1', agentId: 'test-agent' })],
+      });
+
+      // Cast to two-arg signature so the mock's `calls[0][1]` is typed as the
+      // params record. Bun's `mock(async () => {})` infers `args: []`, which
+      // would otherwise make `[1]` a tuple-out-of-range type error (TS2493).
+      const activateAgentMock = mock(
+        async (_worker: unknown, _params: { revived: boolean }) => {},
+      );
+      const deps = createMockDeps({
+        sessionRepository: {
+          ...createMockDeps().sessionRepository,
+          findById: mock(async () => persisted),
+          update: mock(async () => true),
+        },
+        workerManager: {
+          killWorker: mock(async () => {}),
+          restoreWorkersFromPersistence: mock(() => restoredWorkers),
+          activateAgentWorkerPty: activateAgentMock,
+          activateTerminalWorkerPty: mock(async () => {}),
+        } as unknown as SessionPauseResumeDeps['workerManager'],
+      });
+      const service = new SessionPauseResumeService(deps);
+
+      await service.resumeSession('session-1');
+
+      expect(activateAgentMock).toHaveBeenCalledTimes(1);
+      expect(activateAgentMock.mock.calls[0][1].revived).toBe(true);
+    });
+
+    it('should pass revived: true when activating terminal worker on resume', async () => {
+      const terminalWorker = buildInternalTerminalWorker({ id: 'w1' });
+      const restoredWorkers = new Map([['w1', terminalWorker]]);
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-1',
+        serverPid: null,
+        pausedAt: '2026-01-01T00:00:00.000Z',
+        workers: [buildPersistedTerminalWorker({ id: 'w1' })],
+      });
+
+      const activateTerminalMock = mock(
+        async (_worker: unknown, _params: { revived: boolean }) => {},
+      );
+      const deps = createMockDeps({
+        sessionRepository: {
+          ...createMockDeps().sessionRepository,
+          findById: mock(async () => persisted),
+          update: mock(async () => true),
+        },
+        workerManager: {
+          killWorker: mock(async () => {}),
+          restoreWorkersFromPersistence: mock(() => restoredWorkers),
+          activateAgentWorkerPty: mock(async () => {}),
+          activateTerminalWorkerPty: activateTerminalMock,
+        } as unknown as SessionPauseResumeDeps['workerManager'],
+      });
+      const service = new SessionPauseResumeService(deps);
+
+      await service.resumeSession('session-1');
+
+      expect(activateTerminalMock).toHaveBeenCalledTimes(1);
+      expect(activateTerminalMock.mock.calls[0][1].revived).toBe(true);
+    });
+
     it('should restore terminal workers during resume', async () => {
       const terminalWorker = buildInternalTerminalWorker({ id: 'w1' });
       const restoredWorkers = new Map([['w1', terminalWorker]]);

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -1814,6 +1814,127 @@ describe('WorkerLifecycleManager', () => {
     });
   });
 
+  // ========== Output offset semantic alignment (Issue #769) ==========
+  //
+  // Activation paths must seed `worker.outputOffset` from the persisted output
+  // file size when the worker is being revived (PTY died, session re-entered,
+  // pause/resume). Otherwise the cumulative-from-zero counter on the server
+  // diverges from the file-absolute offset the client persists in IndexedDB,
+  // and the client's `request-history` reads against the stale (small)
+  // cumulative offset at the next visit — producing the disguised
+  // "100% reload" symptom in #762.
+  //
+  // Fresh creation (`createWorker`) and full reset (`restartAgentWorker`)
+  // paths must keep the seed at 0 because the file is empty by construction
+  // (or has just been truncated to empty by `resetWorkerOutput`).
+  describe('outputOffset alignment on PTY activation', () => {
+    const PRE_EXISTING_BYTES = 'restored-history-content-1234567890';
+    const PRE_EXISTING_LENGTH = Buffer.byteLength(PRE_EXISTING_BYTES, 'utf-8');
+
+    function seedOutputFile(sessionId: string, workerId: string, content: string): void {
+      const dir = `${TEST_CONFIG_DIR}/_quick/outputs/${sessionId}`;
+      // Re-seed the in-memory FS with the directory + file containing the
+      // pre-existing output bytes. Resolver path matches the one used by
+      // `createDeps` (always points at `${TEST_CONFIG_DIR}/_quick`).
+      setupMemfs({
+        [`${TEST_CONFIG_DIR}/.keep`]: '',
+        [`${dir}/${workerId}.log`]: content,
+      });
+    }
+
+    it('restoreWorker (agent) seeds outputOffset from existing output file size', async () => {
+      const session = createTestSession();
+      sessions.set(session.id, session);
+
+      const agentWorker: InternalAgentWorker = {
+        id: 'restored-agent-offset',
+        type: 'agent',
+        name: 'Restored Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+        pty: null,
+        outputBuffer: '',
+        outputOffset: 0,
+        activityState: 'unknown',
+        activityDetector: null,
+        connectionCallbacks: new Map(),
+      };
+      session.workers.set(agentWorker.id, agentWorker);
+
+      seedOutputFile(session.id, agentWorker.id, PRE_EXISTING_BYTES);
+
+      const result = await lifecycleManager.restoreWorker(session.id, agentWorker.id);
+
+      expect(result.success).toBe(true);
+      expect(agentWorker.outputOffset).toBe(PRE_EXISTING_LENGTH);
+    });
+
+    it('restoreWorker (terminal) seeds outputOffset from existing output file size', async () => {
+      const session = createTestSession();
+      sessions.set(session.id, session);
+
+      const terminalWorker: InternalTerminalWorker = {
+        id: 'restored-terminal-offset',
+        type: 'terminal',
+        name: 'Restored Terminal',
+        createdAt: new Date().toISOString(),
+        pty: null,
+        outputBuffer: '',
+        outputOffset: 0,
+        connectionCallbacks: new Map(),
+      };
+      session.workers.set(terminalWorker.id, terminalWorker);
+
+      seedOutputFile(session.id, terminalWorker.id, PRE_EXISTING_BYTES);
+
+      const result = await lifecycleManager.restoreWorker(session.id, terminalWorker.id);
+
+      expect(result.success).toBe(true);
+      expect(terminalWorker.outputOffset).toBe(PRE_EXISTING_LENGTH);
+    });
+
+    it('getAvailableWorker seeds outputOffset from existing output file size on first activation', async () => {
+      const session = createTestSession();
+      sessions.set(session.id, session);
+
+      const terminalWorker: InternalTerminalWorker = {
+        id: 'available-terminal-offset',
+        type: 'terminal',
+        name: 'Terminal',
+        createdAt: new Date().toISOString(),
+        pty: null,
+        outputBuffer: '',
+        outputOffset: 0,
+        connectionCallbacks: new Map(),
+      };
+      session.workers.set(terminalWorker.id, terminalWorker);
+
+      seedOutputFile(session.id, terminalWorker.id, PRE_EXISTING_BYTES);
+
+      const available = await lifecycleManager.getAvailableWorker(session.id, terminalWorker.id);
+
+      expect(available).not.toBeNull();
+      expect(available!.outputOffset).toBe(PRE_EXISTING_LENGTH);
+    });
+
+    it('createWorker keeps outputOffset at 0 (fresh worker, no pre-existing file)', async () => {
+      const session = createTestSession();
+      sessions.set(session.id, session);
+
+      const worker = await lifecycleManager.createWorker(session.id, {
+        type: 'terminal',
+      });
+
+      expect(worker).not.toBeNull();
+      const internalWorker = session.workers.get(worker!.id);
+      expect(internalWorker).toBeDefined();
+      expect(internalWorker!.type).toBe('terminal');
+      if (internalWorker!.type === 'terminal' || internalWorker!.type === 'agent') {
+        expect(internalWorker!.outputOffset).toBe(0);
+      }
+    });
+  });
+
   describe('getCurrentOutputOffset fallback branch (session not in memory)', () => {
     it('uses the DB-backed resolver when session is not in memory but persisted', async () => {
       // The in-memory `sessions` map is empty; the worker cannot be found

--- a/packages/server/src/services/__tests__/worker-manager-env.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager-env.test.ts
@@ -326,10 +326,10 @@ describe('WorkerManager - AgentConsole env var injection', () => {
   });
 
   describe('terminal worker PTY processes', () => {
-    it('should NOT include any AGENT_CONSOLE env vars', () => {
+    it('should NOT include any AGENT_CONSOLE env vars', async () => {
       const worker = buildInternalTerminalWorker();
 
-      workerManager.activateTerminalWorkerPty(worker, {
+      await workerManager.activateTerminalWorkerPty(worker, {
         sessionId: 'session-123',
         locationPath: '/test/path',
         repositoryEnvVars: {},

--- a/packages/server/src/services/__tests__/worker-manager-env.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager-env.test.ts
@@ -65,6 +65,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         resolver: new SessionDataPathResolver('/test/config/_quick'),
         agentId: 'claude-code',
         continueConversation: false,
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -84,6 +85,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         resolver: new SessionDataPathResolver('/test/config/_quick'),
         agentId: 'claude-code',
         continueConversation: false,
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -101,6 +103,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         resolver: new SessionDataPathResolver('/test/config/_quick'),
         agentId: 'claude-code',
         continueConversation: false,
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -119,6 +122,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         agentId: 'claude-code',
         continueConversation: false,
         repositoryId: 'repo-456',
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -137,6 +141,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         agentId: 'claude-code',
         continueConversation: false,
         // repositoryId is not provided (quick session)
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -155,6 +160,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         agentId: 'claude-code',
         continueConversation: false,
         repositoryId: 'repo-all-four',
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -175,6 +181,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         resolver: new SessionDataPathResolver('/test/config/_quick'),
         agentId: 'claude-code',
         continueConversation: false,
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -196,6 +203,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         agentId: 'claude-code',
         continueConversation: false,
         repositoryId: 'org/repo-name',
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -218,6 +226,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         agentId: 'claude-code',
         continueConversation: false,
         repositoryId: 'repo-1',
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -241,6 +250,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         agentId: 'claude-code',
         continueConversation: false,
         context: { parentSessionId: 'parent-sess-abc' },
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -259,6 +269,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         agentId: 'claude-code',
         continueConversation: false,
         context: { parentWorkerId: 'parent-wkr-xyz' },
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -277,6 +288,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         agentId: 'claude-code',
         continueConversation: false,
         // context is intentionally omitted
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -303,6 +315,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
           parentSessionId: 'real-parent-session',
           parentWorkerId: 'real-parent-worker',
         },
+        revived: false,
       });
 
       const env = getLastSpawnEnv();
@@ -322,6 +335,7 @@ describe('WorkerManager - AgentConsole env var injection', () => {
         repositoryEnvVars: {},
         username: 'testuser',
         resolver: new SessionDataPathResolver('/test/config/_quick'),
+        revived: false,
       });
 
       const env = getLastSpawnEnv();

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -86,6 +86,7 @@ describe('WorkerManager', () => {
     resolver: defaultResolver,
     agentId: CLAUDE_CODE_AGENT_ID,
     continueConversation: false,
+    revived: false,
   };
 
   const defaultTerminalActivationParams = {
@@ -94,6 +95,7 @@ describe('WorkerManager', () => {
     repositoryEnvVars: {},
     username: 'testuser',
     resolver: defaultResolver,
+    revived: false,
   };
 
   // ========== Worker Initialization ==========
@@ -807,17 +809,17 @@ describe('WorkerManager', () => {
   // ========== setupWorkerEventHandlers validation ==========
 
   describe('setupWorkerEventHandlers validation', () => {
-    it('should throw if sessionId is empty string', () => {
+    it('should throw if sessionId is empty string', async () => {
       const worker = createTestTerminalWorker();
       // We need to bypass the PTY null check by setting pty first
       // Actually, activateTerminalWorkerPty calls setupWorkerEventHandlers internally
       // So we test by passing an empty sessionId
-      expect(() => {
+      await expect(
         workerManager.activateTerminalWorkerPty(worker, {
           ...defaultTerminalActivationParams,
           sessionId: '',
-        });
-      }).toThrow('sessionId is required');
+        })
+      ).rejects.toThrow('sessionId is required');
     });
   });
 });

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -142,10 +142,10 @@ describe('WorkerManager', () => {
   // ========== PTY Activation Idempotency ==========
 
   describe('activateAgentWorkerPty', () => {
-    it('should spawn a PTY process', () => {
+    it('should spawn a PTY process', async () => {
       const worker = createTestAgentWorker();
 
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
       expect(worker.pty).not.toBeNull();
       expect(worker.activityDetector).not.toBeNull();
@@ -153,24 +153,24 @@ describe('WorkerManager', () => {
       expect(ptyFactory.spawn).toHaveBeenCalledTimes(1);
     });
 
-    it('should be idempotent - calling twice does not spawn a second PTY', () => {
+    it('should be idempotent - calling twice does not spawn a second PTY', async () => {
       const worker = createTestAgentWorker();
 
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
       const firstPty = worker.pty;
 
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
       expect(worker.pty).toBe(firstPty);
       expect(ptyFactory.spawn).toHaveBeenCalledTimes(1);
     });
 
-    it('should set agentId to the actual agent id, not the requested one, when fallback occurs', () => {
+    it('should set agentId to the actual agent id, not the requested one, when fallback occurs', async () => {
       const worker = createTestAgentWorker();
       // Start with a different agentId to verify fallback actually updates it
       worker.agentId = 'originally-different-agent';
 
-      workerManager.activateAgentWorkerPty(worker, {
+      await workerManager.activateAgentWorkerPty(worker, {
         ...defaultAgentActivationParams,
         agentId: 'non-existent-agent',
       });
@@ -180,12 +180,12 @@ describe('WorkerManager', () => {
       expect(worker.pty).not.toBeNull();
     });
 
-    it('should set initial activity state to idle and fire global callback', () => {
+    it('should set initial activity state to idle and fire global callback', async () => {
       const globalCallback = mock(() => {});
       workerManager.setGlobalActivityCallback(globalCallback);
 
       const worker = createTestAgentWorker('agent-cb');
-      workerManager.activateAgentWorkerPty(worker, {
+      await workerManager.activateAgentWorkerPty(worker, {
         ...defaultAgentActivationParams,
         sessionId: 'sess-cb',
       });
@@ -196,22 +196,22 @@ describe('WorkerManager', () => {
   });
 
   describe('activateTerminalWorkerPty', () => {
-    it('should spawn a PTY process', () => {
+    it('should spawn a PTY process', async () => {
       const worker = createTestTerminalWorker();
 
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       expect(worker.pty).not.toBeNull();
       expect(ptyFactory.spawn).toHaveBeenCalledTimes(1);
     });
 
-    it('should be idempotent - calling twice does not spawn a second PTY', () => {
+    it('should be idempotent - calling twice does not spawn a second PTY', async () => {
       const worker = createTestTerminalWorker();
 
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
       const firstPty = worker.pty;
 
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       expect(worker.pty).toBe(firstPty);
       expect(ptyFactory.spawn).toHaveBeenCalledTimes(1);
@@ -221,9 +221,9 @@ describe('WorkerManager', () => {
   // ========== Worker I/O ==========
 
   describe('writeInput', () => {
-    it('should write data to the PTY', () => {
+    it('should write data to the PTY', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const result = workerManager.writeInput(worker, 'ls -la\r');
 
@@ -241,9 +241,9 @@ describe('WorkerManager', () => {
       expect(result).toBe(false);
     });
 
-    it('should handle activity detection for agent workers on Enter key', () => {
+    it('should handle activity detection for agent workers on Enter key', async () => {
       const worker = createTestAgentWorker();
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
       // Writing a string containing '\r' triggers clearUserTyping
       const result = workerManager.writeInput(worker, 'hello\r');
@@ -253,9 +253,9 @@ describe('WorkerManager', () => {
   });
 
   describe('output buffering via PTY onData', () => {
-    it('should append PTY output to outputBuffer and update outputOffset', () => {
+    it('should append PTY output to outputBuffer and update outputOffset', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const mockPty = ptyFactory.instances[0];
       mockPty.simulateData('hello');
@@ -264,9 +264,9 @@ describe('WorkerManager', () => {
       expect(worker.outputOffset).toBe(Buffer.byteLength('hello', 'utf-8'));
     });
 
-    it('should deliver data to attached callbacks', () => {
+    it('should deliver data to attached callbacks', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const receivedData: string[] = [];
       const onData = mock((data: string, _offset: number) => { receivedData.push(data); });
@@ -280,9 +280,9 @@ describe('WorkerManager', () => {
       expect(receivedData[0]).toBe('output text');
     });
 
-    it('should deliver data to multiple attached callbacks', () => {
+    it('should deliver data to multiple attached callbacks', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const onData1 = mock(() => {});
       const onData2 = mock(() => {});
@@ -298,9 +298,9 @@ describe('WorkerManager', () => {
   });
 
   describe('getOutputBuffer', () => {
-    it('should return the accumulated output buffer', () => {
+    it('should return the accumulated output buffer', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const mockPty = ptyFactory.instances[0];
       mockPty.simulateData('line 1\n');
@@ -309,18 +309,18 @@ describe('WorkerManager', () => {
       expect(workerManager.getOutputBuffer(worker)).toBe('line 1\nline 2\n');
     });
 
-    it('should return empty string when no output has been received', () => {
+    it('should return empty string when no output has been received', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       expect(workerManager.getOutputBuffer(worker)).toBe('');
     });
   });
 
   describe('resize', () => {
-    it('should resize the PTY', () => {
+    it('should resize the PTY', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const result = workerManager.resize(worker, 200, 50);
 
@@ -342,9 +342,9 @@ describe('WorkerManager', () => {
   // ========== Callback Attach/Detach ==========
 
   describe('attachCallbacks / detachCallbacks', () => {
-    it('should attach callbacks and return a connection ID', () => {
+    it('should attach callbacks and return a connection ID', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const connectionId = workerManager.attachCallbacks(worker, {
         onData: () => {},
@@ -355,9 +355,9 @@ describe('WorkerManager', () => {
       expect(worker.connectionCallbacks.size).toBe(1);
     });
 
-    it('should detach callbacks by connection ID', () => {
+    it('should detach callbacks by connection ID', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const connectionId = workerManager.attachCallbacks(worker, {
         onData: () => {},
@@ -370,18 +370,18 @@ describe('WorkerManager', () => {
       expect(worker.connectionCallbacks.size).toBe(0);
     });
 
-    it('should return false when detaching a non-existent connection', () => {
+    it('should return false when detaching a non-existent connection', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const result = workerManager.detachCallbacks(worker, 'nonexistent-id');
 
       expect(result).toBe(false);
     });
 
-    it('should not deliver data after detaching callbacks', () => {
+    it('should not deliver data after detaching callbacks', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const onData = mock(() => {});
       const connectionId = workerManager.attachCallbacks(worker, {
@@ -403,7 +403,7 @@ describe('WorkerManager', () => {
   describe('killWorker', () => {
     it('should kill the PTY process for an agent worker', async () => {
       const worker = createTestAgentWorker();
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
       const mockPty = ptyFactory.instances[0];
       expect(mockPty.killed).toBe(false);
@@ -415,7 +415,7 @@ describe('WorkerManager', () => {
 
     it('should kill the PTY process for a terminal worker', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const mockPty = ptyFactory.instances[0];
       await workerManager.killWorker(worker, 'test-session');
@@ -425,7 +425,7 @@ describe('WorkerManager', () => {
 
     it('should await PTY exit before detaching', async () => {
       const worker = createTestAgentWorker();
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
       // PTY is set before kill
       expect(worker.pty).not.toBeNull();
@@ -438,7 +438,7 @@ describe('WorkerManager', () => {
 
     it('should clean up disposables to prevent memory leaks', async () => {
       const worker = createTestAgentWorker();
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
       // After activation, disposables should be set
       expect(worker.disposables).toBeDefined();
@@ -462,7 +462,7 @@ describe('WorkerManager', () => {
       jest.useFakeTimers();
       try {
         const worker = createTestAgentWorker();
-        workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+        await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
         const mockPty = ptyFactory.instances[0];
         // Override kill to NOT fire exit callback (simulates hung process)
@@ -495,9 +495,9 @@ describe('WorkerManager', () => {
   // ========== detachPty ==========
 
   describe('detachPty', () => {
-    it('should set worker.pty to null', () => {
+    it('should set worker.pty to null', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       expect(worker.pty).not.toBeNull();
 
@@ -525,9 +525,9 @@ describe('WorkerManager', () => {
       expect(workerManager.getActivityState(worker)).toBe('unknown');
     });
 
-    it('should return idle immediately after activation', () => {
+    it('should return idle immediately after activation', async () => {
       const worker = createTestAgentWorker();
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
       expect(workerManager.getActivityState(worker)).toBe('idle');
     });
@@ -536,9 +536,9 @@ describe('WorkerManager', () => {
   // ========== PTY Exit Handling ==========
 
   describe('PTY exit handling', () => {
-    it('should set pty to null on exit', () => {
+    it('should set pty to null on exit', async () => {
       const worker = createTestAgentWorker();
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
       const mockPty = ptyFactory.instances[0];
       mockPty.simulateExit(0);
@@ -546,9 +546,9 @@ describe('WorkerManager', () => {
       expect(worker.pty).toBeNull();
     });
 
-    it('should dispose activity detector on agent worker exit', () => {
+    it('should dispose activity detector on agent worker exit', async () => {
       const worker = createTestAgentWorker();
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
       expect(worker.activityDetector).not.toBeNull();
 
@@ -558,9 +558,9 @@ describe('WorkerManager', () => {
       expect(worker.activityDetector).toBeNull();
     });
 
-    it('should notify attached callbacks on exit', () => {
+    it('should notify attached callbacks on exit', async () => {
       const worker = createTestTerminalWorker();
-      workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
+      await workerManager.activateTerminalWorkerPty(worker, defaultTerminalActivationParams);
 
       const exitCodes: number[] = [];
       const onExit = mock((exitCode: number, _signal: string | null) => { exitCodes.push(exitCode); });
@@ -576,12 +576,12 @@ describe('WorkerManager', () => {
       expect(exitCodes[0]).toBe(42);
     });
 
-    it('should fire global PTY exit callback', () => {
+    it('should fire global PTY exit callback', async () => {
       const globalExitCallback = mock(() => {});
       workerManager.setGlobalPtyExitCallback(globalExitCallback);
 
       const worker = createTestTerminalWorker('term-exit');
-      workerManager.activateTerminalWorkerPty(worker, {
+      await workerManager.activateTerminalWorkerPty(worker, {
         ...defaultTerminalActivationParams,
         sessionId: 'sess-exit',
       });
@@ -592,12 +592,12 @@ describe('WorkerManager', () => {
       expect(globalExitCallback).toHaveBeenCalledWith('sess-exit', 'term-exit', 'unexpected');
     });
 
-    it('should fire global worker exit callback', () => {
+    it('should fire global worker exit callback', async () => {
       const globalWorkerExitCallback = mock(() => {});
       workerManager.setGlobalWorkerExitCallback(globalWorkerExitCallback);
 
       const worker = createTestTerminalWorker('term-wexit');
-      workerManager.activateTerminalWorkerPty(worker, {
+      await workerManager.activateTerminalWorkerPty(worker, {
         ...defaultTerminalActivationParams,
         sessionId: 'sess-wexit',
       });
@@ -624,9 +624,9 @@ describe('WorkerManager', () => {
       }
     });
 
-    it('should convert an active agent worker (pty active)', () => {
+    it('should convert an active agent worker (pty active)', async () => {
       const worker = createTestAgentWorker();
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
       const publicWorker = workerManager.toPublicWorker(worker);
 
@@ -662,9 +662,9 @@ describe('WorkerManager', () => {
   // ========== toPersistedWorker Conversion ==========
 
   describe('toPersistedWorker', () => {
-    it('should persist agent worker with pid when PTY is active', () => {
+    it('should persist agent worker with pid when PTY is active', async () => {
       const worker = createTestAgentWorker();
-      workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
 
       const persisted = workerManager.toPersistedWorker(worker);
 
@@ -791,12 +791,12 @@ describe('WorkerManager', () => {
   // ========== Global Callbacks ==========
 
   describe('setGlobalActivityCallback', () => {
-    it('should fire on activity state changes from PTY output', () => {
+    it('should fire on activity state changes from PTY output', async () => {
       const globalCallback = mock(() => {});
       workerManager.setGlobalActivityCallback(globalCallback);
 
       const worker = createTestAgentWorker('act-worker');
-      workerManager.activateAgentWorkerPty(worker, {
+      await workerManager.activateAgentWorkerPty(worker, {
         ...defaultAgentActivationParams,
         sessionId: 'act-session',
       });

--- a/packages/server/src/services/session-pause-resume-service.ts
+++ b/packages/server/src/services/session-pause-resume-service.ts
@@ -252,15 +252,17 @@ export class SessionPauseResumeService {
               parentWorkerId: internalSession.parentWorkerId,
               templateVars: internalSession.templateVars,
             },
+            revived: true,
           });
           activatedWorkers.push(worker);
         } else if (worker.type === 'terminal') {
-          this.deps.workerManager.activateTerminalWorkerPty(worker, {
+          await this.deps.workerManager.activateTerminalWorkerPty(worker, {
             sessionId: id,
             locationPath: persisted.locationPath,
             repositoryEnvVars,
             username,
             resolver,
+            revived: true,
           });
           activatedWorkers.push(worker);
         }

--- a/packages/server/src/services/session-pause-resume-service.ts
+++ b/packages/server/src/services/session-pause-resume-service.ts
@@ -39,7 +39,18 @@ export interface SessionPauseResumeDeps {
   setSession: (id: string, session: InternalSession) => void;
   deleteSession: (id: string) => void;
   sessionRepository: SessionRepository;
-  workerManager: WorkerManager;
+  // Narrow the surface of WorkerManager to the four methods this service
+  // actually uses. This makes the dependency contract structural (a partial
+  // mock matches the type without `as unknown as` casts) and prevents the
+  // service from quietly growing additional dependencies on WorkerManager
+  // without the test fixture noticing.
+  workerManager: Pick<
+    WorkerManager,
+    | 'killWorker'
+    | 'restoreWorkersFromPersistence'
+    | 'activateAgentWorkerPty'
+    | 'activateTerminalWorkerPty'
+  >;
   pathExists: (path: string) => Promise<boolean>;
   getRepositoryEnvVars: (sessionId: string) => Promise<Record<string, string>>;
   getPathResolverForSession: (session: InternalSession) => SessionDataPathResolver;

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -144,7 +144,7 @@ export class WorkerLifecycleManager {
         createdAt,
         agentId: request.agentId,
       });
-      this.deps.workerManager.activateAgentWorkerPty(agentWorker, {
+      await this.deps.workerManager.activateAgentWorkerPty(agentWorker, {
         sessionId,
         locationPath: session.locationPath,
         repositoryEnvVars,
@@ -159,6 +159,7 @@ export class WorkerLifecycleManager {
           parentWorkerId: session.parentWorkerId,
           templateVars,
         },
+        revived: false,
       });
       worker = agentWorker;
     } else if (request.type === 'terminal') {
@@ -169,12 +170,13 @@ export class WorkerLifecycleManager {
         name: workerName,
         createdAt,
       });
-      this.deps.workerManager.activateTerminalWorkerPty(terminalWorker, {
+      await this.deps.workerManager.activateTerminalWorkerPty(terminalWorker, {
         sessionId,
         locationPath: session.locationPath,
         repositoryEnvVars,
         username,
         resolver,
+        revived: false,
       });
       worker = terminalWorker;
     } else {
@@ -245,7 +247,7 @@ export class WorkerLifecycleManager {
     // Activate PTY based on worker type
     if (worker.type === 'agent') {
       const effectiveAgentId = this.resolveEffectiveAgentId(worker.agentId, { sessionId, workerId });
-      this.deps.workerManager.activateAgentWorkerPty(worker, {
+      await this.deps.workerManager.activateAgentWorkerPty(worker, {
         sessionId,
         locationPath: session.locationPath,
         repositoryEnvVars,
@@ -259,14 +261,16 @@ export class WorkerLifecycleManager {
           parentWorkerId: session.parentWorkerId,
           templateVars: session.templateVars,
         },
+        revived: true,
       });
     } else {
-      this.deps.workerManager.activateTerminalWorkerPty(worker, {
+      await this.deps.workerManager.activateTerminalWorkerPty(worker, {
         sessionId,
         locationPath: session.locationPath,
         repositoryEnvVars,
         username,
         resolver,
+        revived: true,
       });
     }
 
@@ -403,7 +407,7 @@ export class WorkerLifecycleManager {
       createdAt: workerCreatedAt,
       agentId: workerAgentId,
     });
-    this.deps.workerManager.activateAgentWorkerPty(newWorker, {
+    await this.deps.workerManager.activateAgentWorkerPty(newWorker, {
       sessionId,
       locationPath,
       repositoryEnvVars,
@@ -417,6 +421,9 @@ export class WorkerLifecycleManager {
         parentWorkerId: session.parentWorkerId,
         templateVars: session.templateVars,
       },
+      // File was just truncated by resetWorkerOutput above, so the
+      // file-absolute offset is 0 — equivalent to fresh creation.
+      revived: false,
     });
 
     // Re-check session still exists after async gap
@@ -543,7 +550,7 @@ export class WorkerLifecycleManager {
 
       if (existingWorker.type === 'agent') {
         const effectiveAgentId = this.resolveEffectiveAgentId(existingWorker.agentId, { sessionId, workerId });
-        this.deps.workerManager.activateAgentWorkerPty(existingWorker, {
+        await this.deps.workerManager.activateAgentWorkerPty(existingWorker, {
           sessionId,
           locationPath: session.locationPath,
           repositoryEnvVars,
@@ -557,14 +564,16 @@ export class WorkerLifecycleManager {
             parentWorkerId: session.parentWorkerId,
             templateVars: session.templateVars,
           },
+          revived: true,
         });
       } else {
-        this.deps.workerManager.activateTerminalWorkerPty(existingWorker, {
+        await this.deps.workerManager.activateTerminalWorkerPty(existingWorker, {
           sessionId,
           locationPath: session.locationPath,
           repositoryEnvVars,
           username,
           resolver,
+          revived: true,
         });
       }
     } catch (err) {

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -107,13 +107,28 @@ export interface AgentActivationParams extends WorkerContext {
   repositoryId?: string;
   /** Session creation context holding delegation and template information */
   context?: SessionCreationContext;
+  /**
+   * Whether this activation is reviving a worker whose PTY had previously died
+   * (server restart, hibernation, pause/resume) while the persisted output
+   * file remained on disk. When true, `outputOffset` is seeded from the
+   * current file size so subsequent `output` events keep the file-absolute
+   * semantic the client's IndexedDB cache expects (Issue #769).
+   * Set false for fresh worker creation and for `restartWorker` (which
+   * truncates the file to zero before activation).
+   */
+  revived: boolean;
 }
 
 /**
  * Parameters for activating a terminal worker's PTY.
  */
 export interface TerminalActivationParams extends WorkerContext {
-  // No additional parameters needed
+  /**
+   * Whether this activation is reviving a worker whose PTY had previously died
+   * (server restart, hibernation, pause/resume) while the persisted output
+   * file remained on disk. See `AgentActivationParams.revived` for details.
+   */
+  revived: boolean;
 }
 
 /**
@@ -275,10 +290,10 @@ export class WorkerManager {
    * Activate PTY for an agent worker.
    * Mutates the worker object to add pty and activityDetector.
    */
-  activateAgentWorkerPty(
+  async activateAgentWorkerPty(
     worker: InternalAgentWorker,
     params: AgentActivationParams
-  ): void {
+  ): Promise<void> {
     // Idempotent: If PTY already active, skip
     if (worker.pty !== null) {
       logger.debug(
@@ -289,6 +304,17 @@ export class WorkerManager {
     }
 
     const { sessionId, locationPath, agentId, continueConversation, initialPrompt, repositoryEnvVars, repositoryId, context } = params;
+
+    // Issue #769: align outputOffset with file-absolute semantic on revived
+    // activation. Must run BEFORE PTY spawn so the very first onData chunk
+    // advances from the seeded value, not from 0.
+    if (params.revived) {
+      worker.outputOffset = await this.workerOutputFileManager.getCurrentOffset(
+        sessionId,
+        worker.id,
+        params.resolver,
+      );
+    }
 
     const agentManager = this.agentManager;
     const requestedAgent = agentManager.getAgent(agentId);
@@ -370,10 +396,10 @@ export class WorkerManager {
    * Activate PTY for a terminal worker.
    * Mutates the worker object to add pty.
    */
-  activateTerminalWorkerPty(
+  async activateTerminalWorkerPty(
     worker: InternalTerminalWorker,
     params: TerminalActivationParams
-  ): void {
+  ): Promise<void> {
     // Idempotent: If PTY already active, skip
     if (worker.pty !== null) {
       logger.debug(
@@ -384,6 +410,16 @@ export class WorkerManager {
     }
 
     const { sessionId, locationPath, repositoryEnvVars } = params;
+
+    // Issue #769: align outputOffset with file-absolute semantic on revived
+    // activation. See activateAgentWorkerPty for the full rationale.
+    if (params.revived) {
+      worker.outputOffset = await this.workerOutputFileManager.getCurrentOffset(
+        sessionId,
+        worker.id,
+        params.resolver,
+      );
+    }
 
     // additionalEnvVars: repository env vars only
     // Base env (getCleanChildProcessEnv), shell detection, and unset prefix


### PR DESCRIPTION
## Summary

- Thread a `revived: boolean` flag through `activateAgentWorkerPty` / `activateTerminalWorkerPty`. When true (the three revival paths — `restoreWorker`, `getAvailableWorker` PTY-null branch, `session-pause-resume` resume), seed `worker.outputOffset` from the persisted output file size before spawning the PTY. Fresh creation and `restartWorker` keep `revived: false` because their files are empty or have just been truncated.
- Document the offset semantic rule, lifecycle phase × offset table, and Mermaid sequences (happy path + the disguised-100%-reload regression mode) in `docs/design/websocket-protocol.md`. Add the missing `output-truncated` event row to the Server → Client message table.
- Cover all three revived paths with `worker-lifecycle-manager.test.ts` (real WorkerManager + memfs, asserts `outputOffset === getCurrentOffset()`) and pause-resume contract checks in `session-pause-resume-service.test.ts` (asserts `revived: true` reaches the worker-manager layer).

The server's `worker.outputOffset` was cumulative-from-PTY-activation, while the client persisted the file-absolute offset in IndexedDB. On revival the counter restarted from 0; the client's next `request-history` fed back the small cumulative number, hit the line-limit bypass, and the server replayed ~87% of the file as a fake "history" payload — the disguised 100% reload symptom of #762. Aligning both sides on the file-absolute semantic at activation time closes the race.

### TDD polarity check

1. New tests added → 5 fail against unmodified code (3 worker-lifecycle activation tests, 2 pause-resume contract tests).
2. Seed code added in `worker-manager.ts` → all 5 pass.
3. Reverted only the seed block (kept tests + call-site changes) → 3 worker-lifecycle activation tests fail again (pause-resume contract tests still pass because they only assert the call-site param, not the in-memory effect).
4. Restored seed block → all pass.

### CodeRabbit dispositions

- Round 1 / round 2 findings on adding try/catch + NaN/negative validation around `getCurrentOffset()`: skipped. `getCurrentOffset()` already catches its own errors and always returns a non-negative number; outer try/catch would be defensive coding for a scenario the API contract excludes (the design rules in `.claude/rules/design-principles.md` and `CLAUDE.md` "Avoid unnecessary complexity" warn against this).
- Doc finding (`output-truncated` event missing from ws protocol table): fixed — added the row in commit `9f881f6`.
- Test sync/async inconsistency: fixed — every `activate*Pty` test call now awaits, every enclosing `it(...)` is async (commit `8e2f644`).

Final CodeRabbit verdict: 0 findings.

## Test plan

- [x] `bun run typecheck` exits 0.
- [x] `bun run test` exits 0 — 4573 pass / 3 skip / 0 fail across all packages.
- [x] `bun run check:lang` clean (103 files scanned).
- [x] `coderabbit review --agent --base main` returns 0 findings.
- [ ] dev environment session-open / close 3 times: 2nd and later `request-history` payloads are empty or KB-scale delta (not the 87% MB tail).
- [ ] #762 symptom (disguised 100% reload on session switch) does not reproduce on dogfood.

Closes #769
Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)