### PR TITLE
feat: shared session UI affordance — client UI (Part 2b of #678) (closes #775)

### DIFF
--- a/packages/client/src/components/sessions/QuickSessionForm.tsx
+++ b/packages/client/src/components/sessions/QuickSessionForm.tsx
@@ -3,6 +3,7 @@ import { valibotResolver } from '@hookform/resolvers/valibot';
 import { FormField, Input } from '../ui/FormField';
 import { AgentSelector, useResolvedAgentId } from '../AgentSelector';
 import { FormOverlay } from '../ui/Spinner';
+import { useAuth } from '../../lib/auth';
 import type { CreateQuickSessionRequest } from '@agent-console/shared';
 import { CreateQuickSessionRequestSchema } from '@agent-console/shared';
 
@@ -34,6 +35,7 @@ export function QuickSessionForm({
     mode: 'onBlur',
   });
 
+  const { sharedAccountsAvailable } = useAuth();
   const agentId = watch('agentId');
   const resolvedAgentId = useResolvedAgentId(agentId);
 
@@ -72,6 +74,16 @@ export function QuickSessionForm({
               className="flex-1"
             />
           </div>
+          {sharedAccountsAvailable && (
+            <label className="flex items-center gap-2 text-sm text-gray-400">
+              <input
+                type="checkbox"
+                {...register('shared')}
+                className="accent-indigo-600"
+              />
+              Create as shared session
+            </label>
+          )}
           {errors.root && (
             <p className="text-sm text-red-400" role="alert">{errors.root.message}</p>
           )}

--- a/packages/client/src/components/sessions/__tests__/QuickSessionForm.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/QuickSessionForm.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { QuickSessionForm } from '../QuickSessionForm';
+import { setSharedAccountsAvailable, _reset as resetAuth } from '../../../lib/auth';
 
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
@@ -69,6 +70,11 @@ describe('QuickSessionForm', () => {
     mockFetch.mockReset();
     // Default: return agents for AgentSelector
     mockFetch.mockResolvedValue(createMockResponse(mockAgentsResponse));
+    resetAuth();
+  });
+
+  afterEach(() => {
+    resetAuth();
   });
 
   describe('successful submission', () => {
@@ -252,6 +258,83 @@ describe('QuickSessionForm', () => {
       await user.click(cancelButton);
 
       expect(props.onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('shared session checkbox', () => {
+    it('should NOT render the checkbox when sharedAccountsAvailable is false', async () => {
+      setSharedAccountsAvailable(false);
+      renderQuickSessionForm();
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      expect(screen.queryByText('Create as shared session')).toBeNull();
+    });
+
+    it('should render the checkbox when sharedAccountsAvailable is true', async () => {
+      setSharedAccountsAvailable(true);
+      renderQuickSessionForm();
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      expect(screen.getByText('Create as shared session')).toBeTruthy();
+    });
+
+    it('should submit shared: true when the checkbox is checked', async () => {
+      setSharedAccountsAvailable(true);
+      const user = userEvent.setup();
+      const { props } = renderQuickSessionForm();
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      const checkbox = screen.getByRole('checkbox');
+      await user.click(checkbox);
+
+      const pathInput = screen.getByPlaceholderText(/Path.*e\.g\./);
+      await user.clear(pathInput);
+      await user.type(pathInput, '/path/to/project');
+
+      await user.click(screen.getByText('Start'));
+
+      await waitFor(() => {
+        expect(props.onSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      const submitCall = (props.onSubmit as ReturnType<typeof mock>).mock.calls[0];
+      expect(submitCall[0]).toMatchObject({
+        type: 'quick',
+        locationPath: '/path/to/project',
+        shared: true,
+      });
+    });
+
+    it('should not submit shared: true when the checkbox is left unchecked', async () => {
+      setSharedAccountsAvailable(true);
+      const user = userEvent.setup();
+      const { props } = renderQuickSessionForm();
+
+      await waitFor(() => {
+        expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+      });
+
+      const pathInput = screen.getByPlaceholderText(/Path.*e\.g\./);
+      await user.clear(pathInput);
+      await user.type(pathInput, '/path/to/project');
+
+      await user.click(screen.getByText('Start'));
+
+      await waitFor(() => {
+        expect(props.onSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      const submitCall = (props.onSubmit as ReturnType<typeof mock>).mock.calls[0];
+      expect(submitCall[0].shared).not.toBe(true);
     });
   });
 });

--- a/packages/client/src/components/sidebar/ActiveSessionsSidebar.tsx
+++ b/packages/client/src/components/sidebar/ActiveSessionsSidebar.tsx
@@ -4,6 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 import type { AgentActivityState, WorktreeCreationTask, WorktreeDeletionTask, Session } from '@agent-console/shared';
 import type { SessionFilterMode } from '../../types/session-filter';
 import { restartAllAgentWorkers } from '../../lib/api';
+import { useAuth } from '../../lib/auth';
 import { logger } from '../../lib/logger';
 import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon, AlertCircleIcon, RefreshIcon } from '../Icons';
 import { ConfirmDialog } from '../ui/confirm-dialog';
@@ -103,7 +104,10 @@ function SessionItem({ sessionWithActivity, collapsed, isActive, onClick }: Sess
   const { primary, secondary, tooltip } = getSessionDisplayInfo(session);
   const label = getActivityLabel(activityState);
   const isOrphaned = session.recoveryState === 'orphaned';
-  const orphanedTooltip = isOrphaned ? `${tooltip} (Unrecoverable)` : tooltip;
+  const sharedSuffix = session.isShared ? ' [Shared]' : '';
+  const orphanedTooltip = isOrphaned
+    ? `${tooltip} (Unrecoverable)${sharedSuffix}`
+    : `${tooltip}${sharedSuffix}`;
 
   if (collapsed) {
     return (
@@ -112,7 +116,7 @@ function SessionItem({ sessionWithActivity, collapsed, isActive, onClick }: Sess
         className={`w-full p-3 flex justify-center hover:bg-slate-800 transition-colors ${
           isActive ? 'bg-slate-800' : ''
         }`}
-        title={isOrphaned ? orphanedTooltip : `${tooltip} (${label})`}
+        title={isOrphaned ? orphanedTooltip : `${tooltip} (${label})${sharedSuffix}`}
       >
         {isOrphaned ? (
           <AlertCircleIcon className="w-3 h-3 text-red-400" />
@@ -138,8 +142,15 @@ function SessionItem({ sessionWithActivity, collapsed, isActive, onClick }: Sess
           <ActivityIndicator state={activityState} className="mt-1.5" />
         )}
         <div className="min-w-0 flex-1">
-          <div className={`text-sm font-medium truncate ${isOrphaned ? 'text-gray-500 line-through' : 'text-gray-300'}`}>
-            {primary}
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className={`text-sm font-medium truncate ${isOrphaned ? 'text-gray-500 line-through' : 'text-gray-300'}`}>
+              {primary}
+            </span>
+            {session.isShared && (
+              <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-indigo-900 text-indigo-300">
+                Shared
+              </span>
+            )}
           </div>
           <div className={`text-xs truncate ${isOrphaned ? 'text-red-400' : 'text-gray-500'}`}>
             {isOrphaned ? 'Unrecoverable' : secondary}
@@ -355,6 +366,7 @@ export function ActiveSessionsSidebar({
 }: ActiveSessionsSidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
+  const { sharedAccountsAvailable } = useAuth();
   const [isResizing, setIsResizing] = useState(false);
   const [pausedExpanded, setPausedExpanded] = useState(false);
   const sidebarRef = useRef<HTMLDivElement>(null);
@@ -604,6 +616,19 @@ export function ActiveSessionsSidebar({
           >
             Mine
           </button>
+          {sharedAccountsAvailable && (
+            <button
+              onClick={() => sessionFilter.onChange('shared')}
+              className={`text-xs px-2 py-0.5 rounded transition-colors ${
+                sessionFilter.mode === 'shared'
+                  ? 'bg-indigo-600 text-white'
+                  : 'text-slate-400 hover:text-white hover:bg-slate-800'
+              }`}
+              aria-pressed={sessionFilter.mode === 'shared'}
+            >
+              Shared
+            </button>
+          )}
         </div>
       )}
 

--- a/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
+++ b/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
@@ -8,6 +8,7 @@ import {
   SIDEBAR_DEFAULT_WIDTH,
 } from '../../../hooks/useSidebarState';
 import type { SessionWithActivity } from '../../../hooks/useActiveSessionsWithActivity';
+import { setSharedAccountsAvailable, _reset as resetAuth } from '../../../lib/auth';
 import type { AgentActivityState, WorktreeSession, QuickSession, Session } from '@agent-console/shared';
 
 // Helper to create mock worktree session
@@ -74,10 +75,12 @@ describe('ActiveSessionsSidebar', () => {
   beforeEach(() => {
     onToggle = mock(() => {});
     onWidthChange = mock(() => {});
+    resetAuth();
   });
 
   afterEach(() => {
     cleanup();
+    resetAuth();
   });
 
   describe('Rendering', () => {
@@ -683,6 +686,123 @@ describe('ActiveSessionsSidebar', () => {
 
       expect(allButton.getAttribute('aria-pressed')).toBe('false');
       expect(mineButton.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('should NOT render "Shared" filter button when sharedAccountsAvailable is false', async () => {
+      const onChange = mock(() => {});
+      setSharedAccountsAvailable(false);
+
+      await renderWithRouter(
+        <ActiveSessionsSidebar
+          {...defaultProps()}
+          sessionFilter={{ mode: 'all', onChange }}
+        />
+      );
+
+      expect(screen.getByText('All')).toBeTruthy();
+      expect(screen.getByText('Mine')).toBeTruthy();
+      expect(screen.queryByText('Shared')).toBeNull();
+    });
+
+    it('should render "Shared" filter button when sharedAccountsAvailable is true', async () => {
+      const onChange = mock(() => {});
+      setSharedAccountsAvailable(true);
+
+      await renderWithRouter(
+        <ActiveSessionsSidebar
+          {...defaultProps()}
+          sessionFilter={{ mode: 'all', onChange }}
+        />
+      );
+
+      expect(screen.getByText('Shared')).toBeTruthy();
+    });
+
+    it('should call onChange with "shared" when Shared button clicked', async () => {
+      const onChange = mock(() => {});
+      setSharedAccountsAvailable(true);
+
+      await renderWithRouter(
+        <ActiveSessionsSidebar
+          {...defaultProps()}
+          sessionFilter={{ mode: 'all', onChange }}
+        />
+      );
+
+      fireEvent.click(screen.getByText('Shared'));
+      expect(onChange).toHaveBeenCalledWith('shared');
+    });
+
+    it('should reflect shared mode via aria-pressed', async () => {
+      const onChange = mock(() => {});
+      setSharedAccountsAvailable(true);
+
+      await renderWithRouter(
+        <ActiveSessionsSidebar
+          {...defaultProps()}
+          sessionFilter={{ mode: 'shared', onChange }}
+        />
+      );
+
+      expect(screen.getByText('Shared').getAttribute('aria-pressed')).toBe('true');
+      expect(screen.getByText('All').getAttribute('aria-pressed')).toBe('false');
+    });
+  });
+
+  describe('Shared session badge', () => {
+    it('should render "Shared" badge for sessions with isShared true', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({ repositoryName: 'shared-repo', isShared: true }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(
+        <ActiveSessionsSidebar {...defaultProps()} sessions={sessions} />
+      );
+
+      expect(screen.getByText('shared-repo')).toBeTruthy();
+      expect(screen.getByText('Shared')).toBeTruthy();
+    });
+
+    it('should NOT render "Shared" badge for sessions with isShared false', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({ repositoryName: 'normal-repo', isShared: false }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(
+        <ActiveSessionsSidebar {...defaultProps()} sessions={sessions} />
+      );
+
+      expect(screen.getByText('normal-repo')).toBeTruthy();
+      expect(screen.queryByText('Shared')).toBeNull();
+    });
+
+    it('should append [Shared] to tooltip in collapsed mode for shared sessions', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({
+            repositoryName: 'shared-repo',
+            title: 'shared-branch',
+            isShared: true,
+          }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(
+        <ActiveSessionsSidebar {...defaultProps()} collapsed={true} sessions={sessions} />
+      );
+
+      const buttons = screen.getAllByRole('button');
+      const sessionButton = buttons.find(btn =>
+        btn.getAttribute('title')?.includes('shared-repo / shared-branch')
+      );
+      expect(sessionButton?.getAttribute('title')).toContain('[Shared]');
     });
   });
 

--- a/packages/client/src/hooks/__tests__/useSessionFilter.test.ts
+++ b/packages/client/src/hooks/__tests__/useSessionFilter.test.ts
@@ -26,6 +26,12 @@ describe('useSessionFilter', () => {
       const { result } = renderHook(() => useSessionFilter());
       expect(result.current.filterMode).toBe('all');
     });
+
+    it('should restore stored "shared" value', () => {
+      localStorage.setItem(STORAGE_KEY, 'shared');
+      const { result } = renderHook(() => useSessionFilter());
+      expect(result.current.filterMode).toBe('shared');
+    });
   });
 
   describe('setFilterMode', () => {
@@ -99,6 +105,70 @@ describe('useSessionFilter', () => {
         { id: 's1', createdBy: 'user-1' },
         { id: 's3', createdBy: 'user-1' },
         { id: 's4' }, // legacy session (no createdBy) included
+      ]);
+    });
+
+    it('should filter to only isShared sessions when mode is shared', () => {
+      setAuthMode('multi-user');
+      setCurrentUser({ id: 'user-1', username: 'alice', homeDir: '/home/alice' });
+
+      const sharedSessions = [
+        { id: 's1', createdBy: 'user-1', isShared: true },
+        { id: 's2', createdBy: 'user-2', isShared: false },
+        { id: 's3', createdBy: 'user-1', isShared: true },
+        { id: 's4' }, // no isShared -> not shared
+      ];
+
+      const { result } = renderHook(() => useSessionFilter());
+
+      act(() => {
+        result.current.setFilterMode('shared');
+      });
+
+      const filtered = result.current.filterSessions(sharedSessions);
+      expect(filtered).toEqual([
+        { id: 's1', createdBy: 'user-1', isShared: true },
+        { id: 's3', createdBy: 'user-1', isShared: true },
+      ]);
+    });
+
+    it('should return empty array when shared filter matches no sessions', () => {
+      setAuthMode('multi-user');
+      setCurrentUser({ id: 'user-1', username: 'alice', homeDir: '/home/alice' });
+
+      const { result } = renderHook(() => useSessionFilter());
+
+      act(() => {
+        result.current.setFilterMode('shared');
+      });
+
+      const filtered = result.current.filterSessions([
+        { id: 's1', createdBy: 'user-1', isShared: false },
+      ]);
+      expect(filtered).toEqual([]);
+    });
+
+    it('should not filter by isShared when mode is mine (regression guard)', () => {
+      setAuthMode('multi-user');
+      setCurrentUser({ id: 'user-1', username: 'alice', homeDir: '/home/alice' });
+
+      const mixed = [
+        { id: 's1', createdBy: 'user-1', isShared: false },
+        { id: 's2', createdBy: 'user-2', isShared: true },
+        { id: 's3', createdBy: 'user-1', isShared: true },
+      ];
+
+      const { result } = renderHook(() => useSessionFilter());
+
+      act(() => {
+        result.current.setFilterMode('mine');
+      });
+
+      const filtered = result.current.filterSessions(mixed);
+      // 'mine' keys off createdBy only, unaffected by isShared
+      expect(filtered).toEqual([
+        { id: 's1', createdBy: 'user-1', isShared: false },
+        { id: 's3', createdBy: 'user-1', isShared: true },
       ]);
     });
 

--- a/packages/client/src/hooks/useSessionFilter.ts
+++ b/packages/client/src/hooks/useSessionFilter.ts
@@ -26,7 +26,7 @@ export function matchesUserFilter(createdBy: string | undefined, userId: string)
 function readStoredFilterMode(): SessionFilterMode {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === 'all' || stored === 'mine') {
+    if (stored === 'all' || stored === 'mine' || stored === 'shared') {
       return stored;
     }
   } catch {
@@ -38,7 +38,7 @@ function readStoredFilterMode(): SessionFilterMode {
 export function useSessionFilter(): {
   filterMode: SessionFilterMode;
   setFilterMode: (mode: SessionFilterMode) => void;
-  filterSessions: <T extends { createdBy?: string }>(sessions: T[]) => T[];
+  filterSessions: <T extends { createdBy?: string; isShared?: boolean }>(sessions: T[]) => T[];
 } {
   const { currentUser, isMultiUser } = useAuth();
   const [filterMode, setFilterModeState] = useState<SessionFilterMode>(readStoredFilterMode);
@@ -52,9 +52,12 @@ export function useSessionFilter(): {
     }
   }, []);
 
-  const filterSessions = useCallback(<T extends { createdBy?: string }>(sessions: T[]): T[] => {
+  const filterSessions = useCallback(<T extends { createdBy?: string; isShared?: boolean }>(sessions: T[]): T[] => {
     if (!isMultiUser) {
       return sessions;
+    }
+    if (filterMode === 'shared') {
+      return sessions.filter(s => s.isShared === true);
     }
     if (filterMode !== 'mine') {
       return sessions;

--- a/packages/client/src/lib/__tests__/auth.test.ts
+++ b/packages/client/src/lib/__tests__/auth.test.ts
@@ -4,6 +4,8 @@ import {
   setAuthMode,
   getCurrentUser,
   setCurrentUser,
+  getSharedAccountsAvailable,
+  setSharedAccountsAvailable,
   isMultiUserMode,
   subscribeAuth,
   _reset,
@@ -60,6 +62,32 @@ describe('auth module', () => {
     });
   });
 
+  describe('getSharedAccountsAvailable / setSharedAccountsAvailable', () => {
+    it('should default to false', () => {
+      expect(getSharedAccountsAvailable()).toBe(false);
+    });
+
+    it('should return the set value', () => {
+      setSharedAccountsAvailable(true);
+      expect(getSharedAccountsAvailable()).toBe(true);
+    });
+
+    it('should allow toggling back to false', () => {
+      setSharedAccountsAvailable(true);
+      setSharedAccountsAvailable(false);
+      expect(getSharedAccountsAvailable()).toBe(false);
+    });
+
+    it('should notify listeners when changed', () => {
+      const listener = mock(() => {});
+      subscribeAuth(listener);
+
+      setSharedAccountsAvailable(true);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('subscribeAuth', () => {
     it('should notify listener when setAuthMode is called', () => {
       const listener = mock(() => {});
@@ -92,14 +120,16 @@ describe('auth module', () => {
   });
 
   describe('_reset', () => {
-    it('should reset both auth mode and current user', () => {
+    it('should reset auth mode, current user, and shared accounts availability', () => {
       setAuthMode('multi-user');
       setCurrentUser({ id: 'user-1', username: 'alice', homeDir: '/home/alice' });
+      setSharedAccountsAvailable(true);
 
       _reset();
 
       expect(getAuthMode()).toBe('none');
       expect(getCurrentUser()).toBeNull();
+      expect(getSharedAccountsAvailable()).toBe(false);
     });
   });
 });

--- a/packages/client/src/lib/auth.ts
+++ b/packages/client/src/lib/auth.ts
@@ -3,6 +3,7 @@ import type { AuthUser, AuthMode } from '@agent-console/shared';
 
 let authMode: AuthMode = 'none';
 let currentUser: AuthUser | null = null;
+let sharedAccountsAvailable = false;
 
 const stateListeners = new Set<() => void>();
 
@@ -32,6 +33,15 @@ export function isMultiUserMode(): boolean {
   return authMode === 'multi-user';
 }
 
+export function getSharedAccountsAvailable(): boolean {
+  return sharedAccountsAvailable;
+}
+
+export function setSharedAccountsAvailable(value: boolean): void {
+  sharedAccountsAvailable = value;
+  notifyListeners();
+}
+
 /**
  * Subscribe to auth state changes (for useSyncExternalStore).
  * @returns Unsubscribe function
@@ -45,15 +55,26 @@ interface AuthState {
   authMode: AuthMode;
   currentUser: AuthUser | null;
   isMultiUser: boolean;
+  sharedAccountsAvailable: boolean;
 }
 
 let cachedSnapshot: AuthState | null = null;
 
 function getAuthSnapshot(): AuthState {
-  if (cachedSnapshot && cachedSnapshot.authMode === authMode && cachedSnapshot.currentUser === currentUser) {
+  if (
+    cachedSnapshot &&
+    cachedSnapshot.authMode === authMode &&
+    cachedSnapshot.currentUser === currentUser &&
+    cachedSnapshot.sharedAccountsAvailable === sharedAccountsAvailable
+  ) {
     return cachedSnapshot;
   }
-  cachedSnapshot = { authMode, currentUser, isMultiUser: authMode === 'multi-user' };
+  cachedSnapshot = {
+    authMode,
+    currentUser,
+    isMultiUser: authMode === 'multi-user',
+    sharedAccountsAvailable,
+  };
   return cachedSnapshot;
 }
 
@@ -72,6 +93,7 @@ export function useAuth(): AuthState {
 export function _reset(): void {
   authMode = 'none';
   currentUser = null;
+  sharedAccountsAvailable = false;
   cachedSnapshot = null;
   stateListeners.clear();
 }

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { routeTree } from './routeTree.gen';
 import { fetchConfig, fetchCurrentUser } from './lib/api';
 import { setHomeDir } from './lib/path';
-import { setAuthMode, setCurrentUser } from './lib/auth';
+import { setAuthMode, setCurrentUser, setSharedAccountsAvailable } from './lib/auth';
 import {
   hasPendingSaves,
   flush as flushSaveManager,
@@ -139,6 +139,7 @@ async function initApp() {
   try {
     const config = await fetchConfig();
     setAuthMode(config.authMode);
+    setSharedAccountsAvailable(config.sharedAccountsAvailable);
 
     if (config.authMode === 'multi-user') {
       // In multi-user mode, check if user is already authenticated.

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -111,7 +111,11 @@ function RootLayout() {
   // Session filtering for multi-user mode
   const { filterMode, setFilterMode, filterSessions } = useSessionFilter();
   const activeSessions = useMemo(() => {
-    if (!isMultiUser || filterMode !== 'mine' || !currentUser) return allActiveSessions;
+    if (!isMultiUser) return allActiveSessions;
+    if (filterMode === 'shared') {
+      return allActiveSessions.filter(s => s.session.isShared);
+    }
+    if (filterMode !== 'mine' || !currentUser) return allActiveSessions;
     return allActiveSessions.filter(s => matchesUserFilter(s.session.createdBy, currentUser.id));
   }, [allActiveSessions, isMultiUser, filterMode, currentUser]);
   const pausedSessions = useMemo(() => filterSessions(sessions.filter(s => s.pausedAt)), [filterSessions, sessions]);

--- a/packages/client/src/types/session-filter.ts
+++ b/packages/client/src/types/session-filter.ts
@@ -1,1 +1,1 @@
-export type SessionFilterMode = 'all' | 'mine';
+export type SessionFilterMode = 'all' | 'mine' | 'shared';


### PR DESCRIPTION
## Summary

Client UI for the shared-session affordance — **Part 2b of #678**. Consumes the Part 2a server contract (#774 / merged in #778): `Session.isShared` and `/api/config.sharedAccountsAvailable`. No server or shared-type changes.

Closes #775
Refs #678

## Feature Overview (plain-language)

**What this adds:** the UI to *create*, *recognise*, and *filter* shared sessions — a "shared session" is one that runs under a configured shared account so a whole team sees and can join it.

| Where | What you see | How to use it |
|---|---|---|
| **Quick Start dialog** (the session-create form) | a **"Create as shared session"** checkbox | tick it → the new session is created as shared |
| **Sidebar — session list** | a small indigo **`SHARED`** badge next to shared sessions | lets you tell at a glance you are typing into a team-visible space (avoids leaking secrets) |
| **Sidebar — filter row** | a third **`Shared`** button next to `All` / `Mine` | click it → the list shows only shared sessions |

**When it appears vs. not:** all three only show when the server has a shared account configured (`AGENT_CONSOLE_SHARED_USERNAME` set in `AUTH_MODE=multi-user`), reported to the client via `/api/config.sharedAccountsAvailable`. In a single-user setup nothing changes — the checkbox, badge, and filter are entirely absent (the design's opt-in stance).

**Screenshot map:** screenshots `01`–`02` show the **OFF** state (single-user — affordance absent); `03`–`06` show the **ON** state (shared account available — checkbox, badge, and filter visible and working).

## What changed (client-only, 7 production + 4 sibling-test files)

- **`lib/auth.ts`** — the `useSyncExternalStore` singleton gains `sharedAccountsAvailable` (default `false`), set unconditionally from `/api/config` in `main.tsx` (same pattern as `authMode`). Exposed via `useAuth()`.
- **`components/sessions/QuickSessionForm.tsx`** — "Create as shared session" checkbox, rendered only when `sharedAccountsAvailable === true`; threads `shared: true` into the submitted `CreateQuickSessionRequest` (the schema already permits `shared?: boolean`).
- **`components/sidebar/ActiveSessionsSidebar.tsx`** — "Shared" badge on sessions with `isShared === true` (collapsed mode appends a `[Shared]` tooltip suffix); "Shared" filter button next to All/Mine, gated on `sharedAccountsAvailable`.
- **`types/session-filter.ts` / `hooks/useSessionFilter.ts` / `routes/__root.tsx`** — `SessionFilterMode` gains `'shared'`; the hook and the `__root` active-sessions memo filter by `Session.isShared`; the `'mine'` (createdBy-keyed) logic is preserved unchanged.

## Architectural invariants

- **I-5 (Server as source of truth):** the client consumes `Session.isShared` and `config.sharedAccountsAvailable` verbatim. No client-side recomputation of "is shared" and no reconstruction of the shared-account user-id set.
- Other catalog invariants: N/A (no shared resources, persistence, identifiers, or I/O symmetry introduced).

## Q1 reuse confirmation

Extended existing structures only — **no parallel components/state introduced**: the `auth.ts` singleton, the `SessionFilterMode` union + `useSessionFilter`, the existing All/Mine filter button group, the existing `SessionItem` row, the `__root.tsx` `activeSessions` memo, and `QuickSessionForm`.

## Scope decision — out-of-scope follow-up

The shared-create affordance is delivered **via the quick-session form only**. The worktree-session create path (`CreateWorktreeForm` → `useCreateWorktree` → the worktree-creation-task pipeline) is a much larger surface and does not thread `shared` through cleanly. Per `design-principles.md` "Speak up about issues", the UX-consistency gap (worktree sessions cannot yet be created as shared from the UI) is an explicit **out-of-scope follow-up — Issue #787, filed by the Orchestrator (see PR comment).**

## Verification

- **`bun run typecheck`**: exit 0 (post-rebase onto `origin/main` incl. #785; `routeTree.gen.ts` regenerated).
- **`bun run test`** (full suite, post-rebase): `TEST_EXIT: 0` — client 1386 pass / shared 324 / integration 29 / server 2513 / scripts 362, **0 fail** (the #784 isolation-pollution tests now pass via #785).
- **CodeRabbit CLI** (`coderabbit review --agent --base main`): **0 findings on this PR's diff**. One out-of-scope `minor` in `scripts/check-bun-version.mjs` — a pre-existing file from PR #781, unrelated to this client diff — was skipped as out of scope (per `workflow.md` Step 3, recorded here rather than silently skipped).

## Browser QA

All screenshots are **real-device** (Chrome via dev server, `0` console errors). The previous OFF-only screenshot comment was minimized as OUTDATED; the current comment has all 6.

**OFF state — `sharedAccountsAvailable: false`** (default `AUTH_MODE=none` dev server, no patching):
- `01-dashboard-shared-unavailable.png` — single-user dashboard; no All/Mine/Shared filter affordance.
- `02-quicksession-no-shared-checkbox-unavailable.png` — Quick Start form has **no** "Create as shared session" checkbox.

**ON state — `sharedAccountsAvailable: true`** (driving method below):
- `03-dashboard-shared-badge-and-filter-available.png` — dashboard with the `SHARED` badge and the All/Mine/**Shared** filter row.
- `04-quicksession-shared-checkbox-available-checked.png` — Quick Start form with the **"Create as shared session"** checkbox visible and ticked.
- `05-shared-filter-applied.png` — the **Shared** filter selected (highlighted), list scoped to shared sessions.
- `06-sidebar-shared-badge-filter-closeup.png` — close-up: `All | Mine | Shared` filter + the indigo `SHARED` badge.

**ON-state driving method (transparency — option (b)):** the `AUTH_MODE=multi-user` + OS-authentication path cannot be driven by automated QA. To show the real UI in its shared-enabled state, two **temporary, uncommitted** dev-only stubs were applied, screenshots taken, then reverted via `git checkout --` (the working tree is byte-identical to the verified commit; **none of this is in the diff** — verified: no `QA-TEMP` markers, `git diff HEAD` empty): (1) `lib/auth.ts` `getAuthSnapshot()` forced to a stable shared-enabled multi-user snapshot; (2) `routes/__root.tsx` marked the first active session `isShared: true`. These reproduce exactly what the server contract produces in a real shared-account multi-user deployment.

**Automated-test guarantee (still authoritative — not replaced by the screenshots):**
- `QuickSessionForm.test.tsx` — checkbox absent (`false`) / present (`true`) / checked → `shared: true` / unchecked → not `shared: true`.
- `ActiveSessionsSidebar.test.tsx` — Shared filter button absent (`false`) / present (`true`) / `onChange('shared')` / `aria-pressed`; Shared badge present (`isShared: true`) / absent (`false`) / collapsed `[Shared]` tooltip.
- `useSessionFilter.test.ts` — restore stored `'shared'`; filter to `isShared`; **empty boundary** (`'shared'` + no matches → `[]`); `'mine'` regression guard.
- **Owner dogfood post-merge** recipe (genuine end-to-end): run with `AUTH_MODE=multi-user AGENT_CONSOLE_SHARED_USERNAME=<an existing OS account>`, log in, create a session with the checkbox ticked, verify the badge + the "Shared" filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
