### PR TITLE
fix: use neutral cwd for privileged PTY spawn so 0700 homes work (#802)

### DIFF
--- a/packages/server/src/services/__tests__/multi-user-mode.test.ts
+++ b/packages/server/src/services/__tests__/multi-user-mode.test.ts
@@ -468,6 +468,9 @@ describe('MultiUserMode', () => {
       // Terminal should NOT have AGENT_CONSOLE_* vars
       expect(opts.env!.AGENT_CONSOLE_BASE_URL).toBeUndefined();
       expect(opts.env!.AGENT_CONSOLE_SESSION_ID).toBeUndefined();
+      // Regression (#802): the sudo-skip direct path must keep the real cwd as
+      // the outer spawn cwd — it runs as the target user, so 0700 dirs are fine.
+      expect(opts.cwd).toBe('/workspace/project');
     });
 
     it('should include optional agentConsoleContext fields when provided', async () => {
@@ -796,6 +799,63 @@ describe('MultiUserMode', () => {
       // With no env vars and terminal type, should just cd and exec shell
       expect(innerCommand).toContain("cd '/workspace'");
       expect(innerCommand).toContain('exec $SHELL -l');
+    });
+
+    // Regression: #802 — the outer sudo cwd must be a neutral, always-traversable
+    // directory ('/'), NOT request.cwd. bun-pty applies the outer cwd via chdir()
+    // in the pre-exec child while it still runs as the service user; if request.cwd
+    // is inside the target user's 0700 home the service user lacks traverse (x)
+    // permission and chdir() fails with EACCES, aborting the spawn. Landing into
+    // request.cwd is guaranteed by the inner `cd` (run as the target user).
+    it('should use neutral outer cwd "/" while keeping inner cd to request.cwd (agent)', async () => {
+      const mode = await createMode();
+
+      const request: AgentPtySpawnRequest = {
+        type: 'agent',
+        username: 'alice',
+        // A target user's private 0700 home; service user cannot traverse it.
+        cwd: '/home/alice',
+        additionalEnvVars: {},
+        cols: 120,
+        rows: 30,
+        command: 'claude',
+        agentConsoleContext: {
+          baseUrl: 'http://localhost:3457',
+          sessionId: 'sess-1',
+          workerId: 'wkr-1',
+        },
+      };
+
+      mode.spawnPty(request);
+
+      const [cmd, args, opts] = getLastSpawnCall();
+      expect(cmd).toBe('sudo');
+      // Outer cwd must be neutral, not the private home dir.
+      expect(opts.cwd).toBe('/');
+      // Inner command must still cd into the actual working dir (landing guarantee).
+      const innerCommand = args[5];
+      expect(innerCommand).toContain("cd '/home/alice'");
+    });
+
+    it('should use neutral outer cwd "/" while keeping inner cd to request.cwd (terminal)', async () => {
+      const mode = await createMode();
+
+      const request: TerminalPtySpawnRequest = {
+        type: 'terminal',
+        username: 'alice',
+        cwd: '/home/alice',
+        additionalEnvVars: {},
+        cols: 80,
+        rows: 24,
+      };
+
+      mode.spawnPty(request);
+
+      const [cmd, args, opts] = getLastSpawnCall();
+      expect(cmd).toBe('sudo');
+      expect(opts.cwd).toBe('/');
+      const innerCommand = args[5];
+      expect(innerCommand).toContain("cd '/home/alice'");
     });
   });
 });

--- a/packages/server/src/services/__tests__/user-mode.test.ts
+++ b/packages/server/src/services/__tests__/user-mode.test.ts
@@ -19,11 +19,34 @@ import type { Kysely } from 'kysely';
 import { createDatabaseForTest } from '../../database/connection.js';
 import { SqliteUserRepository } from '../../repositories/sqlite-user-repository.js';
 import { SingleUserMode, MultiUserMode } from '../user-mode.js';
-import type { PtyProvider } from '../../lib/pty-provider.js';
+import type { TerminalPtySpawnRequest } from '../user-mode.js';
+import type { PtyProvider, PtySpawnOptions, PtyInstance } from '../../lib/pty-provider.js';
 
 const mockPtyProvider: PtyProvider = {
   spawn: () => { throw new Error('not implemented'); },
 };
+
+/**
+ * A PtyProvider that records the last spawn() call instead of starting a real PTY.
+ */
+function createCapturingPtyProvider(): {
+  provider: PtyProvider;
+  lastCall: () => [string, string[], PtySpawnOptions];
+} {
+  let last: [string, string[], PtySpawnOptions] | undefined;
+  return {
+    provider: {
+      spawn(command, args, options) {
+        last = [command, args, options];
+        return {} as PtyInstance;
+      },
+    },
+    lastCall: () => {
+      if (!last) throw new Error('spawn was not called');
+      return last;
+    },
+  };
+}
 
 describe('SingleUserMode', () => {
   let db: Kysely<any>;
@@ -107,6 +130,33 @@ describe('SingleUserMode', () => {
       const result = await userMode.login('any-user', 'any-password');
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('spawnPty() - direct spawn cwd (#802 regression)', () => {
+    // Single-user mode spawns directly as the server process user (no privilege
+    // drop), so the pre-exec chdir runs as that same user. request.cwd must stay
+    // as the outer cwd here — unlike the privileged sudo path, there is no
+    // service-user traverse problem to avoid. This guards against the #802 fix
+    // accidentally neutralizing the cwd of the unprivileged direct-spawn path.
+    it('should pass request.cwd as the outer spawn cwd', () => {
+      const { provider, lastCall } = createCapturingPtyProvider();
+      const cachedUser = { id: 'cached-id', username: 'cached', homeDir: '/home/cached' };
+      const userMode = new SingleUserMode(provider, cachedUser);
+
+      const request: TerminalPtySpawnRequest = {
+        type: 'terminal',
+        username: 'cached',
+        cwd: '/home/cached/project',
+        additionalEnvVars: {},
+        cols: 80,
+        rows: 24,
+      };
+
+      userMode.spawnPty(request);
+
+      const [, , opts] = lastCall();
+      expect(opts.cwd).toBe('/home/cached/project');
     });
   });
 });

--- a/packages/server/src/services/user-mode.ts
+++ b/packages/server/src/services/user-mode.ts
@@ -26,6 +26,20 @@ import { createLogger } from '../lib/logger.js';
 
 const logger = createLogger('user-mode');
 
+/**
+ * Neutral working directory for the outer `sudo` spawn in MultiUserMode.
+ *
+ * bun-pty applies the outer `cwd` via `chdir()` in the pre-exec child, which
+ * still runs as the service user (before sudo drops privileges to the target
+ * user). If we passed `request.cwd` here and it points inside the target user's
+ * private directory (e.g. a 0700 home), the service user lacks traverse (`x`)
+ * permission and `chdir()` fails with EACCES, aborting the spawn. `/` is always
+ * traversable, so the pre-exec chdir never fails. The actual landing into
+ * `request.cwd` is handled by the inner `cd` in spawnSudoPty(), which runs as
+ * the target user and therefore succeeds even for a 0700 home.
+ */
+const SUDO_NEUTRAL_CWD = '/';
+
 // ========== PtySpawnRequest (Discriminated Union) ==========
 
 /**
@@ -481,7 +495,9 @@ export class MultiUserMode implements UserMode {
         name: 'xterm-256color',
         cols: request.cols,
         rows: request.rows,
-        cwd: request.cwd,
+        // Use a neutral, always-traversable cwd for the pre-exec chdir; the
+        // inner `cd ${request.cwd}` (run as the target user) handles landing.
+        cwd: SUDO_NEUTRAL_CWD,
       },
     );
   }


### PR DESCRIPTION
Closes #802

## Summary

In multi-user mode (`AUTH_MODE=multi-user`), spawning a PTY for a logged-in user **failed with "PTY spawn failed" when that user's home directory is `0700`** (a common secure default).

`MultiUserMode.spawnSudoPty()` passed `request.cwd` (which may be the target user's private directory) as the **outer** bun-pty `cwd`. bun-pty applies the outer `cwd` via `chdir()` in the **pre-exec child, which still runs as the service user** (`agentconsole`), *before* the `-u <user> -i` privilege drop. A `0700` home is not traversable by the service user, so `chdir()` fails with `EACCES` and the spawn aborts. `root` ignores directory permissions, which is why single-user / root-run dev setups never hit this (and the bug never reproduces in dev).

## Fix

Pass a neutral, always-traversable cwd (`/`, named `SUDO_NEUTRAL_CWD`) to the outer privileged spawn instead of the private directory. The inner `cd '<request.cwd>'` — which already exists and runs **as the target user** after the privilege drop — handles landing into the real working directory and succeeds even for a `0700` home.

This design **does not rely on the login shell's `$HOME` landing**: the explicit inner `cd` is the landing guarantee, so there is no assumption about login-shell behavior.

- `packages/server/src/services/user-mode.ts`: add `SUDO_NEUTRAL_CWD = '/'` (documented), change the outer `spawn('sudo', …)` `cwd` from `request.cwd` to `SUDO_NEUTRAL_CWD`. The inner `cd` is unchanged.
- **Single-user (`AUTH_MODE=none`) and the sudo-skip optimization are unchanged.** Those spawn directly as the target user (no privilege drop happens before `chdir`), so `request.cwd` remains the outer cwd — a `0700` owned by the same user is traversable.

## Tests (TDD)

`packages/server/src/services/__tests__/multi-user-mode.test.ts`:
- Sudo path (agent + terminal): with `request.cwd = '/home/alice'` (a private 0700 home), assert the outer spawn `cwd === '/'` **and** the inner command still contains `cd '/home/alice'` (landing regression guard).
- Sudo-skip direct path (terminal): assert the outer cwd is still `request.cwd` (`/workspace/project`) — regression guard that the unprivileged path is unchanged. (Agent direct path already asserted this.)

**Polarity verification** (per `workflow.md` TDD): with only the `user-mode.ts` fix stashed (tests kept), the two new sudo assertions **fail** (`opts.cwd` received the private dir); restoring the fix → **30 pass / 0 fail**. The new tests do not pass in both directions.

## Local verification

```
bun run test    (includes typecheck)
  @agent-console/shared       324 pass / 0 fail
  @agent-console/integration   29 pass / 0 fail
  @agent-console/server      2549 pass / 1 skip / 0 fail
  @agent-console/client      1396 pass / 2 skip / 0 fail
  scripts/ + hooks/ + skills  362 pass / 0 fail
TEST_EXIT: 0
```

CodeRabbit CLI (`coderabbit review --agent --base main`): **0 findings** (re-run against the final commit; the GitHub-side bot is rate-limited, so the local CLI is the documented fallback per `coderabbit-ops`).

## E2E verification — deferred (jointly agreed)

This change has user-observable runtime behavior, but it is only reachable on a **real multi-user OS** (a non-root service user + a target user owning a `0700` home + `sudo`). The dev environment runs as root/single-user, where root ignores directory permissions — which is the exact reason the bug does not reproduce here.

Per `workflow.md` ("Skipping E2E is not a unilateral agent decision"), the Docker E2E was **jointly agreed to defer** with the Orchestrator after the dev environment proved unable to run it: this machine cannot pull from Docker Hub (`docker build` hangs before "Sending build context"; an identical workaround build was found hung for 3h44m), the same registry block documented in #803 itself. An attempt was made (merge `origin/main` to pull the Docker harness, set test homes to `0700`, rebuild) and abandoned at the build stage; the branch was reset to the clean two-commit state.

Justification for accepting the deferral:
1. **Unit TDD** covers the outer/inner cwd contract with polarity proof.
2. **Code-level root-cause confirmation** of the pre-exec `chdir` as service user.
3. **Independent runtime corroboration**: the Docker multi-user harness (#803, now merged) already observed this exact failure on real Linux — "the PTY spawn helper `chdir`s into the cwd as the service user before `sudo` drops privileges; Debian's default `0700` home breaks this with 'PTY spawn failed'" — and explicitly references #802 as the production fix.

**Follow-up:** the real-Linux proof (`0700` home → PTY spawns successfully) is left to **owner dogfood verification post-merge** and/or a **future CI Docker job** (tracked separately). Proposed regression to add then: flip the Docker harness's test homes from the `0711` interim workaround to `0700` and assert the spawn succeeds — turning this fix into a permanent end-to-end guard and removing the documented workaround.

## Browser QA

N/A — server-side only, no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
