### PR TITLE
fix: persist git-diff base spec and re-resolve at diff time (#800)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -72,7 +72,7 @@ The persisted comparison base of a [GitDiffWorker](#gitdiffworker), stored in `w
 - `merge-base:<ref>` — fork point via `git merge-base <ref> HEAD` (e.g. `merge-base:origin/main`); re-resolves each diff.
 - A branch name — re-resolves to the branch tip each diff.
 - An explicit commit hash — stays pinned (no re-resolution).
-- `default-fork-point` — sentinel for migrated workers; resolves the repository's default fork point fresh (prefers `origin/<default>`, falls back to local `<default>`, then the first commit).
+- `reserved:default-fork-point` — sentinel for migrated workers; resolves the repository's default fork point fresh (prefers `origin/<default>`, falls back to local `<default>`, then the first commit). The `reserved:` namespace is illegal in git ref names, so it can never collide with a real branch/tag.
 
 New git-diff workers default to `merge-base:origin/<default>` when the remote default exists, otherwise `merge-base:<default>`.
 - **Aliases:** base commit spec

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -62,6 +62,22 @@ A worker running an AI agent with activity detection and PTY capabilities.
 A worker running a plain terminal shell.
 - **See:** [Worker types in session-worker-design.md](design/session-worker-design.md#worker-types-current--future)
 
+### GitDiffWorker
+A worker that shows the git diff between a base commit and a target ref for its session's working directory. Has no PTY; computes diffs on demand and watches the working tree for changes.
+- **Aliases:** DiffWorker, git-diff worker
+- **See:** [GitDiffWorker in worker.ts](../packages/shared/src/types/worker.ts)
+
+### Base Spec
+The persisted comparison base of a [GitDiffWorker](#gitdiffworker), stored in `workers.base_commit`. Unlike a frozen commit hash, a base spec records the user's *intent* and is **re-resolved on every diff computation**, so the diff stays aligned with GitHub's merge-base (three-dot) view as the branch absorbs upstream commits. Forms:
+- `merge-base:<ref>` — fork point via `git merge-base <ref> HEAD` (e.g. `merge-base:origin/main`); re-resolves each diff.
+- A branch name — re-resolves to the branch tip each diff.
+- An explicit commit hash — stays pinned (no re-resolution).
+- `default-fork-point` — sentinel for migrated workers; resolves the repository's default fork point fresh (prefers `origin/<default>`, falls back to local `<default>`, then the first commit).
+
+New git-diff workers default to `merge-base:origin/<default>` when the remote default exists, otherwise `merge-base:<default>`.
+- **Aliases:** base commit spec
+- **See:** [MERGE_BASE_REF_PREFIX / DEFAULT_FORK_POINT_SPEC in git-diff.ts](../packages/shared/src/types/git-diff.ts)
+
 ## States
 
 ### AgentActivityState

--- a/packages/client/src/components/workers/BaseCommitSelector.tsx
+++ b/packages/client/src/components/workers/BaseCommitSelector.tsx
@@ -36,13 +36,15 @@ export function BaseCommitSelector({
   const shortCommit = currentBaseCommit ? currentBaseCommit.substring(0, 7) : null;
 
   const defaultBranch = branchesData?.defaultBranch ?? null;
-  const mergeBaseRef = defaultBranch ? `${MERGE_BASE_REF_PREFIX}${defaultBranch}` : null;
+  // Local default merge-base spec (e.g. "merge-base:main")
+  const localMergeBaseRef = defaultBranch ? `${MERGE_BASE_REF_PREFIX}${defaultBranch}` : null;
 
   // Build dropdown items based on search state
-  const { mergeBaseVisible, remoteDefault, filteredLocal, filteredRemote, hasItems } = useMemo(() => {
+  const { mergeBaseVisible, originMergeBaseRef, remoteDefault, filteredLocal, filteredRemote, hasItems } = useMemo(() => {
     if (!branchesData) {
       return {
         mergeBaseVisible: false,
+        originMergeBaseRef: null,
         remoteDefault: undefined,
         filteredLocal: [],
         filteredRemote: [],
@@ -58,6 +60,10 @@ export function BaseCommitSelector({
     // Check if the remote default branch actually exists in the branch list
     const remoteDefaultBranch = branchesData.remote.find(b => b === `origin/${defaultBranch}`);
 
+    // Origin merge-base spec (e.g. "merge-base:origin/main") - only when the
+    // remote default branch actually exists. This is the preferred default.
+    const originMb = remoteDefaultBranch ? `${MERGE_BASE_REF_PREFIX}${remoteDefaultBranch}` : null;
+
     // When not searching, exclude defaultBranch from regular lists (it appears in "Default branch" section)
     const localBranches = branchesData.local.filter(b => {
       if (!b.toLowerCase().includes(query)) return false;
@@ -71,13 +77,18 @@ export function BaseCommitSelector({
       return true;
     });
 
+    // Merge-base entries: local variant always shown when default exists,
+    // origin variant additionally shown when origin/<default> exists.
+    const mergeBaseCount = mbVisible ? (originMb ? 2 : 1) : 0;
+
     const defaultBranchCount = defaultBranch && !inputValue
       ? (remoteDefaultBranch ? 1 : 0) + 1 // local default always shown, remote only if it exists
       : 0;
-    const total = (mbVisible ? 1 : 0) + localBranches.length + remoteBranches.length + defaultBranchCount;
+    const total = mergeBaseCount + localBranches.length + remoteBranches.length + defaultBranchCount;
 
     return {
       mergeBaseVisible: mbVisible,
+      originMergeBaseRef: originMb,
       remoteDefault: remoteDefaultBranch,
       filteredLocal: localBranches.slice(0, 10),
       filteredRemote: remoteBranches.slice(0, 10),
@@ -179,19 +190,33 @@ export function BaseCommitSelector({
             ref={dropdownRef}
             className="absolute top-full left-0 mt-1 w-72 max-h-60 overflow-y-auto bg-slate-800 border border-slate-600 rounded shadow-lg z-50"
           >
-            {/* Recommended: merge-base is always visible when defaultBranch exists */}
-            {mergeBaseVisible && mergeBaseRef && (
+            {/* Recommended: merge-base entries are always visible when defaultBranch exists.
+                The origin variant (preferred default) is listed first when it exists. */}
+            {mergeBaseVisible && defaultBranch && (
               <>
                 <SectionHeader label="Recommended" />
-                <button
-                  type="button"
-                  onClick={() => handleSelectBranch(mergeBaseRef)}
-                  className="w-full px-3 py-1.5 text-left text-sm text-blue-300 hover:bg-slate-700 flex items-center gap-2"
-                >
-                  <GitForkIcon className="w-3.5 h-3.5 text-blue-400 shrink-0" />
-                  <span>Fork point from {defaultBranch}</span>
-                  <span className="text-xs text-gray-500 ml-auto">(merge-base)</span>
-                </button>
+                {originMergeBaseRef && remoteDefault && (
+                  <button
+                    type="button"
+                    onClick={() => handleSelectBranch(originMergeBaseRef)}
+                    className="w-full px-3 py-1.5 text-left text-sm text-blue-300 hover:bg-slate-700 flex items-center gap-2"
+                  >
+                    <GitForkIcon className="w-3.5 h-3.5 text-blue-400 shrink-0" />
+                    <span>Fork point from {remoteDefault}</span>
+                    <span className="text-xs text-gray-500 ml-auto">(merge-base)</span>
+                  </button>
+                )}
+                {localMergeBaseRef && (
+                  <button
+                    type="button"
+                    onClick={() => handleSelectBranch(localMergeBaseRef)}
+                    className="w-full px-3 py-1.5 text-left text-sm text-blue-300 hover:bg-slate-700 flex items-center gap-2"
+                  >
+                    <GitForkIcon className="w-3.5 h-3.5 text-blue-400 shrink-0" />
+                    <span>Fork point from {defaultBranch} (local)</span>
+                    <span className="text-xs text-gray-500 ml-auto">(merge-base)</span>
+                  </button>
+                )}
               </>
             )}
 

--- a/packages/client/src/components/workers/__tests__/BaseCommitSelector.test.tsx
+++ b/packages/client/src/components/workers/__tests__/BaseCommitSelector.test.tsx
@@ -8,8 +8,13 @@ import type { BranchesResponse } from '../../../lib/api';
 // Mock fetch at the lowest level; fetchSessionBranches goes through the hono
 // client which ultimately calls globalThis.fetch.
 const originalFetch = globalThis.fetch;
-const mockFetch = mock(() => Promise.resolve(new Response()));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+const mockFetch = mock(
+  (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> =>
+    Promise.resolve(new Response())
+);
+// `typeof fetch` carries React DOM's `preconnect` augmentation; reuse the
+// original implementation so the assigned stub satisfies the full type.
+globalThis.fetch = Object.assign(mockFetch, { preconnect: originalFetch.preconnect });
 
 afterAll(() => {
   globalThis.fetch = originalFetch;
@@ -19,24 +24,22 @@ afterEach(() => {
   cleanup();
 });
 
-function resolveUrl(input: unknown): string {
+function resolveUrl(input: RequestInfo | URL): string {
   if (typeof input === 'string') return input;
   if (input instanceof URL) return input.toString();
-  if (input instanceof Request) return input.url;
-  return String(input);
+  return input.url;
 }
 
 function createBranchesResponse(body: BranchesResponse): Response {
-  return {
-    ok: true,
+  return new Response(JSON.stringify(body), {
     status: 200,
-    json: () => Promise.resolve(body),
-  } as unknown as Response;
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
 function setupBranchesMock(branches: BranchesResponse) {
-  mockFetch.mockImplementation((...args: unknown[]) => {
-    const url = resolveUrl(args[0]);
+  mockFetch.mockImplementation((input: RequestInfo | URL) => {
+    const url = resolveUrl(input);
     if (url.includes('/branches')) {
       return Promise.resolve(createBranchesResponse(branches));
     }

--- a/packages/client/src/components/workers/__tests__/BaseCommitSelector.test.tsx
+++ b/packages/client/src/components/workers/__tests__/BaseCommitSelector.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, mock, beforeEach, afterEach, afterAll } from 'bun:test';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BaseCommitSelector } from '../BaseCommitSelector';
+import type { BranchesResponse } from '../../../lib/api';
+
+// Mock fetch at the lowest level; fetchSessionBranches goes through the hono
+// client which ultimately calls globalThis.fetch.
+const originalFetch = globalThis.fetch;
+const mockFetch = mock(() => Promise.resolve(new Response()));
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function resolveUrl(input: unknown): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  if (input instanceof Request) return input.url;
+  return String(input);
+}
+
+function createBranchesResponse(body: BranchesResponse): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function setupBranchesMock(branches: BranchesResponse) {
+  mockFetch.mockImplementation((...args: unknown[]) => {
+    const url = resolveUrl(args[0]);
+    if (url.includes('/branches')) {
+      return Promise.resolve(createBranchesResponse(branches));
+    }
+    return Promise.resolve(new Response());
+  });
+}
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function renderSelector(
+  props: Partial<React.ComponentProps<typeof BaseCommitSelector>> = {}
+) {
+  const onBaseCommitChange = props.onBaseCommitChange ?? mock(() => {});
+  const result = render(
+    <BaseCommitSelector
+      sessionId="session-1"
+      currentBaseCommit="abc1234def"
+      onBaseCommitChange={onBaseCommitChange}
+      {...props}
+    />,
+    { wrapper: TestWrapper }
+  );
+  return { ...result, onBaseCommitChange };
+}
+
+/** Open the dropdown by clicking the displayed base commit. */
+async function openDropdown(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /abc1234/ }));
+}
+
+describe('BaseCommitSelector merge-base entries', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('renders both origin and local fork-point entries (origin first) when origin/<default> exists', async () => {
+    setupBranchesMock({
+      local: ['main', 'feature/x'],
+      remote: ['origin/main', 'origin/feature/x'],
+      defaultBranch: 'main',
+    });
+    const user = userEvent.setup();
+    renderSelector();
+    await openDropdown(user);
+
+    const originEntry = await screen.findByText('Fork point from origin/main');
+    const localEntry = await screen.findByText('Fork point from main (local)');
+    expect(originEntry).toBeTruthy();
+    expect(localEntry).toBeTruthy();
+
+    // Origin variant must appear before the local variant in DOM order.
+    const position = originEntry.compareDocumentPosition(localEntry);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('renders only the local fork-point entry when origin/<default> does NOT exist', async () => {
+    setupBranchesMock({
+      local: ['main', 'feature/x'],
+      remote: ['origin/feature/x'], // no origin/main
+      defaultBranch: 'main',
+    });
+    const user = userEvent.setup();
+    renderSelector();
+    await openDropdown(user);
+
+    await screen.findByText('Fork point from main (local)');
+    expect(screen.queryByText('Fork point from origin/main')).toBeNull();
+  });
+
+  it('calls onBaseCommitChange with merge-base:origin/<default> when clicking the origin variant', async () => {
+    setupBranchesMock({
+      local: ['main'],
+      remote: ['origin/main'],
+      defaultBranch: 'main',
+    });
+    const user = userEvent.setup();
+    const { onBaseCommitChange } = renderSelector();
+    await openDropdown(user);
+
+    const originEntry = await screen.findByText('Fork point from origin/main');
+    await user.click(originEntry);
+
+    expect(onBaseCommitChange).toHaveBeenCalledWith('merge-base:origin/main');
+  });
+
+  it('calls onBaseCommitChange with merge-base:<default> when clicking the local variant', async () => {
+    setupBranchesMock({
+      local: ['main'],
+      remote: ['origin/main'],
+      defaultBranch: 'main',
+    });
+    const user = userEvent.setup();
+    const { onBaseCommitChange } = renderSelector();
+    await openDropdown(user);
+
+    const localEntry = await screen.findByText('Fork point from main (local)');
+    await user.click(localEntry);
+
+    expect(onBaseCommitChange).toHaveBeenCalledWith('merge-base:main');
+  });
+
+  it('renders no merge-base entries when there is no default branch', async () => {
+    setupBranchesMock({
+      local: ['feature/x'],
+      remote: ['origin/feature/x'],
+      defaultBranch: null,
+    });
+    const user = userEvent.setup();
+    renderSelector();
+    await openDropdown(user);
+
+    // Wait for the query to resolve so the dropdown reflects branchesData.
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    expect(screen.queryByText(/Fork point from/)).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/utils/mock-git-helper.ts
+++ b/packages/server/src/__tests__/utils/mock-git-helper.ts
@@ -33,7 +33,7 @@ export const mockGit = {
   // Low-level
   git: mock(() => Promise.resolve('')) as Mock<AsyncStringFn>,
   gitRaw: mock(() => Promise.resolve('')) as Mock<AsyncStringFn>,
-  gitSafe: mock(() => Promise.resolve(null)) as Mock<AsyncStringNullFn>,
+  gitSafe: mock(() => Promise.resolve(null)) as Mock<(args: string[], cwd: string) => Promise<string | null>>,
   gitRefExists: mock(() => Promise.resolve(false)) as Mock<(ref: string, cwd: string) => Promise<boolean>>,
 
   // Branch operations

--- a/packages/server/src/database/__tests__/migration-v20.test.ts
+++ b/packages/server/src/database/__tests__/migration-v20.test.ts
@@ -43,7 +43,7 @@ describe('migration v20 (sessions.initiated_by)', () => {
     const db = await initializeDatabase(':memory:');
 
     const versionRes = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
-    expect(versionRes.rows[0]?.user_version).toBe(20);
+    expect(versionRes.rows[0]?.user_version).toBe(21);
 
     const columns = await sql<PragmaTableInfoRow>`PRAGMA table_info(sessions)`.execute(db);
     const initiatedBy = columns.rows.find((c) => c.name === 'initiated_by');

--- a/packages/server/src/database/__tests__/migration-v21.test.ts
+++ b/packages/server/src/database/__tests__/migration-v21.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Migration v21 tests — git-diff workers' frozen base_commit hash is reset to
+ * the DEFAULT_FORK_POINT_SPEC sentinel (Issue #800).
+ *
+ * Previously a git-diff worker froze a resolved merge-base hash in
+ * `base_commit`. The new model persists a base *spec* that is re-resolved on
+ * every diff so the base tracks the moving fork point. v21 rewrites every
+ * git-diff worker's frozen hash to the sentinel; agent/terminal workers (whose
+ * `base_commit` is NULL) are untouched.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { sql } from 'kysely';
+import { DEFAULT_FORK_POINT_SPEC } from '@agent-console/shared';
+import { initializeDatabase, closeDatabase, migrateToV21 } from '../connection.js';
+import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
+
+const TEST_CONFIG_DIR = '/test/config';
+
+const FROZEN_HASH = '0123456789abcdef0123456789abcdef01234567'; // 40-char hash
+
+async function seedSession(db: Awaited<ReturnType<typeof initializeDatabase>>, id: string): Promise<void> {
+  await db
+    .insertInto('sessions')
+    .values({
+      id,
+      type: 'quick',
+      location_path: '/tmp',
+      server_pid: null,
+      created_at: '2024-01-01T00:00:00.000Z',
+      updated_at: '2024-01-01T00:00:00.000Z',
+      initial_prompt: null,
+      title: null,
+      repository_id: null,
+      worktree_id: null,
+      paused_at: null,
+      parent_session_id: null,
+      parent_worker_id: null,
+      created_by: null,
+      initiated_by: null,
+      data_scope: 'quick',
+      data_scope_slug: null,
+      recovery_state: 'healthy',
+      orphaned_at: null,
+      orphaned_reason: null,
+    })
+    .execute();
+}
+
+describe('migration v21 (git-diff base_commit → default fork-point spec)', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    setupMemfs({
+      [`${TEST_CONFIG_DIR}/.keep`]: '',
+    });
+    process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+    cleanupMemfs();
+  });
+
+  it('advances the schema version to 21', async () => {
+    const db = await initializeDatabase(':memory:');
+    const versionRes = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
+    expect(versionRes.rows[0]?.user_version).toBe(21);
+  });
+
+  it('resets a git-diff worker with a frozen hash to the sentinel spec', async () => {
+    const db = await initializeDatabase(':memory:');
+    await seedSession(db, 'sess-1');
+
+    // Simulate a pre-v21 git-diff worker that froze a merge-base hash.
+    await db
+      .insertInto('workers')
+      .values({
+        id: 'worker-diff',
+        session_id: 'sess-1',
+        type: 'git-diff',
+        name: 'Diff',
+        pid: null,
+        agent_id: null,
+        base_commit: FROZEN_HASH,
+      })
+      .execute();
+
+    // Force base_commit back to the frozen hash (the migration ran once during
+    // initializeDatabase; re-seed the pre-migration state then re-run).
+    await db.updateTable('workers').set({ base_commit: FROZEN_HASH }).where('id', '=', 'worker-diff').execute();
+    await migrateToV21(db);
+
+    const row = await db
+      .selectFrom('workers')
+      .where('id', '=', 'worker-diff')
+      .select('base_commit')
+      .executeTakeFirstOrThrow();
+
+    expect(row.base_commit).toBe(DEFAULT_FORK_POINT_SPEC);
+  });
+
+  it('leaves agent and terminal workers (base_commit NULL) untouched', async () => {
+    const db = await initializeDatabase(':memory:');
+    await seedSession(db, 'sess-1');
+
+    await db
+      .insertInto('workers')
+      .values({
+        id: 'worker-agent',
+        session_id: 'sess-1',
+        type: 'agent',
+        name: 'Agent',
+        pid: null,
+        agent_id: 'claude-code',
+        base_commit: null,
+      })
+      .execute();
+    await db
+      .insertInto('workers')
+      .values({
+        id: 'worker-term',
+        session_id: 'sess-1',
+        type: 'terminal',
+        name: 'Terminal',
+        pid: null,
+        agent_id: null,
+        base_commit: null,
+      })
+      .execute();
+
+    await migrateToV21(db);
+
+    const agent = await db
+      .selectFrom('workers')
+      .where('id', '=', 'worker-agent')
+      .select('base_commit')
+      .executeTakeFirstOrThrow();
+    const term = await db
+      .selectFrom('workers')
+      .where('id', '=', 'worker-term')
+      .select('base_commit')
+      .executeTakeFirstOrThrow();
+
+    expect(agent.base_commit).toBeNull();
+    expect(term.base_commit).toBeNull();
+  });
+
+  it('is idempotent when re-applied (sentinel rows stay at the sentinel)', async () => {
+    const db = await initializeDatabase(':memory:');
+    await seedSession(db, 'sess-1');
+
+    await db
+      .insertInto('workers')
+      .values({
+        id: 'worker-diff',
+        session_id: 'sess-1',
+        type: 'git-diff',
+        name: 'Diff',
+        pid: null,
+        agent_id: null,
+        base_commit: DEFAULT_FORK_POINT_SPEC,
+      })
+      .execute();
+
+    await expect(migrateToV21(db)).resolves.toBeUndefined();
+
+    const row = await db
+      .selectFrom('workers')
+      .where('id', '=', 'worker-diff')
+      .select('base_commit')
+      .executeTakeFirstOrThrow();
+    expect(row.base_commit).toBe(DEFAULT_FORK_POINT_SPEC);
+  });
+});

--- a/packages/server/src/database/__tests__/migration.test.ts
+++ b/packages/server/src/database/__tests__/migration.test.ts
@@ -643,7 +643,7 @@ describe('migration', () => {
       // Verify the schema version is the latest
       const { sql } = await import('kysely');
       const result = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
-      expect(result.rows[0]?.user_version).toBe(20);
+      expect(result.rows[0]?.user_version).toBe(21);
 
       // Verify description column exists by inserting and reading a repository with description
       await db
@@ -738,7 +738,7 @@ describe('migration', () => {
       // Verify the schema version is the latest
       const { sql } = await import('kysely');
       const result = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
-      expect(result.rows[0]?.user_version).toBe(20);
+      expect(result.rows[0]?.user_version).toBe(21);
 
       // First create a repository (foreign key dependency)
       await db
@@ -1439,7 +1439,7 @@ describe('migration', () => {
 
       const { sql } = await import('kysely');
       const result = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
-      expect(result.rows[0]?.user_version).toBe(20);
+      expect(result.rows[0]?.user_version).toBe(21);
     });
   });
 
@@ -1477,7 +1477,7 @@ describe('migration', () => {
 
       const { sql } = await import('kysely');
       const result = await sql<{ user_version: number }>`PRAGMA user_version`.execute(db);
-      expect(result.rows[0]?.user_version).toBe(20);
+      expect(result.rows[0]?.user_version).toBe(21);
     });
   });
 

--- a/packages/server/src/database/connection.ts
+++ b/packages/server/src/database/connection.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import * as fsPromises from 'fs/promises';
 import * as v from 'valibot';
 import type { AgentDefinition } from '@agent-console/shared';
-import { AgentDefinitionSchema } from '@agent-console/shared';
+import { AgentDefinitionSchema, DEFAULT_FORK_POINT_SPEC } from '@agent-console/shared';
 import type { Database } from './schema.js';
 import type { PersistedSession, PersistedRepository } from '../services/persistence-service.js';
 import { getConfigDir, getDbPath, getRepositoryDir } from '../lib/config.js';
@@ -307,6 +307,10 @@ async function runMigrations(database: Kysely<Database>, dbPath: string): Promis
 
   if (currentVersion < 20) {
     await migrateToV20(database);
+  }
+
+  if (currentVersion < 21) {
+    await migrateToV21(database);
   }
 }
 
@@ -1266,6 +1270,42 @@ export async function migrateToV20(database: Kysely<Database>): Promise<void> {
   await sql`PRAGMA user_version = 20`.execute(database);
 
   logger.info('Migration to v20 completed');
+}
+
+/**
+ * Migration v21: migrate git-diff workers' frozen base_commit hash to the
+ * `DEFAULT_FORK_POINT_SPEC` sentinel spec (Issue #800).
+ *
+ * Previously each git-diff worker froze a resolved merge-base hash in
+ * `base_commit`. The new model persists a base *spec* that is re-resolved on
+ * every diff so the base tracks the moving fork point. Existing rows hold a
+ * frozen hash, so we reset every git-diff worker's `base_commit` to the
+ * sentinel.
+ *
+ * Limitation: a user-pinned explicit base cannot be distinguished from an
+ * auto-frozen merge-base at the DB layer, so user-pinned bases are also reset
+ * to the default spec. This is acceptable per Issue #800.
+ *
+ * Idempotent: re-applying the UPDATE is a no-op once rows already hold the
+ * sentinel.
+ *
+ * @internal Exported for testing.
+ */
+export async function migrateToV21(database: Kysely<Database>): Promise<void> {
+  logger.info('Running migration to v21: Resetting git-diff workers to default base spec');
+
+  // DEFAULT_FORK_POINT_SPEC sentinel — re-resolves the default fork point fresh
+  // on each diff (see packages/shared/src/types/git-diff.ts).
+  await database
+    .updateTable('workers')
+    .set({ base_commit: DEFAULT_FORK_POINT_SPEC })
+    .where('type', '=', 'git-diff')
+    .where('base_commit', 'is not', null)
+    .execute();
+
+  await sql`PRAGMA user_version = 21`.execute(database);
+
+  logger.info('Migration to v21 completed');
 }
 
 /**

--- a/packages/server/src/routes/__tests__/workers.test.ts
+++ b/packages/server/src/routes/__tests__/workers.test.ts
@@ -5,6 +5,7 @@ import { api } from '../api.js';
 import type { AppBindings } from '../../app-context.js';
 import { asAppContext } from '../../__tests__/test-utils.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
+import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
 import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
@@ -30,6 +31,7 @@ describe('Workers API', () => {
   beforeEach(async () => {
     await closeDatabase();
 
+    resetGitMocks();
     setupMemfs({
       [`${TEST_CONFIG_DIR}/.keep`]: '',
     });
@@ -378,6 +380,148 @@ describe('Workers API', () => {
 
       const body = (await res.json()) as { error: string };
       expect(body.error).toContain('Worker');
+    });
+  });
+
+  // ===========================================================================
+  // GET /api/sessions/:sessionId/workers/:workerId/diff
+  // Re-resolves the persisted base *spec* to a concrete hash at diff time (#800)
+  // ===========================================================================
+
+  describe('GET /api/sessions/:sessionId/workers/:workerId/diff', () => {
+    it('resolves the base spec to a hash and diffs against the resolved hash', async () => {
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+
+      // Create a git-diff worker whose persisted baseCommit is a SPEC (not a hash).
+      const worker = await sessionManager.createWorker(session.id, {
+        type: 'git-diff',
+        baseCommit: 'merge-base:origin/main',
+      });
+      expect(worker).not.toBeNull();
+      expect(worker!.type).toBe('git-diff');
+
+      // resolveBaseSpec for a `merge-base:` spec calls getMergeBaseSafe(ref, HEAD).
+      mockGit.getMergeBaseSafe.mockImplementation((ref1: string) =>
+        Promise.resolve(ref1 === 'origin/main' ? 'resolvedbase999' : null),
+      );
+      // getDiffData reads these; defaults are empty, set a numstat so a file appears.
+      mockGit.getDiff.mockImplementation(() => Promise.resolve('diff --git a/foo b/foo\n'));
+      mockGit.getDiffNumstat.mockImplementation(() => Promise.resolve('1\t0\tfoo\n'));
+
+      const res = await app.request(
+        `/api/sessions/${session.id}/workers/${worker!.id}/diff`,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        summary: { baseCommit: string; files: { path: string }[] };
+        rawDiff: string;
+      };
+
+      // The diff must have been computed against the RESOLVED hash, not the raw spec.
+      expect(body.summary.baseCommit).toBe('resolvedbase999');
+      expect(body.summary.baseCommit).not.toBe('merge-base:origin/main');
+      expect(body.summary.files.map((f) => f.path)).toContain('foo');
+      // getDiff was invoked with the resolved hash as its base ref.
+      const getDiffCalls = mockGit.getDiff.mock.calls;
+      expect(getDiffCalls.length).toBeGreaterThan(0);
+      expect(getDiffCalls[0][0]).toBe('resolvedbase999');
+    });
+
+    it('surfaces a 4xx error when the base spec cannot be resolved (no silent empty diff)', async () => {
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+
+      const worker = await sessionManager.createWorker(session.id, {
+        type: 'git-diff',
+        baseCommit: 'merge-base:origin/main',
+      });
+      expect(worker).not.toBeNull();
+
+      // Resolution genuinely fails (unrelated histories / deleted ref).
+      mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve(null));
+
+      const res = await app.request(
+        `/api/sessions/${session.id}/workers/${worker!.id}/diff`,
+      );
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain('Could not resolve diff base');
+      expect(body.error).toContain('merge-base:origin/main');
+    });
+  });
+
+  // ===========================================================================
+  // GET /api/sessions/:sessionId/workers/:workerId/diff/file
+  // ===========================================================================
+
+  describe('GET /api/sessions/:sessionId/workers/:workerId/diff/file', () => {
+    it('resolves the base spec then returns the per-file diff', async () => {
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+
+      const worker = await sessionManager.createWorker(session.id, {
+        type: 'git-diff',
+        baseCommit: 'merge-base:origin/main',
+      });
+      expect(worker).not.toBeNull();
+
+      mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve('resolvedbase999'));
+      // getFileDiff uses gitRaw(['diff', baseCommit, '--', filePath]).
+      mockGit.gitRaw.mockImplementation(() =>
+        Promise.resolve('diff --git a/foo b/foo\n+added\n'),
+      );
+
+      const res = await app.request(
+        `/api/sessions/${session.id}/workers/${worker!.id}/diff/file?path=foo`,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { rawDiff: string };
+      expect(body.rawDiff).toContain('diff --git a/foo b/foo');
+      // The per-file diff resolved the spec to a hash before calling git diff.
+      const gitRawCalls = mockGit.gitRaw.mock.calls;
+      const fileDiffCall = gitRawCalls.find((args) => args[0]?.[0] === 'diff');
+      expect(fileDiffCall).toBeDefined();
+      // args[0] is the git arg array: ['diff', <resolvedBase>, '--', 'foo'].
+      expect(fileDiffCall![0][1]).toBe('resolvedbase999');
+    });
+
+    it('surfaces a 4xx error when the base spec cannot be resolved', async () => {
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+
+      const worker = await sessionManager.createWorker(session.id, {
+        type: 'git-diff',
+        baseCommit: 'merge-base:origin/main',
+      });
+      expect(worker).not.toBeNull();
+
+      mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve(null));
+
+      const res = await app.request(
+        `/api/sessions/${session.id}/workers/${worker!.id}/diff/file?path=foo`,
+      );
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain('Could not resolve diff base');
     });
   });
 });

--- a/packages/server/src/routes/workers.ts
+++ b/packages/server/src/routes/workers.ts
@@ -186,8 +186,12 @@ const workers = new Hono<AppBindings>()
       throw new ValidationError('Worker is not a git-diff worker');
     }
 
-    const { getDiffData } = await import('../services/git-diff-service.js');
-    const diffData = await getDiffData(session.locationPath, worker.baseCommit);
+    const { resolveBaseSpec, getDiffData } = await import('../services/git-diff-service.js');
+    const resolved = await resolveBaseSpec(worker.baseCommit, session.locationPath);
+    if (!resolved) {
+      throw new ValidationError(`Could not resolve diff base: ${worker.baseCommit}`);
+    }
+    const diffData = await getDiffData(session.locationPath, resolved);
 
     return c.json(diffData);
   })
@@ -216,8 +220,12 @@ const workers = new Hono<AppBindings>()
       throw new ValidationError('Worker is not a git-diff worker');
     }
 
-    const { getFileDiff } = await import('../services/git-diff-service.js');
-    const rawDiff = await getFileDiff(session.locationPath, worker.baseCommit, filePath);
+    const { resolveBaseSpec, getFileDiff } = await import('../services/git-diff-service.js');
+    const resolved = await resolveBaseSpec(worker.baseCommit, session.locationPath);
+    if (!resolved) {
+      throw new ValidationError(`Could not resolve diff base: ${worker.baseCommit}`);
+    }
+    const rawDiff = await getFileDiff(session.locationPath, resolved, filePath);
 
     return c.json({ rawDiff });
   });

--- a/packages/server/src/services/__tests__/git-diff-base-reresolve.test.ts
+++ b/packages/server/src/services/__tests__/git-diff-base-reresolve.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Regression test for Issue #800: the git-diff base spec must be re-resolved on
+ * every diff computation, not frozen to a hash at session creation.
+ *
+ * Symptom: after a feature branch absorbs upstream commits (merge of main),
+ * the frozen merge-base hash makes those upstream commits show up as
+ * "unexpected" file diffs — diverging from GitHub's three-dot PR view.
+ *
+ * This test drives the production `resolveBaseSpec` / `getDiffData` against a
+ * REAL temp git repository. Because the `../lib/git.js` module is mocked
+ * process-globally (mock-git-helper.ts) and that mock cannot be reliably undone
+ * mid-process, we configure the SAME shared `mockGit` to delegate to the real
+ * git CLI against the temp repo. This exercises the genuine production code path
+ * deterministically and is immune to cross-file mock ordering.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { MERGE_BASE_REF_PREFIX } from '@agent-console/shared';
+import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
+import {
+  resolveBaseSpec,
+  getDiffData,
+} from '../git-diff-service.js';
+
+/** Run a git command against `cwd`, returning trimmed stdout (throws on failure). */
+async function git(args: string[], cwd: string): Promise<string> {
+  const proc = Bun.spawn(['git', ...args], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`git ${args.join(' ')} failed: ${stderr}`);
+  }
+  return stdout.trim();
+}
+
+/** Run a git command, returning null on failure (mirrors gitSafe). */
+async function gitSafeReal(args: string[], cwd: string): Promise<string | null> {
+  try {
+    return await git(args, cwd);
+  } catch {
+    return null;
+  }
+}
+
+async function createTempDir(prefix: string): Promise<string> {
+  const tmpDir = path.join(os.tmpdir(), `${prefix}${crypto.randomUUID().slice(0, 8)}`);
+  await Bun.spawn(['mkdir', '-p', tmpDir]).exited;
+  return tmpDir;
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+  await Bun.spawn(['rm', '-rf', dir]).exited;
+}
+
+/**
+ * Wire the shared git mock to delegate to the real git CLI for the functions
+ * `resolveBaseSpec` and `getDiffData` depend on. The cwd argument carries the
+ * actual repo path through.
+ */
+function wireRealGit(): void {
+  resetGitMocks();
+
+  mockGit.getDefaultBranch.mockImplementation(() => Promise.resolve('main'));
+  mockGit.gitRefExists.mockImplementation((ref: string, cwd: string) =>
+    gitSafeReal(['rev-parse', '--verify', ref], cwd).then((r) => r !== null)
+  );
+  mockGit.gitSafe.mockImplementation((args: string[], cwd: string) =>
+    gitSafeReal(args, cwd)
+  );
+  mockGit.getMergeBaseSafe.mockImplementation((ref1: string, ref2: string, cwd: string) =>
+    gitSafeReal(['merge-base', ref1, ref2], cwd)
+  );
+
+  // getDiffData dependencies
+  mockGit.getDiff.mockImplementation((baseRef: string, targetRef: string | undefined, cwd: string) =>
+    targetRef
+      ? git(['diff', baseRef, targetRef], cwd)
+      : git(['diff', baseRef], cwd)
+  );
+  mockGit.getDiffNumstat.mockImplementation((baseRef: string, targetRef: string | undefined, cwd: string) =>
+    targetRef
+      ? git(['diff', '--numstat', baseRef, targetRef], cwd)
+      : git(['diff', '--numstat', baseRef], cwd)
+  );
+  mockGit.getStatusPorcelain.mockImplementation((cwd: string) =>
+    git(['status', '--porcelain', '-uall'], cwd)
+  );
+  mockGit.getUntrackedFiles.mockImplementation((cwd: string) =>
+    git(['ls-files', '--others', '--exclude-standard'], cwd).then((out) =>
+      out.split('\n').filter(Boolean)
+    )
+  );
+}
+
+describe('Issue #800: git-diff base spec re-resolution (real repo)', () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    wireRealGit();
+    repo = await createTempDir('git-diff-800-');
+    await git(['init', '-b', 'main'], repo);
+    await git(['config', 'user.email', 'test@example.com'], repo);
+    await git(['config', 'user.name', 'Test'], repo);
+
+    // Initial commit on main
+    await Bun.write(path.join(repo, 'base.txt'), 'base\n');
+    await git(['add', '.'], repo);
+    await git(['commit', '-m', 'initial commit'], repo);
+  });
+
+  afterEach(async () => {
+    await removeTempDir(repo);
+    resetGitMocks();
+  });
+
+  it('does NOT include an upstream-only file in the diff after the feature branch merges main', async () => {
+    // Feature branch off main with its own change
+    await git(['checkout', '-b', 'feature'], repo);
+    await Bun.write(path.join(repo, 'feature.txt'), 'feature change\n');
+    await git(['add', '.'], repo);
+    await git(['commit', '-m', 'feature commit'], repo);
+
+    // Back on main: add an upstream-only commit
+    await git(['checkout', 'main'], repo);
+    await Bun.write(path.join(repo, 'upstream.txt'), 'upstream only\n');
+    await git(['add', '.'], repo);
+    await git(['commit', '-m', 'upstream commit'], repo);
+
+    // Back on the feature branch — this is the persisted base spec
+    await git(['checkout', 'feature'], repo);
+    const spec = `${MERGE_BASE_REF_PREFIX}main`;
+
+    // Diff #1: resolves merge-base(main, HEAD) — should contain the feature
+    // change but NOT the upstream-only file.
+    const resolved1 = await resolveBaseSpec(spec, repo);
+    expect(resolved1).not.toBeNull();
+    const diff1 = await getDiffData(repo, resolved1!);
+    const paths1 = diff1.summary.files.map((f) => f.path);
+    expect(paths1).toContain('feature.txt');
+    expect(paths1).not.toContain('upstream.txt');
+
+    // Merge main into feature (absorb the upstream commit, no conflicts)
+    await git(['merge', 'main', '--no-edit'], repo);
+
+    // Diff #2: SAME spec, re-resolved → merge-base moves forward to include the
+    // upstream commit, so upstream.txt must NOT appear in the diff.
+    const resolved2 = await resolveBaseSpec(spec, repo);
+    expect(resolved2).not.toBeNull();
+    // The merge-base must have advanced (re-resolution actually happened).
+    expect(resolved2).not.toBe(resolved1);
+    const diff2 = await getDiffData(repo, resolved2!);
+    const paths2 = diff2.summary.files.map((f) => f.path);
+    expect(paths2).toContain('feature.txt');
+    // CORE REGRESSION ASSERTION: with the old frozen-hash behavior diff2 WOULD
+    // include upstream.txt.
+    expect(paths2).not.toContain('upstream.txt');
+  });
+
+  it('yields an empty diff when the branch has no own changes (no upstream noise)', async () => {
+    // A branch identical to main: merge-base is HEAD, diff must be empty.
+    await git(['checkout', '-b', 'no-changes'], repo);
+    const spec = `${MERGE_BASE_REF_PREFIX}main`;
+    const resolved = await resolveBaseSpec(spec, repo);
+    expect(resolved).not.toBeNull();
+    const diff = await getDiffData(repo, resolved!);
+    expect(diff.summary.files).toHaveLength(0);
+  });
+});

--- a/packages/server/src/services/__tests__/git-diff-service.test.ts
+++ b/packages/server/src/services/__tests__/git-diff-service.test.ts
@@ -152,6 +152,22 @@ describe('GitDiffService', () => {
       expect(result).toBe('branch-tip-hash');
       expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', 'feature-branch'], '/repo/path');
     });
+
+    // Namespace fix: the sentinel lives in the reserved: namespace
+    // (DEFAULT_FORK_POINT_SPEC === 'reserved:default-fork-point'). A real ref
+    // literally named 'default-fork-point' (the bare string) must NOT be
+    // intercepted as the sentinel — it must fall through to rev-parse so it
+    // round-trips like any other branch/tag.
+    it('resolves a real ref literally named "default-fork-point" via rev-parse (not the sentinel path)', async () => {
+      mockGit.gitSafe.mockResolvedValue('real-ref-hash');
+
+      const result = await resolveBaseSpec('default-fork-point', '/repo/path');
+
+      expect(result).toBe('real-ref-hash');
+      expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', 'default-fork-point'], '/repo/path');
+      // The sentinel chain (computeDefaultBaseSpec) must not have been invoked.
+      expect(mockGit.getMergeBaseSafe).not.toHaveBeenCalled();
+    });
   });
 
   describe('resolveRef', () => {

--- a/packages/server/src/services/__tests__/git-diff-service.test.ts
+++ b/packages/server/src/services/__tests__/git-diff-service.test.ts
@@ -3,8 +3,10 @@ import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
 
+import { DEFAULT_FORK_POINT_SPEC } from '@agent-console/shared';
 import {
-  calculateBaseCommit,
+  computeDefaultBaseSpec,
+  resolveBaseSpec,
   resolveRef,
   getDiffData,
   getFileDiff,
@@ -16,29 +18,139 @@ describe('GitDiffService', () => {
     resetGitMocks();
   });
 
-  describe('calculateBaseCommit', () => {
-    it('should return merge-base when default branch exists', async () => {
+  describe('computeDefaultBaseSpec', () => {
+    it('returns merge-base:origin/<default> when origin/<default> exists', async () => {
       mockGit.getDefaultBranch.mockResolvedValue('main');
-      mockGit.getMergeBaseSafe.mockResolvedValue('abc123def456');
+      mockGit.gitRefExists.mockImplementation((ref: string) =>
+        Promise.resolve(ref === 'origin/main')
+      );
 
-      const result = await calculateBaseCommit('/repo/path');
+      const result = await computeDefaultBaseSpec('/repo/path');
 
-      expect(result).toBe('abc123def456');
-      expect(mockGit.getDefaultBranch).toHaveBeenCalledWith('/repo/path');
-      expect(mockGit.getMergeBaseSafe).toHaveBeenCalledWith('main', 'HEAD', '/repo/path');
+      expect(result).toBe('merge-base:origin/main');
+      expect(mockGit.gitRefExists).toHaveBeenCalledWith('origin/main', '/repo/path');
     });
 
-    it('should fallback to first commit when no default branch', async () => {
+    it('returns merge-base:<default> when default branch exists but origin/<default> does not', async () => {
+      mockGit.getDefaultBranch.mockResolvedValue('main');
+      mockGit.gitRefExists.mockResolvedValue(false);
+
+      const result = await computeDefaultBaseSpec('/repo/path');
+
+      expect(result).toBe('merge-base:main');
+    });
+
+    it('returns the first-commit hash when there is no default branch', async () => {
       mockGit.getDefaultBranch.mockResolvedValue(null);
       mockGit.gitSafe.mockResolvedValue('first-commit-hash');
 
-      const result = await calculateBaseCommit('/repo/path');
+      const result = await computeDefaultBaseSpec('/repo/path');
 
       expect(result).toBe('first-commit-hash');
       expect(mockGit.gitSafe).toHaveBeenCalledWith(
         ['rev-list', '--max-parents=0', 'HEAD'],
         '/repo/path'
       );
+    });
+
+    it('uses only the first root hash when rev-list emits multiple (merged unrelated histories)', async () => {
+      mockGit.getDefaultBranch.mockResolvedValue(null);
+      mockGit.gitSafe.mockResolvedValue('root1hash\nroot2hash');
+
+      const result = await computeDefaultBaseSpec('/repo/path');
+
+      expect(result).toBe('root1hash');
+    });
+
+    it('falls back to HEAD when no default branch and no first commit', async () => {
+      mockGit.getDefaultBranch.mockResolvedValue(null);
+      mockGit.gitSafe.mockResolvedValue(null);
+
+      const result = await computeDefaultBaseSpec('/repo/path');
+
+      expect(result).toBe('HEAD');
+    });
+  });
+
+  describe('resolveBaseSpec', () => {
+    it('resolves DEFAULT_FORK_POINT_SPEC via origin merge-base when origin exists', async () => {
+      mockGit.getDefaultBranch.mockResolvedValue('main');
+      mockGit.gitRefExists.mockImplementation((ref: string) =>
+        Promise.resolve(ref === 'origin/main')
+      );
+      mockGit.getMergeBaseSafe.mockImplementation((ref1: string) =>
+        Promise.resolve(ref1 === 'origin/main' ? 'origin-merge-base' : null)
+      );
+
+      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path');
+
+      expect(result).toBe('origin-merge-base');
+      expect(mockGit.getMergeBaseSafe).toHaveBeenCalledWith('origin/main', 'HEAD', '/repo/path');
+    });
+
+    it('falls back to local merge-base when origin/<default> is missing', async () => {
+      mockGit.getDefaultBranch.mockResolvedValue('main');
+      mockGit.gitRefExists.mockResolvedValue(false);
+      mockGit.getMergeBaseSafe.mockResolvedValue('local-merge-base');
+
+      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path');
+
+      expect(result).toBe('local-merge-base');
+      expect(mockGit.getMergeBaseSafe).toHaveBeenCalledWith('main', 'HEAD', '/repo/path');
+    });
+
+    it('falls back to first commit when no default branch (sentinel never hard-fails)', async () => {
+      mockGit.getDefaultBranch.mockResolvedValue(null);
+      mockGit.gitSafe.mockResolvedValue('first-commit-hash');
+
+      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path');
+
+      expect(result).toBe('first-commit-hash');
+    });
+
+    it('uses only the first root hash when rev-list emits multiple (merged unrelated histories)', async () => {
+      mockGit.getDefaultBranch.mockResolvedValue(null);
+      mockGit.gitSafe.mockResolvedValue('root1hash\nroot2hash');
+
+      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path');
+
+      expect(result).toBe('root1hash');
+    });
+
+    it('resolves merge-base:<ref> via getMergeBaseSafe', async () => {
+      mockGit.getMergeBaseSafe.mockResolvedValue('mb-hash');
+
+      const result = await resolveBaseSpec('merge-base:foo', '/repo/path');
+
+      expect(result).toBe('mb-hash');
+      expect(mockGit.getMergeBaseSafe).toHaveBeenCalledWith('foo', 'HEAD', '/repo/path');
+    });
+
+    it('returns null when merge-base:<ref> cannot be resolved (unrelated histories / deleted ref)', async () => {
+      mockGit.getMergeBaseSafe.mockResolvedValue(null);
+
+      const result = await resolveBaseSpec('merge-base:foo', '/repo/path');
+
+      expect(result).toBeNull();
+    });
+
+    it('keeps an explicit commit hash pinned (no re-resolution to a different value)', async () => {
+      const hash = '0123456789abcdef0123456789abcdef01234567';
+      mockGit.gitSafe.mockResolvedValue(hash);
+
+      const result = await resolveBaseSpec(hash, '/repo/path');
+
+      expect(result).toBe(hash);
+      expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', hash], '/repo/path');
+    });
+
+    it('re-resolves a branch name to its current tip', async () => {
+      mockGit.gitSafe.mockResolvedValue('branch-tip-hash');
+
+      const result = await resolveBaseSpec('feature-branch', '/repo/path');
+
+      expect(result).toBe('branch-tip-hash');
+      expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', 'feature-branch'], '/repo/path');
     });
   });
 

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -2488,10 +2488,9 @@ describe('SessionManager', () => {
       expect(agentPty.killed).toBe(false);
     });
 
-    it('should recalculate git-diff worker baseCommit for active sessions', async () => {
+    it('should keep the git-diff worker base spec unchanged on active-session rename (Issue #800)', async () => {
       const manager = await getSessionManager();
 
-      // Create session first with default getMergeBaseSafe (returns 'abc1234')
       const session = await manager.createSession({
         type: 'worktree',
         locationPath: '/test/path',
@@ -2502,30 +2501,28 @@ describe('SessionManager', () => {
 
       const gitDiffWorker = session.workers.find((w: Worker) => w.type === 'git-diff')!;
       expect(gitDiffWorker).toBeDefined();
-      // Confirm initial baseCommit is the default mock value
-      if (gitDiffWorker.type === 'git-diff') {
-        expect(gitDiffWorker.baseCommit).toBe('abc1234');
-      }
+      // The base is now persisted as a branch-agnostic SPEC. With default mocks
+      // (default branch 'main', no origin/main ref), computeDefaultBaseSpec
+      // yields 'merge-base:main'.
+      const initialSpec = gitDiffWorker.type === 'git-diff' ? gitDiffWorker.baseCommit : undefined;
+      expect(initialSpec).toBe('merge-base:main');
 
-      // Now configure mocks for branch rename: getCurrentBranch returns old branch,
-      // and getMergeBaseSafe returns a new hash (simulating recalculation after rename)
       mockGit.getCurrentBranch.mockImplementation(() => Promise.resolve('old-branch'));
-      mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve('new-merge-base-hash'));
 
       const result = await manager.updateSessionMetadata(session.id, { branch: 'new-branch' });
 
       expect(result.success).toBe(true);
 
-      // Verify the git-diff worker's baseCommit has been updated to the new merge-base
+      // The spec re-resolves on every diff, so a rename must NOT change it.
       const updatedSession = manager.getSession(session.id);
       const updatedGitDiffWorker = updatedSession?.workers.find((w: Worker) => w.type === 'git-diff');
       expect(updatedGitDiffWorker?.type).toBe('git-diff');
       if (updatedGitDiffWorker?.type === 'git-diff') {
-        expect(updatedGitDiffWorker.baseCommit).toBe('new-merge-base-hash');
+        expect(updatedGitDiffWorker.baseCommit).toBe('merge-base:main');
       }
     });
 
-    it('should fire onDiffBaseCommitChanged callback for active sessions after branch rename', async () => {
+    it('should fire onDiffBaseCommitChanged with the unchanged spec for active sessions after branch rename', async () => {
       const manager = await getSessionManager();
 
       const onDiffBaseCommitChanged = mock(() => {});
@@ -2541,21 +2538,20 @@ describe('SessionManager', () => {
 
       const gitDiffWorker = session.workers.find((w: Worker) => w.type === 'git-diff')!;
 
-      // Set mocks AFTER session creation so the rename triggers recalculation
       mockGit.getCurrentBranch.mockImplementation(() => Promise.resolve('old-branch'));
-      mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve('new-merge-base-hash'));
 
       await manager.updateSessionMetadata(session.id, { branch: 'new-branch' });
 
+      // Fires with the unchanged spec so connected clients re-resolve the diff.
       expect(onDiffBaseCommitChanged).toHaveBeenCalledTimes(1);
       expect(onDiffBaseCommitChanged).toHaveBeenCalledWith(
         session.id,
         gitDiffWorker.id,
-        'new-merge-base-hash',
+        'merge-base:main',
       );
     });
 
-    it('should update persisted git-diff worker baseCommit for inactive sessions', async () => {
+    it('should keep the persisted git-diff worker base spec unchanged for inactive sessions (Issue #800)', async () => {
       const manager = await getSessionManager();
 
       const session = await manager.createSession({
@@ -2570,23 +2566,21 @@ describe('SessionManager', () => {
       await manager.pauseSession(session.id);
       expect(manager.getSession(session.id)).toBeUndefined();
 
-      // Configure mocks for the branch rename on the inactive session
       mockGit.getCurrentBranch.mockImplementation(() => Promise.resolve('old-branch'));
-      mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve('new-merge-base-for-inactive'));
 
       const result = await manager.updateSessionMetadata(session.id, { branch: 'new-branch' });
 
       expect(result.success).toBe(true);
       expect(result.branch).toBe('new-branch');
 
-      // Read the persisted session and verify the git-diff worker's baseCommit was updated
+      // The branch-agnostic spec must NOT be frozen / changed on rename.
       const persisted = await manager.getSessionMetadata(session.id);
       expect(persisted).not.toBeNull();
       const persistedGitDiffWorker = persisted!.workers.find((w: PersistedWorker) => w.type === 'git-diff');
       expect(persistedGitDiffWorker).toBeDefined();
       expect(persistedGitDiffWorker!.type).toBe('git-diff');
       if (persistedGitDiffWorker!.type === 'git-diff') {
-        expect(persistedGitDiffWorker!.baseCommit).toBe('new-merge-base-for-inactive');
+        expect(persistedGitDiffWorker!.baseCommit).toBe('merge-base:main');
       }
     });
   });
@@ -2604,7 +2598,7 @@ describe('SessionManager', () => {
       });
 
       // Configure mocks: getCurrentBranch returns old branch, renameBranch succeeds,
-      // but getMergeBaseSafe throws (causing calculateBaseCommit to fail)
+      // but getMergeBaseSafe throws (causing default-fork-point resolution via resolveBaseSpec to fail)
       mockGit.getCurrentBranch.mockImplementation(() => Promise.resolve('old-branch'));
       mockGit.getMergeBaseSafe.mockImplementation(() => {
         throw new Error('git merge-base failed');
@@ -2624,7 +2618,7 @@ describe('SessionManager', () => {
       }
     });
 
-    it('should succeed branch rename for inactive session even when calculateBaseCommit fails', async () => {
+    it('should succeed branch rename for inactive session regardless of git base resolution', async () => {
       const manager = await getSessionManager();
 
       const session = await manager.createSession({
@@ -2639,8 +2633,8 @@ describe('SessionManager', () => {
       await manager.pauseSession(session.id);
       expect(manager.getSession(session.id)).toBeUndefined();
 
-      // Configure mocks: getCurrentBranch returns old branch, renameBranch succeeds,
-      // but getDefaultBranch throws (causing calculateBaseCommit to fail)
+      // Branch rename no longer recomputes a base hash (Issue #800), so it must
+      // succeed even if default-branch lookup would fail.
       mockGit.getCurrentBranch.mockImplementation(() => Promise.resolve('old-branch'));
       mockGit.getDefaultBranch.mockImplementation(() => {
         throw new Error('git default branch lookup failed');
@@ -2661,7 +2655,7 @@ describe('SessionManager', () => {
       }
     });
 
-    it('should preserve original workers when calculateBaseCommit throws for inactive session', async () => {
+    it('should preserve original git-diff worker base spec on inactive-session rename + title update', async () => {
       const manager = await getSessionManager();
 
       const session = await manager.createSession({
@@ -2683,12 +2677,7 @@ describe('SessionManager', () => {
       await manager.pauseSession(session.id);
       expect(manager.getSession(session.id)).toBeUndefined();
 
-      // Configure mocks: getCurrentBranch returns old branch, renameBranch succeeds,
-      // but getDefaultBranch throws (causing calculateBaseCommit to fail)
       mockGit.getCurrentBranch.mockImplementation(() => Promise.resolve('old-branch'));
-      mockGit.getDefaultBranch.mockImplementation(() => {
-        throw new Error('calculateBaseCommit failure');
-      });
 
       // Update both title and branch
       const result = await manager.updateSessionMetadata(session.id, {
@@ -2712,7 +2701,7 @@ describe('SessionManager', () => {
       }
     });
 
-    it('should use HEAD as fallback when calculateBaseCommit returns null for inactive session', async () => {
+    it('should preserve the git-diff worker base spec on inactive-session rename (Issue #800)', async () => {
       const manager = await getSessionManager();
 
       const session = await manager.createSession({
@@ -2723,27 +2712,29 @@ describe('SessionManager', () => {
         agentId: 'claude-code',
       });
 
+      // Capture the initial base spec assigned at creation.
+      const originalMetadata = await manager.getSessionMetadata(session.id);
+      const originalGitDiffWorker = originalMetadata!.workers.find((w: PersistedWorker) => w.type === 'git-diff');
+      const originalBaseSpec = originalGitDiffWorker!.type === 'git-diff' ? originalGitDiffWorker!.baseCommit : undefined;
+
       // Pause the session to make it inactive
       await manager.pauseSession(session.id);
 
-      // Configure mocks: getCurrentBranch returns old branch, renameBranch succeeds,
-      // getDefaultBranch returns null AND gitSafe returns null (calculateBaseCommit returns null)
       mockGit.getCurrentBranch.mockImplementation(() => Promise.resolve('old-branch'));
-      mockGit.getDefaultBranch.mockImplementation(() => Promise.resolve(null));
-      mockGit.gitSafe.mockImplementation(() => Promise.resolve(null));
 
       const result = await manager.updateSessionMetadata(session.id, { branch: 'new-branch' });
 
       expect(result.success).toBe(true);
 
-      // Verify the persisted git-diff worker's baseCommit was updated to 'HEAD' (not skipped)
+      // The branch-agnostic spec re-resolves on every diff, so it must NOT be
+      // frozen / changed on rename.
       const persisted = await manager.getSessionMetadata(session.id);
       expect(persisted).not.toBeNull();
       const persistedGitDiffWorker = persisted!.workers.find((w: PersistedWorker) => w.type === 'git-diff');
       expect(persistedGitDiffWorker).toBeDefined();
       expect(persistedGitDiffWorker!.type).toBe('git-diff');
       if (persistedGitDiffWorker!.type === 'git-diff') {
-        expect(persistedGitDiffWorker!.baseCommit).toBe('HEAD');
+        expect(persistedGitDiffWorker!.baseCommit).toBe(originalBaseSpec);
       }
     });
   });

--- a/packages/server/src/services/__tests__/session-metadata-service.test.ts
+++ b/packages/server/src/services/__tests__/session-metadata-service.test.ts
@@ -212,14 +212,14 @@ describe('SessionMetadataService', () => {
       expect(result.error).toBe('Can only rename branch for worktree sessions');
     });
 
-    it('should update git-diff workers base commit for inactive session', async () => {
+    it('should keep git-diff workers base spec unchanged on branch rename for inactive session (Issue #800)', async () => {
       const persisted = buildPersistedWorktreeSession({
         id: 'session-3',
         worktreeId: 'old-branch',
         locationPath: '/test/path',
         workers: [
           buildPersistedAgentWorker({ id: 'w1', name: 'Claude' }),
-          buildPersistedGitDiffWorker({ id: 'w2', name: 'Diff', baseCommit: 'old-commit' }),
+          buildPersistedGitDiffWorker({ id: 'w2', name: 'Diff', baseCommit: 'merge-base:main' }),
         ],
       });
       const saveMock = mock((_session: PersistedSession) => Promise.resolve());
@@ -230,46 +230,17 @@ describe('SessionMetadataService', () => {
         }),
       });
       service = new SessionMetadataService(deps);
-      // calculateBaseCommit uses getDefaultBranch + getMergeBaseSafe
-      mockGit.getDefaultBranch.mockImplementation(() => Promise.resolve('main'));
-      mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve('new-merge-base'));
 
       const result = await service.updateSessionMetadata('session-3', { branch: 'new-branch' });
 
       expect(result.success).toBe(true);
       const savedSession = saveMock.mock.calls[0][0] as PersistedWorktreeSession;
-      expect((savedSession.workers[1] as PersistedGitDiffWorker).baseCommit).toBe('new-merge-base');
+      // The branch-agnostic spec re-resolves on every diff, so it must NOT be
+      // frozen to a new hash on rename.
+      expect((savedSession.workers[1] as PersistedGitDiffWorker).baseCommit).toBe('merge-base:main');
       // Non-git-diff workers should be unchanged
       expect(savedSession.workers[0].type).toBe('agent');
-    });
-
-    it('should succeed branch rename even when calculateBaseCommit fails for inactive session', async () => {
-      const persisted = buildPersistedWorktreeSession({
-        id: 'session-3',
-        worktreeId: 'old-branch',
-        locationPath: '/test/path',
-        workers: [
-          buildPersistedGitDiffWorker({ id: 'w1', name: 'Diff', baseCommit: 'old-commit' }),
-        ],
-      });
-      const saveMock = mock((_session: PersistedSession) => Promise.resolve());
-      deps = createMockDeps({
-        sessionRepository: createMockSessionRepository({
-          findById: mock(() => Promise.resolve(persisted)),
-          save: saveMock,
-        }),
-      });
-      service = new SessionMetadataService(deps);
-      // Make calculateBaseCommit fail by having getDefaultBranch throw
-      mockGit.getDefaultBranch.mockImplementation(() => { throw new Error('git error'); });
-
-      const result = await service.updateSessionMetadata('session-3', { branch: 'new-branch' });
-
-      expect(result.success).toBe(true);
-      expect(result.branch).toBe('new-branch');
-      // Workers should preserve original base commit since calculateBaseCommit failed
-      const savedSession = saveMock.mock.calls[0][0] as PersistedWorktreeSession;
-      expect((savedSession.workers[0] as PersistedGitDiffWorker).baseCommit).toBe('old-commit');
+      expect(savedSession.worktreeId).toBe('new-branch');
     });
 
     it('should update both title and branch for inactive session in single save', async () => {
@@ -298,13 +269,13 @@ describe('SessionMetadataService', () => {
       expect(savedSession.worktreeId).toBe('new-branch');
     });
 
-    it('should use HEAD as fallback when calculateBaseCommit returns null', async () => {
+    it('should preserve an explicit pinned base spec on branch rename (no re-resolution / freezing)', async () => {
       const persisted = buildPersistedWorktreeSession({
         id: 'session-3',
         worktreeId: 'old-branch',
         locationPath: '/test/path',
         workers: [
-          buildPersistedGitDiffWorker({ id: 'w1', name: 'Diff', baseCommit: 'old-commit' }),
+          buildPersistedGitDiffWorker({ id: 'w1', name: 'Diff', baseCommit: 'abc1234' }),
         ],
       });
       const saveMock = mock((_session: PersistedSession) => Promise.resolve());
@@ -315,14 +286,11 @@ describe('SessionMetadataService', () => {
         }),
       });
       service = new SessionMetadataService(deps);
-      // Make calculateBaseCommit return null: getDefaultBranch returns null, gitSafe returns null
-      mockGit.getDefaultBranch.mockImplementation(() => Promise.resolve(null));
-      mockGit.gitSafe.mockImplementation(() => Promise.resolve(null));
 
       await service.updateSessionMetadata('session-3', { branch: 'new-branch' });
 
       const savedSession = saveMock.mock.calls[0][0] as PersistedWorktreeSession;
-      expect((savedSession.workers[0] as PersistedGitDiffWorker).baseCommit).toBe('HEAD');
+      expect((savedSession.workers[0] as PersistedGitDiffWorker).baseCommit).toBe('abc1234');
     });
   });
 

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -684,7 +684,7 @@ describe('WorkerLifecycleManager', () => {
       expect(mockOnWorkerRestarted).not.toHaveBeenCalled();
     });
 
-    it('should recalculate git-diff worker baseCommit after branch rename', async () => {
+    it('should keep the git-diff worker base spec unchanged after branch rename (Issue #800)', async () => {
       const session = createTestSession({ worktreeId: 'old-branch' });
       sessions.set(session.id, session);
 
@@ -699,25 +699,23 @@ describe('WorkerLifecycleManager', () => {
         type: 'git-diff',
         name: 'Git Diff',
         createdAt: new Date().toISOString(),
-        baseCommit: 'old-base-commit',
+        baseCommit: 'merge-base:main',
       };
       session.workers.set(gitDiffWorker.id, gitDiffWorker);
 
-      // Configure git mocks for branch rename
       mockGit.getCurrentBranch.mockImplementation(() => Promise.resolve('old-branch'));
-      // Configure calculateBaseCommit's underlying mock to return new merge-base
-      mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve('new-merge-base'));
 
       await lifecycleManager.restartAgentWorker(
         session.id, agentWorker!.id, true, undefined, 'new-branch'
       );
 
-      // git-diff worker's baseCommit should be updated
+      // The branch-agnostic spec re-resolves on every diff, so it must NOT be
+      // frozen to a new hash here.
       const updatedDiffWorker = session.workers.get(gitDiffWorker.id) as InternalGitDiffWorker;
-      expect(updatedDiffWorker.baseCommit).toBe('new-merge-base');
+      expect(updatedDiffWorker.baseCommit).toBe('merge-base:main');
     });
 
-    it('should fire onDiffBaseCommitChanged callback after branch rename', async () => {
+    it('should fire onDiffBaseCommitChanged with the unchanged spec after branch rename', async () => {
       const session = createTestSession({ worktreeId: 'old-branch' });
       sessions.set(session.id, session);
 
@@ -731,62 +729,20 @@ describe('WorkerLifecycleManager', () => {
         type: 'git-diff',
         name: 'Git Diff',
         createdAt: new Date().toISOString(),
-        baseCommit: 'old-base-commit',
+        baseCommit: 'merge-base:main',
       };
       session.workers.set(gitDiffWorker.id, gitDiffWorker);
 
       mockGit.getCurrentBranch.mockImplementation(() => Promise.resolve('old-branch'));
-      mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve('new-merge-base'));
 
       await lifecycleManager.restartAgentWorker(
         session.id, agentWorker!.id, true, undefined, 'new-branch'
       );
 
+      // Fires with the unchanged spec so connected clients re-resolve the diff.
       expect(mockOnDiffBaseCommitChanged).toHaveBeenCalledWith(
-        session.id, gitDiffWorker.id, 'new-merge-base'
+        session.id, gitDiffWorker.id, 'merge-base:main'
       );
-    });
-
-    it('should complete restart even when updateGitDiffWorkersAfterBranchRename fails', async () => {
-      const session = createTestSession({ worktreeId: 'old-branch' });
-      sessions.set(session.id, session);
-
-      const agentWorker = await lifecycleManager.createWorker(session.id, {
-        type: 'agent',
-        agentId: CLAUDE_CODE_AGENT_ID,
-      });
-
-      const gitDiffWorker: InternalGitDiffWorker = {
-        id: 'diff-worker-fail',
-        type: 'git-diff',
-        name: 'Git Diff',
-        createdAt: new Date().toISOString(),
-        baseCommit: 'old-base-commit',
-      };
-      session.workers.set(gitDiffWorker.id, gitDiffWorker);
-
-      // Configure git mocks: branch rename succeeds, but calculateBaseCommit throws
-      mockGit.getCurrentBranch.mockImplementation(() => Promise.resolve('old-branch'));
-      mockGit.getDefaultBranch.mockImplementation(() => {
-        throw new Error('calculateBaseCommit failure');
-      });
-
-      // The restart should complete successfully despite the git-diff update failure
-      const restarted = await lifecycleManager.restartAgentWorker(
-        session.id, agentWorker!.id, true, undefined, 'new-branch'
-      );
-
-      expect(restarted).not.toBeNull();
-      expect(restarted!.id).toBe(agentWorker!.id);
-      expect(restarted!.type).toBe('agent');
-      // Branch rename should have succeeded
-      expect(session.type).toBe('worktree');
-      if (session.type === 'worktree') {
-        expect(session.worktreeId).toBe('new-branch');
-      }
-      // Old PTY killed, new PTY spawned
-      expect(ptyFactory.instances[0].killed).toBe(true);
-      expect(ptyFactory.instances.length).toBe(2);
     });
 
     it('should NOT update git-diff workers when no branch parameter is provided', async () => {
@@ -822,66 +778,33 @@ describe('WorkerLifecycleManager', () => {
   // ========== Update Git-Diff Workers After Branch Rename ==========
 
   describe('updateGitDiffWorkersAfterBranchRename', () => {
-    it('should fall back to HEAD when calculateBaseCommit returns null', async () => {
+    it('should keep the base spec unchanged and fire the callback with it (Issue #800)', async () => {
       const session = createTestSession();
       sessions.set(session.id, session);
 
       const gitDiffWorker: InternalGitDiffWorker = {
-        id: 'diff-worker-null',
+        id: 'diff-worker-spec',
         type: 'git-diff',
         name: 'Git Diff',
         createdAt: new Date().toISOString(),
-        baseCommit: 'old-base',
+        baseCommit: 'merge-base:main',
       };
       session.workers.set(gitDiffWorker.id, gitDiffWorker);
 
-      // Make calculateBaseCommit return null (no default branch, no first commit)
-      mockGit.getDefaultBranch.mockImplementation(() => Promise.resolve(null));
-      mockGit.gitSafe.mockImplementation(() => Promise.resolve(null));
-
       await lifecycleManager.updateGitDiffWorkersAfterBranchRename(session.id);
 
+      // The branch-agnostic spec must NOT be frozen to a new hash; it stays as-is
+      // and the callback re-pushes a freshly re-resolved diff.
       const updatedWorker = session.workers.get(gitDiffWorker.id) as InternalGitDiffWorker;
-      expect(updatedWorker.baseCommit).toBe('HEAD');
+      expect(updatedWorker.baseCommit).toBe('merge-base:main');
       expect(mockOnDiffBaseCommitChanged).toHaveBeenCalledWith(
-        session.id, gitDiffWorker.id, 'HEAD'
+        session.id, gitDiffWorker.id, 'merge-base:main'
       );
     });
 
     it('should not fail when session does not exist', async () => {
       // Should silently return without error
       await lifecycleManager.updateGitDiffWorkersAfterBranchRename('non-existent');
-    });
-
-    it('should propagate error when calculateBaseCommit throws', async () => {
-      const session = createTestSession();
-      sessions.set(session.id, session);
-
-      const gitDiffWorker: InternalGitDiffWorker = {
-        id: 'diff-worker-1',
-        type: 'git-diff',
-        name: 'Git Diff 1',
-        createdAt: new Date().toISOString(),
-        baseCommit: 'old-base',
-      };
-      session.workers.set(gitDiffWorker.id, gitDiffWorker);
-
-      // Make calculateBaseCommit throw
-      mockGit.getDefaultBranch.mockImplementation(() => {
-        throw new Error('calculateBaseCommit failure');
-      });
-
-      // Error should propagate to callers (callers wrap in try/catch)
-      await expect(
-        lifecycleManager.updateGitDiffWorkersAfterBranchRename(session.id)
-      ).rejects.toThrow('calculateBaseCommit failure');
-
-      // Worker should remain unchanged since the operation failed
-      const unchangedWorker = session.workers.get(gitDiffWorker.id) as InternalGitDiffWorker;
-      expect(unchangedWorker.baseCommit).toBe('old-base');
-
-      // Callback should not have been called
-      expect(mockOnDiffBaseCommitChanged).not.toHaveBeenCalled();
     });
 
     it('should skip non-git-diff workers', async () => {

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock, jest } from 'bun:test';
 import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
+import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
 import {
   buildInternalGitDiffWorker,
   buildPersistedAgentWorker,
@@ -39,6 +40,7 @@ describe('WorkerManager', () => {
   beforeEach(async () => {
     await closeDatabase();
 
+    resetGitMocks();
     setupMemfs({ [`${TEST_CONFIG_DIR}/.keep`]: '' });
     process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
 
@@ -136,6 +138,73 @@ describe('WorkerManager', () => {
       expect(worker.outputBuffer).toBe('');
       expect(worker.outputOffset).toBe(0);
       expect(worker.connectionCallbacks.size).toBe(0);
+    });
+  });
+
+  describe('initializeGitDiffWorker', () => {
+    it('stores the computed default base spec (not a resolved hash) when no baseCommit is provided', async () => {
+      // origin/main exists → computeDefaultBaseSpec returns the merge-base spec.
+      mockGit.getDefaultBranch.mockImplementation(() => Promise.resolve('main'));
+      mockGit.gitRefExists.mockImplementation((ref: string) =>
+        Promise.resolve(ref === 'origin/main'),
+      );
+      // If the implementation incorrectly resolved the spec to a hash, this would
+      // be the value it stored. The assertion below proves it stores the spec, not this.
+      mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve('resolvedhash123'));
+
+      const worker = await workerManager.initializeGitDiffWorker({
+        id: 'git-diff-default',
+        name: 'Diff',
+        createdAt: new Date().toISOString(),
+        locationPath: '/repo',
+      });
+
+      expect(worker.type).toBe('git-diff');
+      expect(worker.baseCommit).toBe('merge-base:origin/main');
+      // The spec must NOT be pre-resolved to a hash at init time.
+      expect(worker.baseCommit).not.toBe('resolvedhash123');
+    });
+
+    it('falls back to the local merge-base spec when origin/<default> does not exist', async () => {
+      mockGit.getDefaultBranch.mockImplementation(() => Promise.resolve('develop'));
+      mockGit.gitRefExists.mockImplementation(() => Promise.resolve(false));
+
+      const worker = await workerManager.initializeGitDiffWorker({
+        id: 'git-diff-local',
+        name: 'Diff',
+        createdAt: new Date().toISOString(),
+        locationPath: '/repo',
+      });
+
+      expect(worker.baseCommit).toBe('merge-base:develop');
+    });
+
+    it('stores an explicitly-provided baseCommit verbatim as the spec, without pre-resolution', async () => {
+      const worker = await workerManager.initializeGitDiffWorker({
+        id: 'git-diff-explicit',
+        name: 'Diff',
+        createdAt: new Date().toISOString(),
+        locationPath: '/repo',
+        baseCommit: 'merge-base:origin/develop',
+      });
+
+      expect(worker.baseCommit).toBe('merge-base:origin/develop');
+      // A verbatim spec must not trigger any rev-parse / merge-base resolution at init.
+      expect(mockGit.gitSafe).not.toHaveBeenCalled();
+      expect(mockGit.getMergeBaseSafe).not.toHaveBeenCalled();
+    });
+
+    it('stores an explicit commit-hash baseCommit verbatim (stays pinned)', async () => {
+      const worker = await workerManager.initializeGitDiffWorker({
+        id: 'git-diff-hash',
+        name: 'Diff',
+        createdAt: new Date().toISOString(),
+        locationPath: '/repo',
+        baseCommit: 'deadbeef1234',
+      });
+
+      expect(worker.baseCommit).toBe('deadbeef1234');
+      expect(mockGit.gitSafe).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/server/src/services/git-diff-service.ts
+++ b/packages/server/src/services/git-diff-service.ts
@@ -9,6 +9,7 @@
  */
 
 import type { GitDiffData, GitDiffSummary, GitDiffFile, GitFileStatus, GitStageState, GitDiffTarget } from '@agent-console/shared';
+import { MERGE_BASE_REF_PREFIX, DEFAULT_FORK_POINT_SPEC } from '@agent-console/shared';
 import {
   getDefaultBranch,
   getMergeBaseSafe,
@@ -17,6 +18,7 @@ import {
   getStatusPorcelain,
   getUntrackedFiles,
   gitRaw,
+  gitRefExists,
   gitSafe,
 } from '../lib/git.js';
 import { readFile, stat } from 'fs/promises';
@@ -43,23 +45,111 @@ interface FileStatusInfo {
 // ============================================================
 
 /**
- * Calculate the base commit for diff comparison.
- * Uses merge-base between default branch (main/master) and HEAD.
+ * Resolve the repository's first (root) commit hash. `rev-list --max-parents=0`
+ * can emit multiple root hashes when unrelated histories were merged, so take
+ * only the first line. Returns null when there is no commit.
+ */
+async function getFirstCommit(repoPath: string): Promise<string | null> {
+  const result = await gitSafe(['rev-list', '--max-parents=0', 'HEAD'], repoPath);
+  return result?.split('\n')[0] ?? null;
+}
+
+/**
+ * Resolve the repository's default fork point to a commit hash.
+ *
+ * Resolution chain (the first non-null wins):
+ * 1. merge-base with `origin/<default>` when `origin/<default>` exists
+ * 2. merge-base with the local `<default>` branch when a default branch exists
+ * 3. the repository's first commit (`rev-list --max-parents=0 HEAD`)
+ *
+ * Returns null only when every step fails (e.g. unrelated histories with no
+ * default branch and no first commit).
  *
  * @param repoPath - Path to the git repository
  * @returns Base commit hash, or null if cannot be determined
  */
-export async function calculateBaseCommit(repoPath: string): Promise<string | null> {
+async function resolveDefaultForkPoint(repoPath: string): Promise<string | null> {
   const defaultBranch = await getDefaultBranch(repoPath);
-  if (!defaultBranch) {
-    // If no default branch, fall back to first commit
-    const firstCommit = await gitSafe(['rev-list', '--max-parents=0', 'HEAD'], repoPath);
-    return firstCommit;
+
+  if (defaultBranch) {
+    const originRef = `origin/${defaultBranch}`;
+    if (await gitRefExists(originRef, repoPath)) {
+      const mergeBase = await getMergeBaseSafe(originRef, 'HEAD', repoPath);
+      if (mergeBase) {
+        return mergeBase;
+      }
+    }
+
+    const localMergeBase = await getMergeBaseSafe(defaultBranch, 'HEAD', repoPath);
+    if (localMergeBase) {
+      return localMergeBase;
+    }
   }
 
-  // Get merge-base between default branch and HEAD
-  const mergeBase = await getMergeBaseSafe(defaultBranch, 'HEAD', repoPath);
-  return mergeBase;
+  // No default branch (or merge-base unavailable): fall back to first commit.
+  return getFirstCommit(repoPath);
+}
+
+/**
+ * Compute the concrete default base *spec* at git-diff worker creation time.
+ *
+ * Produces a spec (intent) that is re-resolved on every diff via
+ * {@link resolveBaseSpec} — NOT a frozen commit hash. This keeps the diff base
+ * tracking the moving fork point as the feature branch absorbs upstream commits.
+ *
+ * - `origin/<default>` exists → `merge-base:origin/<default>`
+ * - default branch exists (no origin ref) → `merge-base:<default>`
+ * - no default branch → the repository's first commit hash (an explicit pinned
+ *   hash is correct here since there is no branch to track), or `'HEAD'` when
+ *   even that cannot be resolved.
+ *
+ * @param repoPath - Path to the git repository
+ * @returns A base spec string (never null)
+ */
+export async function computeDefaultBaseSpec(repoPath: string): Promise<string> {
+  const defaultBranch = await getDefaultBranch(repoPath);
+
+  if (defaultBranch) {
+    if (await gitRefExists(`origin/${defaultBranch}`, repoPath)) {
+      return `${MERGE_BASE_REF_PREFIX}origin/${defaultBranch}`;
+    }
+    return `${MERGE_BASE_REF_PREFIX}${defaultBranch}`;
+  }
+
+  // No default branch: pin to the first commit (no branch to track).
+  const firstCommit = await getFirstCommit(repoPath);
+  return firstCommit ?? 'HEAD';
+}
+
+/**
+ * Resolve a persisted base *spec* to a concrete commit hash at diff time.
+ *
+ * Spec kinds:
+ * - `DEFAULT_FORK_POINT_SPEC` sentinel → the default fork-point chain
+ *   (origin merge-base → local merge-base → first commit). Falls back
+ *   gracefully and never hard-fails when a default exists.
+ * - `merge-base:<ref>` → `git merge-base <ref> HEAD`. Returns null on genuine
+ *   failure (unrelated histories / deleted ref) so the caller surfaces an error
+ *   — no silent fallback for an explicit merge-base spec.
+ * - branch name or explicit hash → `git rev-parse`. Branch names re-resolve to
+ *   tip; hashes stay pinned.
+ *
+ * @param spec - The persisted base spec
+ * @param repoPath - Path to the git repository
+ * @returns Resolved commit hash, or null on genuine resolution failure
+ */
+export async function resolveBaseSpec(spec: string, repoPath: string): Promise<string | null> {
+  if (spec === DEFAULT_FORK_POINT_SPEC) {
+    return resolveDefaultForkPoint(repoPath);
+  }
+
+  if (spec.startsWith(MERGE_BASE_REF_PREFIX)) {
+    const ref = spec.slice(MERGE_BASE_REF_PREFIX.length);
+    return getMergeBaseSafe(ref, 'HEAD', repoPath);
+  }
+
+  // Branch name or explicit commit hash.
+  return resolveRef(spec, repoPath);
 }
 
 /**

--- a/packages/server/src/services/session-metadata-service.ts
+++ b/packages/server/src/services/session-metadata-service.ts
@@ -14,14 +14,13 @@
 
 import type { Session } from '@agent-console/shared';
 import type { InternalSession } from './internal-types.js';
-import type { PersistedSession, PersistedWorker } from './persistence-service.js';
+import type { PersistedSession } from './persistence-service.js';
 import type { SessionRepository } from '../repositories/index.js';
 import type { SessionLifecycleCallbacks } from './session-lifecycle-types.js';
 import {
   getCurrentBranch as gitGetCurrentBranch,
   renameBranch as gitRenameBranch,
 } from '../lib/git.js';
-import { calculateBaseCommit } from './git-diff-service.js';
 import { createLogger } from '../lib/logger.js';
 
 const logger = createLogger('session-metadata');
@@ -144,28 +143,10 @@ export class SessionMetadataService {
       return { success: true, branch: newBranch };
     }
 
-    // Update base commit for git-diff workers
-    let updatedWorkers: typeof metadata.workers | undefined;
-    try {
-      const newBaseCommit = await calculateBaseCommit(metadata.locationPath);
-      const resolvedBaseCommit = newBaseCommit ?? 'HEAD';
-      updatedWorkers = metadata.workers.map(w => {
-        if (w.type === 'git-diff') {
-          return { ...w, baseCommit: resolvedBaseCommit };
-        }
-        return w;
-      });
-    } catch (diffUpdateError) {
-      logger.error(
-        { sessionId, err: diffUpdateError },
-        'Failed to update git-diff workers after branch sync for inactive session'
-      );
-    }
-
+    // Git-diff workers persist a branch-agnostic base *spec* that re-resolves on
+    // every diff (Issue #800), so a branch sync does NOT require recomputing or
+    // freezing a base hash here. Leave each worker's spec unchanged.
     const toSave = { ...metadata, worktreeId: newBranch };
-    if (updatedWorkers !== undefined) {
-      toSave.workers = updatedWorkers;
-    }
     await this.deps.sessionRepository.save(toSave);
 
     logger.info({ sessionId, newBranch }, 'Branch synced from git (inactive session)');
@@ -184,7 +165,6 @@ export class SessionMetadataService {
 
     const result: SessionMetadataUpdateResult = { success: true };
     let updatedTitle: string | undefined;
-    let updatedWorkers: PersistedWorker[] | undefined;
     let updatedWorktreeId: string | undefined;
 
     // Title update
@@ -208,24 +188,10 @@ export class SessionMetadataService {
         return { success: false, error: message };
       }
 
-      // Update git-diff workers' base commit after successful branch rename.
-      // This is a secondary concern - failure should not abort the branch rename.
-      try {
-        const newBaseCommit = await calculateBaseCommit(metadata.locationPath);
-        const resolvedBaseCommit = newBaseCommit ?? 'HEAD';
-        updatedWorkers = metadata.workers.map(w => {
-          if (w.type === 'git-diff') {
-            return { ...w, baseCommit: resolvedBaseCommit };
-          }
-          return w;
-        });
-      } catch (diffUpdateError) {
-        logger.error(
-          { sessionId, err: diffUpdateError },
-          'Failed to update git-diff workers after branch rename for inactive session'
-        );
-      }
-
+      // Git-diff workers persist a branch-agnostic base *spec* that re-resolves
+      // on every diff (Issue #800), so a branch rename does NOT require
+      // recomputing or freezing a base hash here. Leave each worker's spec
+      // unchanged.
       updatedWorktreeId = updates.branch;
       result.branch = updates.branch;
     }
@@ -238,11 +204,6 @@ export class SessionMetadataService {
       }
       if (updatedWorktreeId !== undefined && toSave.type === 'worktree') {
         toSave.worktreeId = updatedWorktreeId;
-        // If calculateBaseCommit threw, updatedWorkers is undefined and we preserve
-        // the original metadata.workers via the ...metadata spread above.
-        if (updatedWorkers !== undefined) {
-          toSave.workers = updatedWorkers;
-        }
       }
       await this.deps.sessionRepository.save(toSave);
     }

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -39,7 +39,7 @@ import type { AgentManager } from './agent-manager.js';
 import type { NotificationManager } from './notifications/notification-manager.js';
 import type { InterSessionMessageService } from './inter-session-message-service.js';
 import type { AnnotationService } from './annotation-service.js';
-import { stopWatching, calculateBaseCommit } from './git-diff-service.js';
+import { stopWatching } from './git-diff-service.js';
 import {
   getCurrentBranch as gitGetCurrentBranch,
   renameBranch as gitRenameBranch,
@@ -464,26 +464,26 @@ export class WorkerLifecycleManager {
   }
 
   /**
-   * Update git-diff workers' base commit after a branch rename.
-   * Recalculates the merge-base once and updates all git-diff workers.
-   * Fires onDiffBaseCommitChanged callback for each updated worker.
+   * Re-push git-diff workers' diff after a branch rename.
+   *
+   * In the spec-based model (Issue #800) the persisted base *spec* is
+   * branch-agnostic and re-resolves to the moving fork point on every diff, so
+   * a branch rename does NOT require freezing a new base hash. We keep each
+   * worker's `baseCommit` spec unchanged and fire `onDiffBaseCommitChanged`
+   * (passing the spec) so connected clients receive a freshly re-resolved diff.
+   *
    * Does NOT persist the session - callers are responsible for persistence.
    */
   async updateGitDiffWorkersAfterBranchRename(sessionId: string): Promise<void> {
     const session = this.deps.getSession(sessionId);
     if (!session) return;
 
-    // Calculate base commit once for the session (same locationPath for all workers)
-    const newBaseCommit = await calculateBaseCommit(session.locationPath);
-    const resolvedBaseCommit = newBaseCommit ?? 'HEAD';
-
     for (const worker of session.workers.values()) {
       if (worker.type !== 'git-diff') continue;
 
-      worker.baseCommit = resolvedBaseCommit;
-
+      // Spec stays unchanged; re-push so the diff re-resolves against the new branch.
       this.deps.getSessionLifecycleCallbacks()?.onDiffBaseCommitChanged?.(
-        sessionId, worker.id, resolvedBaseCommit
+        sessionId, worker.id, worker.baseCommit
       );
     }
   }

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -42,7 +42,7 @@ import { ActivityDetector } from './activity-detector.js';
 import { CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
 import type { AgentManager } from './agent-manager.js';
 import { expandTemplate } from '../lib/template.js';
-import { calculateBaseCommit, resolveRef } from './git-diff-service.js';
+import { computeDefaultBaseSpec } from './git-diff-service.js';
 import { serverConfig } from '../lib/server-config.js';
 import type { WorkerOutputFileManager } from '../lib/worker-output-file.js';
 import { createLogger } from '../lib/logger.js';
@@ -258,27 +258,27 @@ export class WorkerManager {
   }
 
   /**
-   * Initialize a git-diff worker (async for base commit calculation).
+   * Initialize a git-diff worker (async for base spec computation).
+   *
+   * The worker stores a base *spec* (intent), not a frozen commit hash. The
+   * spec is re-resolved to a concrete hash on every diff computation, so the
+   * diff base tracks the moving fork point as the branch absorbs upstream
+   * commits (Issue #800).
    */
   async initializeGitDiffWorker(params: GitDiffWorkerInitParams): Promise<InternalGitDiffWorker> {
     const { id, name, createdAt, locationPath, baseCommit } = params;
 
-    let resolvedBaseCommit: string;
-
-    if (baseCommit) {
-      const resolved = await resolveRef(baseCommit, locationPath);
-      resolvedBaseCommit = resolved ?? 'HEAD';
-    } else {
-      const mergeBase = await calculateBaseCommit(locationPath);
-      resolvedBaseCommit = mergeBase ?? 'HEAD';
-    }
+    // An explicitly-provided baseCommit is treated as a verbatim spec (caller
+    // intent — e.g. a branch name or commit hash), not pre-resolved. Otherwise
+    // compute the default base spec for this repository.
+    const baseSpec = baseCommit ?? (await computeDefaultBaseSpec(locationPath));
 
     const worker: InternalGitDiffWorker = {
       id,
       type: 'git-diff',
       name,
       createdAt,
-      baseCommit: resolvedBaseCommit,
+      baseCommit: baseSpec,
     };
 
     return worker;

--- a/packages/server/src/websocket/__tests__/git-diff-handler.test.ts
+++ b/packages/server/src/websocket/__tests__/git-diff-handler.test.ts
@@ -10,7 +10,7 @@ describe('GitDiffHandler', () => {
   let sentMessages: string[];
   let mockGetDiffData: ReturnType<typeof mock>;
   let mockResolveRef: ReturnType<typeof mock>;
-  let mockGetMergeBase: ReturnType<typeof mock>;
+  let mockResolveBaseSpec: ReturnType<typeof mock>;
   let mockStartWatching: ReturnType<typeof mock>;
   let mockStopWatching: ReturnType<typeof mock>;
   let handlers: ReturnType<typeof createGitDiffHandlers>;
@@ -47,11 +47,22 @@ describe('GitDiffHandler', () => {
       }
       return null;
     });
-    mockGetMergeBase = mock(async (ref1: string, _ref2: string) => {
-      if (ref1 === 'main' || ref1 === 'master') {
+    // Default: re-resolution returns the spec verbatim (identity) so existing
+    // hash-based assertions hold. Specific cases override this per-test.
+    mockResolveBaseSpec = mock(async (spec: string) => {
+      if (spec === 'merge-base:main') {
         return 'merge-base-commit-hash';
       }
-      return null;
+      if (spec === 'merge-base:nonexistent-branch') {
+        return null;
+      }
+      if (spec === 'main') {
+        return 'resolved-commit-hash';
+      }
+      if (spec === 'invalid-branch') {
+        return null;
+      }
+      return spec;
     });
     mockStartWatching = mock(() => {});
     mockStopWatching = mock(() => {});
@@ -59,7 +70,7 @@ describe('GitDiffHandler', () => {
     const deps: GitDiffHandlerDependencies = {
       getDiffData: mockGetDiffData,
       resolveRef: mockResolveRef,
-      getMergeBase: mockGetMergeBase,
+      resolveBaseSpec: mockResolveBaseSpec,
       startWatching: mockStartWatching,
       stopWatching: mockStopWatching,
       getFileLines: mock(() => Promise.resolve([])),
@@ -194,56 +205,55 @@ describe('GitDiffHandler', () => {
     });
 
     describe('set-base-commit message', () => {
-      it('should resolve ref and send diff data for valid ref', async () => {
+      it('should store the ref as the base spec and re-resolve it on diff for a valid ref', async () => {
         await connectWorker('old-base');
 
         await sendMessage(JSON.stringify({ type: 'set-base-commit', ref: 'main' }));
 
-        expect(mockResolveRef).toHaveBeenCalledWith('main', '/repo/path');
+        // The raw ref is stored as the spec and re-resolved via resolveBaseSpec.
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('main', '/repo/path');
         expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'resolved-commit-hash', 'working-dir');
 
         const sentMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
         expect(sentMsg.type).toBe('diff-data');
       });
 
-      it('should send error for invalid ref', async () => {
+      it('should surface an error (not a silent empty diff) when the spec cannot be resolved', async () => {
         await connectWorker('old-base');
 
         await sendMessage(JSON.stringify({ type: 'set-base-commit', ref: 'invalid-branch' }));
 
-        expect(mockResolveRef).toHaveBeenCalledWith('invalid-branch', '/repo/path');
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('invalid-branch', '/repo/path');
         expect(mockGetDiffData).not.toHaveBeenCalled();
 
         const sentMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
         expect(sentMsg.type).toBe('diff-error');
-        expect((sentMsg as { error: string }).error).toContain('Invalid ref');
+        expect((sentMsg as { error: string }).error).toContain('Could not resolve diff base: invalid-branch');
       });
 
-      it('should call getMergeBase and send diff data for merge-base: prefix', async () => {
+      it('should re-resolve a merge-base: spec on diff', async () => {
         await connectWorker('old-base');
 
         await sendMessage(JSON.stringify({ type: 'set-base-commit', ref: 'merge-base:main' }));
 
-        expect(mockGetMergeBase).toHaveBeenCalledWith('main', 'HEAD', '/repo/path');
-        expect(mockResolveRef).not.toHaveBeenCalled();
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('merge-base:main', '/repo/path');
         expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'merge-base-commit-hash', 'working-dir');
 
         const sentMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
         expect(sentMsg.type).toBe('diff-data');
       });
 
-      it('should send error when getMergeBase returns null for merge-base: prefix', async () => {
+      it('should surface an error when a merge-base: spec resolves to null (unrelated histories / deleted ref)', async () => {
         await connectWorker('old-base');
 
         await sendMessage(JSON.stringify({ type: 'set-base-commit', ref: 'merge-base:nonexistent-branch' }));
 
-        expect(mockGetMergeBase).toHaveBeenCalledWith('nonexistent-branch', 'HEAD', '/repo/path');
-        expect(mockResolveRef).not.toHaveBeenCalled();
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('merge-base:nonexistent-branch', '/repo/path');
         expect(mockGetDiffData).not.toHaveBeenCalled();
 
         const sentMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
         expect(sentMsg.type).toBe('diff-error');
-        expect((sentMsg as { error: string }).error).toContain("Could not find fork point from 'nonexistent-branch'");
+        expect((sentMsg as { error: string }).error).toContain('Could not resolve diff base: merge-base:nonexistent-branch');
       });
     });
 
@@ -294,7 +304,7 @@ describe('GitDiffHandler', () => {
         const deps = {
           getDiffData: mockGetDiffData,
           resolveRef: mockResolveRef,
-          getMergeBase: mockGetMergeBase,
+          resolveBaseSpec: mockResolveBaseSpec,
           startWatching: mockStartWatching,
           stopWatching: mockStopWatching,
           getFileLines: mock(() => Promise.resolve(['line1', 'line2', 'line3'])),
@@ -340,7 +350,7 @@ describe('GitDiffHandler', () => {
         const deps: GitDiffHandlerDependencies = {
           getDiffData: mockGetDiffData,
           resolveRef: mockResolveRef,
-          getMergeBase: mockGetMergeBase,
+          resolveBaseSpec: mockResolveBaseSpec,
           startWatching: mockStartWatching,
           stopWatching: mockStopWatching,
           getFileLines: mock(() => Promise.reject(new Error('Invalid file path: ../etc/passwd'))),
@@ -383,7 +393,7 @@ describe('GitDiffHandler', () => {
         const deps: GitDiffHandlerDependencies = {
           getDiffData: mockGetDiffData,
           resolveRef: mockResolveRef,
-          getMergeBase: mockGetMergeBase,
+          resolveBaseSpec: mockResolveBaseSpec,
           startWatching: mockStartWatching,
           stopWatching: mockStopWatching,
           getFileLines: mock(() => Promise.reject(new Error('File not found'))),

--- a/packages/server/src/websocket/__tests__/git-diff-handler.test.ts
+++ b/packages/server/src/websocket/__tests__/git-diff-handler.test.ts
@@ -255,6 +255,51 @@ describe('GitDiffHandler', () => {
         expect(sentMsg.type).toBe('diff-error');
         expect((sentMsg as { error: string }).error).toContain('Could not resolve diff base: merge-base:nonexistent-branch');
       });
+
+      // Validate-before-replace contract: a failed set-base-commit must NOT
+      // clobber the last good spec. The previous behavior assigned
+      // state.baseSpec before proving the new spec resolved, so a single bad
+      // ref poisoned every later refresh / file-watch send.
+      it('retains the previous base spec when re-resolution fails so later refreshes use the OLD spec', async () => {
+        await connectWorker('old-base');
+
+        // 'invalid-branch' resolves to null in the mock -> send must fail.
+        await sendMessage(JSON.stringify({ type: 'set-base-commit', ref: 'invalid-branch' }));
+
+        const failMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
+        expect(failMsg.type).toBe('diff-error');
+        expect((failMsg as { error: string }).error).toContain('Could not resolve diff base: invalid-branch');
+
+        sentMessages = [];
+        mockGetDiffData.mockClear();
+
+        // A subsequent refresh must diff against the OLD good spec, not the bad one.
+        await sendMessage(JSON.stringify({ type: 'refresh' }));
+
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('old-base', '/repo/path');
+        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'old-base', 'working-dir');
+
+        const refreshMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
+        expect(refreshMsg.type).toBe('diff-data');
+      });
+
+      it('commits the new base spec when re-resolution succeeds', async () => {
+        await connectWorker('old-base');
+
+        await sendMessage(JSON.stringify({ type: 'set-base-commit', ref: 'main' }));
+
+        const setMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
+        expect(setMsg.type).toBe('diff-data');
+
+        sentMessages = [];
+        mockGetDiffData.mockClear();
+
+        // A subsequent refresh uses the newly committed spec, not 'old-base'.
+        await sendMessage(JSON.stringify({ type: 'refresh' }));
+
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('main', '/repo/path');
+        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'resolved-commit-hash', 'working-dir');
+      });
     });
 
     describe('refresh after set-base-commit', () => {
@@ -480,6 +525,27 @@ describe('GitDiffHandler', () => {
       await sendMessage(JSON.stringify({ type: 'refresh' }));
 
       expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'updated-base', 'working-dir');
+    });
+
+    // Validate-before-replace: a server-pushed spec that fails to resolve must
+    // not clobber the last good spec.
+    it('retains the old base spec when the pushed spec is unresolvable', async () => {
+      await connectWorker('original-base');
+
+      // 'invalid-branch' resolves to null in the mock -> update must fail.
+      await handlers.updateBaseCommit('worker-1', 'invalid-branch');
+
+      const failMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
+      expect(failMsg.type).toBe('diff-error');
+      expect((failMsg as { error: string }).error).toContain('Could not resolve diff base: invalid-branch');
+
+      sentMessages = [];
+      mockGetDiffData.mockClear();
+
+      // A subsequent refresh must diff against the OLD good spec, not the bad one.
+      await sendMessage(JSON.stringify({ type: 'refresh' }));
+
+      expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'original-base', 'working-dir');
     });
   });
 });

--- a/packages/server/src/websocket/git-diff-handler.ts
+++ b/packages/server/src/websocket/git-diff-handler.ts
@@ -48,18 +48,24 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
    * The base *spec* is re-resolved to a concrete commit hash on every call, so
    * the diff base tracks the moving fork point (Issue #800). If the spec cannot
    * be resolved, an error is surfaced instead of a silent empty diff.
+   *
+   * Returns `true` when diff data was sent, `false` when an error was surfaced
+   * (resolution failed or getDiffData threw). Callers that mutate
+   * `state.baseSpec` use this signal to commit the new spec only after a
+   * successful send (validate-before-replace), so a single bad spec never
+   * clobbers the last good one.
    */
   async function sendDiffData(
     ws: WSContext,
     locationPath: string,
     baseSpec: string,
     targetRef: GitDiffTarget = 'working-dir'
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       const resolved = await resolveBaseSpec(baseSpec, locationPath);
       if (resolved === null) {
         sendError(ws, `Could not resolve diff base: ${baseSpec}`);
-        return;
+        return false;
       }
       const diffData = await getDiffData(locationPath, resolved, targetRef);
       const msg: GitDiffServerMessage = {
@@ -67,9 +73,11 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
         data: diffData,
       };
       ws.send(JSON.stringify(msg));
+      return true;
     } catch (e) {
       const error = e instanceof Error ? e.message : 'Failed to get diff data';
       sendError(ws, error);
+      return false;
     }
   }
 
@@ -164,12 +172,14 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
           break;
 
         case 'set-base-commit': {
-          // Store the raw ref as the connection-local base spec. sendDiffData
-          // re-resolves it (merge-base:, branch name, or hash) and surfaces an
-          // error if resolution fails. This change is connection-local and is
-          // not persisted (matching the prior behavior).
-          state.baseSpec = parsed.ref;
-          await sendDiffData(ws, locationPath, state.baseSpec, currentTargetRef);
+          // Validate-before-replace: re-resolve the raw ref (merge-base:,
+          // branch name, or hash) via sendDiffData and only commit the new spec
+          // when the send succeeds. If resolution fails, sendError is surfaced
+          // and state.baseSpec retains its last good value, so later refreshes
+          // and file-watch sends keep producing the previous diff instead of
+          // reusing a bad spec. This change is connection-local (not persisted).
+          const ok = await sendDiffData(ws, locationPath, parsed.ref, currentTargetRef);
+          if (ok) state.baseSpec = parsed.ref;
           break;
         }
 
@@ -236,6 +246,10 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
   /**
    * Update the base spec for an active connection and send fresh diff data.
    * If no active connection exists for the workerId, silently returns.
+   *
+   * Validate-before-replace: the new spec is committed to `state.baseSpec` only
+   * after a successful send, so a server-pushed spec that points at a
+   * deleted/invalid ref does not clobber the last good spec.
    */
   async function updateBaseCommit(workerId: string, newBaseSpec: string): Promise<void> {
     const state = activeConnections.get(workerId);
@@ -243,8 +257,8 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
       return;
     }
 
-    state.baseSpec = newBaseSpec;
-    await sendDiffData(state.ws, state.locationPath, newBaseSpec, state.targetRef);
+    const ok = await sendDiffData(state.ws, state.locationPath, newBaseSpec, state.targetRef);
+    if (ok) state.baseSpec = newBaseSpec;
   }
 
   /**

--- a/packages/server/src/websocket/git-diff-handler.ts
+++ b/packages/server/src/websocket/git-diff-handler.ts
@@ -1,5 +1,4 @@
 import type { WSContext } from 'hono/ws';
-import { MERGE_BASE_REF_PREFIX } from '@agent-console/shared';
 import type { GitDiffClientMessage, GitDiffServerMessage, GitDiffData, GitDiffTarget, ReviewAnnotationSet } from '@agent-console/shared';
 import type { AnnotationService } from '../services/annotation-service.js';
 import { createLogger } from '../lib/logger.js';
@@ -13,7 +12,8 @@ const log = createLogger('git-diff-handler');
 export interface GitDiffHandlerDependencies {
   getDiffData: (repoPath: string, baseCommit: string, targetRef?: GitDiffTarget) => Promise<GitDiffData>;
   resolveRef: (ref: string, repoPath: string) => Promise<string | null>;
-  getMergeBase: (ref1: string, ref2: string, repoPath: string) => Promise<string | null>;
+  /** Resolve a persisted base *spec* to a concrete commit hash at diff time. */
+  resolveBaseSpec: (spec: string, repoPath: string) => Promise<string | null>;
   startWatching: (repoPath: string, onChange: () => void) => void;
   stopWatching: (repoPath: string) => void;
   getFileLines: (repoPath: string, filePath: string, startLine: number, endLine: number, ref: GitDiffTarget) => Promise<string[]>;
@@ -27,7 +27,8 @@ export interface GitDiffHandlerDependencies {
 interface ConnectionState {
   ws: WSContext;
   locationPath: string;
-  baseCommit: string;
+  /** Persisted base *spec* (intent), re-resolved to a hash on every diff. */
+  baseSpec: string;
   targetRef: GitDiffTarget;
 }
 
@@ -39,19 +40,28 @@ const activeConnections = new Map<string, ConnectionState>();
 // ============================================================
 
 export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
-  const { getDiffData, resolveRef, getMergeBase, startWatching, stopWatching, getFileLines, annotationService } = deps;
+  const { getDiffData, resolveRef, resolveBaseSpec, startWatching, stopWatching, getFileLines, annotationService } = deps;
 
   /**
    * Send diff data to the client.
+   *
+   * The base *spec* is re-resolved to a concrete commit hash on every call, so
+   * the diff base tracks the moving fork point (Issue #800). If the spec cannot
+   * be resolved, an error is surfaced instead of a silent empty diff.
    */
   async function sendDiffData(
     ws: WSContext,
     locationPath: string,
-    baseCommit: string,
+    baseSpec: string,
     targetRef: GitDiffTarget = 'working-dir'
   ): Promise<void> {
     try {
-      const diffData = await getDiffData(locationPath, baseCommit, targetRef);
+      const resolved = await resolveBaseSpec(baseSpec, locationPath);
+      if (resolved === null) {
+        sendError(ws, `Could not resolve diff base: ${baseSpec}`);
+        return;
+      }
+      const diffData = await getDiffData(locationPath, resolved, targetRef);
       const msg: GitDiffServerMessage = {
         type: 'diff-data',
         data: diffData,
@@ -83,14 +93,14 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
     sessionId: string,
     workerId: string,
     locationPath: string,
-    baseCommit: string
+    baseSpec: string
   ): Promise<void> {
     log.info({ sessionId, workerId, locationPath }, 'Git diff WebSocket connected');
 
     // Store connection state (default target is working-dir)
     const connectionKey = workerId;
     const targetRef: GitDiffTarget = 'working-dir';
-    activeConnections.set(connectionKey, { ws, locationPath, baseCommit, targetRef });
+    activeConnections.set(connectionKey, { ws, locationPath, baseSpec, targetRef });
 
     // Start file watching - when files change, send updated diff data
     // Note: File watching only makes sense for working-dir target
@@ -98,14 +108,14 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
       const state = activeConnections.get(connectionKey);
       if (state && state.targetRef === 'working-dir') {
         log.debug({ locationPath }, 'File change detected, sending updated diff');
-        sendDiffData(state.ws, state.locationPath, state.baseCommit, state.targetRef).catch((err) => {
+        sendDiffData(state.ws, state.locationPath, state.baseSpec, state.targetRef).catch((err) => {
           log.error({ err }, 'Failed to send diff data on file change');
         });
       }
     });
 
     // Send initial diff data
-    await sendDiffData(ws, locationPath, baseCommit, targetRef);
+    await sendDiffData(ws, locationPath, baseSpec, targetRef);
   }
 
   /**
@@ -150,32 +160,16 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
 
       switch (parsed.type) {
         case 'refresh':
-          await sendDiffData(ws, locationPath, state.baseCommit, currentTargetRef);
+          await sendDiffData(ws, locationPath, state.baseSpec, currentTargetRef);
           break;
 
         case 'set-base-commit': {
-          let resolved: string | null;
-
-          if (parsed.ref.startsWith(MERGE_BASE_REF_PREFIX)) {
-            // Resolve via git merge-base <branch> HEAD
-            const branchName = parsed.ref.slice(MERGE_BASE_REF_PREFIX.length);
-            resolved = await getMergeBase(branchName, 'HEAD', locationPath);
-            if (resolved) {
-              state.baseCommit = resolved;
-              await sendDiffData(ws, locationPath, resolved, currentTargetRef);
-            } else {
-              sendError(ws, `Could not find fork point from '${branchName}'`);
-            }
-          } else {
-            // Resolve via git rev-parse
-            resolved = await resolveRef(parsed.ref, locationPath);
-            if (resolved) {
-              state.baseCommit = resolved;
-              await sendDiffData(ws, locationPath, resolved, currentTargetRef);
-            } else {
-              sendError(ws, `Invalid ref: ${parsed.ref}`);
-            }
-          }
+          // Store the raw ref as the connection-local base spec. sendDiffData
+          // re-resolves it (merge-base:, branch name, or hash) and surfaces an
+          // error if resolution fails. This change is connection-local and is
+          // not persisted (matching the prior behavior).
+          state.baseSpec = parsed.ref;
+          await sendDiffData(ws, locationPath, state.baseSpec, currentTargetRef);
           break;
         }
 
@@ -195,7 +189,7 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
           }
 
           state.targetRef = targetRef;
-          await sendDiffData(ws, locationPath, state.baseCommit, targetRef);
+          await sendDiffData(ws, locationPath, state.baseSpec, targetRef);
           break;
         }
 
@@ -240,17 +234,17 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
   }
 
   /**
-   * Update the base commit for an active connection and send fresh diff data.
+   * Update the base spec for an active connection and send fresh diff data.
    * If no active connection exists for the workerId, silently returns.
    */
-  async function updateBaseCommit(workerId: string, newBaseCommit: string): Promise<void> {
+  async function updateBaseCommit(workerId: string, newBaseSpec: string): Promise<void> {
     const state = activeConnections.get(workerId);
     if (!state) {
       return;
     }
 
-    state.baseCommit = newBaseCommit;
-    await sendDiffData(state.ws, state.locationPath, newBaseCommit, state.targetRef);
+    state.baseSpec = newBaseSpec;
+    await sendDiffData(state.ws, state.locationPath, newBaseSpec, state.targetRef);
   }
 
   /**

--- a/packages/server/src/websocket/routes.ts
+++ b/packages/server/src/websocket/routes.ts
@@ -277,12 +277,11 @@ export async function setupWebSocketRoutes(
   const { sessionManager, notificationManager, agentManager, repositoryManager, annotationService } = appContext;
 
   // Initialize git-diff handlers with injected dependencies
-  const { getDiffData, getFileLines, resolveRef, startWatching, stopWatching } = await import('../services/git-diff-service.js');
-  const { getMergeBaseSafe } = await import('../lib/git.js');
+  const { getDiffData, getFileLines, resolveRef, resolveBaseSpec, startWatching, stopWatching } = await import('../services/git-diff-service.js');
   initializeGitDiffHandlers({
     getDiffData,
     resolveRef,
-    getMergeBase: getMergeBaseSafe,
+    resolveBaseSpec,
     startWatching,
     stopWatching,
     getFileLines,

--- a/packages/shared/src/types/git-diff.ts
+++ b/packages/shared/src/types/git-diff.ts
@@ -179,8 +179,16 @@ export const MERGE_BASE_REF_PREFIX = 'merge-base:';
  * commit. Because it re-resolves on every diff, the base tracks the moving
  * fork point (e.g. after the feature branch absorbs upstream commits), matching
  * GitHub's three-dot PR view.
+ *
+ * The value lives in the `reserved:` namespace. Git forbids `:` in ref names
+ * (see `git check-ref-format`), so this token can never collide with a real
+ * branch/tag — a repository may legitimately have a ref named
+ * `default-fork-point`, and it must still round-trip through `resolveBaseSpec`
+ * instead of being intercepted as the sentinel. The `reserved:` prefix is
+ * distinct from the `merge-base:` prefix and is matched by exact equality, not
+ * by `startsWith`.
  */
-export const DEFAULT_FORK_POINT_SPEC = 'default-fork-point';
+export const DEFAULT_FORK_POINT_SPEC = 'reserved:default-fork-point';
 
 // ============================================================
 // WebSocket Messages for GitDiffWorker

--- a/packages/shared/src/types/git-diff.ts
+++ b/packages/shared/src/types/git-diff.ts
@@ -52,7 +52,9 @@ export type GitDiffTarget = 'working-dir' | string;  // 'working-dir' or commit 
 
 /** Diff summary (sent via WebSocket) */
 export interface GitDiffSummary {
-  baseCommit: string;        // Comparison base commit hash
+  // Resolved commit hash actually diffed against (the persisted base *spec* is
+  // re-resolved to this on each diff).
+  baseCommit: string;
   targetRef: GitDiffTarget;  // Target: 'working-dir' or commit hash
   files: GitDiffFile[];
   totalAdditions: number;
@@ -168,6 +170,17 @@ export interface ReviewQueueGroup {
  * the server resolves it via `git merge-base <branch> HEAD` instead of `git rev-parse`.
  */
 export const MERGE_BASE_REF_PREFIX = 'merge-base:';
+
+/**
+ * Sentinel base spec persisted for migrated git-diff workers and used as a
+ * fallback. Means "resolve the repository's default fork point fresh on each
+ * diff": prefer the merge-base with `origin/<default>`, fall back to the
+ * merge-base with the local `<default>` branch, then to the repository's first
+ * commit. Because it re-resolves on every diff, the base tracks the moving
+ * fork point (e.g. after the feature branch absorbs upstream commits), matching
+ * GitHub's three-dot PR view.
+ */
+export const DEFAULT_FORK_POINT_SPEC = 'default-fork-point';
 
 // ============================================================
 // WebSocket Messages for GitDiffWorker


### PR DESCRIPTION
## Summary

The git-diff worker resolved `baseCommit` to a commit hash **once at session creation** and froze it in `workers.base_commit`. The diff was computed as `git diff <frozenHash>` thereafter, so once the feature branch absorbed upstream commits (merge of main, rebase), those upstream changes showed up as "unexpected" file diffs — diverging from GitHub's three-dot (merge-base) PR view.

This PR persists the base **spec** (intent) instead of the resolved hash and **re-resolves it on every diff computation**.

Closes #800

## What changed

**Resolution model (`packages/shared`, `packages/server`)**
- New `DEFAULT_FORK_POINT_SPEC` sentinel + `resolveBaseSpec()` / `computeDefaultBaseSpec()` in `git-diff-service.ts`.
  - `merge-base:<ref>` and branch-name specs re-resolve every diff; explicit commit-hash specs stay **pinned**.
  - Resolution failure (unrelated histories / deleted ref) surfaces an error via the existing `sendError` / `ValidationError` path — **not** a silent empty diff.
  - `getFirstCommit()` takes only the first line of `rev-list --max-parents=0 HEAD` (repos with merged unrelated histories can emit multiple roots).
- New git-diff workers default to `merge-base:origin/<default>`, falling back to `merge-base:<default>` (local), then the first commit.
- WebSocket handler holds the base **spec** (re-resolved on each send); REST `/diff` and `/diff/file` routes resolve the spec first.
- Branch-rename path keeps the spec unchanged (it re-resolves automatically) instead of freezing a new hash — same fix applied to the **inactive-session** rename path in `session-metadata-service.ts` (sibling call site, bundled per design-principles).

**DB migration**
- `migrateToV21` resets existing git-diff workers' frozen `base_commit` to the sentinel spec. Note: user-pinned explicit bases can't be distinguished from auto-frozen merge-bases at the DB layer, so they're reset to the default spec too (acceptable per the Issue).

**UI (`packages/client`)**
- `BaseCommitSelector` now exposes **both** merge-base variants explicitly — `Fork point from origin/<default>` (shown when the remote default exists, listed first) and `Fork point from <default>` (local) — so the comparison target is never ambiguous.

**Docs**
- `docs/glossary.md`: added `GitDiffWorker` and `Base Spec` entries (glossary-maintenance trigger).

## Boundary behaviors covered (acceptance criteria)

- `origin/<default>` exists → default `merge-base:origin/<default>`; no remote default → `merge-base:<default>`; no default branch → first-commit fallback preserved.
- `git merge-base` failure → error surfaced to the client, not a silent empty diff.
- **Regression (the symptom):** real-repo test — after merging the default branch into the feature branch, the diff does **NOT** include upstream-only changes (base re-resolves to the new fork point). The test also asserts the merge-base actually advanced (`resolved2 !== resolved1`), proving re-resolution happened.
- Explicit commit-hash base remains pinned across diffs; branch names re-resolve to tip.
- Multi-root first-commit edge case; migration v21; selector entry rendering/ordering.

## TDD / polarity

Per `workflow.md`, the real-repo regression test was written first and its polarity verified: against the old frozen-hash model (resolve once, reuse) the upstream-only file **is** included; the shipping fix re-resolves so it is excluded.

## Verification

- `bun run typecheck` → exit 0.
- `bun run test` (full suite) → exit 0 (server 2535 pass / client 1396 pass / shared 324 pass / integration 29 pass / scripts 362 pass).
- CodeRabbit CLI (`--base main`) → **No findings** after addressing the 2 minor multi-root findings.

## Notes / observations

- Manual `set-base-commit` changes remain connection-local (not persisted) — this matches prior behavior and is out of scope for this fix; flagged for potential follow-up.
- The design docs (`session-worker-design.md`, `websocket-protocol.md`) do not document the git-diff worker's base-commit behavior at all (they predate the feature), so there was no frozen-hash spec to update; the new contract is documented in `docs/glossary.md` instead.
- Browser QA of the selector's true-path (both merge-base entries visible) was deferred — it needs a running dev server + a git-diff worker against a repo with both `origin/<default>` and a local default; please dogfood post-merge. Behavior is covered by 5 new unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
