### PR TITLE
fix: cancel interactive prompt with ESC before injecting MessagePanel text

### DIFF
--- a/packages/server/src/services/__tests__/pty-message-injection-service.test.ts
+++ b/packages/server/src/services/__tests__/pty-message-injection-service.test.ts
@@ -148,4 +148,99 @@ describe('PtyMessageInjectionService', () => {
     // isWorkerActive was checked for each delayed callback
     expect(isWorkerActive).toHaveBeenCalledWith('s1', 'w1');
   });
+
+  describe('asking state (Issue #792)', () => {
+    const ESC = '\x1b';
+
+    it('sends ESC first, then the text part, then the final Enter (content only)', () => {
+      const result = service.injectMessage('s1', 'w1', 'hello world', undefined, true);
+
+      expect(result).toBe(true);
+      // Synchronously: ESC only, exactly one write before any timer advances.
+      expect(writeInput).toHaveBeenNthCalledWith(1, 's1', 'w1', ESC);
+      expect(writeInput).toHaveBeenCalledTimes(1);
+
+      // After 150ms: the raw text part (NOT wrapped in any paste markers).
+      jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
+      expect(writeInput).toHaveBeenNthCalledWith(2, 's1', 'w1', 'hello world');
+      expect(writeInput).toHaveBeenCalledTimes(2);
+
+      // After 300ms: final Enter to submit.
+      jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
+      expect(writeInput).toHaveBeenNthCalledWith(3, 's1', 'w1', '\r');
+      expect(writeInput).toHaveBeenCalledTimes(3);
+    });
+
+    it('sends ESC, then text, then file parts, then final Enter (content + files)', () => {
+      const result = service.injectMessage('s1', 'w1', 'hello', ['/tmp/a.txt'], true);
+
+      expect(result).toBe(true);
+      // Immediate: ESC.
+      expect(writeInput).toHaveBeenNthCalledWith(1, 's1', 'w1', ESC);
+      expect(writeInput).toHaveBeenCalledTimes(1);
+
+      // After 150ms: text part.
+      jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
+      expect(writeInput).toHaveBeenNthCalledWith(2, 's1', 'w1', 'hello');
+      expect(writeInput).toHaveBeenCalledTimes(2);
+
+      // After 300ms: first file part (leading \r submits the previous part).
+      jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
+      expect(writeInput).toHaveBeenNthCalledWith(3, 's1', 'w1', '\r/tmp/a.txt');
+      expect(writeInput).toHaveBeenCalledTimes(3);
+
+      // After 450ms: final Enter.
+      jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
+      expect(writeInput).toHaveBeenNthCalledWith(4, 's1', 'w1', '\r');
+      expect(writeInput).toHaveBeenCalledTimes(4);
+    });
+
+    it('preserves LF newlines in the text part (Issue #660 still holds while asking)', () => {
+      const result = service.injectMessage('s1', 'w1', 'line1\nline2\nline3', undefined, true);
+
+      expect(result).toBe(true);
+      // ESC immediate.
+      expect(writeInput).toHaveBeenNthCalledWith(1, 's1', 'w1', ESC);
+      expect(writeInput).toHaveBeenCalledTimes(1);
+
+      // Text part written verbatim with \n preserved (not split, not converted to \r).
+      jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
+      expect(writeInput).toHaveBeenNthCalledWith(2, 's1', 'w1', 'line1\nline2\nline3');
+      expect(writeInput).toHaveBeenCalledTimes(2);
+    });
+
+    it('normalizes CRLF to LF in the text part while asking', () => {
+      service.injectMessage('s1', 'w1', 'a\r\nb', undefined, true);
+
+      // ESC then the normalized text part.
+      jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS);
+      expect(writeInput).toHaveBeenNthCalledWith(1, 's1', 'w1', ESC);
+      expect(writeInput).toHaveBeenNthCalledWith(2, 's1', 'w1', 'a\nb');
+    });
+
+    it('returns false and writes nothing when there is no content or files', () => {
+      const result = service.injectMessage('s1', 'w1', '', undefined, true);
+
+      expect(result).toBe(false);
+      // No ESC written when there is nothing to deliver.
+      expect(writeInput).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the first write (ESC) fails (PTY inactive)', () => {
+      writeInput = mock(() => false);
+      service = new PtyMessageInjectionService(
+        writeInput as (sessionId: string, workerId: string, data: string) => boolean,
+        isWorkerActive as (sessionId: string, workerId: string) => boolean,
+      );
+
+      const result = service.injectMessage('s1', 'w1', 'hello', undefined, true);
+
+      expect(result).toBe(false);
+      // ESC attempted once, then bail out — no queued writes.
+      expect(writeInput).toHaveBeenCalledTimes(1);
+      expect(writeInput).toHaveBeenCalledWith('s1', 'w1', ESC);
+      jest.advanceTimersByTime(PtyMessageInjectionService.DELAY_MS * 3);
+      expect(writeInput).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -836,16 +836,16 @@ describe('SessionManager', () => {
     });
 
     it('should use injected PtyMessageInjectionService when provided', async () => {
-      const injectCalls: Array<{ sessionId: string; workerId: string; content: string; filePaths?: string[] }> = [];
+      const injectCalls: Array<{ sessionId: string; workerId: string; content: string; filePaths?: string[]; isAsking?: boolean }> = [];
       const mockInjectionService = new PtyMessageInjectionService(
         () => true,
         () => true,
       );
       // Spy on injectMessage to verify delegation
       const originalInject = mockInjectionService.injectMessage.bind(mockInjectionService);
-      mockInjectionService.injectMessage = (sessionId, workerId, content, filePaths) => {
-        injectCalls.push({ sessionId, workerId, content, filePaths });
-        return originalInject(sessionId, workerId, content, filePaths);
+      mockInjectionService.injectMessage = (sessionId, workerId, content, filePaths, isAsking) => {
+        injectCalls.push({ sessionId, workerId, content, filePaths, isAsking });
+        return originalInject(sessionId, workerId, content, filePaths, isAsking);
       };
 
       const module = await import(`../session-manager.js?v=${++importCounter}`);
@@ -872,6 +872,85 @@ describe('SessionManager', () => {
       expect(injectCalls[0].content).toBe('hello via DI');
       expect(injectCalls[0].sessionId).toBe(session.id);
       expect(injectCalls[0].workerId).toBe(agentWorker.id);
+    });
+
+    it('should pass isAsking=true to injectMessage when the target worker is in the asking state (Issue #792)', async () => {
+      const injectCalls: Array<{ isAsking?: boolean }> = [];
+      const mockInjectionService = new PtyMessageInjectionService(
+        () => true,
+        () => true,
+      );
+      const originalInject = mockInjectionService.injectMessage.bind(mockInjectionService);
+      mockInjectionService.injectMessage = (sessionId, workerId, content, filePaths, isAsking) => {
+        injectCalls.push({ isAsking });
+        return originalInject(sessionId, workerId, content, filePaths, isAsking);
+      };
+
+      const module = await import(`../session-manager.js?v=${++importCounter}`);
+      const manager = await module.SessionManager.create({
+        userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
+        pathExists: mockPathExists,
+        jobQueue: testJobQueue,
+        agentManager,
+        ptyMessageInjectionService: mockInjectionService,
+        repositoryLookup: defaultRepositoryLookup,
+        repositoryEnvLookup: defaultRepositoryEnvLookup,
+      });
+
+      const session = await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      const agentWorker = session.workers.find((w: Worker) => w.type === 'agent')!;
+
+      // Force the target worker into the asking state.
+      manager.getWorkerActivityState = (sessionId: string, workerId: string) =>
+        sessionId === session.id && workerId === agentWorker.id ? 'asking' : 'idle';
+
+      const message = manager.sendMessage(session.id, null, agentWorker.id, 'answer to prompt');
+      expect(message).not.toBeNull();
+      expect(injectCalls).toHaveLength(1);
+      expect(injectCalls[0].isAsking).toBe(true);
+    });
+
+    it('should pass isAsking=false to injectMessage when the target worker is not asking (Issue #792)', async () => {
+      const injectCalls: Array<{ isAsking?: boolean }> = [];
+      const mockInjectionService = new PtyMessageInjectionService(
+        () => true,
+        () => true,
+      );
+      const originalInject = mockInjectionService.injectMessage.bind(mockInjectionService);
+      mockInjectionService.injectMessage = (sessionId, workerId, content, filePaths, isAsking) => {
+        injectCalls.push({ isAsking });
+        return originalInject(sessionId, workerId, content, filePaths, isAsking);
+      };
+
+      const module = await import(`../session-manager.js?v=${++importCounter}`);
+      const manager = await module.SessionManager.create({
+        userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
+        pathExists: mockPathExists,
+        jobQueue: testJobQueue,
+        agentManager,
+        ptyMessageInjectionService: mockInjectionService,
+        repositoryLookup: defaultRepositoryLookup,
+        repositoryEnvLookup: defaultRepositoryEnvLookup,
+      });
+
+      const session = await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      const agentWorker = session.workers.find((w: Worker) => w.type === 'agent')!;
+
+      // Worker is idle (not asking).
+      manager.getWorkerActivityState = () => 'idle';
+
+      const message = manager.sendMessage(session.id, null, agentWorker.id, 'normal message');
+      expect(message).not.toBeNull();
+      expect(injectCalls).toHaveLength(1);
+      expect(injectCalls[0].isAsking).toBe(false);
     });
 
     it('should return null when injected PtyMessageInjectionService returns false', async () => {

--- a/packages/server/src/services/pty-message-injection-service.ts
+++ b/packages/server/src/services/pty-message-injection-service.ts
@@ -11,6 +11,9 @@ type WorkerActiveChecker = (sessionId: string, workerId: string) => boolean;
 export class PtyMessageInjectionService {
   static readonly DELAY_MS = 150;
 
+  /** ESC keystroke used to cancel an active interactive prompt before delivering text. */
+  private static readonly ESC = '\x1b';
+
   constructor(
     private readonly writeInput: PtyWriter,
     private readonly isWorkerActive: WorkerActiveChecker,
@@ -28,9 +31,24 @@ export class PtyMessageInjectionService {
    * embedded newline to be interpreted as submit and split a single message
    * into multiple submissions.
    *
+   * See Issue #792: when `isAsking` is true the agent is parked at an interactive
+   * prompt (the "asking" activity state). Modern Claude Code CLIs drop text typed
+   * while such a prompt is open — the bare submit CR then confirms the default
+   * option instead of delivering the message. To handle this we send an ESC first
+   * to cancel the active prompt, then deliver the text as a normal composer
+   * message. Older CLIs cancelled the prompt implicitly; modern CLIs dropped that
+   * leniency. ESC is sent only in the asking state — the non-asking path is
+   * unchanged from before.
+   *
    * Returns true if the first part was successfully written, false otherwise.
    */
-  injectMessage(sessionId: string, workerId: string, content: string, filePaths?: string[]): boolean {
+  injectMessage(
+    sessionId: string,
+    workerId: string,
+    content: string,
+    filePaths?: string[],
+    isAsking = false,
+  ): boolean {
     const parts: string[] = [];
     if (content) parts.push(content.replace(/\r?\n/g, '\n'));
     if (filePaths && filePaths.length > 0) {
@@ -42,8 +60,11 @@ export class PtyMessageInjectionService {
       return false;
     }
 
-    const injected = this.writeInput(sessionId, workerId, parts[0]);
-    if (!injected) {
+    // In the asking state, send ESC first (synchronously) to cancel the prompt;
+    // otherwise send the first content part immediately as before.
+    const firstWrite = isAsking ? PtyMessageInjectionService.ESC : parts[0];
+    const ok = this.writeInput(sessionId, workerId, firstWrite);
+    if (!ok) {
       logger.warn({ sessionId, workerId }, 'Failed to inject worker message (PTY inactive)');
       return false;
     }
@@ -51,6 +72,12 @@ export class PtyMessageInjectionService {
     // Queue remaining parts and final Enter with delays
     // Use longer delays to ensure TUI processes each input before the next
     const sendQueue: Array<() => void> = [];
+
+    if (isAsking) {
+      // The first content part runs after the initial delay so the prompt has
+      // time to close after the ESC was sent synchronously above.
+      sendQueue.push(() => this.writeInput(sessionId, workerId, parts[0]));
+    }
 
     for (let i = 1; i < parts.length; i++) {
       const part = parts[i];

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -407,8 +407,11 @@ export class SessionManager {
       timestamp: new Date().toISOString(),
     };
 
-    // Inject message parts into target worker's PTY
-    const injected = this.ptyMessageInjectionService.injectMessage(sessionId, toWorkerId, content, filePaths);
+    // Inject message parts into target worker's PTY. When the target is parked at
+    // an interactive prompt (asking state), the injection service sends ESC first
+    // to cancel it so the text is delivered as a normal composer message (Issue #792).
+    const isAsking = this.getWorkerActivityState(sessionId, toWorkerId) === 'asking';
+    const injected = this.ptyMessageInjectionService.injectMessage(sessionId, toWorkerId, content, filePaths, isAsking);
     if (!injected) return null;
 
     // Store and broadcast
@@ -749,9 +752,10 @@ export class SessionManager {
     return this.workerLifecycleManager.writeWorkerInput(sessionId, workerId, data);
   }
 
-  /** Inject content into a worker's PTY as submitted input (with CR conversion and delayed Enter). */
+  /** Inject content into a worker's PTY as submitted input (CR conversion + delayed Enter; sends ESC first to cancel an active interactive prompt when the worker is in the asking state — see injectMessage / Issue #792). */
   injectPtyMessage(sessionId: string, workerId: string, content: string): boolean {
-    return this.ptyMessageInjectionService.injectMessage(sessionId, workerId, content);
+    const isAsking = this.getWorkerActivityState(sessionId, workerId) === 'asking';
+    return this.ptyMessageInjectionService.injectMessage(sessionId, workerId, content, undefined, isAsking);
   }
 
   /** Write raw data to a worker's PTY (no CR conversion, no delayed Enter). */


### PR DESCRIPTION
Closes #792

Supersedes the reverted bracketed-paste approach (closed PR #793), which real-device E2E proved did **not** change the prompt outcome. Issue #792's root-cause was re-diagnosed (see the Issue) — bracketed paste was a misdiagnosis.

## Root cause

When a Claude Code agent is parked at an interactive prompt (the **asking** activity state) and the user answers via the MessagePanel, modern Claude Code CLIs drop the injected text and the bare submit `\r` confirms the default highlighted option. Older CLIs implicitly cancelled the prompt and delivered the text as a normal message; modern CLIs dropped that leniency. The expected behavior (owner-specified) is: **cancel the prompt with ESC, then deliver the text as a normal composer message.**

## Fix

`pty-message-injection-service.ts`: `injectMessage` gains an `isAsking` parameter. When asking, it writes `ESC` (`\x1b`) first (synchronously) to cancel the prompt, then queues the text part after the first `DELAY_MS` (so the prompt closes first), then file parts and the final `\r` — using the existing delayed/`isWorkerActive`-guarded loop. When **not** asking, the path is **byte-identical to main** (so normal sends are structurally non-regressed). ESC is gated **only** on the asking state — sending it unconditionally would interrupt a non-prompt agent (owner constraint). The Issue #660 `\r?\n → \n` normalization is preserved; **bracketed paste is not used** (E2E confirmed #660 alone handles multi-line).

`session-manager.ts`: both `injectMessage` call sites (`sendMessage`, `injectPtyMessage`) compute `isAsking = getWorkerActivityState(...) === 'asking'` via the existing activity detector (no new detector).

Signature change (per pre-pr Q8): `injectMessage` gains one optional param; 2 production call sites + tests. Low churn.

## Verification

**Local — `bun run test` exit 0** (typecheck included): server 2521 pass / 1 skip / 0 fail · client 1386 · shared 324 · integration 29 · scripts/hooks 362. Unit polarity: 7 asking-state tests fail without the production fix, pass with it.

**CodeRabbit** (`coderabbit review --agent --base main`): **0 findings**.

**Real-device E2E** (real `claude` v2.1.150, full shipping path MessagePanel/REST → `sendMessage` → `injectMessage`; isolated quick session; injection bytes and activity-state transitions captured via temporary primary-source instrumentation, since reverted):

- **Polarity (the goal), shipping path:**
  - *PRE-FIX* (fix reverted to main): free-text answer at an AskUserQuestion prompt → `User answered … → Apple` (default option confirmed, the typed `Durian …` dropped) — bug reproduced.
  - *POST-FIX*: same prompt → `User declined to answer questions` then `❯ Actually my favorite is Durian BP792_A1_POSTFIX` delivered → claude received the free-text answer (`「選択肢にはなかった答えでしたが、しっかり受け取りました」`). Expected behavior achieved.

- **① detection reliability at injection (primary-source log):** at a stable prompt, the injection decision logged `activityState: "asking", isAsking: true` → ESC sent. Detection reliable at injection time.

- **① false-positive / stale-`asking` harm (the key risk):** during an active 12 s generation, an injection logged `activityState: "active", isAsking: false` → **no ESC**, and the long generation completed **uninterrupted** (the second message was appended normally afterward). Transition timeline: ESC cancels a real prompt → `asking→idle` in **~12 ms**; real generation runs as `active`, never `asking`. A residual `asking` lag (observed up to ~2.8 s after a *terminal*-answered prompt) coincides with idle/short-ack settling, where ESC hits an empty/settling composer and is benign — **no interruption of active generation was observed in any test.**

- **② ESC→text timing:** the 150 ms gap was sufficient — the text reached the composer cleanly with no race/drop.

- **No regression (non-asking):** trigger sends, a post-answer message, and a 3-line Japanese multi-line message all logged `isAsking: false` and were delivered normally; the multi-line message arrived **intact, not split** (claude: "3行とも改行が保持された状態で届いています") — confirming bracketed-paste removal is safe.

**Residual note:** the false-positive ESC is structurally avoided for the dangerous case (active generation reports `active`), and benign for the residual idle-settling lag. If a future need arises to fully eliminate the lag, an additional time-since-last-output guard on the asking gate is the candidate mitigation (not needed per current measurements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
