### PR TITLE
fix: wrap PTY-injected text in bracketed paste delimiters

### DIFF
--- a/packages/server/src/services/__tests__/pty-message-injection-service.test.ts
+++ b/packages/server/src/services/__tests__/pty-message-injection-service.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, mock, jest } from 'bun:test';
 import { PtyMessageInjectionService } from '../pty-message-injection-service.js';
 
+// Bracketed paste delimiters (DEC private mode 2004) — see Issue #792.
+const PASTE_START = '\x1b[200~';
+const PASTE_END = '\x1b[201~';
+const wrap = (s: string) => `${PASTE_START}${s}${PASTE_END}`;
+
 describe('PtyMessageInjectionService', () => {
   let writeInput: ReturnType<typeof mock>;
   let isWorkerActive: ReturnType<typeof mock>;
@@ -20,38 +25,47 @@ describe('PtyMessageInjectionService', () => {
     jest.useRealTimers();
   });
 
-  it('should inject single content part and queue final Enter', () => {
+  it('should inject single content part wrapped in bracketed paste and queue unwrapped final Enter', () => {
     const result = service.injectMessage('s1', 'w1', 'hello world');
 
     expect(result).toBe(true);
-    // First part written immediately
-    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', 'hello world');
+    // First part written immediately, wrapped in bracketed paste delimiters
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', wrap('hello world'));
     expect(writeInput).toHaveBeenCalledTimes(1);
 
-    // Final Enter queued with delay
+    // Final Enter queued with delay — NOT wrapped (submit keystroke)
     jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
     expect(writeInput).toHaveBeenCalledWith('s1', 'w1', '\r');
     expect(writeInput).toHaveBeenCalledTimes(2);
   });
 
-  it('should preserve LF newlines as soft newlines in content (Issue #660)', () => {
-    service.injectMessage('s1', 'w1', 'line1\nline2\nline3');
-    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', 'line1\nline2\nline3');
+  it('should preserve LF newlines inside the bracketed paste envelope (Issue #660 + #792)', () => {
+    const result = service.injectMessage('s1', 'w1', 'line1\nline2\nline3');
+
+    expect(result).toBe(true);
+    // Newlines stay inside the envelope as literal text, single write, not split
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', wrap('line1\nline2\nline3'));
+    expect(writeInput).toHaveBeenCalledTimes(1);
+
+    // Exactly one final \r submit
+    jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
+    expect(writeInput).toHaveBeenLastCalledWith('s1', 'w1', '\r');
+    expect(writeInput).toHaveBeenCalledTimes(2);
   });
 
-  it('should normalize CRLF to LF (single soft newline) in content', () => {
+  it('should normalize CRLF to LF inside the bracketed paste envelope', () => {
     service.injectMessage('s1', 'w1', 'line1\r\nline2\r\nline3');
-    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', 'line1\nline2\nline3');
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', wrap('line1\nline2\nline3'));
   });
 
-  it('preserves multiple consecutive newlines as soft newlines (Issue #660)', () => {
+  it('preserves multiple consecutive newlines inside the envelope (Issue #660 regression)', () => {
     // Regression test: previously \n was converted to \r (submit), so 3 blank
     // lines split a single message into 3 separate submissions to the agent.
     const result = service.injectMessage('s1', 'w1', 'First line\n\n\nSecond line');
 
     expect(result).toBe(true);
-    // Newlines preserved verbatim as part of the same message body.
-    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', 'First line\n\n\nSecond line');
+    // Newlines preserved verbatim inside a single wrapped write.
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', wrap('First line\n\n\nSecond line'));
     // Only ONE write before any timer advances — body is not split.
     expect(writeInput).toHaveBeenCalledTimes(1);
 
@@ -65,39 +79,39 @@ describe('PtyMessageInjectionService', () => {
     expect(writeInput).toHaveBeenCalledTimes(2);
   });
 
-  it('should inject content followed by file paths with delays', () => {
+  it('should inject content followed by file paths with delays, each part wrapped', () => {
     const result = service.injectMessage('s1', 'w1', 'check these', ['/tmp/a.txt', '/tmp/b.txt']);
 
     expect(result).toBe(true);
-    // Immediate: content
-    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', 'check these');
+    // Immediate: content wrapped
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', wrap('check these'));
     expect(writeInput).toHaveBeenCalledTimes(1);
 
-    // After 150ms: first file
+    // After 150ms: first file — leading \r (submit of prev part) unwrapped, content wrapped
     jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
-    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', '\r/tmp/a.txt');
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', `\r${wrap('/tmp/a.txt')}`);
     expect(writeInput).toHaveBeenCalledTimes(2);
 
     // After 300ms: second file
     jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
-    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', '\r/tmp/b.txt');
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', `\r${wrap('/tmp/b.txt')}`);
     expect(writeInput).toHaveBeenCalledTimes(3);
 
-    // After 450ms: final Enter
+    // After 450ms: final Enter — unwrapped
     jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
     expect(writeInput).toHaveBeenCalledWith('s1', 'w1', '\r');
     expect(writeInput).toHaveBeenCalledTimes(4);
   });
 
-  it('should inject files only when content is empty', () => {
+  it('should inject files only (wrapped) when content is empty', () => {
     const result = service.injectMessage('s1', 'w1', '', ['/tmp/file.txt']);
 
     expect(result).toBe(true);
-    // First file written immediately
-    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', '/tmp/file.txt');
+    // First file written immediately, wrapped
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', wrap('/tmp/file.txt'));
     expect(writeInput).toHaveBeenCalledTimes(1);
 
-    // Final Enter after delay
+    // Final Enter after delay — unwrapped
     jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
     expect(writeInput).toHaveBeenCalledWith('s1', 'w1', '\r');
     expect(writeInput).toHaveBeenCalledTimes(2);
@@ -136,6 +150,7 @@ describe('PtyMessageInjectionService', () => {
     );
 
     service.injectMessage('s1', 'w1', 'check', ['/tmp/a.txt']);
+    expect(writeInput).toHaveBeenCalledWith('s1', 'w1', wrap('check'));
     expect(writeInput).toHaveBeenCalledTimes(1);
 
     // Worker becomes inactive before delayed writes fire

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -16,6 +16,10 @@ import type { PtyProvider, PtySpawnOptions } from '../../lib/pty-provider.js';
 import { SingleUserMode } from '../user-mode.js';
 import { PtyMessageInjectionService } from '../pty-message-injection-service.js';
 
+// Bracketed paste delimiters (DEC private mode 2004) — see Issue #792.
+// Injected content/file parts are wrapped so modern TUIs accept them.
+const wrapPaste = (s: string) => `\x1b[200~${s}\x1b[201~`;
+
 // Test config directory
 const TEST_CONFIG_DIR = '/test/config';
 
@@ -638,8 +642,9 @@ describe('SessionManager', () => {
       const result = manager.injectPtyMessage(session.id, agentWorker.id, 'hello');
 
       expect(result).toBe(true);
-      // injectMessage writes content (CR-converted) then delayed \r via ptyMessageInjectionService
-      expect(ptyFactory.instances[0].writtenData).toContain('hello');
+      // injectMessage writes content wrapped in bracketed paste delimiters,
+      // then a delayed unwrapped \r submit (Issue #792).
+      expect(ptyFactory.instances[0].writtenData).toContain(wrapPaste('hello'));
     });
   });
 
@@ -680,7 +685,7 @@ describe('SessionManager', () => {
 
       const message = manager.sendMessage(session.id, null, agentWorker.id, 'hello world');
       expect(message).not.toBeNull();
-      expect(ptyFactory.instances[0].writtenData).toContain('hello world');
+      expect(ptyFactory.instances[0].writtenData).toContain(wrapPaste('hello world'));
     });
 
     it('should preserve LF newlines as soft newlines in multi-line content (Issue #660)', async () => {
@@ -696,11 +701,12 @@ describe('SessionManager', () => {
       expect(message).not.toBeNull();
       // Content stored in message should retain original newlines
       expect(message!.content).toBe('line1\nline2\nline3');
-      // PTY input must preserve newlines as soft newlines (\n), not submit (\r).
+      // PTY input must preserve newlines as soft newlines (\n), not submit (\r),
+      // inside the bracketed paste envelope (Issue #660 + #792).
       // Converting to \r would split this into 3 separate submissions to the agent.
       const pty = ptyFactory.instances[0];
-      expect(pty.writtenData).toContain('line1\nline2\nline3');
-      expect(pty.writtenData).not.toContain('line1\rline2\rline3');
+      expect(pty.writtenData).toContain(wrapPaste('line1\nline2\nline3'));
+      expect(pty.writtenData).not.toContain(wrapPaste('line1\rline2\rline3'));
     });
 
     it('should normalize CRLF line endings from form submissions to LF', async () => {
@@ -718,10 +724,10 @@ describe('SessionManager', () => {
       expect(message!.content).toBe('line1\r\nline2\r\nline3');
       const pty = ptyFactory.instances[0];
       // \r\n should be normalized to a single \n (soft newline), preserving body
-      // structure without triggering submit. See Issue #660.
-      expect(pty.writtenData).toContain('line1\nline2\nline3');
-      expect(pty.writtenData).not.toContain('\r\r');
-      expect(pty.writtenData).not.toContain('line1\rline2\rline3');
+      // structure without triggering submit, inside the bracketed paste
+      // envelope. See Issue #660 + #792.
+      expect(pty.writtenData).toContain(wrapPaste('line1\nline2\nline3'));
+      expect(pty.writtenData).not.toContain(wrapPaste('line1\rline2\rline3'));
     });
 
     it('should inject content with file paths when files provided', async () => {
@@ -736,14 +742,16 @@ describe('SessionManager', () => {
       const message = manager.sendMessage(session.id, null, agentWorker.id, 'check these', ['/tmp/file1.txt', '/tmp/file2.txt']);
       expect(message).not.toBeNull();
 
-      // First part is sent immediately
+      // First part is sent immediately, wrapped in bracketed paste (Issue #792)
       const pty = ptyFactory.instances[0];
-      expect(pty.writtenData).toContain('check these');
+      expect(pty.writtenData).toContain(wrapPaste('check these'));
 
-      // Wait for delayed parts (150ms * 3 = content, file1, file2, enter)
+      // Wait for delayed parts (150ms * 3 = content, file1, file2, enter).
+      // Leading \r submits the previous part (unwrapped); the file path itself
+      // is wrapped.
       await new Promise(resolve => setTimeout(resolve, 700));
-      expect(pty.writtenData).toContain('\r/tmp/file1.txt');
-      expect(pty.writtenData).toContain('\r/tmp/file2.txt');
+      expect(pty.writtenData).toContain(`\r${wrapPaste('/tmp/file1.txt')}`);
+      expect(pty.writtenData).toContain(`\r${wrapPaste('/tmp/file2.txt')}`);
     });
 
     it('should inject files only when content is empty', async () => {
@@ -758,9 +766,9 @@ describe('SessionManager', () => {
       const message = manager.sendMessage(session.id, null, agentWorker.id, '', ['/tmp/file1.txt']);
       expect(message).not.toBeNull();
 
-      // First part (file path) is sent immediately
+      // First part (file path) is sent immediately, wrapped (Issue #792)
       const pty = ptyFactory.instances[0];
-      expect(pty.writtenData).toContain('/tmp/file1.txt');
+      expect(pty.writtenData).toContain(wrapPaste('/tmp/file1.txt'));
 
       // Wait for final Enter
       await new Promise(resolve => setTimeout(resolve, 300));

--- a/packages/server/src/services/pty-message-injection-service.ts
+++ b/packages/server/src/services/pty-message-injection-service.ts
@@ -16,6 +16,15 @@ export class PtyMessageInjectionService {
     private readonly isWorkerActive: WorkerActiveChecker,
   ) {}
 
+  /** Bracketed paste mode delimiters (DEC private mode 2004). */
+  private static readonly PASTE_START = '\x1b[200~';
+  private static readonly PASTE_END = '\x1b[201~';
+
+  /** Wrap a single injected part in bracketed paste delimiters. */
+  private wrapPaste(part: string): string {
+    return `${PtyMessageInjectionService.PASTE_START}${part}${PtyMessageInjectionService.PASTE_END}`;
+  }
+
   /**
    * Build message parts from content and file paths, then inject into PTY.
    * Content newlines (CRLF or LF from browser form submissions) are normalized
@@ -23,6 +32,15 @@ export class PtyMessageInjectionService {
    * final delayed CR (\r) acts as the submit keystroke. Remaining parts and
    * a final Enter are queued with delays so TUI agents can process each
    * input sequentially.
+   *
+   * Each injected content/file part is wrapped in bracketed paste delimiters
+   * (`ESC[200~` … `ESC[201~`). Modern TUIs (e.g. recent Claude Code, which
+   * enables `ESC[?2004h`) discard multi-character non-pasted input on the
+   * interactive prompt, so unwrapped raw text was silently dropped and only
+   * the trailing bare `\r` reached the prompt. The normalized LF newlines end
+   * up inside the bracketed paste envelope, where they are literal text and
+   * never submit — the final separate `\r` remains the only submit keystroke.
+   * See Issue #792.
    *
    * See Issue #660: previously this converted \r?\n to \r, which caused any
    * embedded newline to be interpreted as submit and split a single message
@@ -42,7 +60,7 @@ export class PtyMessageInjectionService {
       return false;
     }
 
-    const injected = this.writeInput(sessionId, workerId, parts[0]);
+    const injected = this.writeInput(sessionId, workerId, this.wrapPaste(parts[0]));
     if (!injected) {
       logger.warn({ sessionId, workerId }, 'Failed to inject worker message (PTY inactive)');
       return false;
@@ -54,7 +72,9 @@ export class PtyMessageInjectionService {
 
     for (let i = 1; i < parts.length; i++) {
       const part = parts[i];
-      sendQueue.push(() => this.writeInput(sessionId, workerId, `\r${part}`));
+      // Leading \r submits the *previous* part (unwrapped); only the part
+      // content itself is wrapped in bracketed paste delimiters.
+      sendQueue.push(() => this.writeInput(sessionId, workerId, `\r${this.wrapPaste(part)}`));
     }
     // Final Enter to submit
     sendQueue.push(() => this.writeInput(sessionId, workerId, '\r'));


### PR DESCRIPTION
Closes #792

## Problem

When a Claude Code agent worker shows an interactive prompt and the user answers via the MessagePanel, the typed text was dropped — the injection landed as a bare Enter that confirmed the default highlighted option (option 1). Reported from owner dogfooding after a recent Claude Code CLI update; plain non-prompt sends still worked.

## Root cause

Recent Claude Code enables **bracketed paste mode** (`ESC[?2004h`). `PtyMessageInjectionService.injectMessage` wrote the message text to the PTY without the `ESC[200~ … ESC[201~` paste wrappers, so the modern interactive-prompt input handler discarded it and only the trailing bare `\r` reached the prompt — confirming the default option. The repository had zero bracketed-paste handling.

## Fix

`packages/server/src/services/pty-message-injection-service.ts`: wrap every injected content/file part in bracketed paste delimiters (`\x1b[200~` … `\x1b[201~`), **unconditionally** (not gated on activity-detector state). The final delayed `\r` remains a separate, **unwrapped** submit keystroke; the per-file leading `\r` (submit of the previous part) also stays unwrapped — only the part payload is wrapped. The Issue #660 newline normalization (`/\r?\n/g → \n`) is preserved and the normalized LF newlines now live inside the paste envelope (literal text, never submit).

Two private constants (`PASTE_START` / `PASTE_END`) plus a `wrapPaste()` helper avoid string-literal duplication.

### Sibling call-site (Option A bundle)

Grepping sibling call sites surfaced 6 assertions in `__tests__/session-manager.test.ts` that assert the delegated `injectMessage` byte stream (`session-manager.ts` / `pty-operation-executor.ts` only delegate — no production sibling change needed). Bundled the test-assertion updates in this PR to keep `main` GREEN (Option A per the grep-siblings rule).

## Verification

**Local suite — `bun run test` exit 0:**
- server 2513 pass / 1 skip / 0 fail · client 1386 pass / 2 skip / 0 fail · shared 324 pass · integration 29 pass · scripts/hooks 362 pass
- `bun run typecheck` clean (runs as part of `bun run test`)

**CodeRabbit** (`coderabbit review --agent --base main`): **0 findings**.

**Real-device verification** (deterministic PTY probes against the real `claude` v2.1.144 binary, since the dev environment auto-approves common tool calls and this Claude Code version's permission prompt offers no free-text option — environment/version-specific blocker, documented transparently per CLAUDE.md "Real-device verification"):

1. **Precondition (primary-verified, 3 independent probe runs):** real `claude` emits `ESC[?2004h` — bracketed paste mode is enforced. This is the diagnosed root cause, observed directly (not inferred).
2. **Bug reproduced — PRE-FIX bytes:** at a real Bash-tool permission prompt (`Do you want to proceed? ❯ 1. Yes / 2. … / 3. No`), injecting an un-wrapped answer followed by a delayed `\r` (the exact byte sequence the pre-fix code produced) → the answer text was dropped, the default highlighted **option 1 was confirmed and the command ran**. Exactly the reported symptom.
3. **Fix mechanism verified — POST-FIX bytes:** a `\x1b[200~ … \x1b[201~`-wrapped multi-character injection was correctly received and acted upon by the real `claude` binary (it executed the wrapped instruction). This is the mechanism the fix introduces; un-wrapped text at the new prompt handler does not survive (corroborated by upstream anthropics/claude-code #13183, #47745).
4. **No regression for normal sends:** bracketed-paste wrapping is exactly what a human terminal paste already emits (xterm.js sends `ESC[200~`/`ESC[201~` on paste), so injected normal messages now match the human-paste path; a wrapped composer message was processed normally by `claude` in the probe, and the full unit/integration suite (which exercises the real `injectMessage` byte stream via session-manager) is green.

**Residual risk (honest, matches the Issue's own note):** a pure list-selector permission prompt has no free-text field, so injected text cannot be consumed there by design — that path needs arrow/digit navigation and bracketed paste neither solves nor regresses it. The MessagePanel free-text answer path — the one users hit and the one this fix targets — is the bracketed-paste path and is addressed. Owner dogfood re-verification on a free-text interactive prompt post-merge is recommended as the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
