### PR TITLE
feat: add Docker verification environment for multi-user mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Build context exclusions for the multi-user verification image (docker/Dockerfile).
+# Keep the context small and avoid copying host-built artifacts that must be
+# rebuilt inside the Linux container (bun-pty native module in particular).
+**/node_modules
+dist
+**/dist
+.git
+.agent-console*
+*.log
+.DS_Store
+packages/client/src/routeTree.gen.ts

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,123 @@
+# Multi-user verification image for Agent Console (AUTH_MODE=multi-user).
+#
+# Purpose: run the already-implemented multi-user mode on a real Linux box so we
+# can verify OS authentication (pamtester) and per-user PTY identity isolation
+# (sudo -u <user>) end to end. This is a VERIFICATION environment, not a
+# production deployment recipe — production should use systemd + TLS (see
+# docs/multi-user-setup-guide.md).
+#
+# Base image: oven/bun (Debian). Both stages share the same base so the bun-pty
+# native module installed in the runtime stage matches the runtime glibc.
+#
+# The default BUN_BASE is a directly-pullable fixed tag so a clean environment
+# (CI, another machine) can `docker build` this without any local cache. The
+# in-image step below normalizes bun to BUN_VERSION (>= 1.3.5, required by
+# Bun.Terminal and the repo's preinstall gate), so you may override BUN_BASE
+# with an older locally-cached base when registry pulls are unavailable, e.g.:
+#   DOCKER_BUILDKIT=0 docker build --build-arg BUN_BASE=oven/bun:1.3.4 ...
+# See docker/README.md ("Building behind a blocked Docker Hub").
+
+ARG BUN_BASE=oven/bun:1.3.8
+ARG BUN_VERSION=1.3.8
+
+# ===== Stage 1: build the standalone dist bundle =====
+FROM ${BUN_BASE} AS builder
+ARG BUN_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    BUN_INSTALL=/usr/local
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl unzip ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
+ && bun --version
+
+WORKDIR /app
+COPY . .
+# Full install (dev deps are needed for the client/server build). The preinstall
+# bun-version gate and the minimumReleaseAge supply-chain gate both run here.
+RUN bun install --frozen-lockfile
+# Produces /app/dist/{index.js, package.json, public/}.
+RUN bun run build
+
+# ===== Stage 2: runtime as the non-root service user =====
+FROM ${BUN_BASE} AS runtime
+ARG BUN_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    BUN_INSTALL=/usr/local
+
+# Runtime OS dependencies:
+# - sudo:          the server spawns PTYs via `sudo -u <user> -i`
+# - pamtester:     Linux OS-credential validation (MultiUserMode.validateLinux)
+# - libpam-modules / login: provide /etc/pam.d/login + pam_unix/unix_chkpwd
+# - passwd:        useradd/chpasswd for creating test users
+# - git:           agents/worktrees expect git on PATH
+# - procps:        ps/whoami diagnostics inside the container
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      curl unzip ca-certificates \
+      sudo pamtester libpam-modules libpam-runtime login passwd git procps \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
+ && bun --version \
+ && test -f /etc/pam.d/login
+
+# --- Service user (runs the server process; non-root) ---
+# Added to the `shadow` group so pam_unix can read /etc/shadow and verify any
+# user's password in-process. Without this, a non-root caller falls back to the
+# unix_chkpwd helper, which only permits verifying the caller's OWN password —
+# so every login would 401. (Discovered via this verification environment;
+# documented in docs/multi-user-setup-guide.md.)
+RUN useradd --create-home --shell /usr/sbin/nologin agentconsole \
+ && usermod -aG shadow agentconsole
+
+# --- sudoers: allow the service user to launch login shells as other users ---
+COPY docker/sudoers-agentconsole /etc/sudoers.d/agentconsole
+RUN chmod 0440 /etc/sudoers.d/agentconsole \
+ && visudo -cf /etc/sudoers.d/agentconsole
+
+# --- Test OS users with known passwords (VERIFICATION ONLY) ---
+# Passwords are intentionally well-known; this image must never be exposed.
+#
+# Home dirs are set to 0711 (traversable but not readable by others). The server
+# spawns `sudo -u <user> -i` with the session's working directory as the PTY
+# cwd, and the forked child performs chdir(cwd) WHILE STILL the service user
+# (before sudo switches to the target user). Debian's default HOME_MODE=0700
+# would deny that chdir and the spawn fails with "PTY spawn failed". 0711 lets
+# the service user enter the directory without exposing its contents. This
+# mirrors the real-deployment requirement documented in
+# docs/multi-user-setup-guide.md ("service user must be able to enter session
+# working directories").
+RUN useradd --create-home --shell /bin/bash alice \
+ && useradd --create-home --shell /bin/bash bob \
+ && echo 'alice:alice-password' | chpasswd \
+ && echo 'bob:bob-password' | chpasswd \
+ && chmod 0711 /home/alice /home/bob
+
+# --- Application bundle ---
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+# Install the native bun-pty binary for this platform into the dist bundle.
+RUN cd dist && bun install
+
+# Data directory (DB, jwt-secret, worker output) owned by the service user.
+ENV AGENT_CONSOLE_HOME=/home/agentconsole/.agent-console
+RUN mkdir -p "${AGENT_CONSOLE_HOME}" \
+ && chown -R agentconsole:agentconsole "${AGENT_CONSOLE_HOME}" /app/dist
+
+# Server configuration.
+# NOTE: NODE_ENV is intentionally left UNSET. In production NODE_ENV=production
+# makes the auth cookie `secure`, which is dropped over plain HTTP — fine behind
+# TLS but it would break the localhost HTTP verification done here.
+ENV AUTH_MODE=multi-user \
+    PORT=8080 \
+    HOST=0.0.0.0 \
+    LOG_LEVEL=info
+
+# Run from inside dist/ so bun-pty resolves its native library relative to the
+# bundle's node_modules (the documented standalone layout: `cd dist && bun start`).
+WORKDIR /app/dist
+USER agentconsole
+EXPOSE 8080
+CMD ["bun", "index.js"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,117 @@
+# Multi-User Mode Verification on Docker
+
+This directory contains a **verification environment** for Agent Console's
+multi-user mode (`AUTH_MODE=multi-user`). It runs the already-implemented
+multi-user feature on real Debian Linux so we can confirm two things that cannot
+be exercised on macOS dev machines:
+
+1. **OS authentication** via `pamtester` (the Linux credential path).
+2. **Per-user PTY identity isolation** via `sudo -u <user> -i` — each logged-in
+   user's terminals and agents run under their own OS identity, not the service
+   user.
+
+> This is **not** a production deployment recipe. Production should run under
+> systemd behind TLS — see [`../docs/multi-user-setup-guide.md`](../docs/multi-user-setup-guide.md).
+
+## What's in here
+
+| File | Purpose |
+|------|---------|
+| `Dockerfile` | Two-stage build: build the `dist/` bundle, then a runtime image with `pamtester`, `sudo`, a non-root `agentconsole` service user, and two test users (`alice`, `bob`). |
+| `docker-compose.yml` | Starts the server in `AUTH_MODE=multi-user` on host port `8080`. |
+| `sudoers-agentconsole` | Grants the service user permission to launch login shells as any non-root user. |
+| `verify-client.ts` | Drives the real shipping path (login → session → terminal worker → WS) and asserts `whoami` inside the PTY. |
+| `../scripts/verify-multiuser-docker.sh` | One-command orchestrator: build, start, run all checks, report. |
+
+## Running the verification
+
+From the repository root (requires `docker` and `bun` on the host):
+
+```bash
+scripts/verify-multiuser-docker.sh
+```
+
+This builds the image, starts the container, runs every check, prints a
+pass/fail summary, and tears the container down. Useful flags:
+
+- `--keep` — leave the container running afterwards (inspect at http://localhost:8080).
+- `--no-build` — reuse the already-built image.
+- `PORT=9090 scripts/verify-multiuser-docker.sh` — map a different host port.
+
+### What it checks
+
+1. `GET /api/config` reports `"authMode":"multi-user"`.
+2. An unauthenticated request to a protected route returns `401`.
+3. Login with a wrong password returns `401` (proves `pamtester` is actually running).
+4. `alice` / `bob` log in successfully (`200`).
+5. **Identity isolation**: `alice`'s terminal `whoami` prints `alice`, `bob`'s
+   prints `bob` — never the `agentconsole` service user.
+
+## Test credentials (verification only)
+
+| User | Password | Role |
+|------|----------|------|
+| `agentconsole` | _(none, `nologin`)_ | service user that runs the server |
+| `alice` | `alice-password` | test end user |
+| `bob` | `bob-password` | test end user |
+
+These passwords are intentionally well-known. **Never expose this image**; it
+exists solely for local verification.
+
+## Why these OS pieces are required
+
+- **`pamtester`** — `MultiUserMode.validateLinux()` shells out to
+  `pamtester login <user> authenticate`. Without it installed, every login
+  returns `401`.
+- **`agentconsole` in the `shadow` group** — a *non-root* caller of `pam_unix`
+  can only verify another user's password if it can read `/etc/shadow`
+  directly. Without `shadow`-group membership, `pam_unix` falls back to the
+  `unix_chkpwd` helper, which only permits verifying the *caller's own*
+  password — so every login would `401`. This requirement was discovered
+  through this verification environment and is documented in the setup guide.
+- **sudoers** — `MultiUserMode.spawnSudoPty()` runs `sudo -u <user> -i sh -c`.
+  The `agentconsole` user is granted `NOPASSWD` shell access to any non-root
+  user, and nothing else.
+- **`0711` test home directories** — the PTY spawn helper `chdir`s into the
+  session's working directory _as the service user_ before `sudo` switches to
+  the target user. Debian's default `0700` home would deny that `chdir` and the
+  spawn fails with "PTY spawn failed". The image sets the test homes to `0711`
+  (traversable, not readable). This is an operational workaround; the root-cause
+  fix is tracked in
+  [issue #802](https://github.com/ms2sato/agent-console/issues/802).
+
+## Building behind a blocked Docker Hub
+
+The default `BUN_BASE` (`oven/bun:1.3.8`) is a directly-pullable fixed tag, so a
+clean environment with normal Docker Hub access builds with no extra flags:
+
+```bash
+docker build -f docker/Dockerfile -t agent-console-multiuser-verify .
+```
+
+If your environment can reach general networks (apt, npm, bun.sh) but **cannot
+pull from Docker Hub's registry** (a common corporate/proxy situation where
+`docker pull` hangs at "resolve image config"), build from a base image you
+already have cached and disable BuildKit so it never round-trips the registry:
+
+```bash
+DOCKER_BUILDKIT=0 docker build \
+  --build-arg BUN_BASE=oven/bun:1.3.4 \
+  -f docker/Dockerfile -t agent-console-multiuser-verify .
+```
+
+The in-image step normalizes bun to `BUN_VERSION` (default `1.3.8`) regardless of
+the base tag, so an older cached base still produces a `>= 1.3.5` runtime. bun
+itself is fetched from `bun.sh` and npm packages from the npm registry — neither
+goes through Docker Hub.
+
+## Notes / limitations
+
+- **HTTP, not HTTPS.** `NODE_ENV` is left unset on purpose. In production
+  (`NODE_ENV=production`) the auth cookie is marked `secure` and would be
+  dropped over plain HTTP. TLS is mandatory in real deployments.
+- **No static UI in this image.** The bundled login UI is only served when
+  `NODE_ENV=production`; verification here is API/WebSocket-driven. To click
+  through the browser UI you need `NODE_ENV=production` + TLS.
+- **arm64/amd64**: the image builds natively for the host architecture; the
+  `bun-pty` native module is installed inside the runtime stage to match.

--- a/docker/README.md
+++ b/docker/README.md
@@ -107,11 +107,15 @@ goes through Docker Hub.
 
 ## Notes / limitations
 
-- **HTTP, not HTTPS.** `NODE_ENV` is left unset on purpose. In production
-  (`NODE_ENV=production`) the auth cookie is marked `secure` and would be
-  dropped over plain HTTP. TLS is mandatory in real deployments.
+- **HTTP, not HTTPS.** `NODE_ENV` is left unset on purpose. With
+  `NODE_ENV=production` the auth cookie is marked `Secure`, which a browser only
+  sends in a secure context (HTTPS, or `http://localhost`). A network-exposed
+  plain-HTTP deployment therefore needs TLS; a localhost / SSH-port-forward
+  deployment does not. See the guide's
+  [TLS, `NODE_ENV`, and secure contexts](../docs/multi-user-setup-guide.md#tls-node_env-and-secure-contexts).
 - **No static UI in this image.** The bundled login UI is only served when
-  `NODE_ENV=production`; verification here is API/WebSocket-driven. To click
-  through the browser UI you need `NODE_ENV=production` + TLS.
+  `NODE_ENV=production` (the same flag that makes the cookie `Secure`);
+  verification here is API/WebSocket-driven. To click through the browser UI you
+  need `NODE_ENV=production` plus a secure context (HTTPS, or `http://localhost`).
 - **arm64/amd64**: the image builds natively for the host architecture; the
   `bun-pty` native module is installed inside the runtime stage to match.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,24 @@
+# Multi-user verification stack for Agent Console.
+#
+# Usage (from repo root):
+#   scripts/verify-multiuser-docker.sh           # build, start, verify, report
+#   docker compose -f docker/docker-compose.yml up --build -d   # manual start
+#
+# The server runs in AUTH_MODE=multi-user as the non-root `agentconsole` user
+# and exposes the API/WS on host port 8080.
+services:
+  agent-console:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: agent-console-multiuser-verify
+    container_name: agent-console-multiuser-verify
+    ports:
+      - "8080:8080"
+    # Health: /api/config is reachable without auth and reports authMode.
+    healthcheck:
+      test: ["CMD", "bun", "-e", "fetch('http://localhost:8080/api/config').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 5s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,8 +13,11 @@ services:
       dockerfile: docker/Dockerfile
     image: agent-console-multiuser-verify
     container_name: agent-console-multiuser-verify
+    # Bind to loopback only: this stack ships intentionally known test
+    # credentials and must never be reachable from the LAN. ${PORT:-8080} keeps
+    # the host port in sync with scripts/verify-multiuser-docker.sh's PORT env.
     ports:
-      - "8080:8080"
+      - "127.0.0.1:${PORT:-8080}:8080"
     # Health: /api/config is reachable without auth and reports authMode.
     healthcheck:
       test: ["CMD", "bun", "-e", "fetch('http://localhost:8080/api/config').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]

--- a/docker/sudoers-agentconsole
+++ b/docker/sudoers-agentconsole
@@ -1,0 +1,7 @@
+# Allow the Agent Console service user to launch login shells as any non-root
+# user, without a password. This is the ONLY sudo privilege the service user
+# gets. The server invokes: sudo -u <user> -i sh -c '...'.
+#
+# Both /bin/* and /usr/bin/* forms are listed because Ubuntu uses the usr-merge
+# layout (/bin -> /usr/bin); sudo matches the resolved command path.
+agentconsole ALL=(ALL,!root) NOPASSWD: /bin/sh, /bin/bash, /usr/bin/sh, /usr/bin/bash

--- a/docker/verify-client.ts
+++ b/docker/verify-client.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env bun
+/**
+ * Multi-user PTY identity-isolation probe.
+ *
+ * Drives the real shipping path end to end for one OS user:
+ *   login -> create quick session -> create terminal worker -> open worker WS
+ *   -> run `whoami` in the PTY -> assert the PTY runs as that OS user.
+ *
+ * The terminal echoes the command we type, and the shell prompt may itself
+ * contain the username, so we cannot just grep for the bare username. Instead we
+ * print a unique marker line `ACUSER:<whoami>` and assert on that — the echoed
+ * input contains the literal `$(whoami)`, never the expanded value, so a
+ * `ACUSER:<user>` line can only come from the command actually executing as
+ * <user>.
+ *
+ * Usage: bun docker/verify-client.ts <baseUrl> <username> <password> <expectedUser> <locationPath>
+ * Exit code 0 on success, 1 on failure. Prints a one-line RESULT summary.
+ */
+
+const [, , baseUrl, username, password, expectedUser, locationPath] = Bun.argv;
+
+if (!baseUrl || !username || !password || !expectedUser || !locationPath) {
+  console.error('usage: bun verify-client.ts <baseUrl> <username> <password> <expectedUser> <locationPath>');
+  process.exit(2);
+}
+
+const MARKER = 'ACUSER:';
+const ANSI = /\x1b\[[0-9;?]*[A-Za-z]/g;
+
+function fail(msg: string): never {
+  console.log(`RESULT ${username}: FAIL — ${msg}`);
+  process.exit(1);
+}
+
+// 1. Login and capture the auth_token cookie from Set-Cookie.
+const loginRes = await fetch(`${baseUrl}/api/auth/login`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ username, password }),
+});
+if (!loginRes.ok) {
+  fail(`login returned HTTP ${loginRes.status}`);
+}
+const setCookies = typeof loginRes.headers.getSetCookie === 'function'
+  ? loginRes.headers.getSetCookie()
+  : [loginRes.headers.get('set-cookie') ?? ''].filter(Boolean);
+const tokenCookie = setCookies.find((c) => c.includes('auth_token='));
+if (!tokenCookie) {
+  fail('login succeeded but no auth_token cookie was set');
+}
+// Extract just the "auth_token=<jwt>" pair, dropping cookie attributes.
+const match = tokenCookie!.match(/auth_token=[^;]+/);
+const cookie = match ? match[0] : tokenCookie!.split(';')[0];
+
+const authHeaders = { 'Content-Type': 'application/json', Cookie: cookie };
+
+// 2. Create a quick session owned by this user (createdBy resolves to the user).
+const sessionRes = await fetch(`${baseUrl}/api/sessions`, {
+  method: 'POST',
+  headers: authHeaders,
+  body: JSON.stringify({ type: 'quick', locationPath, title: `verify-${username}` }),
+});
+if (sessionRes.status !== 201) {
+  fail(`create session returned HTTP ${sessionRes.status}: ${await sessionRes.text()}`);
+}
+const sessionId = (await sessionRes.json()).session.id as string;
+
+// 3. Create a terminal worker (spawns `sudo -u <user> -i sh -c 'exec $SHELL -l'`).
+const workerRes = await fetch(`${baseUrl}/api/sessions/${sessionId}/workers`, {
+  method: 'POST',
+  headers: authHeaders,
+  body: JSON.stringify({ type: 'terminal' }),
+});
+if (workerRes.status !== 201) {
+  fail(`create worker returned HTTP ${workerRes.status}: ${await workerRes.text()}`);
+}
+const workerId = (await workerRes.json()).worker.id as string;
+
+// 4. Open the worker WebSocket and run the probe command.
+const wsBase = baseUrl.replace(/^http/, 'ws');
+const wsUrl = `${wsBase}/ws/session/${sessionId}/worker/${workerId}`;
+const ws = new WebSocket(wsUrl, { headers: { Cookie: cookie } } as unknown as string[]);
+
+const probe = `printf '${MARKER}%s\\n' "$(whoami)"\n`;
+let buffer = '';
+
+const result: Promise<{ ok: boolean; detail: string }> = new Promise((resolve) => {
+  const timeout = setTimeout(() => {
+    resolve({ ok: false, detail: `timed out; last output: ${JSON.stringify(buffer.slice(-200))}` });
+  }, 10_000);
+
+  let sent = false;
+  const sendProbe = () => {
+    if (sent) return;
+    sent = true;
+    ws.send(JSON.stringify({ type: 'input', data: probe }));
+  };
+
+  ws.addEventListener('open', () => {
+    // Give the login shell a moment to initialize before typing.
+    setTimeout(sendProbe, 800);
+    // Retry once in case the first keystrokes raced the shell startup.
+    setTimeout(() => ws.send(JSON.stringify({ type: 'input', data: probe })), 3000);
+  });
+
+  ws.addEventListener('message', (ev) => {
+    let msg: { type?: string; data?: string };
+    try {
+      msg = JSON.parse(typeof ev.data === 'string' ? ev.data : '');
+    } catch {
+      return;
+    }
+    if (msg.type === 'output' && typeof msg.data === 'string') {
+      buffer += msg.data;
+      const clean = buffer.replace(ANSI, '');
+      const line = clean.split(/\r?\n/).find((l) => l.includes(MARKER) && !l.includes('$(whoami)'));
+      if (line) {
+        const actual = line.slice(line.indexOf(MARKER) + MARKER.length).trim();
+        clearTimeout(timeout);
+        resolve({
+          ok: actual === expectedUser,
+          detail: `whoami => '${actual}' (expected '${expectedUser}')`,
+        });
+      }
+    }
+  });
+
+  ws.addEventListener('error', () => {
+    clearTimeout(timeout);
+    resolve({ ok: false, detail: 'websocket error' });
+  });
+});
+
+const { ok, detail } = await result;
+try {
+  ws.close();
+} catch {
+  // ignore
+}
+
+if (ok) {
+  console.log(`RESULT ${username}: PASS — ${detail}`);
+  process.exit(0);
+} else {
+  fail(detail);
+}

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -24,8 +24,39 @@ Browser (User: alice) ──> Agent Console Server (agentconsole)
 ## Prerequisites
 
 - Agent Console installed and working in single-user mode first (verify with `AUTH_MODE=none`)
+- [Bun](https://bun.com) **≥ 1.3.5** (required by `Bun.Terminal`; enforced by the repo's preinstall check)
 - Root or sudo access on the server machine (for initial setup only)
 - Linux (Ubuntu/Debian, RHEL/Fedora, etc.) or macOS
+- **Linux only:** the `pamtester` package must be installed (see [Step 0](#step-0-install-pamtester-linux-only)). Without it, **every login returns 401.**
+
+> **Want to try multi-user mode without a Linux machine?** A ready-made Docker
+> verification environment lives in [`docker/`](../docker/README.md). It builds a
+> Debian image (`oven/bun`) with `pamtester`, the service user, sudoers, and two test users,
+> then verifies authentication and per-user PTY isolation with a single command
+> (`scripts/verify-multiuser-docker.sh`). Use it to see the whole setup working
+> before reproducing it on a real host.
+
+## Step 0: Install pamtester (Linux only)
+
+On Linux, Agent Console validates OS credentials by shelling out to
+`pamtester login <user> authenticate`. This binary is **not** part of the OS
+authentication implementation but a hard runtime dependency of it — if it is
+missing, `MultiUserMode` cannot validate any password and **all logins fail with
+401**.
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install -y pamtester
+
+# RHEL / Fedora (EPEL)
+sudo dnf install -y pamtester
+```
+
+`pamtester` authenticates against the `login` PAM service, so `/etc/pam.d/login`
+must exist (it does on any standard desktop/server install; minimal container
+images may need the `login` / `libpam-modules` packages).
+
+> **macOS** uses `dscl -authonly` instead and does **not** require `pamtester`.
 
 ## Step 1: Create the Service User
 
@@ -35,12 +66,42 @@ The service user (`agentconsole`) runs the server process. It is a system accoun
 
 ```bash
 sudo useradd --system --create-home --shell /usr/sbin/nologin agentconsole
+# Required on Linux: let the service user verify other users' passwords (see below)
+sudo usermod -aG shadow agentconsole
 ```
 
 What each flag does:
 - `--system` — Creates a system account (low UID range, hidden from login screen)
 - `--create-home` — Creates `/home/agentconsole` for config and database storage
 - `--shell /usr/sbin/nologin` — Prevents direct SSH or console login
+
+#### Why the `shadow` group is required (Linux)
+
+This is the single most common reason multi-user login fails with **every login
+returning 401 despite correct passwords**, so it is worth understanding.
+
+When the server validates a password it runs `pamtester` as the **non-root**
+service user. `pam_unix` (the module that checks Unix passwords) verifies a
+password one of two ways:
+
+1. **In-process** — if it can read `/etc/shadow` directly. Only `root` and
+   members of the `shadow` group can read `/etc/shadow`.
+2. **Via the `unix_chkpwd` helper** — used when the caller cannot read
+   `/etc/shadow`. For security, `unix_chkpwd` lets a non-root caller verify
+   **only its own** password, and refuses to check any other user's.
+
+So a non-root service user that is **not** in the `shadow` group can never
+validate another user's password — every login fails. Adding `agentconsole` to
+the `shadow` group lets `pam_unix` take path (1) and validate any user's
+password in-process.
+
+> **Security trade-off**: `shadow`-group membership lets the service user read
+> all password hashes. This is inherent to non-root OS authentication on Linux.
+> The alternative is running the server as `root`, which is worse. Keep the
+> service account locked down (`nologin` shell, no other privileges) accordingly.
+
+> **macOS** does not need this — it authenticates via `dscl -authonly`, which
+> does not require reading `/etc/shadow`.
 
 Verify:
 
@@ -169,8 +230,9 @@ User=agentconsole
 Group=agentconsole
 WorkingDirectory=/home/agentconsole/agent-console
 Environment=AUTH_MODE=multi-user
-Environment=PORT=4001
+Environment=PORT=8080
 Environment=HOST=0.0.0.0
+Environment=NODE_ENV=production
 ExecStart=/home/agentconsole/.bun/bin/bun run start
 Restart=on-failure
 RestartSec=5
@@ -179,6 +241,9 @@ RestartSec=5
 WantedBy=multi-user.target
 EOF
 ```
+
+> `NODE_ENV=production` makes the auth cookie `Secure`. In production this is
+> correct **only behind TLS** (see [TLS is required](#tls-is-required-in-production)).
 
 Enable and start:
 
@@ -225,7 +290,7 @@ sudo tee /Library/LaunchDaemons/com.agentconsole.server.plist > /dev/null << 'EO
         <key>AUTH_MODE</key>
         <string>multi-user</string>
         <key>PORT</key>
-        <string>4001</string>
+        <string>8080</string>
         <key>HOST</key>
         <string>0.0.0.0</string>
     </dict>
@@ -257,17 +322,48 @@ Users do **not** need:
 
 Their existing environment (`.bashrc`, `.zshrc`, SSH keys, git config, API keys) works automatically because PTY processes run as their user via `sudo -u <user> -i`, which loads their login shell profile.
 
+### The service user must be able to enter session working directories
+
+When the server starts a PTY it spawns `sudo -u <user> -i` with the session's
+working directory as the PTY's `cwd`. The spawn helper performs `chdir(cwd)` in
+the forked child **before** `sudo` switches to the target user — i.e. while the
+process is still the service user. If the service user cannot enter that
+directory, the spawn fails with **"PTY spawn failed"** even though
+authentication succeeded.
+
+This matters when a session's working directory is a user's home directory and
+that home is mode `0700` (the default on Debian/Ubuntu, `HOME_MODE 0700`). The
+service user cannot `chdir` into a `0700` home it does not own.
+
+Ensure the service user has **traverse (execute) permission** on every directory
+used as a session working directory. The least-privilege fix for home
+directories is `0711` (traversable but not readable by others):
+
+```bash
+sudo chmod 0711 /home/alice
+```
+
+`0711` lets the service user enter the directory to launch the PTY without being
+able to list or read its contents; the user's files keep their own permissions.
+Worktree directories created by the server are already owned by the service user
+and need no change.
+
+> `0711` is an **operational** workaround. The underlying cause — the spawn
+> helper passing the target user's private directory as the PTY `cwd` and
+> `chdir`-ing into it as the service user — is tracked for a root-cause fix in
+> [issue #802](https://github.com/ms2sato/agent-console/issues/802).
+
 ## Step 6: Verify the Setup
 
 After starting the server, check the following:
 
 ```bash
 # 1. Server is running
-curl http://localhost:4001/api/config
+curl http://localhost:8080/api/config
 # Should return JSON with "authMode": "multi-user"
 
 # 2. Login works (replace with a real OS user/password)
-curl -X POST http://localhost:4001/api/auth/login \
+curl -X POST http://localhost:8080/api/auth/login \
   -H 'Content-Type: application/json' \
   -d '{"username": "alice", "password": "alice-password"}'
 # Should return user info and set auth cookie
@@ -277,16 +373,64 @@ curl -X POST http://localhost:4001/api/auth/login \
 # Output should be the logged-in user's username, not "agentconsole"
 ```
 
+> For an automated, end-to-end version of these three checks (plus per-user PTY
+> isolation), run the Docker verification: `scripts/verify-multiuser-docker.sh`
+> (see [`docker/README.md`](../docker/README.md)).
+
 ## Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AUTH_MODE` | `none` | `none` for single-user, `multi-user` for multi-user mode |
-| `PORT` | `4001` | Server port |
-| `HOST` | `localhost` | Bind address (`0.0.0.0` to allow network access) |
-| `AGENT_CONSOLE_HOME` | `~/.agent-console` | Config and database directory |
+| `PORT` | `3457` | Server port. `3457` is the dev fallback; pick any port for production (this guide uses `8080`). |
+| `HOST` | `0.0.0.0` | Bind address. Defaults to all interfaces; set to `127.0.0.1` to restrict to localhost. |
+| `AGENT_CONSOLE_HOME` | `~/.agent-console` | Config and database directory. The SQLite database is `<AGENT_CONSOLE_HOME>/data.db`; the JWT signing secret is `<AGENT_CONSOLE_HOME>/jwt-secret` (auto-generated, mode 0600, on first start). |
+| `NODE_ENV` | _(unset)_ | Set to `production` in real deployments. This marks the auth cookie `secure`, so it is **only sent over HTTPS** — see [TLS is required](#tls-is-required-in-production). |
+
+The full list of server variables is defined in
+[`packages/server/src/lib/server-config.ts`](../packages/server/src/lib/server-config.ts).
+
+## TLS is required in production
+
+When `NODE_ENV=production`, the authentication cookie is issued with the
+`Secure` attribute, meaning browsers send it **only over HTTPS**. Serving
+multi-user mode over plain HTTP in production would cause the cookie to be
+dropped and every authenticated request to fail. Terminate TLS in front of
+Agent Console (reverse proxy such as nginx/Caddy, or a load balancer) and set
+`APP_URL`/`HOST` accordingly.
+
+> The Docker verification environment in [`docker/`](../docker/README.md)
+> deliberately leaves `NODE_ENV` unset so it can be exercised over localhost
+> HTTP. That is a verification convenience, **not** a production pattern.
 
 ## Troubleshooting
+
+### Every login returns 401, even with correct passwords (Linux)
+
+Two causes, both on the server side:
+
+1. **`pamtester` is not installed.** The Linux credential check shells out to
+   `pamtester`; if it is missing, `MultiUserMode` cannot validate any password.
+   Install it (see [Step 0](#step-0-install-pamtester-linux-only)) and confirm
+   `/etc/pam.d/login` exists.
+2. **The service user is not in the `shadow` group.** A non-root service user
+   cannot verify other users' passwords without `shadow`-group membership (see
+   [Why the `shadow` group is required](#why-the-shadow-group-is-required-linux)).
+   Fix and restart the service:
+
+   ```bash
+   sudo usermod -aG shadow agentconsole
+   sudo systemctl restart agent-console   # group change applies to a fresh process
+   ```
+
+The server log shows `pamtester: Authentication failure` followed by
+`Login failed: invalid credentials` in both cases.
+
+### "PTY spawn failed" after a successful login
+
+The session's working directory is not enterable by the service user (commonly a
+`0700` home directory). See
+[The service user must be able to enter session working directories](#the-service-user-must-be-able-to-enter-session-working-directories).
 
 ### "This account is currently not available" when testing sudo
 

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -394,50 +394,66 @@ The full list of server variables is defined in
 
 ## TLS, `NODE_ENV`, and secure contexts
 
-A single flag, `NODE_ENV=production`, controls two coupled behaviors:
+For browser access there are **two independent concerns**. Conflating them leads
+to the wrong conclusion that "a trusted private network means plain HTTP is
+fine" — it is not.
 
-- The authentication cookie is issued with the `Secure` attribute
-  (`auth.ts`: `secure: NODE_ENV === 'production'`), so browsers send it **only in
-  a secure context**.
+**Concern 1 — confidentiality (don't send passwords in the clear).** OS
+passwords are POSTed to `/api/auth/login`. The transport carrying them must be
+private. This is satisfied by **either** TLS (HTTPS) **or** an already-trusted
+network path: a VPN / zero-trust overlay (e.g. Cloudflare WARP), an SSH tunnel,
+or pure loopback. On such a network, TLS is not required *for confidentiality*.
+
+**Concern 2 — the `Secure` cookie / browser secure context.** A single flag,
+`NODE_ENV=production`, controls two coupled behaviors:
+
+- The auth cookie is issued with the `Secure` attribute (`auth.ts`:
+  `secure: NODE_ENV === 'production'`).
 - The bundled web UI is served only in production (`index.ts` gates static file
   serving on `isProduction`). With `NODE_ENV` unset the server exposes the
   API/WebSocket but **not** the login UI.
 
-So any browser-based deployment needs `NODE_ENV=production` (to get the UI),
-which in turn makes the cookie `Secure`. Whether you also need TLS then depends
-on how the browser reaches the server.
+Because any browser deployment needs `NODE_ENV=production` (for the UI), the
+cookie is always `Secure`, and a browser sends a `Secure` cookie **only to a
+secure context**: an `https://` origin, or `http://localhost` / `http://127.0.0.1`.
+This is decided purely by the URL's scheme and host — **it does not matter how
+safe the network is**. A WARP-protected `http://<internal-host>:<port>` still
+drops the cookie and login fails.
 
-### Network-exposed over plain HTTP → TLS is required
+### Decision table
 
-If users reach the server at `http://<host>` where `<host>` is **not** localhost,
-two things break:
+| How the browser reaches the server | Confidentiality | `Secure` cookie sent? | Works? |
+|---|---|---|---|
+| `https://<host>` (TLS terminated anywhere — internal CA, Cloudflare, reverse proxy) | ✅ TLS | ✅ (https origin) | ✅ |
+| `http://localhost:<port>` (directly, or a forward/tunnel that makes the origin appear as localhost) | ✅ loopback/tunnel | ✅ (localhost = secure context) | ✅ |
+| `http://<non-localhost host>:<port>` plain HTTP — **even on WARP/VPN/internal LAN** | ✅ if on a trusted net | ❌ dropped | ❌ login fails |
 
-1. The `Secure` cookie is dropped (browsers only send `Secure` cookies over
-   HTTPS), so every authenticated request fails.
-2. OS passwords travel in clear text over the network.
+So on a trusted private network you have two valid options today: terminate TLS
+to get an `https://` origin, **or** have each member reach the server as
+`http://localhost:<port>` (e.g. a per-machine port-forward from the host/VM, or
+`ssh -L <port>:localhost:<port> <host>`). What does **not** work is pointing
+browsers at a plain-HTTP non-localhost URL, regardless of how private the network
+is.
 
-Terminate TLS in front of Agent Console (reverse proxy such as nginx/Caddy, or a
-load balancer) and forward both the HTTP routes and the WebSocket upgrade
-(`/ws/*`). Set `APP_URL`/`HOST` accordingly.
+> **Plain HTTP on a trusted network (e.g. Cloudflare WARP) — planned support.**
+> If members access the server directly at `http://<internal-host>:<port>` over a
+> network that is already private, confidentiality is covered but the `Secure`
+> cookie is still dropped, so login fails. Decoupling the cookie's `Secure`
+> attribute from `NODE_ENV` (a planned `AUTH_COOKIE_SECURE`-style setting) is
+> tracked in [issue #805](https://github.com/ms2sato/agent-console/issues/805).
+> Until that lands, use TLS termination (`https://`) or localhost access for
+> browser logins on such a network.
 
-### localhost or SSH port-forward → TLS is not required
-
-If each user reaches the server at `http://localhost:<port>` — directly on the
-machine, or through an SSH tunnel (`ssh -L <port>:localhost:<port> <host>`) — TLS
-is unnecessary:
-
-- An SSH tunnel already encrypts the transport, so passwords are not exposed.
-- Browsers treat `http://localhost` (and `127.0.0.1`) as a **secure context**
-  (the W3C Secure Contexts spec classifies loopback addresses as potentially
-  trustworthy), so the `Secure` cookie is still accepted.
-
-This is a valid low-friction setup for a small or trusted team.
+When you do terminate TLS, do it in front of Agent Console (reverse proxy such as
+nginx/Caddy, or a load balancer), forward both the HTTP routes and the WebSocket
+upgrade (`/ws/*`), and set `APP_URL`/`HOST` accordingly.
 
 > **Not empirically verified here.** The Docker verification in this repo uses a
 > non-browser client with `NODE_ENV` unset, so the `NODE_ENV=production` +
-> `Secure` cookie + `http://localhost` browser path was not exercised. The above
-> reflects the documented browser secure-context behavior — confirm it in your
-> own browser before relying on it for a deployment.
+> `Secure` cookie + browser path (whether `https` or `http://localhost`) was not
+> exercised. The above reflects the documented browser secure-context behavior
+> (W3C Secure Contexts treats loopback as potentially trustworthy) — confirm it
+> in your own browser before relying on it for a deployment.
 
 ## Troubleshooting
 

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -242,8 +242,10 @@ WantedBy=multi-user.target
 EOF
 ```
 
-> `NODE_ENV=production` makes the auth cookie `Secure`. In production this is
-> correct **only behind TLS** (see [TLS is required](#tls-is-required-in-production)).
+> `NODE_ENV=production` enables the web UI and makes the auth cookie `Secure`.
+> The cookie then requires a secure context — HTTPS, or `http://localhost` (e.g.
+> via an SSH tunnel). See
+> [TLS, `NODE_ENV`, and secure contexts](#tls-node_env-and-secure-contexts).
 
 Enable and start:
 
@@ -385,23 +387,57 @@ curl -X POST http://localhost:8080/api/auth/login \
 | `PORT` | `3457` | Server port. `3457` is the dev fallback; pick any port for production (this guide uses `8080`). |
 | `HOST` | `0.0.0.0` | Bind address. Defaults to all interfaces; set to `127.0.0.1` to restrict to localhost. |
 | `AGENT_CONSOLE_HOME` | `~/.agent-console` | Config and database directory. The SQLite database is `<AGENT_CONSOLE_HOME>/data.db`; the JWT signing secret is `<AGENT_CONSOLE_HOME>/jwt-secret` (auto-generated, mode 0600, on first start). |
-| `NODE_ENV` | _(unset)_ | Set to `production` in real deployments. This marks the auth cookie `secure`, so it is **only sent over HTTPS** — see [TLS is required](#tls-is-required-in-production). |
+| `NODE_ENV` | _(unset)_ | Set to `production` for browser-based deployments: it enables the web UI **and** marks the auth cookie `Secure` (the two are the same flag). The `Secure` cookie then needs a secure context — HTTPS, or `http://localhost` — see [TLS, `NODE_ENV`, and secure contexts](#tls-node_env-and-secure-contexts). |
 
 The full list of server variables is defined in
 [`packages/server/src/lib/server-config.ts`](../packages/server/src/lib/server-config.ts).
 
-## TLS is required in production
+## TLS, `NODE_ENV`, and secure contexts
 
-When `NODE_ENV=production`, the authentication cookie is issued with the
-`Secure` attribute, meaning browsers send it **only over HTTPS**. Serving
-multi-user mode over plain HTTP in production would cause the cookie to be
-dropped and every authenticated request to fail. Terminate TLS in front of
-Agent Console (reverse proxy such as nginx/Caddy, or a load balancer) and set
-`APP_URL`/`HOST` accordingly.
+A single flag, `NODE_ENV=production`, controls two coupled behaviors:
 
-> The Docker verification environment in [`docker/`](../docker/README.md)
-> deliberately leaves `NODE_ENV` unset so it can be exercised over localhost
-> HTTP. That is a verification convenience, **not** a production pattern.
+- The authentication cookie is issued with the `Secure` attribute
+  (`auth.ts`: `secure: NODE_ENV === 'production'`), so browsers send it **only in
+  a secure context**.
+- The bundled web UI is served only in production (`index.ts` gates static file
+  serving on `isProduction`). With `NODE_ENV` unset the server exposes the
+  API/WebSocket but **not** the login UI.
+
+So any browser-based deployment needs `NODE_ENV=production` (to get the UI),
+which in turn makes the cookie `Secure`. Whether you also need TLS then depends
+on how the browser reaches the server.
+
+### Network-exposed over plain HTTP → TLS is required
+
+If users reach the server at `http://<host>` where `<host>` is **not** localhost,
+two things break:
+
+1. The `Secure` cookie is dropped (browsers only send `Secure` cookies over
+   HTTPS), so every authenticated request fails.
+2. OS passwords travel in clear text over the network.
+
+Terminate TLS in front of Agent Console (reverse proxy such as nginx/Caddy, or a
+load balancer) and forward both the HTTP routes and the WebSocket upgrade
+(`/ws/*`). Set `APP_URL`/`HOST` accordingly.
+
+### localhost or SSH port-forward → TLS is not required
+
+If each user reaches the server at `http://localhost:<port>` — directly on the
+machine, or through an SSH tunnel (`ssh -L <port>:localhost:<port> <host>`) — TLS
+is unnecessary:
+
+- An SSH tunnel already encrypts the transport, so passwords are not exposed.
+- Browsers treat `http://localhost` (and `127.0.0.1`) as a **secure context**
+  (the W3C Secure Contexts spec classifies loopback addresses as potentially
+  trustworthy), so the `Secure` cookie is still accepted.
+
+This is a valid low-friction setup for a small or trusted team.
+
+> **Not empirically verified here.** The Docker verification in this repo uses a
+> non-browser client with `NODE_ENV` unset, so the `NODE_ENV=production` +
+> `Secure` cookie + `http://localhost` browser path was not exercised. The above
+> reflects the documented browser secure-context behavior — confirm it in your
+> own browser before relying on it for a deployment.
 
 ## Troubleshooting
 

--- a/scripts/verify-multiuser-docker.sh
+++ b/scripts/verify-multiuser-docker.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# One-command verification of Agent Console multi-user mode on Docker/Linux.
+#
+# Builds and starts the verification container (docker/Dockerfile), then checks:
+#   1. /api/config reports authMode=multi-user
+#   2. a protected route returns 401 without authentication
+#   3. login with a wrong password is rejected (401)  -> proves pamtester runs
+#   4. alice / bob log in successfully (200)           -> proves pamtester auth
+#   5. PTY identity isolation: alice's terminal whoami => alice,
+#                              bob's   terminal whoami => bob
+#      (not the agentconsole service user) -> proves sudo -u <user> isolation
+#
+# Usage (from repo root):
+#   scripts/verify-multiuser-docker.sh            # build + verify + tear down
+#   scripts/verify-multiuser-docker.sh --keep     # leave the container running
+#   scripts/verify-multiuser-docker.sh --no-build # reuse the existing image
+#
+# Requires: docker, bun (both on the host).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.yml"
+PORT="${PORT:-8080}"
+BASE_URL="http://localhost:${PORT}"
+KEEP=0
+BUILD_FLAG="--build"
+
+for arg in "$@"; do
+  case "$arg" in
+    --keep) KEEP=1 ;;
+    --no-build) BUILD_FLAG="" ;;
+    *) echo "unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+
+cleanup() {
+  if [ "$KEEP" -eq 1 ]; then
+    echo "[info] --keep set; container left running at ${BASE_URL}"
+  else
+    echo "[info] tearing down container"
+    compose down --remove-orphans >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+check() { # check <name> <condition-exit-code>
+  if [ "$2" -eq 0 ]; then
+    echo "  [PASS] $1"; PASS=$((PASS + 1))
+  else
+    echo "  [FAIL] $1"; FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== Building and starting the multi-user verification container ==="
+# shellcheck disable=SC2086
+compose up $BUILD_FLAG -d || { echo "compose up failed" >&2; exit 1; }
+
+echo "=== Waiting for the server to become healthy ==="
+ready=1
+for i in $(seq 1 40); do
+  code="$(curl -s -o /dev/null -w '%{http_code}' "${BASE_URL}/api/config" 2>/dev/null || true)"
+  if [ "$code" = "200" ]; then ready=0; break; fi
+  sleep 1
+done
+if [ "$ready" -ne 0 ]; then
+  echo "[error] server did not become ready; recent logs:" >&2
+  compose logs --tail 60 || true
+  exit 1
+fi
+
+echo
+echo "=== 1. /api/config authMode ==="
+config_json="$(curl -s "${BASE_URL}/api/config")"
+echo "  $config_json"
+echo "$config_json" | grep -q '"authMode":"multi-user"'
+check "authMode is multi-user" $?
+
+echo
+echo "=== 2. protected route requires auth ==="
+code="$(curl -s -o /dev/null -w '%{http_code}' "${BASE_URL}/api/sessions/does-not-exist")"
+echo "  GET /api/sessions/does-not-exist (unauthenticated) -> HTTP ${code}"
+[ "$code" = "401" ]
+check "unauthenticated request returns 401" $?
+
+echo
+echo "=== 3. wrong password is rejected (pamtester is running) ==="
+code="$(curl -s -o /dev/null -w '%{http_code}' -X POST "${BASE_URL}/api/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"alice","password":"definitely-wrong"}')"
+echo "  POST /api/auth/login alice:<wrong> -> HTTP ${code}"
+[ "$code" = "401" ]
+check "wrong password returns 401" $?
+
+echo
+echo "=== 4. correct credentials authenticate (pamtester + shadow group) ==="
+for u in alice bob; do
+  code="$(curl -s -o /dev/null -w '%{http_code}' -X POST "${BASE_URL}/api/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"${u}\",\"password\":\"${u}-password\"}")"
+  echo "  POST /api/auth/login ${u}:<correct> -> HTTP ${code}"
+  [ "$code" = "200" ]
+  check "${u} login returns 200" $?
+done
+
+echo
+echo "=== 5. PTY identity isolation (whoami over the worker WebSocket) ==="
+bun "${REPO_ROOT}/docker/verify-client.ts" "$BASE_URL" alice alice-password alice /home/alice
+check "alice terminal runs as alice" $?
+bun "${REPO_ROOT}/docker/verify-client.ts" "$BASE_URL" bob bob-password bob /home/bob
+check "bob terminal runs as bob" $?
+
+echo
+echo "=================================================="
+echo "  RESULT: ${PASS} passed, ${FAIL} failed"
+echo "=================================================="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #804

## Summary

Adds a **Docker-based verification environment** for the already-implemented
multi-user mode (`AUTH_MODE=multi-user`), plus corrections to the setup guide
that were caught by actually running it. The feature's Linux-specific paths
(`pamtester` OS auth, per-user PTY isolation via `sudo -u <user>`) cannot be
exercised on macOS dev machines, so this gives a one-command way to prove they
work on real Linux.

**No production code is changed** — only `docker/`, `scripts/`, `.dockerignore`,
and `docs/`.

## What's added

- `docker/Dockerfile` — two-stage build on `oven/bun` (Debian); runtime installs
  `pamtester` + `sudo`, creates a non-root `agentconsole` service user (in the
  `shadow` group) and two test users (`alice`, `bob`), runs the server in
  multi-user mode.
- `docker/docker-compose.yml`, `docker/sudoers-agentconsole`
- `docker/verify-client.ts` — drives the real shipping path (login → session →
  terminal worker → worker WebSocket) and asserts `whoami` inside the PTY.
- `scripts/verify-multiuser-docker.sh` — one command: build, start, run all
  checks, report.
- `docker/README.md` — how to run it.

## Verification (executed end to end on Docker — 7/7 pass)

```
=== 1. /api/config authMode ===
  {"homeDir":"","capabilities":{"vscode":false},"serverPid":1,"authMode":"multi-user","sharedAccountsAvailable":false}
  [PASS] authMode is multi-user
=== 2. protected route requires auth ===
  GET /api/sessions/does-not-exist (unauthenticated) -> HTTP 401
  [PASS] unauthenticated request returns 401
=== 3. wrong password is rejected (pamtester is running) ===
  POST /api/auth/login alice:<wrong> -> HTTP 401
  [PASS] wrong password returns 401
=== 4. correct credentials authenticate (pamtester + shadow group) ===
  POST /api/auth/login alice:<correct> -> HTTP 200
  [PASS] alice login returns 200
  POST /api/auth/login bob:<correct> -> HTTP 200
  [PASS] bob login returns 200
=== 5. PTY identity isolation (whoami over the worker WebSocket) ===
RESULT alice: PASS — whoami => 'alice' (expected 'alice')
RESULT bob: PASS — whoami => 'bob' (expected 'bob')
==================================================
  RESULT: 7 passed, 0 failed
==================================================
```

### `shadow` group polarity proof (same image, only the group membership differs)

```
# WITHOUT shadow membership:
groups now: uid=1001(agentconsole) gid=1001(agentconsole) groups=1001(agentconsole)
  POST /api/auth/login alice:<correct> (no shadow) -> HTTP 401
  Password: pamtester: Authentication failure
  user-mode "Login failed: invalid credentials"
POLARITY: PASS — login correctly FAILS without shadow membership

# WITH shadow membership: HTTP 200 (see check 4 above)
```

## Three "only surfaces when you run it" requirements (now documented in the guide)

1. **`pamtester` must be installed** on Linux — else every login 401.
2. **The non-root service user must be in the `shadow` group** — otherwise
   `pam_unix` falls back to `unix_chkpwd`, which only lets a caller verify its
   *own* password. Proven above by polarity.
3. **The service user needs traverse (x) permission on each session working
   directory.** The PTY spawn helper `chdir`s into the cwd as the service user
   before `sudo` drops privileges; Debian's default `0700` home breaks this with
   "PTY spawn failed". Documented as an **interim `0711` operational workaround**;
   the **root-cause production fix is tracked in #802** (out of scope here — it
   requires production code changes).

## Doc corrections (`docs/multi-user-setup-guide.md`, validated against the code)

- `PORT`: `4001` was wrong; `3457` is the dev fallback, guide now uses `8080`.
- `HOST` default is `0.0.0.0` (not `localhost`).
- DB path is `<AGENT_CONSOLE_HOME>/data.db`; JWT secret is `<…>/jwt-secret`.
- TLS is required in production (the auth cookie is `Secure` when
  `NODE_ENV=production`).
- Bun `>= 1.3.5`.

## Local verification

```
bun run check:lang   -> OK — language check clean (103 files scanned)
bun run test         -> TEST_EXIT: 0
  @agent-console/client    1396 pass / 0 fail
  @agent-console/shared     324 pass / 0 fail
  @agent-console/integration 29 pass / 0 fail
  @agent-console/server    2547 pass / 1 skip / 0 fail
  scripts/ + hooks/ + skills 362 pass / 0 fail
preflight-check.js   -> no coverage gaps, no rule/skill dup, language clean
```

`scripts/verify-multiuser-docker.sh` was executed locally on macOS (workflow
rule 7).

## Environment note (transparency)

This machine's Docker could reach general networks (apt, npm, bun.sh) but **could
not pull from Docker Hub's registry** (`docker pull` hung at "resolve image
config"). The image was therefore built locally from a cached base via
`DOCKER_BUILDKIT=0 docker build --build-arg BUN_BASE=oven/bun:1.3.4 …`, and the
verification ran against it. The **committed** Dockerfile defaults to the
directly-pullable `oven/bun:1.3.8` so a clean environment builds with a plain
`docker build`; the cached-base fallback is documented in `docker/README.md`
("Building behind a blocked Docker Hub"). The default-base build path itself was
not runnable here due to the registry block.

## Browser QA

N/A — no UI changes. Multi-user mode is verified via API/WebSocket; the bundled
login UI is only served under `NODE_ENV=production` (which the verification image
deliberately avoids so it can run over localhost HTTP).

## Notes

- No dedicated tracking Issue exists for this verification task; #802 is the
  related follow-up for the production-side root-cause fix and is **not** closed
  by this PR.
- BuildKit prints a benign `SecretsUsedInArgOrEnv` lint warning for
  `ENV AUTH_MODE` (false positive — it is configuration, not a secret); the
  build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
