### PR TITLE
feat: CI docker multi-user E2E + 0700-home regression guard (#808)

### DIFF
--- a/.github/workflows/docker-multiuser-e2e.yml
+++ b/.github/workflows/docker-multiuser-e2e.yml
@@ -48,6 +48,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This job never pushes; drop the auto-persisted git credentials.
+          persist-credentials: false
 
       # verify-multiuser-docker.sh runs docker/verify-client.ts on the host (the
       # PTY identity probe), so bun must be on PATH. Docker + compose v2 are

--- a/.github/workflows/docker-multiuser-e2e.yml
+++ b/.github/workflows/docker-multiuser-e2e.yml
@@ -4,11 +4,11 @@ name: Docker Multi-User E2E
 # default base (oven/bun:1.3.8, no --build-arg override) to prove clean-pull
 # reproducibility, then runs scripts/verify-multiuser-docker.sh end to end:
 # authMode / unauth 401 / wrong+right password / alice+bob PTY whoami isolation
-# (7 checks total). The matrix runs the same checks against both home-permission
-# modes:
-#   - 0711: the image default (conservative deployment recommendation)
-#   - 0700: Debian's default; regression guard for the #806 neutral-cwd PTY-spawn
-#           fix (a 0700 home must still spawn a PTY and resolve whoami).
+# (7 checks total).
+#
+# The test users' home dirs are the OS default 0700 (set in docker/Dockerfile),
+# so this job also permanently guards the #806 neutral-cwd PTY-spawn fix: a 0700
+# home must still spawn a PTY and resolve whoami.
 #
 # Docker build is heavier than the unit suite, so this is path-filtered to the
 # multi-user surface (the harness, the auth route, and the user-mode service).
@@ -43,13 +43,9 @@ concurrency:
 
 jobs:
   e2e:
-    name: e2e (home ${{ matrix.home_mode }})
+    name: e2e (home 0700)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        home_mode: ['0711', '0700']
 
     steps:
       - uses: actions/checkout@v4
@@ -65,8 +61,5 @@ jobs:
         with:
           bun-version: "1.3.5"
 
-      - name: Build image and run multi-user E2E (home ${{ matrix.home_mode }})
-        env:
-          # Consumed by docker-compose.yml's build.args -> Dockerfile ARG.
-          TEST_HOME_MODE: ${{ matrix.home_mode }}
+      - name: Build image and run multi-user E2E (home 0700)
         run: scripts/verify-multiuser-docker.sh

--- a/.github/workflows/docker-multiuser-e2e.yml
+++ b/.github/workflows/docker-multiuser-e2e.yml
@@ -32,6 +32,11 @@ on:
       - 'packages/server/src/routes/auth.ts'
       - '.github/workflows/docker-multiuser-e2e.yml'
 
+# This job only checks out the repo and builds/runs docker locally; it never
+# writes to the repo, comments, or pushes. Least-privilege read-only token.
+permissions:
+  contents: read
+
 concurrency:
   group: docker-multiuser-e2e-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docker-multiuser-e2e.yml
+++ b/.github/workflows/docker-multiuser-e2e.yml
@@ -1,0 +1,64 @@
+name: Docker Multi-User E2E
+
+# Builds the multi-user verification image (docker/Dockerfile) from its committed
+# default base (oven/bun:1.3.8, no --build-arg override) to prove clean-pull
+# reproducibility, then runs scripts/verify-multiuser-docker.sh end to end:
+# authMode / unauth 401 / wrong+right password / alice+bob PTY whoami isolation
+# (7 checks total). The matrix runs the same checks against both home-permission
+# modes:
+#   - 0711: the image default (conservative deployment recommendation)
+#   - 0700: Debian's default; regression guard for the #806 neutral-cwd PTY-spawn
+#           fix (a 0700 home must still spawn a PTY and resolve whoami).
+#
+# Docker build is heavier than the unit suite, so this is path-filtered to the
+# multi-user surface (the harness, the auth route, and the user-mode service).
+# It is NOT a required check for unrelated PRs.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/**'
+      - 'scripts/verify-multiuser-docker.sh'
+      - 'packages/server/src/services/user-mode.ts'
+      - 'packages/server/src/routes/auth.ts'
+      - '.github/workflows/docker-multiuser-e2e.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docker/**'
+      - 'scripts/verify-multiuser-docker.sh'
+      - 'packages/server/src/services/user-mode.ts'
+      - 'packages/server/src/routes/auth.ts'
+      - '.github/workflows/docker-multiuser-e2e.yml'
+
+concurrency:
+  group: docker-multiuser-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: e2e (home ${{ matrix.home_mode }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        home_mode: ['0711', '0700']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # verify-multiuser-docker.sh runs docker/verify-client.ts on the host (the
+      # PTY identity probe), so bun must be on PATH. Docker + compose v2 are
+      # preinstalled on ubuntu-latest.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.5"
+
+      - name: Build image and run multi-user E2E (home ${{ matrix.home_mode }})
+        env:
+          # Consumed by docker-compose.yml's build.args -> Dockerfile ARG.
+          TEST_HOME_MODE: ${{ matrix.home_mode }}
+        run: scripts/verify-multiuser-docker.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,20 +80,25 @@ RUN chmod 0440 /etc/sudoers.d/agentconsole \
 # --- Test OS users with known passwords (VERIFICATION ONLY) ---
 # Passwords are intentionally well-known; this image must never be exposed.
 #
-# Home dirs are set to 0711 (traversable but not readable by others). The server
-# spawns `sudo -u <user> -i` with the session's working directory as the PTY
-# cwd, and the forked child performs chdir(cwd) WHILE STILL the service user
-# (before sudo switches to the target user). Debian's default HOME_MODE=0700
-# would deny that chdir and the spawn fails with "PTY spawn failed". 0711 lets
-# the service user enter the directory without exposing its contents. This
-# mirrors the real-deployment requirement documented in
-# docs/multi-user-setup-guide.md ("service user must be able to enter session
-# working directories").
+# TEST_HOME_MODE controls the permission bits on the test users' home dirs:
+#
+# - 0711 (default) — traversable but not readable by others. This mirrors the
+#   conservative real-deployment recommendation in docs/multi-user-setup-guide.md
+#   ("service user must be able to enter session working directories").
+# - 0700 — Debian's default; private to the owner. Before #806 a 0700 home broke
+#   the PTY spawn: the forked child ran chdir(session cwd) WHILE STILL the
+#   service user (before sudo switched to the target user), and the service user
+#   lacked traverse permission, so the spawn failed with "PTY spawn failed".
+#   #806 fixed this by performing the pre-exec chdir into a neutral, always
+#   traversable cwd (`/`) and deferring the `cd` into the session directory to
+#   the inner shell that runs AS the target user. The CI E2E job builds a second
+#   image with TEST_HOME_MODE=0700 to permanently guard that fix (issue #808).
+ARG TEST_HOME_MODE=0711
 RUN useradd --create-home --shell /bin/bash alice \
  && useradd --create-home --shell /bin/bash bob \
  && echo 'alice:alice-password' | chpasswd \
  && echo 'bob:bob-password' | chpasswd \
- && chmod 0711 /home/alice /home/bob
+ && chmod "${TEST_HOME_MODE}" /home/alice /home/bob
 
 # --- Application bundle ---
 WORKDIR /app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,25 +80,21 @@ RUN chmod 0440 /etc/sudoers.d/agentconsole \
 # --- Test OS users with known passwords (VERIFICATION ONLY) ---
 # Passwords are intentionally well-known; this image must never be exposed.
 #
-# TEST_HOME_MODE controls the permission bits on the test users' home dirs:
-#
-# - 0711 (default) — traversable but not readable by others. This mirrors the
-#   conservative real-deployment recommendation in docs/multi-user-setup-guide.md
-#   ("service user must be able to enter session working directories").
-# - 0700 — Debian's default; private to the owner. Before #806 a 0700 home broke
-#   the PTY spawn: the forked child ran chdir(session cwd) WHILE STILL the
-#   service user (before sudo switched to the target user), and the service user
-#   lacked traverse permission, so the spawn failed with "PTY spawn failed".
-#   #806 fixed this by performing the pre-exec chdir into a neutral, always
-#   traversable cwd (`/`) and deferring the `cd` into the session directory to
-#   the inner shell that runs AS the target user. The CI E2E job builds a second
-#   image with TEST_HOME_MODE=0700 to permanently guard that fix (issue #808).
-ARG TEST_HOME_MODE=0711
+# Home dirs are left at 0700 — the OS default (Debian/Ubuntu HOME_MODE) and the
+# most restrictive, private-to-the-owner mode. This is the permanent regression
+# guard for #806: before that fix the PTY spawn ran chdir(session cwd) WHILE
+# STILL the service user (before sudo switched to the target user), so a 0700
+# home it did not own denied the chdir and the spawn failed with "PTY spawn
+# failed". #806 fixed it by performing the pre-exec chdir into a neutral,
+# always-traversable cwd (`/`) and deferring the `cd` into the session directory
+# to the inner shell that runs AS the target user. Keeping the test homes at the
+# default 0700 means the CI E2E job permanently exercises that fixed path so a
+# regression resurfaces as a failing build (issue #808).
 RUN useradd --create-home --shell /bin/bash alice \
  && useradd --create-home --shell /bin/bash bob \
  && echo 'alice:alice-password' | chpasswd \
  && echo 'bob:bob-password' | chpasswd \
- && chmod "${TEST_HOME_MODE}" /home/alice /home/bob
+ && chmod 0700 /home/alice /home/bob
 
 # --- Application bundle ---
 WORKDIR /app

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,13 +72,18 @@ exists solely for local verification.
 - **sudoers** — `MultiUserMode.spawnSudoPty()` runs `sudo -u <user> -i sh -c`.
   The `agentconsole` user is granted `NOPASSWD` shell access to any non-root
   user, and nothing else.
-- **`0711` test home directories** — the PTY spawn helper `chdir`s into the
-  session's working directory _as the service user_ before `sudo` switches to
-  the target user. Debian's default `0700` home would deny that `chdir` and the
-  spawn fails with "PTY spawn failed". The image sets the test homes to `0711`
-  (traversable, not readable). This is an operational workaround; the root-cause
-  fix is tracked in
-  [issue #802](https://github.com/ms2sato/agent-console/issues/802).
+- **`0711` test home directories (default)** — historically the PTY spawn helper
+  `chdir`ed into the session's working directory _as the service user_ before
+  `sudo` switched to the target user, so Debian's default `0700` home denied that
+  `chdir` and the spawn failed with "PTY spawn failed". The root cause was fixed
+  in [#806](https://github.com/ms2sato/agent-console/pull/806) (the pre-exec
+  `chdir` now lands on a neutral `/`; the real `cd` happens in the inner shell
+  that runs as the target user). The image still defaults the test homes to
+  `0711` to mirror the conservative deployment recommendation, but the home mode
+  is now a build arg: pass `--build-arg TEST_HOME_MODE=0700` (or set
+  `TEST_HOME_MODE=0700` in the compose env) to build a `0700`-home image. The CI
+  E2E job ([#808](https://github.com/ms2sato/agent-console/issues/808)) runs both
+  modes so the `0700` path is permanently guarded.
 
 ## Building behind a blocked Docker Hub
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,18 +72,18 @@ exists solely for local verification.
 - **sudoers** — `MultiUserMode.spawnSudoPty()` runs `sudo -u <user> -i sh -c`.
   The `agentconsole` user is granted `NOPASSWD` shell access to any non-root
   user, and nothing else.
-- **`0711` test home directories (default)** — historically the PTY spawn helper
-  `chdir`ed into the session's working directory _as the service user_ before
-  `sudo` switched to the target user, so Debian's default `0700` home denied that
-  `chdir` and the spawn failed with "PTY spawn failed". The root cause was fixed
-  in [#806](https://github.com/ms2sato/agent-console/pull/806) (the pre-exec
-  `chdir` now lands on a neutral `/`; the real `cd` happens in the inner shell
-  that runs as the target user). The image still defaults the test homes to
-  `0711` to mirror the conservative deployment recommendation, but the home mode
-  is now a build arg: pass `--build-arg TEST_HOME_MODE=0700` (or set
-  `TEST_HOME_MODE=0700` in the compose env) to build a `0700`-home image. The CI
-  E2E job ([#808](https://github.com/ms2sato/agent-console/issues/808)) runs both
-  modes so the `0700` path is permanently guarded.
+- **`0700` test home directories** — the test users' homes use the OS default
+  `0700` (private to the owner). Historically the PTY spawn helper `chdir`ed into
+  the session's working directory _as the service user_ before `sudo` switched to
+  the target user, so a `0700` home denied that `chdir` and the spawn failed with
+  "PTY spawn failed". This was fixed in
+  [#806](https://github.com/ms2sato/agent-console/pull/806): the pre-exec `chdir`
+  now lands on a neutral `/`, and the real `cd` happens in the inner shell that
+  runs as the target user — so a default `0700` home spawns successfully with no
+  permission change. Keeping the test homes at `0700` makes this image a
+  permanent regression guard for that fix; the CI E2E job
+  ([#808](https://github.com/ms2sato/agent-console/issues/808)) fails the build
+  if the `0700` path ever breaks again.
 
 ## Building behind a blocked Docker Hub
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,11 +11,6 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-      args:
-        # Permission bits for the test users' home dirs. Default 0711 matches the
-        # conservative deployment recommendation; the CI E2E job sets 0700 to
-        # regression-test the #806 neutral-cwd PTY-spawn fix. See docker/Dockerfile.
-        TEST_HOME_MODE: ${TEST_HOME_MODE:-0711}
     image: agent-console-multiuser-verify
     container_name: agent-console-multiuser-verify
     # Bind to loopback only: this stack ships intentionally known test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,11 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+      args:
+        # Permission bits for the test users' home dirs. Default 0711 matches the
+        # conservative deployment recommendation; the CI E2E job sets 0700 to
+        # regression-test the #806 neutral-cwd PTY-spawn fix. See docker/Dockerfile.
+        TEST_HOME_MODE: ${TEST_HOME_MODE:-0711}
     image: agent-console-multiuser-verify
     container_name: agent-console-multiuser-verify
     # Bind to loopback only: this stack ships intentionally known test

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -324,36 +324,20 @@ Users do **not** need:
 
 Their existing environment (`.bashrc`, `.zshrc`, SSH keys, git config, API keys) works automatically because PTY processes run as their user via `sudo -u <user> -i`, which loads their login shell profile.
 
-### The service user must be able to enter session working directories
+### Default `0700` home directories work as-is
 
-When the server starts a PTY it spawns `sudo -u <user> -i` with the session's
-working directory as the PTY's `cwd`. The spawn helper performs `chdir(cwd)` in
-the forked child **before** `sudo` switches to the target user — i.e. while the
-process is still the service user. If the service user cannot enter that
-directory, the spawn fails with **"PTY spawn failed"** even though
-authentication succeeded.
+User home directories at the OS default mode `0700` (Debian/Ubuntu
+`HOME_MODE 0700`, private to the owner) work with **no permission change**.
 
-This matters when a session's working directory is a user's home directory and
-that home is mode `0700` (the default on Debian/Ubuntu, `HOME_MODE 0700`). The
-service user cannot `chdir` into a `0700` home it does not own.
-
-Ensure the service user has **traverse (execute) permission** on every directory
-used as a session working directory. The least-privilege fix for home
-directories is `0711` (traversable but not readable by others):
-
-```bash
-sudo chmod 0711 /home/alice
-```
-
-`0711` lets the service user enter the directory to launch the PTY without being
-able to list or read its contents; the user's files keep their own permissions.
-Worktree directories created by the server are already owned by the service user
-and need no change.
-
-> `0711` is an **operational** workaround. The underlying cause — the spawn
-> helper passing the target user's private directory as the PTY `cwd` and
-> `chdir`-ing into it as the service user — is tracked for a root-cause fix in
-> [issue #802](https://github.com/ms2sato/agent-console/issues/802).
+When the server starts a PTY it spawns `sudo -u <user> -i` for the session's
+working directory. The privileged spawn performs its pre-exec `chdir` into a
+neutral, always-traversable directory (`/`) while still the service user, and
+the real `cd` into the session's working directory happens in the inner login
+shell that already runs **as the target user**. The service user therefore never
+needs to enter another user's private directory — the target user can always
+enter their own home — so you do not need to loosen home permissions for
+multi-user mode. Worktree directories created by the server are owned by the
+service user and likewise need no change.
 
 ## Step 6: Verify the Setup
 

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -493,9 +493,13 @@ The server log shows `pamtester: Authentication failure` followed by
 
 ### "PTY spawn failed" after a successful login
 
-The session's working directory is not enterable by the service user (commonly a
-`0700` home directory). See
-[The service user must be able to enter session working directories](#the-service-user-must-be-able-to-enter-session-working-directories).
+This usually points to a PTY spawn-path regression or a sudoers / config
+mismatch — **not** to home-directory permissions. A user's default `0700` home
+is supported and needs no change; see
+[Default `0700` home directories work as-is](#default-0700-home-directories-work-as-is).
+Check that the service user's sudoers entry grants `NOPASSWD` login-shell access
+to the target user and that the server log shows the `sudo -u <user> -i` command
+it attempted.
 
 ### "This account is currently not available" when testing sudo
 


### PR DESCRIPTION
## Summary

Adds a CI job that builds the `docker/` multi-user verification image and runs the existing end-to-end multi-user checks on a runner with normal Docker Hub access — closing the verification gaps from #803 (clean-pull build of the committed default base) and #802/#806 (the `0700`-home PTY-spawn fix could not be exercised locally).

This is **not** a new E2E — it runs the existing `scripts/verify-multiuser-docker.sh` harness in CI.

## What the job does

A new path-filtered workflow `.github/workflows/docker-multiuser-e2e.yml`:

1. **Clean-pull build** — builds `docker/Dockerfile` from its committed **default base** (`oven/bun:1.3.8`, no `--build-arg` override), proving the reproducibility that #803 could not verify on the maintainer's Docker-Hub-blocked machine.
2. **7-check E2E** — runs `scripts/verify-multiuser-docker.sh`: authMode, unauth 401, wrong-password 401, alice/bob login 200, alice/bob PTY `whoami` isolation (shadow polarity).
3. **#806 regression guard (default `0700` homes)** — the test users' homes are kept at the OS default `0700` (most restrictive, private to the owner). Since #806 the privileged PTY spawn performs its pre-exec `chdir` into a neutral `/` and defers the real `cd` to the inner shell running as the target user, so a `0700` home spawns successfully with no permission change. Keeping the homes at `0700` makes the image a **permanent regression guard**: a re-break fails the build.

`0711` was an interim workaround predating #806 and has been **erased entirely** (Dockerfile, compose, workflow, README, and the setup guide) in favor of the OS default `0700`.

## Trigger scope

Path-filtered to the multi-user surface (`docker/**`, `scripts/verify-multiuser-docker.sh`, `packages/server/src/services/user-mode.ts`, `packages/server/src/routes/auth.ts`, and the workflow itself) so the heavy docker build does not run on every PR. **Not** a required check for unrelated PRs. Hardening: least-privilege `permissions: contents: read` + `persist-credentials: false`.

## Verification

- `bun run test` (full suite, includes typecheck): all packages green, 0 fail — no production code touched.
- `rg '0711'`: **0 hits** (workaround fully erased). `bun run check:lang`: exit 0.

---

## ✅ CI proof (real-machine docker, run 27652913692)

Clean-pull build of the committed default base:

```
#6 [builder 1/6] FROM docker.io/oven/bun:1.3.8@sha256:371d30538b69303ced927bb5915697ac7e2fa8cb409ee332c66009de64de5aa3
```

**e2e (home 0700)** — default OS mode, #806 regression guard:
```
[PASS] authMode is multi-user
[PASS] unauthenticated request returns 401
[PASS] wrong password returns 401
[PASS] alice login returns 200
[PASS] bob login returns 200
RESULT alice: PASS — whoami => 'alice' (expected 'alice')
[PASS] alice terminal runs as alice
RESULT bob: PASS — whoami => 'bob' (expected 'bob')
[PASS] bob terminal runs as bob
RESULT: 7 passed, 0 failed
```

This is the first real-machine docker proof of both the #803 default-base build and the #806 default-`0700`-home fix.

## Note for the reviewer

This is a CI configuration change — **merge is the owner's decision**.

Closes #808
