### PR TITLE
feat: shared session UI affordance — server contract (Part 2a of #678) (closes #774)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -44,6 +44,7 @@ A session tied only to a directory path, without repository or worktree manageme
 ### SharedSession
 A session running under a shared account OS identity, accessible to all authenticated users.
 - **Contrast:** [PersonalSession](#personalsession)
+- **Identifier:** `Session.isShared: boolean` (boolean discriminator on the wire, server-derived via `SharedAccountRegistry.isSharedUserId(createdBy)`)
 - **See:** [Terminology in shared-orchestrator-session.md](design/shared-orchestrator-session.md#terminology)
 
 ### WorktreeSession
@@ -108,6 +109,7 @@ The dedicated OS account (typically `agentconsole`) that runs the server process
 ### Shared Account
 A dedicated OS account distinct from service user and individual users, used for shared sessions.
 - **Aliases:** Shared session account, shared service account (historical, briefly used in PR #682 draft)
+- **Capability flag:** `/api/config.sharedAccountsAvailable: boolean` (server exposes this when `AGENT_CONSOLE_SHARED_USERNAME` resolves to a real OS user; gate for client UI affordance)
 - **See:** [Terminology in shared-orchestrator-session.md](design/shared-orchestrator-session.md#terminology)
 
 ## Events & Communication

--- a/packages/client/src/__tests__/routes/WorktreeRow.test.tsx
+++ b/packages/client/src/__tests__/routes/WorktreeRow.test.tsx
@@ -42,6 +42,7 @@ function createTestSession(overrides?: Partial<WorktreeSession>): SessionWithAct
     activationState: 'running' as const,
     createdAt: new Date().toISOString(),
     workers: [],
+    isShared: false,
     recoveryState: 'healthy',
     ...overrides,
   };
@@ -61,6 +62,7 @@ function createPausedSession(overrides?: Partial<WorktreeSession>): Session {
     createdAt: new Date().toISOString(),
     workers: [],
     pausedAt: new Date().toISOString(),
+    isShared: false,
     recoveryState: 'healthy',
     ...overrides,
   };

--- a/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
+++ b/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
@@ -27,6 +27,7 @@ function createMockWorktreeSession(
     activationState: 'running' as const,
     createdAt: new Date().toISOString(),
     workers: [],
+    isShared: false,
     recoveryState: 'healthy',
     ...overrides,
   };
@@ -44,6 +45,7 @@ function createMockQuickSession(
     activationState: 'running' as const,
     createdAt: new Date().toISOString(),
     workers: [],
+    isShared: false,
     recoveryState: 'healthy',
     ...overrides,
   };

--- a/packages/client/src/hooks/__tests__/useAppWs.test.ts
+++ b/packages/client/src/hooks/__tests__/useAppWs.test.ts
@@ -201,8 +201,8 @@ describe('useAppWsEvent', () => {
 
       const ws = MockWebSocket.getLastInstance();
       const mockSessions = [
-        { id: 'session-1', type: 'quick', locationPath: '/path/1', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], recoveryState: 'healthy' },
-        { id: 'session-2', type: 'quick', locationPath: '/path/2', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], recoveryState: 'healthy' },
+        { id: 'session-1', type: 'quick', locationPath: '/path/1', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], isShared: false, recoveryState: 'healthy' },
+        { id: 'session-2', type: 'quick', locationPath: '/path/2', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], isShared: false, recoveryState: 'healthy' },
       ];
       const mockActivityStates = [
         { sessionId: 'session-1', workerId: 'worker-1', activityState: 'active' },
@@ -227,7 +227,7 @@ describe('useAppWsEvent', () => {
       renderHook(() => useAppWsEvent({ onSessionCreated }));
 
       const ws = MockWebSocket.getLastInstance();
-      const mockSession = { id: 'session-1', type: 'quick', locationPath: '/path/1', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], recoveryState: 'healthy' };
+      const mockSession = { id: 'session-1', type: 'quick', locationPath: '/path/1', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], isShared: false, recoveryState: 'healthy' };
 
       act(() => {
         ws?.simulateOpen();
@@ -247,7 +247,7 @@ describe('useAppWsEvent', () => {
       renderHook(() => useAppWsEvent({ onSessionUpdated }));
 
       const ws = MockWebSocket.getLastInstance();
-      const mockSession = { id: 'session-1', type: 'quick', locationPath: '/path/1', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], title: 'Updated Title', recoveryState: 'healthy' };
+      const mockSession = { id: 'session-1', type: 'quick', locationPath: '/path/1', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], title: 'Updated Title', isShared: false, recoveryState: 'healthy' };
 
       act(() => {
         ws?.simulateOpen();
@@ -446,6 +446,7 @@ describe('useAppWsEvent', () => {
         createdAt: '2024-01-01',
         workers: [],
         pausedAt: '2026-01-01T00:00:00.000Z',
+        isShared: false,
         recoveryState: 'healthy',
       };
 
@@ -467,7 +468,7 @@ describe('useAppWsEvent', () => {
       renderHook(() => useAppWsEvent({ onSessionResumed }));
 
       const ws = MockWebSocket.getLastInstance();
-      const mockSession = { id: 'session-1', type: 'quick', locationPath: '/path/1', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], recoveryState: 'healthy' };
+      const mockSession = { id: 'session-1', type: 'quick', locationPath: '/path/1', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], isShared: false, recoveryState: 'healthy' };
       const mockActivityStates = [
         { sessionId: 'session-1', workerId: 'worker-1', activityState: 'active' },
       ];

--- a/packages/client/src/lib/__tests__/app-websocket.test.ts
+++ b/packages/client/src/lib/__tests__/app-websocket.test.ts
@@ -322,7 +322,7 @@ describe('app-websocket', () => {
       ws?.simulateOpen();
 
       // Test all valid message types (sessions must include all required fields for schema validation)
-      const mockSession = { id: 'test', type: 'quick', locationPath: '/test', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], recoveryState: 'healthy' };
+      const mockSession = { id: 'test', type: 'quick', locationPath: '/test', status: 'active', activationState: 'running', createdAt: '2024-01-01', workers: [], isShared: false, recoveryState: 'healthy' };
       const validTypes = [
         { type: 'sessions-sync', sessions: [], activityStates: [] },
         { type: 'session-created', session: mockSession },

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -23,7 +23,7 @@ import type {
   UpdateRepositoryRequest,
   WorkerMessage,
   GenerateRepositoryDescriptionResponse,
-  AuthMode,
+  ConfigResponse,
   LoginRequest,
   LoginResponse,
   CurrentUserResponse,
@@ -32,6 +32,8 @@ import type {
   SkillDefinition,
   MessageTemplate,
 } from '@agent-console/shared';
+
+export type { ConfigResponse } from '@agent-console/shared';
 import { api } from './api-client';
 
 // Base URL kept only for the wildcard worktree delete endpoint which Hono RPC doesn't handle well
@@ -65,15 +67,6 @@ async function handleApiError(res: Response, fallbackMessage: string): Promise<n
   const serverMessage = (body?.error?.trim() || body?.message?.trim() || undefined);
   const message = serverMessage ?? (res.statusText ? `${fallbackMessage}: ${res.statusText}` : fallbackMessage);
   throw new ApiError(message, res.status, body?.code);
-}
-
-export interface ConfigResponse {
-  homeDir: string;
-  capabilities: {
-    vscode: boolean;
-  };
-  serverPid: number;
-  authMode: AuthMode;
 }
 
 export async function fetchConfig(): Promise<ConfigResponse> {

--- a/packages/integration/src/review-queue-boundary.test.ts
+++ b/packages/integration/src/review-queue-boundary.test.ts
@@ -39,10 +39,14 @@ function createMockSessionManager(sessions: Map<string, Session>): SessionManage
  */
 function createMockSession(overrides: Partial<Session> & { id: string }): Session {
   return {
+    type: 'quick',
     status: 'active',
+    activationState: 'running',
     locationPath: '/test/path',
     workers: [],
     createdAt: '2026-01-01T00:00:00Z',
+    isShared: false,
+    recoveryState: 'healthy',
     ...overrides,
   };
 }

--- a/packages/server/src/__tests__/utils/build-test-data.ts
+++ b/packages/server/src/__tests__/utils/build-test-data.ts
@@ -226,6 +226,7 @@ export function buildWorktreeSession(
     activationState: 'running',
     createdAt: '2026-01-01T00:00:00.000Z',
     workers: [],
+    isShared: false,
     recoveryState: 'healthy',
     ...overrides,
   };
@@ -242,6 +243,7 @@ export function buildQuickSession(
     activationState: 'running',
     createdAt: '2026-01-01T00:00:00.000Z',
     workers: [],
+    isShared: false,
     recoveryState: 'healthy',
     ...overrides,
   };

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -272,6 +272,7 @@ export async function createAppContext(
       },
       getWorktreeIndexNumber: (path) => worktreeService.getWorktreeIndexNumber(path),
     },
+    sharedAccountLookup: sharedAccountRegistry,
   });
 
   // 6.5. Create timer manager with persistence
@@ -592,6 +593,7 @@ export async function createTestContext(
       },
       getWorktreeIndexNumber: (path) => worktreeService.getWorktreeIndexNumber(path),
     },
+    sharedAccountLookup: sharedAccountRegistry,
   });
 
   // Wire cross-dependencies

--- a/packages/server/src/routes/__tests__/api.test.ts
+++ b/packages/server/src/routes/__tests__/api.test.ts
@@ -2,8 +2,20 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import type { Hono } from 'hono';
 import type { AppBindings } from '../../app-context.js';
 import { setupTestEnvironment, cleanupTestEnvironment, createTestApp } from '../../__tests__/test-utils.js';
-import type { SkillDefinition } from '@agent-console/shared';
+import type { ConfigResponse, SkillDefinition } from '@agent-console/shared';
 import type { MessageTemplateRepository } from '../../repositories/message-template-repository.js';
+import { SharedAccountRegistry } from '../../services/shared-account-registry.js';
+import type { SystemCapabilitiesService } from '../../services/system-capabilities-service.js';
+
+/** Minimal SystemCapabilitiesService mock that returns no detected capabilities. */
+function createMockSystemCapabilities(): SystemCapabilitiesService {
+  return {
+    detect: async () => {},
+    getCapabilities: () => ({ vscode: false }),
+    hasVSCode: () => false,
+    getVSCodeCommand: () => null,
+  } as unknown as SystemCapabilitiesService;
+}
 
 describe('API route mounting', () => {
   let app: Hono<AppBindings>;
@@ -34,5 +46,64 @@ describe('API route mounting', () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { templates: unknown[] };
     expect(Array.isArray(body.templates)).toBe(true);
+  });
+});
+
+describe('GET /api/config — sharedAccountsAvailable', () => {
+  beforeEach(async () => {
+    await setupTestEnvironment();
+  });
+
+  afterEach(async () => {
+    await cleanupTestEnvironment();
+  });
+
+  it('returns sharedAccountsAvailable: false when the registry is disabled', async () => {
+    // The default test app uses SharedAccountRegistry.createDisabled() — no
+    // override needed. This case mirrors AGENT_CONSOLE_SHARED_USERNAME unset.
+    const app = await createTestApp({
+      systemCapabilities: createMockSystemCapabilities(),
+    });
+
+    const res = await app.request('/api/config');
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ConfigResponse;
+    expect(body.sharedAccountsAvailable).toBe(false);
+    // The set of shared-account user-ids must NOT leak into the response.
+    // Boundary contract: only the boolean gate is exposed.
+    expect(body).not.toHaveProperty('sharedAccountIds');
+    expect(body).not.toHaveProperty('sharedAccounts');
+  });
+
+  it('returns sharedAccountsAvailable: true when the registry is enabled', async () => {
+    // Construct an enabled registry by stubbing the OS lookup + user repository
+    // so create() returns an instance with a configured shared account.
+    const fakeUserRepository = {
+      upsertByOsUid: async () => ({
+        id: 'shared-user-uuid',
+        username: 'sharedusr',
+        homeDir: '/home/sharedusr',
+      }),
+    };
+    const enabledRegistry = await SharedAccountRegistry.create({
+      username: 'sharedusr',
+      userRepository: fakeUserRepository as never,
+      lookupOsUser: async () => ({ uid: 9999, homeDir: '/home/sharedusr' }),
+    });
+
+    const app = await createTestApp({
+      sharedAccountRegistry: enabledRegistry,
+      systemCapabilities: createMockSystemCapabilities(),
+    });
+
+    const res = await app.request('/api/config');
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ConfigResponse;
+    expect(body.sharedAccountsAvailable).toBe(true);
+    // Boundary contract: still no exposure of the underlying user-id set.
+    expect(body).not.toHaveProperty('sharedAccountIds');
+    expect(body).not.toHaveProperty('sharedAccounts');
   });
 });

--- a/packages/server/src/routes/__tests__/api.test.ts
+++ b/packages/server/src/routes/__tests__/api.test.ts
@@ -4,17 +4,23 @@ import type { AppBindings } from '../../app-context.js';
 import { setupTestEnvironment, cleanupTestEnvironment, createTestApp } from '../../__tests__/test-utils.js';
 import type { ConfigResponse, SkillDefinition } from '@agent-console/shared';
 import type { MessageTemplateRepository } from '../../repositories/message-template-repository.js';
+import type { UserRepository } from '../../repositories/user-repository.js';
 import { SharedAccountRegistry } from '../../services/shared-account-registry.js';
-import type { SystemCapabilitiesService } from '../../services/system-capabilities-service.js';
+import { SystemCapabilitiesService } from '../../services/system-capabilities-service.js';
 
-/** Minimal SystemCapabilitiesService mock that returns no detected capabilities. */
+/**
+ * Minimal SystemCapabilitiesService mock that returns no detected capabilities.
+ *
+ * Constructs a real instance and seeds its private state via Reflect so we
+ * avoid running the underlying `which` shell-out. Mirrors the pattern used in
+ * `__tests__/system.test.ts`. Returning a real instance also lets the test
+ * stay structurally honest without `as unknown as` casts.
+ */
 function createMockSystemCapabilities(): SystemCapabilitiesService {
-  return {
-    detect: async () => {},
-    getCapabilities: () => ({ vscode: false }),
-    hasVSCode: () => false,
-    getVSCodeCommand: () => null,
-  } as unknown as SystemCapabilitiesService;
+  const service = new SystemCapabilitiesService();
+  Reflect.set(service, 'capabilities', { vscode: false });
+  Reflect.set(service, 'vscodeCommand', null);
+  return service;
 }
 
 describe('API route mounting', () => {
@@ -85,10 +91,11 @@ describe('GET /api/config — sharedAccountsAvailable', () => {
         username: 'sharedusr',
         homeDir: '/home/sharedusr',
       }),
-    };
+      findById: async () => null,
+    } satisfies UserRepository;
     const enabledRegistry = await SharedAccountRegistry.create({
       username: 'sharedusr',
-      userRepository: fakeUserRepository as never,
+      userRepository: fakeUserRepository,
       lookupOsUser: async () => ({ uid: 9999, homeDir: '/home/sharedusr' }),
     });
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -23,7 +23,7 @@ const api = new Hono<AppBindings>()
   // /config is needed by the client to determine the auth mode before authenticating.
   .route('/auth', auth)
   .get('/config', (c) => {
-    const { systemCapabilities, userMode } = c.get('appContext');
+    const { systemCapabilities, userMode, sharedAccountRegistry } = c.get('appContext');
     // In multi-user mode before login, authUser may not be available.
     // Use userMode.authenticate() directly instead of relying on auth middleware.
     const authUser = userMode.authenticate(() => getCookie(c, AUTH_COOKIE_NAME));
@@ -32,6 +32,7 @@ const api = new Hono<AppBindings>()
       capabilities: systemCapabilities.getCapabilities(),
       serverPid: process.pid,
       authMode: serverConfig.AUTH_MODE,
+      sharedAccountsAvailable: sharedAccountRegistry.isEnabled(),
     });
   })
   // Auth middleware runs on all remaining API routes.

--- a/packages/server/src/services/__tests__/session-converter-service.test.ts
+++ b/packages/server/src/services/__tests__/session-converter-service.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'bun:test';
 import type { Worker } from '@agent-console/shared';
 import type { PersistedWorker } from '../persistence-service.js';
 import type { InternalWorker, InternalAgentWorker } from '../worker-types.js';
-import { SessionConverterService, type SessionConverterDeps, type RepositoryDisplayLookup } from '../session-converter-service.js';
+import { SessionConverterService, type SessionConverterDeps, type RepositoryDisplayLookup, type SharedAccountLookup } from '../session-converter-service.js';
 import {
   buildInternalAgentWorker,
   buildInternalTerminalWorker,
@@ -21,6 +21,7 @@ import {
 describe('SessionConverterService', () => {
   let service: SessionConverterService;
   let mockLookup: RepositoryDisplayLookup;
+  let mockSharedLookup: SharedAccountLookup;
   let toPublicWorkerResults: Map<string, Worker>;
   let toPersistedWorkerResults: Map<string, PersistedWorker>;
 
@@ -32,11 +33,18 @@ describe('SessionConverterService', () => {
       },
     };
 
+    // Default lookup treats only the specific UUID 'shared-account-uuid' as a
+    // shared account. Tests that need the inverse override the deps.
+    mockSharedLookup = {
+      isSharedUserId: (userId: string) => userId === 'shared-account-uuid',
+    };
+
     toPublicWorkerResults = new Map();
     toPersistedWorkerResults = new Map();
 
     const deps: SessionConverterDeps = {
       repositoryDisplayLookup: mockLookup,
+      sharedAccountLookup: mockSharedLookup,
       toPublicWorker: (w: InternalWorker): Worker => {
         const existing = toPublicWorkerResults.get(w.id);
         if (existing) return existing;
@@ -195,6 +203,49 @@ describe('SessionConverterService', () => {
       expect(result.initiatedBy).toBeUndefined();
     });
 
+    it('sets isShared to true when createdBy resolves to a shared account', () => {
+      const session = buildInternalQuickSession([], {
+        createdBy: 'shared-account-uuid',
+      });
+
+      const result = service.toPublicSession(session);
+
+      expect(result.isShared).toBe(true);
+    });
+
+    it('sets isShared to false when createdBy is a regular user', () => {
+      const session = buildInternalQuickSession([], {
+        createdBy: 'regular-user-uuid',
+      });
+
+      const result = service.toPublicSession(session);
+
+      expect(result.isShared).toBe(false);
+    });
+
+    it('sets isShared to false (not undefined) when createdBy is undefined', () => {
+      const session = buildInternalQuickSession([], {
+        createdBy: undefined,
+      });
+
+      const result = service.toPublicSession(session);
+
+      expect(result.isShared).toBe(false);
+      // Boundary contract: the field is always a concrete boolean on the wire.
+      expect(typeof result.isShared).toBe('boolean');
+    });
+
+    it('does not error and produces isShared on a session with empty worker list', () => {
+      const session = buildInternalQuickSession([], {
+        createdBy: 'shared-account-uuid',
+      });
+
+      const result = service.toPublicSession(session);
+
+      expect(result.workers).toEqual([]);
+      expect(result.isShared).toBe(true);
+    });
+
     it('falls back to Unknown repository name when repository is not found', () => {
       mockLookup = {
         getRepositoryDisplayInfo: () => undefined,
@@ -204,6 +255,7 @@ describe('SessionConverterService', () => {
       // because the session has zero workers.
       const deps: SessionConverterDeps = {
         repositoryDisplayLookup: mockLookup,
+        sharedAccountLookup: mockSharedLookup,
         toPublicWorker: ((): Worker => {
           throw new Error('unreachable: session has no workers');
         }) as (w: InternalWorker) => Worker,
@@ -342,6 +394,49 @@ describe('SessionConverterService', () => {
       const result = service.persistedToPublicSession(persisted);
 
       expect(result.initiatedBy).toBeUndefined();
+    });
+
+    it('sets isShared to true on a persisted session whose createdBy is shared', () => {
+      const persisted = buildPersistedQuickSession({
+        id: 'ps-shared-derive',
+        locationPath: '/tmp/quick',
+        serverPid: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        createdBy: 'shared-account-uuid',
+      });
+
+      const result = service.persistedToPublicSession(persisted);
+
+      expect(result.isShared).toBe(true);
+    });
+
+    it('sets isShared to false on a persisted session whose createdBy is regular', () => {
+      const persisted = buildPersistedQuickSession({
+        id: 'ps-regular-derive',
+        locationPath: '/tmp/quick',
+        serverPid: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        createdBy: 'user-42',
+      });
+
+      const result = service.persistedToPublicSession(persisted);
+
+      expect(result.isShared).toBe(false);
+    });
+
+    it('sets isShared to false (not undefined) on a persisted legacy session with no createdBy', () => {
+      const persisted = buildPersistedQuickSession({
+        id: 'ps-legacy',
+        locationPath: '/tmp/quick',
+        serverPid: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        // createdBy intentionally omitted (legacy row)
+      });
+
+      const result = service.persistedToPublicSession(persisted);
+
+      expect(result.isShared).toBe(false);
+      expect(typeof result.isShared).toBe('boolean');
     });
   });
 

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -498,6 +498,87 @@ describe('SessionManager', () => {
     });
   });
 
+  describe('isShared wiring (sharedAccountLookup option)', () => {
+    // These tests verify that the `sharedAccountLookup` option on
+    // SessionManager.create() is forwarded to SessionConverterService and
+    // used to derive `Session.isShared` on the public surface. The
+    // converter's own derivation logic (boundary cases for createdBy ===
+    // null / undefined / shared / regular) is exhaustively covered in
+    // session-converter-service.test.ts; this suite only verifies the
+    // wiring contract from SessionManager's perspective.
+
+    it('forwards sharedAccountLookup to the converter so isShared is true when createdBy is a shared-account user-id', async () => {
+      const module = await import(`../session-manager.js?v=${++importCounter}`);
+      const manager = await module.SessionManager.create({
+        userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
+        pathExists: mockPathExists,
+        jobQueue: testJobQueue,
+        agentManager,
+        repositoryLookup: defaultRepositoryLookup,
+        repositoryEnvLookup: defaultRepositoryEnvLookup,
+        sharedAccountLookup: {
+          isSharedUserId: (userId: string) => userId === 'shared-account-uuid',
+        },
+      });
+
+      const created = await manager.createSession(
+        { type: 'quick', locationPath: '/test/path', agentId: 'claude-code' },
+        { createdBy: 'shared-account-uuid', initiatedBy: 'caller-user-id' },
+      );
+
+      expect(created.isShared).toBe(true);
+
+      // getSession() also runs through toPublicSession; verify the wiring
+      // is consistent across both code paths.
+      const retrieved = manager.getSession(created.id);
+      expect(retrieved?.isShared).toBe(true);
+    });
+
+    it('forwards sharedAccountLookup so isShared is false when createdBy is a regular user-id', async () => {
+      const module = await import(`../session-manager.js?v=${++importCounter}`);
+      const manager = await module.SessionManager.create({
+        userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
+        pathExists: mockPathExists,
+        jobQueue: testJobQueue,
+        agentManager,
+        repositoryLookup: defaultRepositoryLookup,
+        repositoryEnvLookup: defaultRepositoryEnvLookup,
+        sharedAccountLookup: {
+          isSharedUserId: (userId: string) => userId === 'shared-account-uuid',
+        },
+      });
+
+      const created = await manager.createSession(
+        { type: 'quick', locationPath: '/test/path', agentId: 'claude-code' },
+        { createdBy: 'regular-user-uuid' },
+      );
+
+      expect(created.isShared).toBe(false);
+      expect(typeof created.isShared).toBe('boolean');
+    });
+
+    it('falls back to a never-shared lookup when sharedAccountLookup is omitted (default behaviour)', async () => {
+      // The default factory (`getSessionManager`) does not pass
+      // sharedAccountLookup. Per the SessionManager option's documented
+      // fallback (`{ isSharedUserId: () => false }`), every session must
+      // report isShared === false regardless of createdBy.
+      const manager = await getSessionManager();
+
+      const created = await manager.createSession(
+        { type: 'quick', locationPath: '/test/path', agentId: 'claude-code' },
+        // Even a user-id that LOOKS shared must come back as false because
+        // the default lookup ignores its argument and always returns false.
+        { createdBy: 'shared-account-uuid' },
+      );
+
+      expect(created.isShared).toBe(false);
+      expect(typeof created.isShared).toBe('boolean');
+
+      const retrieved = manager.getSession(created.id);
+      expect(retrieved?.isShared).toBe(false);
+    });
+  });
+
   describe('getAllSessions', () => {
     it('should return empty array when no sessions', async () => {
       const manager = await getSessionManager();

--- a/packages/server/src/services/session-converter-service.ts
+++ b/packages/server/src/services/session-converter-service.ts
@@ -30,10 +30,20 @@ export interface RepositoryDisplayLookup {
 }
 
 /**
+ * Minimum view of SharedAccountRegistry needed by the converter to derive
+ * `Session.isShared`. Decoupled as an interface so tests can inject a stub
+ * without instantiating a real registry.
+ */
+export interface SharedAccountLookup {
+  isSharedUserId(userId: string): boolean;
+}
+
+/**
  * Dependencies injected into SessionConverterService.
  */
 export interface SessionConverterDeps {
   repositoryDisplayLookup: RepositoryDisplayLookup;
+  sharedAccountLookup: SharedAccountLookup;
   toPublicWorker: (worker: InternalWorker) => Worker;
   toPersistedWorker: (worker: InternalWorker) => PersistedWorker;
   getServerPid: () => number | null;
@@ -55,6 +65,19 @@ export class SessionConverterService {
    * A session is 'hibernated' if all PTY workers have no PTY (after server restart).
    * Sessions with no PTY workers (only git-diff) are considered 'running'.
    */
+  /**
+   * Derive `Session.isShared` from `createdBy`. Returns `false` (not
+   * undefined / null) for legacy sessions whose `createdBy` is missing,
+   * matching the AC's boundary requirement that the field is always a
+   * concrete boolean on the wire. The set of shared-account user-ids is
+   * never exposed to clients — this method is the only public surface
+   * that consumes the registry's `isSharedUserId` predicate.
+   */
+  private deriveIsShared(createdBy: string | null | undefined): boolean {
+    if (createdBy == null) return false;
+    return this.deps.sharedAccountLookup.isSharedUserId(createdBy);
+  }
+
   computeActivationState(session: InternalSession): SessionActivationState {
     const ptyWorkers = Array.from(session.workers.values()).filter(
       (w): w is InternalAgentWorker | InternalTerminalWorker =>
@@ -129,6 +152,7 @@ export class SessionConverterService {
       parentWorkerId: session.parentWorkerId,
       createdBy: session.createdBy,
       initiatedBy: session.initiatedBy,
+      isShared: this.deriveIsShared(session.createdBy),
       recoveryState: session.recoveryState ?? 'healthy',
     };
 
@@ -201,6 +225,7 @@ export class SessionConverterService {
       parentWorkerId: p.parentWorkerId,
       createdBy: p.createdBy,
       initiatedBy: p.initiatedBy,
+      isShared: this.deriveIsShared(p.createdBy),
       recoveryState: p.recoveryState ?? 'healthy',
     };
 

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -57,7 +57,7 @@ import type { JobQueue } from '../jobs/index.js';
 import { SessionInitializationService } from './session-initialization-service.js';
 import { SessionDeletionService } from './session-deletion-service.js';
 import { SessionPauseResumeService } from './session-pause-resume-service.js';
-import { SessionConverterService } from './session-converter-service.js';
+import { SessionConverterService, type SharedAccountLookup } from './session-converter-service.js';
 import type { RepositoryLookup, RepositoryEnvLookup } from './repository-lookup-types.js';
 
 /**
@@ -123,6 +123,12 @@ interface SessionManagerOptions {
    * (used when spawning PTYs for worktree sessions).
    */
   repositoryEnvLookup: RepositoryEnvLookup;
+  /**
+   * Optional lookup used to derive `Session.isShared` server-side. Defaults
+   * to a stub that always returns false (safe for tests + the AUTH_MODE=none
+   * path where shared sessions are never registered).
+   */
+  sharedAccountLookup?: SharedAccountLookup;
 }
 
 export class SessionManager {
@@ -195,6 +201,12 @@ export class SessionManager {
           return info ? { name: info.name, path: info.path } : undefined;
         },
       },
+      // Default to a never-shared lookup when the caller hasn't wired the
+      // registry. Production callers (createAppContext) always pass the real
+      // SharedAccountRegistry; the fallback exists so unit tests that
+      // construct SessionManager directly do not need to thread through the
+      // registry just to satisfy the converter dep.
+      sharedAccountLookup: options.sharedAccountLookup ?? { isSharedUserId: () => false },
       toPublicWorker: (w) => this.workerManager.toPublicWorker(w),
       toPersistedWorker: (w) => this.workerManager.toPersistedWorker(w),
       getServerPid: () => getServerPid(),

--- a/packages/shared/src/schemas/__tests__/app-server-message.test.ts
+++ b/packages/shared/src/schemas/__tests__/app-server-message.test.ts
@@ -30,6 +30,7 @@ const worktreeSession = {
   repositoryName: 'my-repo',
   worktreeId: 'feature-branch',
   isMainWorktree: false,
+  isShared: false,
   recoveryState: 'healthy' as const,
 };
 
@@ -41,6 +42,7 @@ const quickSession = {
   activationState: 'running' as const,
   createdAt: '2026-01-01T00:00:00Z',
   workers: [],
+  isShared: false,
   recoveryState: 'healthy' as const,
 };
 
@@ -169,6 +171,43 @@ describe('AppServerMessageSchema', () => {
       expectInvalid({
         type: 'session-created',
         session: { ...worktreeSession, initiatedBy: 123 },
+      });
+    });
+
+    it('should accept session with isShared: true', () => {
+      const output = expectValid({
+        type: 'session-created',
+        session: { ...worktreeSession, isShared: true },
+      });
+      if (output.type === 'session-created') {
+        expect(output.session.isShared).toBe(true);
+      }
+    });
+
+    it('should accept session with isShared: false', () => {
+      const output = expectValid({
+        type: 'session-updated',
+        session: { ...quickSession, isShared: false },
+      });
+      if (output.type === 'session-updated') {
+        expect(output.session.isShared).toBe(false);
+      }
+    });
+
+    it('should reject session with non-boolean isShared', () => {
+      expectInvalid({
+        type: 'session-created',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        session: { ...worktreeSession, isShared: 'true' as any },
+      });
+    });
+
+    it('should reject session missing isShared (now required)', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { isShared: _omit, ...sessionWithoutIsShared } = worktreeSession;
+      expectInvalid({
+        type: 'session-created',
+        session: sessionWithoutIsShared,
       });
     });
 

--- a/packages/shared/src/schemas/__tests__/app-server-message.test.ts
+++ b/packages/shared/src/schemas/__tests__/app-server-message.test.ts
@@ -197,8 +197,7 @@ describe('AppServerMessageSchema', () => {
     it('should reject session with non-boolean isShared', () => {
       expectInvalid({
         type: 'session-created',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        session: { ...worktreeSession, isShared: 'true' as any },
+        session: { ...worktreeSession, isShared: 'true' },
       });
     });
 

--- a/packages/shared/src/schemas/app-server-message.ts
+++ b/packages/shared/src/schemas/app-server-message.ts
@@ -52,6 +52,7 @@ const SessionBaseSchema = v.object({
   parentWorkerId: v.optional(v.string()),
   createdBy: v.optional(v.string()),
   initiatedBy: v.optional(v.string()),
+  isShared: v.boolean(),
   recoveryState: v.picklist(['healthy', 'orphaned']),
 });
 

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -21,3 +21,24 @@ export interface LoginResponse {
 export interface CurrentUserResponse {
   user: AuthUser | null;
 }
+
+/**
+ * Response shape for `GET /api/config`.
+ *
+ * Returned to the client before authentication so the client can decide
+ * whether to render auth UI and which optional features to surface.
+ *
+ * `sharedAccountsAvailable` is a boolean gate for shared-session UI; the
+ * underlying set of shared-account user-ids is intentionally NOT exposed
+ * (per docs/design/shared-orchestrator-session.md §UI). Per-session
+ * `Session.isShared` is the safe abstraction for client rendering.
+ */
+export interface ConfigResponse {
+  homeDir: string;
+  capabilities: {
+    vscode: boolean;
+  };
+  serverPid: number;
+  authMode: AuthMode;
+  sharedAccountsAvailable: boolean;
+}

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -58,6 +58,15 @@ export interface SessionBase {
    * See docs/design/shared-orchestrator-session.md §"Schema Notes".
    */
   initiatedBy?: string;
+  /**
+   * Whether this session is owned by a configured shared account. Derived
+   * server-side from `createdBy` resolving to a registered shared account
+   * via SharedAccountRegistry; clients consume this boolean only and never
+   * see the underlying set of shared-account user-ids. `false` when
+   * `createdBy` is null/undefined (legacy sessions) or refers to a regular
+   * user. See docs/design/shared-orchestrator-session.md §UI.
+   */
+  isShared: boolean;
   /** Session recovery state, surfaced from server. 'healthy' | 'orphaned'. */
   recoveryState: 'healthy' | 'orphaned';
 }


### PR DESCRIPTION
## Summary

Server contract for the shared-session UI affordance (Part 2a of #678). Two additions to the data layer that the (future) Part 2b client UI will consume:

- **`/api/config.sharedAccountsAvailable: boolean`** — gate so the client can show / hide shared-session affordances based on whether `AGENT_CONSOLE_SHARED_USERNAME` resolves to a real OS account.
- **`Session.isShared: boolean`** (server-derived) — per-session signal computed via `SharedAccountRegistry.isSharedUserId(createdBy)`. Always a concrete boolean on the wire.

`Session.createdBy` is preserved as-is. The Issue's original AC misread the design doc's reject target (the *set* of shared-account user-ids — not per-session `createdBy`) as a single rule; the Issue body has been corrected, and this PR follows the corrected scope. Multi-user UX (`useSessionFilter` "mine" filter, future #683 tree view, future #684 owner display) continues to need per-session owner identification.

## Implementation notes

- `SessionConverterService.deriveIsShared(createdBy)` is the single writer (I-2). Both `toPublicSession` (in-memory) and `persistedToPublicSession` (paused, loaded from DB) call it.
- `SessionManagerOptions.sharedAccountLookup` is **optional** with a `() => false` default — so the dozens of unit-test SessionManager constructors don't need to thread the registry just to satisfy the converter dep. Production wires the real registry at `app-context.ts`.
- `ConfigResponse` is added to `packages/shared/src/types/auth.ts` (small + system-related; co-locates with `LoginResponse`/`CurrentUserResponse`). Client `lib/api.ts` re-exports it instead of duplicating.
- Boundary contract: shared-account user-id **set** is never exposed (`/api/config` test asserts no `sharedAccountIds` / `sharedAccounts` array leaks).

## Q8 signature shape pre-estimate

`grep -rn "\bSession\b" packages/client/src packages/server/src --include="*.ts" --include="*.tsx" | grep -v __tests__` = **318 references / 71 files**.

Change is **purely additive** (new required field on `SessionBase`). Production call sites that don't read `isShared` are unaffected. Test fixtures that build `Session` objects via literal needed the new field — 6 such fixtures updated in this PR.

## Architectural Invariants

- **I-2 (Single writer for derived values):** `deriveIsShared` in `SessionConverterService` is the only function computing `isShared`. All other code reads it from the `Session` object.
- **I-5 (Server as source of truth):** `isShared` is derived server-side and validated by Valibot on the wire (`SessionBaseSchema`). Client never computes it.
- **I-6 (Boundary validation):** `/api/config` response shape is declared in shared types (`ConfigResponse`) and exercised by tests asserting both presence of `sharedAccountsAvailable` and absence of any shared-account-id list. WebSocket session payloads are validated by `SessionBaseSchema` (4 new tests cover `isShared` true / false / non-boolean reject / missing reject).

## CodeRabbit findings

CodeRabbit CLI returned 1 `major` finding suggesting `isShared` be made optional (`isShared?: boolean`). **Rejected** — the AC explicitly requires `isShared` to be `false` (not `null`, not `undefined`) for legacy `created_by === null` sessions, and the server normalizes legacy DB rows through `deriveIsShared` in `persistedToPublicSession`. Wire contract is "always boolean", which is exactly the AC's intent. Making it optional would weaken the boundary and require every consumer to defensively coalesce.

## Verification

- ✅ `bun run typecheck` — exit 0
- ✅ `bun run test` — TEST_EXIT 0 (server 2513 pass / shared 324 / client 1361 / integration 29 / scripts+hooks+skills 362, 0 fail across 4527 tests)
- ✅ `bun run check:lang` — exit 0
- ✅ `node .claude/skills/orchestrator/preflight-check.js` — exit 0 (4 production files all covered)
- ✅ `coderabbit review --agent --base main` — 1 major finding, justified reject above; 0 CRITICAL / 0 HIGH (treating `major` as HIGH-equivalent and addressing via PR-body justification)

## Test plan

- [ ] CI green (typecheck + tests + preflight + language-lint)
- [ ] CodeRabbit GitHub-side review state
- [ ] Manual sanity (post-merge dogfood): `/api/config` shows `sharedAccountsAvailable: false` in default config; flipping `AGENT_CONSOLE_SHARED_USERNAME` to a real OS user flips it to `true`

Closes #774
Refs #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)