### PR TITLE
feat: make auth cookie Secure flag configurable for trusted-network HTTP (closes #805)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,9 +107,11 @@ RUN mkdir -p "${AGENT_CONSOLE_HOME}" \
  && chown -R agentconsole:agentconsole "${AGENT_CONSOLE_HOME}" /app/dist
 
 # Server configuration.
-# NOTE: NODE_ENV is intentionally left UNSET. In production NODE_ENV=production
-# makes the auth cookie `secure`, which is dropped over plain HTTP — fine behind
-# TLS but it would break the localhost HTTP verification done here.
+# NOTE: NODE_ENV is intentionally left UNSET. NODE_ENV=production makes the auth
+# cookie `secure` by default; AUTH_COOKIE_SECURE, when set, takes precedence over
+# that NODE_ENV fallback. A `secure` cookie is dropped over plain HTTP — fine
+# behind TLS but it would break the localhost HTTP verification done here.
+# AUTH_COOKIE_SECURE is also left unset, so the NODE_ENV fallback applies.
 ENV AUTH_MODE=multi-user \
     PORT=8080 \
     HOST=0.0.0.0 \

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -387,7 +387,8 @@ curl -X POST http://localhost:8080/api/auth/login \
 | `PORT` | `3457` | Server port. `3457` is the dev fallback; pick any port for production (this guide uses `8080`). |
 | `HOST` | `0.0.0.0` | Bind address. Defaults to all interfaces; set to `127.0.0.1` to restrict to localhost. |
 | `AGENT_CONSOLE_HOME` | `~/.agent-console` | Config and database directory. The SQLite database is `<AGENT_CONSOLE_HOME>/data.db`; the JWT signing secret is `<AGENT_CONSOLE_HOME>/jwt-secret` (auto-generated, mode 0600, on first start). |
-| `NODE_ENV` | _(unset)_ | Set to `production` for browser-based deployments: it enables the web UI **and** marks the auth cookie `Secure` (the two are the same flag). The `Secure` cookie then needs a secure context — HTTPS, or `http://localhost` — see [TLS, `NODE_ENV`, and secure contexts](#tls-node_env-and-secure-contexts). |
+| `NODE_ENV` | _(unset)_ | Set to `production` for browser-based deployments: it enables the web UI **and**, by default, marks the auth cookie `Secure`. The `Secure` cookie then needs a secure context — HTTPS, or `http://localhost` — see [TLS, `NODE_ENV`, and secure contexts](#tls-node_env-and-secure-contexts). |
+| `AUTH_COOKIE_SECURE` | _(unset)_ | Tri-state override for the auth cookie's `Secure` attribute, decoupling it from `NODE_ENV`. Unset → follows `NODE_ENV` (default); `false` → never `Secure` (for trusted-network plain-HTTP deployments); `true` → always `Secure`. Invalid values fail fast at startup. See [Plain HTTP on a trusted network](#plain-http-on-a-trusted-network-auth_cookie_secure). |
 
 The full list of server variables is defined in
 [`packages/server/src/lib/server-config.ts`](../packages/server/src/lib/server-config.ts).
@@ -407,18 +408,21 @@ or pure loopback. On such a network, TLS is not required *for confidentiality*.
 **Concern 2 — the `Secure` cookie / browser secure context.** A single flag,
 `NODE_ENV=production`, controls two coupled behaviors:
 
-- The auth cookie is issued with the `Secure` attribute (`auth.ts`:
-  `secure: NODE_ENV === 'production'`).
+- The auth cookie is issued with the `Secure` attribute. By default this follows
+  `NODE_ENV === 'production'`, but it can be decoupled with the
+  `AUTH_COOKIE_SECURE` override (see [Plain HTTP on a trusted
+  network](#plain-http-on-a-trusted-network-auth_cookie_secure) below).
 - The bundled web UI is served only in production (`index.ts` gates static file
   serving on `isProduction`). With `NODE_ENV` unset the server exposes the
   API/WebSocket but **not** the login UI.
 
 Because any browser deployment needs `NODE_ENV=production` (for the UI), the
-cookie is always `Secure`, and a browser sends a `Secure` cookie **only to a
+cookie is `Secure` by default, and a browser sends a `Secure` cookie **only to a
 secure context**: an `https://` origin, or `http://localhost` / `http://127.0.0.1`.
 This is decided purely by the URL's scheme and host — **it does not matter how
 safe the network is**. A WARP-protected `http://<internal-host>:<port>` still
-drops the cookie and login fails.
+drops the cookie and login fails — unless you explicitly relax the requirement
+with `AUTH_COOKIE_SECURE=false` (see below).
 
 ### Decision table
 
@@ -427,22 +431,47 @@ drops the cookie and login fails.
 | `https://<host>` (TLS terminated anywhere — internal CA, Cloudflare, reverse proxy) | ✅ TLS | ✅ (https origin) | ✅ |
 | `http://localhost:<port>` (directly, or a forward/tunnel that makes the origin appear as localhost) | ✅ loopback/tunnel | ✅ (localhost = secure context) | ✅ |
 | `http://<non-localhost host>:<port>` plain HTTP — **even on WARP/VPN/internal LAN** | ✅ if on a trusted net | ❌ dropped | ❌ login fails |
+| `http://<non-localhost host>:<port>` plain HTTP **with `AUTH_COOKIE_SECURE=false`** — only on a trusted net | ✅ if on a trusted net | ➖ sent without `Secure` | ✅ |
 
-So on a trusted private network you have two valid options today: terminate TLS
-to get an `https://` origin, **or** have each member reach the server as
+So on a trusted private network you have three valid options: terminate TLS to
+get an `https://` origin; have each member reach the server as
 `http://localhost:<port>` (e.g. a per-machine port-forward from the host/VM, or
-`ssh -L <port>:localhost:<port> <host>`). What does **not** work is pointing
-browsers at a plain-HTTP non-localhost URL, regardless of how private the network
-is.
+`ssh -L <port>:localhost:<port> <host>`); **or**, when the network itself is
+already trusted, set `AUTH_COOKIE_SECURE=false` so the cookie is issued without
+`Secure` and plain-HTTP non-localhost logins work (see below). Without that
+override, pointing browsers at a plain-HTTP non-localhost URL does **not** work,
+regardless of how private the network is.
 
-> **Plain HTTP on a trusted network (e.g. Cloudflare WARP) — planned support.**
-> If members access the server directly at `http://<internal-host>:<port>` over a
-> network that is already private, confidentiality is covered but the `Secure`
-> cookie is still dropped, so login fails. Decoupling the cookie's `Secure`
-> attribute from `NODE_ENV` (a planned `AUTH_COOKIE_SECURE`-style setting) is
-> tracked in [issue #805](https://github.com/ms2sato/agent-console/issues/805).
-> Until that lands, use TLS termination (`https://`) or localhost access for
-> browser logins on such a network.
+### Plain HTTP on a trusted network (`AUTH_COOKIE_SECURE`)
+
+When members access the server directly at `http://<internal-host>:<port>` over a
+network that is already private (e.g. Cloudflare WARP, a VPN, or a zero-trust
+overlay), confidentiality is covered by the network layer, but the browser still
+drops the `Secure` auth cookie, so login never persists. To support this topology,
+set `AUTH_COOKIE_SECURE=false`: the auth cookie is then issued **without** the
+`Secure` attribute, and plain-HTTP logins work.
+
+```bash
+# Trusted private network, plain HTTP, no app-level TLS:
+NODE_ENV=production AUTH_MODE=multi-user AUTH_COOKIE_SECURE=false <start command>
+```
+
+`AUTH_COOKIE_SECURE` is tri-state:
+
+| Value | Effect |
+|---|---|
+| _(unset, default)_ | `Secure` follows `NODE_ENV` — `Secure` in production, not otherwise. No change from historical behavior. |
+| `false` | Cookie issued **without** `Secure`, regardless of `NODE_ENV`. |
+| `true` | Cookie **always** `Secure`, regardless of `NODE_ENV`. |
+
+Any other value fails fast at startup. When `AUTH_COOKIE_SECURE=false` is combined
+with `NODE_ENV=production`, the server emits a loud startup warning naming the risk.
+
+> **⚠️ Only on a genuinely trusted network.** Disabling `Secure` means the session
+> cookie is transmitted over plain HTTP, so any untrusted segment on the path
+> enables session hijacking. Use it only where the network layer (WARP/VPN/overlay)
+> already guarantees confidentiality — never on the public internet or an untrusted
+> LAN.
 
 When you do terminate TLS, do it in front of Agent Console (reverse proxy such as
 nginx/Caddy, or a load balancer), forward both the HTTP routes and the WebSocket

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,7 +8,7 @@ import { createWorktreeWithSession } from './services/worktree-creation-service.
 import { deleteWorktree } from './services/worktree-deletion-service.js';
 import { setupWebSocketRoutes, broadcastToApp } from './websocket/routes.js';
 import { onApiError } from './lib/error-handler.js';
-import { serverConfig } from './lib/server-config.js';
+import { serverConfig, shouldWarnInsecureAuthCookie } from './lib/server-config.js';
 import { rootLogger, createLogger } from './lib/logger.js';
 import { getConfigDir } from './lib/config.js';
 import { createAppContext, shutdownAppContext, type AppContext, type AppBindings } from './app-context.js';
@@ -177,6 +177,14 @@ logger.info(
   { port: PORT, env: isProduction ? 'production' : 'development', pid: process.pid },
   'Server starting'
 );
+
+if (shouldWarnInsecureAuthCookie()) {
+  logger.warn(
+    'AUTH_COOKIE_SECURE=false disables the Secure attribute on the auth cookie while NODE_ENV=production. ' +
+    'The session cookie will be transmitted over plain HTTP. Only do this on a trusted private network ' +
+    '(e.g. Cloudflare WARP / VPN); on an untrusted network this enables session hijack.'
+  );
+}
 
 const server = Bun.serve({
   fetch: app.fetch,

--- a/packages/server/src/lib/__tests__/env-parser.test.ts
+++ b/packages/server/src/lib/__tests__/env-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { parseEnvVars } from '../env-parser.js';
+import { parseEnvVars, parseOptionalBoolean } from '../env-parser.js';
 
 describe('parseEnvVars', () => {
   it('should return empty object for null input', () => {
@@ -141,5 +141,41 @@ API_URL=https://api.example.com/v1?token=xyz # production endpoint`;
       API_KEY: 'abc123def456',
       API_URL: 'https://api.example.com/v1?token=xyz',
     });
+  });
+});
+
+describe('parseOptionalBoolean', () => {
+  it('returns undefined for undefined input', () => {
+    expect(parseOptionalBoolean(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(parseOptionalBoolean('')).toBeUndefined();
+  });
+
+  it("returns true for 'true'", () => {
+    expect(parseOptionalBoolean('true')).toBe(true);
+  });
+
+  it("returns false for 'false'", () => {
+    expect(parseOptionalBoolean('false')).toBe(false);
+  });
+
+  it("throws for '1' with the offending value in the message", () => {
+    expect(() => parseOptionalBoolean('1')).toThrow(
+      "Expected 'true', 'false', or unset, got: '1'"
+    );
+  });
+
+  it("throws for 'yes' with the generic message", () => {
+    expect(() => parseOptionalBoolean('yes')).toThrow(
+      "Expected 'true', 'false', or unset, got: 'yes'"
+    );
+  });
+
+  it("throws for 'TRUE' (case-sensitive, uppercase rejected)", () => {
+    expect(() => parseOptionalBoolean('TRUE')).toThrow(
+      "Expected 'true', 'false', or unset, got: 'TRUE'"
+    );
   });
 });

--- a/packages/server/src/lib/__tests__/server-config.test.ts
+++ b/packages/server/src/lib/__tests__/server-config.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import {
-  parseAuthCookieSecure,
   resolveAuthCookieSecure,
   shouldWarnInsecureAuthCookie,
 } from '../server-config.js';
@@ -153,43 +152,7 @@ describe('server-config', () => {
       process.env.AUTH_COOKIE_SECURE = '1';
 
       await expect(importServerConfig()).rejects.toThrow(
-        "Invalid AUTH_COOKIE_SECURE: '1'. Must be 'true', 'false', or unset."
-      );
-    });
-  });
-
-  describe('parseAuthCookieSecure', () => {
-    it('returns undefined for undefined input', () => {
-      expect(parseAuthCookieSecure(undefined)).toBeUndefined();
-    });
-
-    it('returns undefined for empty string', () => {
-      expect(parseAuthCookieSecure('')).toBeUndefined();
-    });
-
-    it("returns true for 'true'", () => {
-      expect(parseAuthCookieSecure('true')).toBe(true);
-    });
-
-    it("returns false for 'false'", () => {
-      expect(parseAuthCookieSecure('false')).toBe(false);
-    });
-
-    it("throws for '1'", () => {
-      expect(() => parseAuthCookieSecure('1')).toThrow(
-        "Invalid AUTH_COOKIE_SECURE: '1'. Must be 'true', 'false', or unset."
-      );
-    });
-
-    it("throws for 'yes'", () => {
-      expect(() => parseAuthCookieSecure('yes')).toThrow(
-        "Invalid AUTH_COOKIE_SECURE: 'yes'. Must be 'true', 'false', or unset."
-      );
-    });
-
-    it("throws for 'TRUE' (case-sensitive)", () => {
-      expect(() => parseAuthCookieSecure('TRUE')).toThrow(
-        "Invalid AUTH_COOKIE_SECURE: 'TRUE'. Must be 'true', 'false', or unset."
+        /Invalid AUTH_COOKIE_SECURE: Expected 'true', 'false', or unset, got: '1'/
       );
     });
   });

--- a/packages/server/src/lib/__tests__/server-config.test.ts
+++ b/packages/server/src/lib/__tests__/server-config.test.ts
@@ -1,4 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  parseAuthCookieSecure,
+  resolveAuthCookieSecure,
+  shouldWarnInsecureAuthCookie,
+} from '../server-config.js';
 
 describe('server-config', () => {
   const originalEnv = { ...process.env };
@@ -110,6 +115,158 @@ describe('server-config', () => {
       const { serverConfig } = await importServerConfig();
 
       expect(serverConfig.AGENT_CONSOLE_SHARED_USERNAME).toBe('agent-console-shared');
+    });
+
+    it('should default AUTH_COOKIE_SECURE to undefined when not set', async () => {
+      delete process.env.AUTH_COOKIE_SECURE;
+
+      const { serverConfig } = await importServerConfig();
+
+      expect(serverConfig.AUTH_COOKIE_SECURE).toBeUndefined();
+    });
+
+    it('should treat empty AUTH_COOKIE_SECURE as unset', async () => {
+      process.env.AUTH_COOKIE_SECURE = '';
+
+      const { serverConfig } = await importServerConfig();
+
+      expect(serverConfig.AUTH_COOKIE_SECURE).toBeUndefined();
+    });
+
+    it('should expose AUTH_COOKIE_SECURE=true as boolean true', async () => {
+      process.env.AUTH_COOKIE_SECURE = 'true';
+
+      const { serverConfig } = await importServerConfig();
+
+      expect(serverConfig.AUTH_COOKIE_SECURE).toBe(true);
+    });
+
+    it('should expose AUTH_COOKIE_SECURE=false as boolean false', async () => {
+      process.env.AUTH_COOKIE_SECURE = 'false';
+
+      const { serverConfig } = await importServerConfig();
+
+      expect(serverConfig.AUTH_COOKIE_SECURE).toBe(false);
+    });
+
+    it('should throw for invalid AUTH_COOKIE_SECURE value', async () => {
+      process.env.AUTH_COOKIE_SECURE = '1';
+
+      await expect(importServerConfig()).rejects.toThrow(
+        "Invalid AUTH_COOKIE_SECURE: '1'. Must be 'true', 'false', or unset."
+      );
+    });
+  });
+
+  describe('parseAuthCookieSecure', () => {
+    it('returns undefined for undefined input', () => {
+      expect(parseAuthCookieSecure(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for empty string', () => {
+      expect(parseAuthCookieSecure('')).toBeUndefined();
+    });
+
+    it("returns true for 'true'", () => {
+      expect(parseAuthCookieSecure('true')).toBe(true);
+    });
+
+    it("returns false for 'false'", () => {
+      expect(parseAuthCookieSecure('false')).toBe(false);
+    });
+
+    it("throws for '1'", () => {
+      expect(() => parseAuthCookieSecure('1')).toThrow(
+        "Invalid AUTH_COOKIE_SECURE: '1'. Must be 'true', 'false', or unset."
+      );
+    });
+
+    it("throws for 'yes'", () => {
+      expect(() => parseAuthCookieSecure('yes')).toThrow(
+        "Invalid AUTH_COOKIE_SECURE: 'yes'. Must be 'true', 'false', or unset."
+      );
+    });
+
+    it("throws for 'TRUE' (case-sensitive)", () => {
+      expect(() => parseAuthCookieSecure('TRUE')).toThrow(
+        "Invalid AUTH_COOKIE_SECURE: 'TRUE'. Must be 'true', 'false', or unset."
+      );
+    });
+  });
+
+  describe('resolveAuthCookieSecure', () => {
+    it('unset + production -> true (preserves current behavior)', () => {
+      expect(
+        resolveAuthCookieSecure({ AUTH_COOKIE_SECURE: undefined, NODE_ENV: 'production' })
+      ).toBe(true);
+    });
+
+    it('unset + development -> false', () => {
+      expect(
+        resolveAuthCookieSecure({ AUTH_COOKIE_SECURE: undefined, NODE_ENV: 'development' })
+      ).toBe(false);
+    });
+
+    it('unset + undefined NODE_ENV -> false', () => {
+      expect(
+        resolveAuthCookieSecure({ AUTH_COOKIE_SECURE: undefined, NODE_ENV: undefined })
+      ).toBe(false);
+    });
+
+    it('false + production -> false', () => {
+      expect(
+        resolveAuthCookieSecure({ AUTH_COOKIE_SECURE: false, NODE_ENV: 'production' })
+      ).toBe(false);
+    });
+
+    it('false + development -> false', () => {
+      expect(
+        resolveAuthCookieSecure({ AUTH_COOKIE_SECURE: false, NODE_ENV: 'development' })
+      ).toBe(false);
+    });
+
+    it('true + development -> true', () => {
+      expect(
+        resolveAuthCookieSecure({ AUTH_COOKIE_SECURE: true, NODE_ENV: 'development' })
+      ).toBe(true);
+    });
+
+    it('true + production -> true', () => {
+      expect(
+        resolveAuthCookieSecure({ AUTH_COOKIE_SECURE: true, NODE_ENV: 'production' })
+      ).toBe(true);
+    });
+  });
+
+  describe('shouldWarnInsecureAuthCookie', () => {
+    it('false + production -> true (the only true case)', () => {
+      expect(
+        shouldWarnInsecureAuthCookie({ AUTH_COOKIE_SECURE: false, NODE_ENV: 'production' })
+      ).toBe(true);
+    });
+
+    it('false + development -> false', () => {
+      expect(
+        shouldWarnInsecureAuthCookie({ AUTH_COOKIE_SECURE: false, NODE_ENV: 'development' })
+      ).toBe(false);
+    });
+
+    it('undefined + production -> false', () => {
+      expect(
+        shouldWarnInsecureAuthCookie({ AUTH_COOKIE_SECURE: undefined, NODE_ENV: 'production' })
+      ).toBe(false);
+    });
+
+    it('true + production -> false', () => {
+      expect(
+        shouldWarnInsecureAuthCookie({ AUTH_COOKIE_SECURE: true, NODE_ENV: 'production' })
+      ).toBe(false);
+    });
+
+    it('undefined + development -> false', () => {
+      expect(
+        shouldWarnInsecureAuthCookie({ AUTH_COOKIE_SECURE: undefined, NODE_ENV: 'development' })
+      ).toBe(false);
     });
   });
 

--- a/packages/server/src/lib/env-parser.ts
+++ b/packages/server/src/lib/env-parser.ts
@@ -62,3 +62,25 @@ export function parseEnvVars(envVarsText: string | null | undefined): Record<str
 
   return result;
 }
+
+/**
+ * Parse an optional boolean environment variable value.
+ * - undefined or '' -> undefined (unset)
+ * - 'true' -> true
+ * - 'false' -> false
+ * - anything else -> throws (fail-fast) with a generic, variable-name-agnostic message
+ *
+ * Callers that know the variable name should catch and re-throw with that context.
+ */
+export function parseOptionalBoolean(raw: string | undefined): boolean | undefined {
+  if (raw === undefined || raw === '') {
+    return undefined;
+  }
+  if (raw === 'true') {
+    return true;
+  }
+  if (raw === 'false') {
+    return false;
+  }
+  throw new Error(`Expected 'true', 'false', or unset, got: '${raw}'`);
+}

--- a/packages/server/src/lib/server-config.ts
+++ b/packages/server/src/lib/server-config.ts
@@ -1,3 +1,5 @@
+import { parseOptionalBoolean } from './env-parser.js';
+
 /**
  * Centralized server-specific environment configuration.
  *
@@ -97,32 +99,14 @@ export const serverConfig = {
    *
    * Any other non-empty value throws (fail-fast). Case-sensitive.
    */
-  AUTH_COOKIE_SECURE: parseAuthCookieSecure(process.env.AUTH_COOKIE_SECURE),
+  AUTH_COOKIE_SECURE: (() => {
+    try {
+      return parseOptionalBoolean(process.env.AUTH_COOKIE_SECURE);
+    } catch (e) {
+      throw new Error(`Invalid AUTH_COOKIE_SECURE: ${(e as Error).message}`);
+    }
+  })(),
 } as const;
-
-/**
- * Parse the AUTH_COOKIE_SECURE tri-state env value.
- * - undefined or '' -> undefined (unset)
- * - 'true' -> true
- * - 'false' -> false
- * - anything else -> throws (fail-fast)
- *
- * @internal Exported for testing.
- */
-export function parseAuthCookieSecure(raw: string | undefined): boolean | undefined {
-  if (raw === undefined || raw === '') {
-    return undefined;
-  }
-  if (raw === 'true') {
-    return true;
-  }
-  if (raw === 'false') {
-    return false;
-  }
-  throw new Error(
-    `Invalid AUTH_COOKIE_SECURE: '${raw}'. Must be 'true', 'false', or unset.`
-  );
-}
 
 /**
  * Resolve whether the auth cookie should carry the Secure attribute.

--- a/packages/server/src/lib/server-config.ts
+++ b/packages/server/src/lib/server-config.ts
@@ -85,7 +85,65 @@ export const serverConfig = {
    * Empty string is treated as unset (operator-friendly).
    */
   AGENT_CONSOLE_SHARED_USERNAME: process.env.AGENT_CONSOLE_SHARED_USERNAME || undefined,
+  /**
+   * Controls the Secure attribute on the auth session cookie. Tri-state:
+   * - unset (undefined or empty string): current behavior, secure = (NODE_ENV === 'production').
+   *   Empty string is treated as unset (operator-friendly).
+   * - 'false': never set Secure. For trusted-network plain-HTTP deployments
+   *   (e.g. Cloudflare WARP / VPN internal networks) where the browser would
+   *   otherwise drop the Secure cookie over HTTP. Disabling on an untrusted
+   *   network enables session hijack.
+   * - 'true': always set Secure.
+   *
+   * Any other non-empty value throws (fail-fast). Case-sensitive.
+   */
+  AUTH_COOKIE_SECURE: parseAuthCookieSecure(process.env.AUTH_COOKIE_SECURE),
 } as const;
+
+/**
+ * Parse the AUTH_COOKIE_SECURE tri-state env value.
+ * - undefined or '' -> undefined (unset)
+ * - 'true' -> true
+ * - 'false' -> false
+ * - anything else -> throws (fail-fast)
+ *
+ * @internal Exported for testing.
+ */
+export function parseAuthCookieSecure(raw: string | undefined): boolean | undefined {
+  if (raw === undefined || raw === '') {
+    return undefined;
+  }
+  if (raw === 'true') {
+    return true;
+  }
+  if (raw === 'false') {
+    return false;
+  }
+  throw new Error(
+    `Invalid AUTH_COOKIE_SECURE: '${raw}'. Must be 'true', 'false', or unset.`
+  );
+}
+
+/**
+ * Resolve whether the auth cookie should carry the Secure attribute.
+ * Unset AUTH_COOKIE_SECURE preserves the historical behavior (Secure in production).
+ */
+export function resolveAuthCookieSecure(
+  config: Pick<ServerConfig, 'AUTH_COOKIE_SECURE' | 'NODE_ENV'> = serverConfig,
+): boolean {
+  return config.AUTH_COOKIE_SECURE ?? config.NODE_ENV === 'production';
+}
+
+/**
+ * Whether to emit the loud startup warning: secure cookies are explicitly
+ * disabled in a production serving context, where the auth cookie would
+ * otherwise be Secure. Fires ONLY in this case to avoid dev-startup noise.
+ */
+export function shouldWarnInsecureAuthCookie(
+  config: Pick<ServerConfig, 'AUTH_COOKIE_SECURE' | 'NODE_ENV'> = serverConfig,
+): boolean {
+  return config.AUTH_COOKIE_SECURE === false && config.NODE_ENV === 'production';
+}
 
 /**
  * Default patterns to ignore when watching for file changes.

--- a/packages/server/src/routes/__tests__/auth.test.ts
+++ b/packages/server/src/routes/__tests__/auth.test.ts
@@ -141,6 +141,14 @@ describe('Auth Routes', () => {
       expect(setCookieHeader).toContain('HttpOnly');
       expect(setCookieHeader).toContain('Path=/');
       expect(setCookieHeader).toContain('SameSite=Lax');
+      // Secure follows the default (unset AUTH_COOKIE_SECURE) resolution:
+      // Secure iff NODE_ENV === 'production'. This verifies the shipping route
+      // path uses resolveAuthCookieSecure and preserves current behavior.
+      if (serverConfig.NODE_ENV === 'production') {
+        expect(setCookieHeader).toContain('Secure');
+      } else {
+        expect(setCookieHeader).not.toContain('Secure');
+      }
     });
 
     it('should return validation error for missing username', async () => {

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -14,7 +14,7 @@ import { getCookie, setCookie, deleteCookie } from 'hono/cookie';
 import { LoginRequestSchema } from '@agent-console/shared';
 import { vValidator } from '../middleware/validation.js';
 import type { AppBindings } from '../app-context.js';
-import { serverConfig } from '../lib/server-config.js';
+import { serverConfig, resolveAuthCookieSecure } from '../lib/server-config.js';
 import { AUTH_COOKIE_NAME } from '../lib/auth-constants.js';
 
 /** Cookie max-age in seconds (7 days, matches JWT expiry) */
@@ -88,7 +88,7 @@ const auth = new Hono<AppBindings>()
     // Set httpOnly cookie with the token
     setCookie(c, AUTH_COOKIE_NAME, result.token, {
       httpOnly: true,
-      secure: serverConfig.NODE_ENV === 'production',
+      secure: resolveAuthCookieSecure(serverConfig),
       sameSite: 'Lax',
       path: '/',
       maxAge: AUTH_COOKIE_MAX_AGE,


### PR DESCRIPTION
## Summary

Decouples the auth cookie's `Secure` attribute from `NODE_ENV` via a new tri-state `AUTH_COOKIE_SECURE` override, unblocking trusted-network plain-HTTP deployments (e.g. Cloudflare WARP internal network where members reach `http://<internal-host>:<port>`).

Closes #805

## Problem

The auth cookie's `Secure` flag was hard-wired to `NODE_ENV === 'production'` (`auth.ts:91`). Because `NODE_ENV=production` is **also** required to serve the built SPA (`index.ts`), an operator cannot unset it to drop `Secure` without disabling the UI. Browsers send `Secure` cookies only over `https` or `http://localhost` — a URL-scheme/host decision independent of network-layer security. So on a trusted private network served over plain `http://<host>:<port>`, the browser drops the auth cookie and **login never persists**, even though the network itself is encrypted/trusted.

## Change

- **`server-config.ts`**: new tri-state `AUTH_COOKIE_SECURE` env config + two exported pure functions:
  - `resolveAuthCookieSecure(config)` → `config.AUTH_COOKIE_SECURE ?? (NODE_ENV === 'production')`
  - `shouldWarnInsecureAuthCookie(config)` → `true` only when `AUTH_COOKIE_SECURE === false && NODE_ENV === 'production'`
  - `parseAuthCookieSecure(raw)` (`@internal`) — tri-state parser, **fail-fast** on invalid values.
- **`auth.ts:91`**: `secure: resolveAuthCookieSecure(serverConfig)`.
- **`index.ts`**: loud `logger.warn` at startup when secure cookies are disabled in production, naming the session-hijack risk.
- **docs**: `docs/multi-user-setup-guide.md` TLS section — replaced #803's forward-reference placeholder with the shipped setting (env-var row, decision-table row, dedicated section, risk warning).

## Design decisions

- **Naming** `AUTH_COOKIE_SECURE` — consistent with the existing `AUTH_MODE` env convention.
- **Invalid value → fail-fast** at startup, matching the existing `AUTH_MODE` IIFE-throw pattern. Empty string is treated as unset (operator-friendly, like `AGENT_CONSOLE_SHARED_USERNAME`).
- **Default preserves current behavior** byte-for-byte: unset → `secure` follows `NODE_ENV`.

## Boundary behavior (acceptance criteria)

| `AUTH_COOKIE_SECURE` | `NODE_ENV` | `secure` | startup warn |
|---|---|---|---|
| unset | production | `true` (unchanged) | no |
| unset | dev/unset | `false` (unchanged) | no |
| `false` | production | `false` | **yes** |
| `false` | dev | `false` | no |
| `true` | any | `true` | no |
| invalid | — | fail-fast at startup | — |

## Verification

- **Polarity confirmed**: with the new tests present, reverting the two resolver bodies makes 3 server-config tests fail (`resolveAuthCookieSecure false+prod`, `true+dev`; `shouldWarnInsecureAuthCookie false+prod`); restoring the fix → all pass.
- `bun run typecheck` — clean (all 3 packages).
- `bun run test` (full suite) — **green, exit 0** (server 2571 pass / 1 skip, client 1396 pass / 2 skip, shared 324, integration 29, scripts+hooks+skills 362).
- `bun run check:lang` — clean (103 files).
- CodeRabbit CLI (`--base origin/main`) — **0 findings**.

> **E2E note.** The tri-state behavior is verified through the shipping route path via `auth.test.ts` (asserts the `Set-Cookie` `Secure` attribute follows the default resolution) plus exhaustive unit coverage of the pure resolvers. The real browser-on-WARP path is the owner's deployment environment and is not reproducible in this dev environment; recommend owner dogfood verification post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note on CodeRabbit

The full diff was reviewed by the local CodeRabbit CLI (`--base origin/main`), including the `parseOptionalBoolean` extraction refactor (`efd46fd`).

- **1 NITPICK (deferred)** — CodeRabbit suggested trimming whitespace in `parseOptionalBoolean` before matching `'true'`/`'false'`. **Deferred**: this refactor's mandate is behavior-preserving, the pre-refactor parser did not trim, and the sibling `AUTH_MODE` parser does not trim either — adding trimming here would change behavior (`' true '` would flip from throw → `true`) and break consistency. Env-var whitespace robustness is a separate, project-wide enhancement decision, not in scope for this PR.
- No CRITICAL / HIGH / MEDIUM findings.
