### PR TITLE
fix: wrap long URLs/paths in worker-view text components (closes #796)

### DIFF
--- a/packages/client/src/components/PageErrorFallback.tsx
+++ b/packages/client/src/components/PageErrorFallback.tsx
@@ -23,7 +23,7 @@ export function PageErrorFallback({
       <PageBreadcrumb items={breadcrumbItems} />
       <div className="card text-center py-10">
         <p className="text-red-400 mb-2">{errorMessage}</p>
-        <p className="text-gray-500 text-sm mb-4">{error.message}</p>
+        <p className="text-gray-500 text-sm mb-4 break-words">{error.message}</p>
         <div className="flex justify-center gap-2">
           <button onClick={reset} className="btn btn-secondary">
             Retry

--- a/packages/client/src/components/WorkerErrorRecovery.tsx
+++ b/packages/client/src/components/WorkerErrorRecovery.tsx
@@ -215,7 +215,7 @@ export function WorkerErrorRecovery({
         </div>
         <h2 className="text-red-400 text-xl font-semibold mb-2">{title}</h2>
         <p className="text-gray-300 mb-2">{description}</p>
-        <p className="text-gray-500 text-sm mb-6">{errorMessage}</p>
+        <p className="text-gray-500 text-sm mb-6 break-words">{errorMessage}</p>
         <div className="flex justify-center gap-3">
           {renderActions(primaryAction, { onRetry, onDeleteSession, onGoToDashboard, onRestart, onResumeSession })}
         </div>

--- a/packages/client/src/components/__tests__/PageErrorFallback.test.tsx
+++ b/packages/client/src/components/__tests__/PageErrorFallback.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { screen, cleanup } from '@testing-library/react';
+import { PageErrorFallback } from '../PageErrorFallback';
+import { renderWithRouter } from '../../test/renderWithRouter';
+
+const longUrl = `https://example.com/${'a'.repeat(180)}`;
+
+describe('PageErrorFallback', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the error.message paragraph with break-words so long URLs wrap', async () => {
+    await renderWithRouter(
+      <PageErrorFallback
+        error={new Error(longUrl)}
+        reset={() => {}}
+        breadcrumbItems={[]}
+        errorMessage="something failed"
+        backTo="/"
+        backLabel="Back"
+      />
+    );
+
+    const messageEl = screen.getByText(longUrl);
+    expect(messageEl.className).toContain('break-words');
+  });
+});

--- a/packages/client/src/components/__tests__/WorkerErrorRecovery.test.tsx
+++ b/packages/client/src/components/__tests__/WorkerErrorRecovery.test.tsx
@@ -333,5 +333,13 @@ describe('WorkerErrorRecovery', () => {
         expect(screen.getByText('Something specific went wrong')).toBeTruthy();
       });
     }
+
+    it('renders the error message paragraph with break-words so long URLs wrap', () => {
+      const longUrl = `https://example.com/${'a'.repeat(180)}`;
+      renderComponent({ errorMessage: longUrl });
+
+      const messageEl = screen.getByText(longUrl);
+      expect(messageEl.className).toContain('break-words');
+    });
   });
 });

--- a/packages/client/src/components/ui/FormField.tsx
+++ b/packages/client/src/components/ui/FormField.tsx
@@ -38,7 +38,7 @@ export function FormField({ label, error, children, fieldId }: FormFieldProps) {
       )}
       {enhancedChildren}
       {error && (
-        <p id={errorId} className="text-sm text-red-400" role="alert">{error.message}</p>
+        <p id={errorId} className="text-sm text-red-400 break-words" role="alert">{error.message}</p>
       )}
     </div>
   );

--- a/packages/client/src/components/ui/__tests__/FormField.test.tsx
+++ b/packages/client/src/components/ui/__tests__/FormField.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { render, screen, cleanup } from '@testing-library/react';
+import type { FieldError } from 'react-hook-form';
+import { FormField } from '../FormField';
+
+const longUrl = `https://example.com/${'a'.repeat(180)}`;
+
+describe('FormField', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders label and children', () => {
+    render(
+      <FormField label="Name">
+        <input />
+      </FormField>
+    );
+
+    expect(screen.getByText('Name')).toBeTruthy();
+    expect(screen.getByRole('textbox')).toBeTruthy();
+  });
+
+  it('renders the error alert with break-words so long URLs wrap', () => {
+    render(
+      <FormField error={{ message: longUrl } as FieldError}>
+        <input />
+      </FormField>
+    );
+
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toBe(longUrl);
+    expect(alert.className).toContain('break-words');
+  });
+});

--- a/packages/client/src/components/workers/DiffViewer.tsx
+++ b/packages/client/src/components/workers/DiffViewer.tsx
@@ -361,7 +361,7 @@ export function DiffViewer({ rawDiff, files, scrollToFile, onFileVisible, expand
               >
                 <div className="sticky top-0 z-20 bg-slate-800 px-4 py-2 flex items-center gap-3 border-b border-gray-700 opacity-60">
                   <FileStatusBadge status={file.status} />
-                  <span className="text-gray-200 font-medium">{file.path}</span>
+                  <span className="text-gray-200 font-medium min-w-0 break-all">{file.path}</span>
                   <span className="text-xs px-1.5 py-0.5 rounded bg-green-900/40 text-green-400/70 font-medium ml-2">
                     Verified
                   </span>
@@ -387,7 +387,7 @@ export function DiffViewer({ rawDiff, files, scrollToFile, onFileVisible, expand
               {/* File header */}
               <div className="sticky top-0 z-20 bg-slate-800 px-4 py-2 flex items-center gap-3 border-b border-gray-700">
                 <FileStatusBadge status={file.status} />
-                <span className="text-gray-200 font-medium">{file.path}</span>
+                <span className="text-gray-200 font-medium min-w-0 break-all">{file.path}</span>
                 {hasAnnotations && (
                   <span className="text-xs px-1.5 py-0.5 rounded bg-amber-800/60 text-amber-300 font-medium ml-2">
                     Review

--- a/packages/client/src/components/workers/__tests__/DiffViewer.test.tsx
+++ b/packages/client/src/components/workers/__tests__/DiffViewer.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll, afterEach } from 'bun:test';
+import { render, screen, cleanup } from '@testing-library/react';
+import { DiffViewer } from '../DiffViewer';
+import type { GitDiffFile } from '@agent-console/shared';
+
+// happy-dom does not provide IntersectionObserver, which DiffViewer constructs in an effect.
+beforeAll(() => {
+  globalThis.IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  } as unknown as typeof IntersectionObserver;
+});
+
+const longPath = `https://example.com/${'a'.repeat(180)}`;
+
+describe('DiffViewer', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the file-header path span with break-all and min-w-0 so long paths wrap', () => {
+    const file: GitDiffFile = {
+      path: longPath,
+      status: 'added',
+      stageState: 'unstaged',
+      additions: 1,
+      deletions: 0,
+      isBinary: false,
+    };
+
+    render(<DiffViewer rawDiff="" files={[file]} scrollToFile={null} />);
+
+    // The file-header span carries `font-medium` and renders the full path.
+    const span = screen.getByText(longPath);
+    expect(span.className).toContain('font-medium');
+    expect(span.className).toContain('break-all');
+    expect(span.className).toContain('min-w-0');
+  });
+});


### PR DESCRIPTION
## Summary

Long unbroken strings (URLs, file paths) rendered as DOM text in the worker / terminal view forced **horizontal layout breakout** because the text elements lacked `overflow-wrap` / `word-break`, and flex children lacked `min-w-0`. This applies the established project break convention so long strings wrap mid-word and the layout width is preserved.

Closes #796

## Root cause

A flex child with no `min-w-0` cannot shrink below its content's min-width; a text element with no `overflow-wrap`/`word-break` has a min-content width equal to its longest unbreakable token. A ~170-char URL therefore widens its container past the viewport. The diff **line** content already wrapped correctly (it uses `break-all`), which confirmed the convention and isolated the unhandled siblings.

## Changed components (Issue-listed scope)

| Component | Element | Fix |
|---|---|---|
| `workers/DiffViewer.tsx` (lines 364, 390) | sticky file-header path span (both header variants) | `min-w-0 break-all` (flex child) |
| `WorkerErrorRecovery.tsx` (line 218) | error message `<p>` | `break-words` |
| `PageErrorFallback.tsx` (line 26) | `error.message` `<p>` | `break-words` |
| `ui/FormField.tsx` (line 41) | validation error `<p role="alert">` | `break-words` |

Convention reused (no new CSS): `break-words` for prose/error text, `break-all` for path/code-like strings, `min-w-0` for flex children — matching `InitialPromptDialog.tsx`, `DiffViewer` diff lines (`break-all`), and `.memo-content` in `styles.css`.

## Browser QA (true-path: reproduced BEFORE, fixed AFTER)

Reproduced the breakout naturally on a real worker-view surface: created an untracked file with a ~170-char URL-like name in a worktree and opened the **Diff** tab. The sticky file-header path overflowed horizontally.

- **BEFORE**: header span `scrollWidth` 1424 px, right edge at x=2016 (viewport 1280) — clipped/cut off; sticky-header container `scrollWidth` 1525 > `clientWidth` 736 → horizontal overflow.
- **AFTER**: header span `scrollWidth` 619 px, wraps to 3 lines, right edge x=1210 (inside viewport); container `scrollWidth` 736 == `clientWidth` 736 → no horizontal overflow. The `+/-` count stays right-aligned; diff line content still wraps as before (no regression).

Screenshots are attached in a PR comment (uploaded via `scripts/upload-qa-screenshots.sh`).

## Tests

Per `test-trigger.md`, sibling `__tests__` tests are touched in the same PR (each asserts the rendered element carries the break utility — correct polarity: fails on unfixed code):

- **new** `workers/__tests__/DiffViewer.test.tsx` (stubs `IntersectionObserver`; asserts header span has `break-all` + `min-w-0`)
- **new** `__tests__/PageErrorFallback.test.tsx`
- **new** `ui/__tests__/FormField.test.tsx`
- **updated** `__tests__/WorkerErrorRecovery.test.tsx` (added long-URL case)

## Verification

- `bun run typecheck`: exit 0
- `bun run test` (full suite): exit 0 — client 1391 pass / shared 324 / integration 29 / server 2513 / scripts 362, 0 fail
- `bun run check:lang`: exit 0
- `coderabbit review --plain --base main`: **No findings**

## Bundle-or-leave note (siblings outside the Issue's listed scope)

A broader read-only scan surfaced additional text surfaces. I scoped this PR to the four components the Issue explicitly listed; the rest are left for a possible follow-up:

- **Recommend follow-up (same "arbitrary error text" concern):** `ui/alert-dialog.tsx` `Description` (used by `ui/error-dialog.tsx`) renders arbitrary error messages that can contain URLs.
- **Low risk (mostly fixed/short strings):** `Terminal.tsx` status text / truncation+restart banners / cache-error banner (server-supplied, largely fixed-format), `SessionPage.tsx` branch-name span, `MessagePanel.tsx` slash-command description (controlled content).

Happy to bundle the `alert-dialog` Description fix into this PR or open a follow-up issue — owner's call.
