### PR TITLE
fix: restore test isolation broken after #778 — main RED hot-fix (closes #784)

### DIFF
--- a/packages/server/src/lib/__tests__/repository-remote.test.ts
+++ b/packages/server/src/lib/__tests__/repository-remote.test.ts
@@ -1,13 +1,8 @@
-import { describe, it, expect, mock } from 'bun:test';
+import { describe, it, expect, beforeEach } from 'bun:test';
 import type { Repository } from '@agent-console/shared';
+import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
 
-const mockGetRemoteUrl = mock(() => Promise.resolve('https://github.com/test/repo.git' as string | null));
-
-mock.module('../git.js', () => ({
-  getRemoteUrl: mockGetRemoteUrl,
-}));
-
-// Import after mock.module
+// Import after the shared git mock is registered (via mock-git-helper import)
 const { withRepositoryRemote } = await import('../repository-remote.js');
 
 function createTestRepository(overrides?: Partial<Repository>): Repository {
@@ -23,8 +18,12 @@ function createTestRepository(overrides?: Partial<Repository>): Repository {
 }
 
 describe('withRepositoryRemote', () => {
+  beforeEach(() => {
+    resetGitMocks();
+  });
+
   it('should enrich repository with remoteUrl from git remote', async () => {
-    mockGetRemoteUrl.mockResolvedValueOnce('https://github.com/test/repo.git');
+    mockGit.getRemoteUrl.mockResolvedValueOnce('https://github.com/test/repo.git');
     const repo = createTestRepository();
     const enriched = await withRepositoryRemote(repo);
 
@@ -36,7 +35,7 @@ describe('withRepositoryRemote', () => {
   });
 
   it('should set remoteUrl to undefined when no remote exists', async () => {
-    mockGetRemoteUrl.mockResolvedValueOnce(null);
+    mockGit.getRemoteUrl.mockResolvedValueOnce(null);
     const repo = createTestRepository();
     const enriched = await withRepositoryRemote(repo);
 
@@ -44,7 +43,7 @@ describe('withRepositoryRemote', () => {
   });
 
   it('should not mutate the original repository object', async () => {
-    mockGetRemoteUrl.mockResolvedValueOnce('https://github.com/test/repo.git');
+    mockGit.getRemoteUrl.mockResolvedValueOnce('https://github.com/test/repo.git');
     const repo = createTestRepository();
     const enriched = await withRepositoryRemote(repo);
 
@@ -54,7 +53,7 @@ describe('withRepositoryRemote', () => {
   });
 
   it('should preserve all existing repository fields', async () => {
-    mockGetRemoteUrl.mockResolvedValueOnce('https://github.com/test/repo.git');
+    mockGit.getRemoteUrl.mockResolvedValueOnce('https://github.com/test/repo.git');
     const repo = createTestRepository({
       description: 'A test repo',
       setupCommand: 'bun install',

--- a/packages/server/src/services/__tests__/session-validation-service.test.ts
+++ b/packages/server/src/services/__tests__/session-validation-service.test.ts
@@ -1,23 +1,18 @@
 import * as path from 'path';
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { setupTestConfigDir, cleanupTestConfigDir, setupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
+import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
 import type { PersistedSession } from '../persistence-service.js';
 import type { SessionValidationResult } from '@agent-console/shared';
-
-// Mock gitRefExists to avoid actual git commands
-let mockGitRefExists: () => Promise<boolean> = () => Promise.resolve(true);
-
-mock.module('../../lib/git.js', () => ({
-  gitRefExists: () => mockGitRefExists(),
-}));
 
 describe('SessionValidationService', () => {
   const TEST_CONFIG_DIR = '/test/config';
   let importCounter = 0;
 
   beforeEach(() => {
-    // Reset the mock
-    mockGitRefExists = () => Promise.resolve(true);
+    // Reset the mock; preserve the original default (gitRefExists -> true)
+    resetGitMocks();
+    mockGit.gitRefExists.mockImplementation(() => Promise.resolve(true));
   });
 
   afterEach(() => {
@@ -123,7 +118,7 @@ describe('SessionValidationService', () => {
       process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
 
       // Mock gitRefExists to return false for this test
-      mockGitRefExists = () => Promise.resolve(false);
+      mockGit.gitRefExists.mockImplementation(() => Promise.resolve(false));
 
       const { validationService } = await getServices();
 
@@ -154,7 +149,7 @@ describe('SessionValidationService', () => {
       process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
 
       // Mock gitRefExists to return true
-      mockGitRefExists = () => Promise.resolve(true);
+      mockGit.gitRefExists.mockImplementation(() => Promise.resolve(true));
 
       const { validationService } = await getServices();
 

--- a/packages/server/src/services/__tests__/worktree-creation-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-creation-service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import type { HookCommandResult, Worktree } from '@agent-console/shared';
 import type { SessionManager } from '../session-manager.js';
 import { buildWorktreeSession } from '../../__tests__/utils/build-test-data.js';
+import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
 // --- Mock worktreeService (now passed as parameter, no mock.module needed) ---
 
 const mockListWorktrees = mock<(repoPath: string, repoId: string) => Promise<Worktree[]>>(() =>
@@ -23,16 +24,6 @@ const mockWorktreeService = {
   removeWorktree: mockRemoveWorktree,
   executeHookCommand: mockExecuteHookCommand,
 };
-
-// --- Mock fetchRemote ---
-
-const mockFetchRemote = mock<(branch: string, cwd: string) => Promise<void>>(() =>
-  Promise.resolve(),
-);
-
-mock.module('../../lib/git.js', () => ({
-  fetchRemote: mockFetchRemote,
-}));
 
 // --- Mock logger ---
 mock.module('../../lib/logger.js', () => ({
@@ -89,14 +80,13 @@ const DEFAULT_PARAMS = {
 
 describe('createWorktreeWithSession', () => {
   beforeEach(() => {
+    resetGitMocks();
     mockListWorktrees.mockReset();
     mockCreateWorktree.mockReset();
     mockRemoveWorktree.mockReset();
     mockExecuteHookCommand.mockReset();
-    mockFetchRemote.mockReset();
 
     // Default implementations
-    mockFetchRemote.mockImplementation(() => Promise.resolve());
     mockCreateWorktree.mockImplementation(() =>
       Promise.resolve({ worktreePath: CREATED_PATH, index: 2 }),
     );
@@ -121,7 +111,7 @@ describe('createWorktreeWithSession', () => {
     expect(result.setupCommandResult).toEqual({ success: true, output: 'setup done' });
 
     // Verify fetch was called with remote branch
-    expect(mockFetchRemote).toHaveBeenCalledWith('main', '/repos/my-repo');
+    expect(mockGit.fetchRemote).toHaveBeenCalledWith('main', '/repos/my-repo');
     // Verify createWorktree used origin/ prefix
     expect(mockCreateWorktree).toHaveBeenCalledWith(
       '/repos/my-repo', 'feature-new', 'repo-1', 'origin/main',
@@ -138,7 +128,7 @@ describe('createWorktreeWithSession', () => {
     );
 
     expect(result.success).toBe(true);
-    expect(mockFetchRemote).not.toHaveBeenCalled();
+    expect(mockGit.fetchRemote).not.toHaveBeenCalled();
     // baseBranch is passed as-is (no origin/ prefix)
     expect(mockCreateWorktree).toHaveBeenCalledWith(
       '/repos/my-repo', 'feature-new', 'repo-1', 'main',
@@ -155,7 +145,7 @@ describe('createWorktreeWithSession', () => {
   });
 
   it('falls back to local branch when fetch fails', async () => {
-    mockFetchRemote.mockImplementation(() => Promise.reject(new Error('network error')));
+    mockGit.fetchRemote.mockImplementation(() => Promise.reject(new Error('network error')));
 
     const sm = createMockSessionManager();
     const result = await createWorktreeWithSession(DEFAULT_PARAMS, sm, mockWorktreeService);


### PR DESCRIPTION
## Summary

P0 hot-fix: `main` went RED at `486d128` (PR #778 squash merge). Three server tests failed **in CI only** (green locally) — order-dependent test mock pollution, the same class as PR #780.

- `mcp-server.test.ts:1440` — `mockGit.fetchRemote` "was not called"
- `repositories.test.ts:176` — Expected 400, Received 200 (GitError path)
- `migration.test.ts:1072` — partial-failure mock not honored

## Root cause (confirmed by primary evidence)

bun's `mock.module()` is process-global with **per-key merge and last-registration-wins**, keyed by resolved module path. Four test files registered competing `mock.module` for the same resolved path `packages/server/src/lib/git.js`:

| File | Registered |
|---|---|
| `__tests__/utils/mock-git-helper.ts:88` (canonical, used by 13 files incl. all 3 victims) | `{ ...mockGit (35 fns), GitError }` |
| `services/__tests__/worktree-creation-service.test.ts:33` | `{ fetchRemote }` |
| `services/__tests__/session-validation-service.test.ts:10` | `{ gitRefExists }` |
| `lib/__tests__/repository-remote.test.ts:6` | `{ getRemoteUrl }` |

On CI's Linux file-discovery order a partial registration won the key last and orphaned the shared spy the victims assert on. macOS discovery order kept the shared mock winning → green locally. PR #778 added **no** `mock.module`; it only shifted discovery timing/shape. Verified with a deterministic 1-file probe reproducing bun's per-key-merge last-wins behavior independent of file order.

## Fix (isolation, not symptom)

Convert the three competing files to use the shared `mock-git-helper.ts` (`mockGit` + `resetGitMocks`), following the established pattern of the other 13 consumers. Each test's behavior is preserved (e.g. `session-validation-service.test.ts` keeps its `gitRefExists=true` default explicitly, since `resetGitMocks()` defaults it to `false`).

**Three `mock.module(git.js)` registrations removed, zero added.** Only one registration of `lib/git.js` now exists, so the last-wins order-dependence is **eliminated by construction** — no other file can win the git.js mock key regardless of discovery order.

Test-only change; no production code modified.

## Verification

- Full suite `bun run test`: **0 fail, exit 0** (system bun 1.3.8)
- Full server suite under **CI-pinned bun 1.3.4**: **2513 pass / 1 skip / 0 fail**, 122 files
- 3 CI victims standalone (both bun versions): 159 pass / 0 fail
- 3 modified files standalone (both bun versions): 24 pass / 0 fail
- `bun run typecheck`: 0 errors
- CodeRabbit CLI (`--agent --base main`): **0 findings**

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)