### PR TITLE
fix: recover orphaned worktree when primary repo dir is deleted (closes #811)

### DIFF
--- a/packages/server/src/lib/__tests__/git.test.ts
+++ b/packages/server/src/lib/__tests__/git.test.ts
@@ -761,5 +761,99 @@ index abc1234..def5678 100644
         await fs.rm(tempWorktreePath, { recursive: true, force: true });
       }
     });
+
+    it('should swallow an ENOENT-coded prune error after worktree cleanup (stat→spawn race)', async () => {
+      const fs = await import('node:fs/promises');
+
+      const tempWorktreePath = `/tmp/git-test-worktree-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      await fs.mkdir(tempWorktreePath, { recursive: true });
+      // cwd exists at stat() time so the prune is attempted...
+      const tempRepoPath = `/tmp/git-test-repo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      await fs.mkdir(tempRepoPath, { recursive: true });
+
+      try {
+        // First call (remove) fails with a .git-class error; second call (prune)
+        // throws synchronously with an ENOENT code, simulating cwd vanishing
+        // between stat() and spawn().
+        let callCount = 0;
+        (Bun as { spawn: typeof Bun.spawn }).spawn = ((args: string[], options?: Record<string, unknown>) => {
+          spawnCalls.push({ args, options: options || {} });
+          callCount++;
+          if (callCount === 1) {
+            return {
+              exited: Promise.resolve(128),
+              stdout: new ReadableStream({ start(controller) { controller.close(); } }),
+              stderr: new ReadableStream({
+                start(controller) {
+                  controller.enqueue(new TextEncoder().encode("fatal: '.git' does not exist"));
+                  controller.close();
+                },
+              }),
+            };
+          }
+          // Second call (prune): spawn itself throws ENOENT (cwd gone).
+          throw Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
+        }) as typeof Bun.spawn;
+
+        const { removeWorktree } = await getGitModule();
+
+        // Must resolve without throwing: the worktree fs.rm already succeeded.
+        await removeWorktree(tempWorktreePath, tempRepoPath, { force: true });
+
+        // Worktree dir was removed.
+        let worktreeStillExists = true;
+        try {
+          await fs.stat(tempWorktreePath);
+        } catch {
+          worktreeStillExists = false;
+        }
+        expect(worktreeStillExists).toBe(false);
+
+        // Both remove and prune were attempted (prune threw and was swallowed).
+        expect(spawnCalls.length).toBe(2);
+        expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune']);
+      } finally {
+        await fs.rm(tempWorktreePath, { recursive: true, force: true });
+        await fs.rm(tempRepoPath, { recursive: true, force: true });
+      }
+    });
+
+    it('should propagate a non-ENOENT prune error (guard is narrow)', async () => {
+      const fs = await import('node:fs/promises');
+
+      const tempWorktreePath = `/tmp/git-test-worktree-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      await fs.mkdir(tempWorktreePath, { recursive: true });
+      const tempRepoPath = `/tmp/git-test-repo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      await fs.mkdir(tempRepoPath, { recursive: true });
+
+      try {
+        let callCount = 0;
+        (Bun as { spawn: typeof Bun.spawn }).spawn = ((args: string[], options?: Record<string, unknown>) => {
+          spawnCalls.push({ args, options: options || {} });
+          callCount++;
+          if (callCount === 1) {
+            return {
+              exited: Promise.resolve(128),
+              stdout: new ReadableStream({ start(controller) { controller.close(); } }),
+              stderr: new ReadableStream({
+                start(controller) {
+                  controller.enqueue(new TextEncoder().encode("fatal: '.git' does not exist"));
+                  controller.close();
+                },
+              }),
+            };
+          }
+          // Second call (prune): a non-ENOENT error must propagate.
+          throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' });
+        }) as typeof Bun.spawn;
+
+        const { removeWorktree } = await getGitModule();
+
+        await expect(removeWorktree(tempWorktreePath, tempRepoPath, { force: true })).rejects.toThrow('EPERM');
+      } finally {
+        await fs.rm(tempWorktreePath, { recursive: true, force: true });
+        await fs.rm(tempRepoPath, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/packages/server/src/lib/__tests__/git.test.ts
+++ b/packages/server/src/lib/__tests__/git.test.ts
@@ -601,6 +601,10 @@ index abc1234..def5678 100644
       // (which may be memfs when running in the full test suite).
       const tempWorktreePath = `/tmp/git-test-worktree-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       await fs.mkdir(tempWorktreePath, { recursive: true });
+      // cwd (primary repo) must exist on disk for the prune step to run, since the
+      // fallback now skips prune when the primary repo dir is missing.
+      const tempRepoPath = `/tmp/git-test-repo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      await fs.mkdir(tempRepoPath, { recursive: true });
 
       try {
         // First call fails with .git error, second call (worktree prune) succeeds
@@ -637,16 +641,17 @@ index abc1234..def5678 100644
 
         const { removeWorktree } = await getGitModule();
 
-        await removeWorktree(tempWorktreePath, '/repo', { force: true });
+        await removeWorktree(tempWorktreePath, tempRepoPath, { force: true });
 
         // Should have called git worktree remove first, then git worktree prune
         expect(spawnCalls.length).toBe(2);
         expect(spawnCalls[0].args).toEqual(['git', 'worktree', 'remove', tempWorktreePath, '--force', '--force']);
         expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune']);
-        expect(spawnCalls[1].options.cwd).toBe('/repo');
+        expect(spawnCalls[1].options.cwd).toBe(tempRepoPath);
       } finally {
-        // Clean up temp directory (may already be removed by removeWorktree)
+        // Clean up temp directories (worktree may already be removed by removeWorktree)
         await fs.rm(tempWorktreePath, { recursive: true, force: true });
+        await fs.rm(tempRepoPath, { recursive: true, force: true });
       }
     });
 
@@ -655,6 +660,9 @@ index abc1234..def5678 100644
 
       const tempWorktreePath = `/tmp/git-test-worktree-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       await fs.mkdir(tempWorktreePath, { recursive: true });
+      // cwd (primary repo) must exist for the prune step to run.
+      const tempRepoPath = `/tmp/git-test-repo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      await fs.mkdir(tempRepoPath, { recursive: true });
 
       try {
         // First call fails with "is not a working tree" error, second call (worktree prune) succeeds
@@ -691,15 +699,65 @@ index abc1234..def5678 100644
 
         const { removeWorktree } = await getGitModule();
 
-        await removeWorktree(tempWorktreePath, '/repo', { force: true });
+        await removeWorktree(tempWorktreePath, tempRepoPath, { force: true });
 
         // Should have called git worktree remove first, then git worktree prune
         expect(spawnCalls.length).toBe(2);
         expect(spawnCalls[0].args).toEqual(['git', 'worktree', 'remove', tempWorktreePath, '--force', '--force']);
         expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune']);
-        expect(spawnCalls[1].options.cwd).toBe('/repo');
+        expect(spawnCalls[1].options.cwd).toBe(tempRepoPath);
       } finally {
-        // Clean up temp directory (may already be removed by removeWorktree)
+        // Clean up temp directories (worktree may already be removed by removeWorktree)
+        await fs.rm(tempWorktreePath, { recursive: true, force: true });
+        await fs.rm(tempRepoPath, { recursive: true, force: true });
+      }
+    });
+
+    it('should skip prune when force is true and the primary repo dir (cwd) does not exist', async () => {
+      const fs = await import('node:fs/promises');
+
+      const tempWorktreePath = `/tmp/git-test-worktree-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      await fs.mkdir(tempWorktreePath, { recursive: true });
+      // Primary repo dir (cwd) deliberately does NOT exist on disk.
+      const missingRepoPath = `/tmp/git-test-missing-repo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+      try {
+        // First (and only) call: git worktree remove fails with a .git-class error.
+        // Prune must NOT be attempted because cwd is missing.
+        (Bun as { spawn: typeof Bun.spawn }).spawn = ((args: string[], options?: Record<string, unknown>) => {
+          spawnCalls.push({ args, options: options || {} });
+          return {
+            exited: Promise.resolve(128),
+            stdout: new ReadableStream({
+              start(controller) { controller.close(); },
+            }),
+            stderr: new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode("fatal: '.git' does not exist"));
+                controller.close();
+              },
+            }),
+          };
+        }) as typeof Bun.spawn;
+
+        const { removeWorktree } = await getGitModule();
+
+        // Must not throw even though the primary repo dir is gone.
+        await removeWorktree(tempWorktreePath, missingRepoPath, { force: true });
+
+        // fs.rm happened: the worktree dir is gone.
+        let worktreeStillExists = true;
+        try {
+          await fs.stat(tempWorktreePath);
+        } catch {
+          worktreeStillExists = false;
+        }
+        expect(worktreeStillExists).toBe(false);
+
+        // Only the remove was attempted; prune was skipped (cwd missing).
+        expect(spawnCalls.length).toBe(1);
+        expect(spawnCalls[0].args).toEqual(['git', 'worktree', 'remove', tempWorktreePath, '--force', '--force']);
+      } finally {
         await fs.rm(tempWorktreePath, { recursive: true, force: true });
       }
     });

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -346,7 +346,15 @@ export async function removeWorktree(
         cwdExists = false;
       }
       if (cwdExists) {
-        await git(['worktree', 'prune'], cwd, HEAVY_GIT_TIMEOUT_MS);
+        try {
+          await git(['worktree', 'prune'], cwd, HEAVY_GIT_TIMEOUT_MS);
+        } catch (pruneError) {
+          const code = (pruneError as NodeJS.ErrnoException | undefined)?.code;
+          // cwd may vanish between stat() and spawn(); cleanup already succeeded.
+          if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+            throw pruneError;
+          }
+        }
       }
       return;
     }

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -334,7 +334,20 @@ export async function removeWorktree(
     ) {
       const fs = await import('node:fs/promises');
       await fs.rm(worktreePath, { recursive: true, force: true });
-      await git(['worktree', 'prune'], cwd, HEAVY_GIT_TIMEOUT_MS);
+      // Only prune when the primary repo dir (cwd) still exists. If the primary
+      // was deleted out-of-band, `git worktree prune` would run against a dead
+      // cwd and Bun.spawn throws ENOENT. Pruning against an absent common dir is
+      // a no-op anyway, so skipping it is safe.
+      let cwdExists = false;
+      try {
+        await fs.stat(cwd);
+        cwdExists = true;
+      } catch {
+        cwdExists = false;
+      }
+      if (cwdExists) {
+        await git(['worktree', 'prune'], cwd, HEAVY_GIT_TIMEOUT_MS);
+      }
       return;
     }
     throw error;

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -344,7 +344,12 @@ detached
   });
 
   describe('removeWorktree', () => {
+    // ① Primary repo dir exists + clean: behavior unchanged (normal git path).
+    //   The pre-check stats repoPath against memfs, so the primary must exist in
+    //   the in-memory volume for the normal git path to run.
     it('should remove worktree successfully', async () => {
+      // Primary repo dir must exist for the normal git path (pre-check passes)
+      fs.mkdirSync('/repo', { recursive: true });
       // Pre-populate DB record for the worktree being removed
       mockRepo.records.push({
         id: 'wt-1',
@@ -361,11 +366,18 @@ detached
 
       expect(result.success).toBe(true);
       expect(result.error).toBeUndefined();
+      // Normal git path runs because the primary exists
+      expect(mockGit.removeWorktree).toHaveBeenCalledWith(
+        '/worktrees/feature',
+        '/repo',
+        { force: false }
+      );
       // Verify record was deleted from mock repository
       expect(mockRepo.records.length).toBe(0);
     });
 
     it('should use force flag when specified', async () => {
+      fs.mkdirSync('/repo', { recursive: true });
       // Pre-populate DB record
       mockRepo.records.push({
         id: 'wt-1',
@@ -388,6 +400,7 @@ detached
     });
 
     it('should return error on failure', async () => {
+      fs.mkdirSync('/repo', { recursive: true });
       mockGit.removeWorktree.mockImplementation(() =>
         Promise.reject(new GitError('worktree has changes', 128, 'fatal: worktree has uncommitted changes'))
       );
@@ -399,6 +412,76 @@ detached
 
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
+    });
+
+    // ② Primary repo dir MISSING + worktree dir present: git-independent recovery.
+    it('should recover orphaned worktree when primary repo dir is missing', async () => {
+      // Primary repo dir does NOT exist (deleted out-of-band).
+      // Worktree dir exists on disk and has a DB record.
+      fs.mkdirSync('/worktrees/feature', { recursive: true });
+      mockRepo.records.push({
+        id: 'wt-1',
+        repositoryId: 'repo-1',
+        path: '/worktrees/feature',
+        indexNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      const result = await service.removeWorktree('/repo-missing', '/worktrees/feature');
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+      // DB record removed even though no git ran
+      expect(mockRepo.records.length).toBe(0);
+      // Worktree directory is gone
+      expect(fs.existsSync('/worktrees/feature')).toBe(false);
+      // git was NOT invoked (recovery skips git entirely)
+      expect(mockGit.removeWorktree).not.toHaveBeenCalled();
+    });
+
+    // ③ Primary MISSING + worktree dir ALSO already deleted: idempotent recovery.
+    it('should be idempotent when primary missing and worktree dir already gone', async () => {
+      // Neither the primary nor the worktree dir exists.
+      mockRepo.records.push({
+        id: 'wt-1',
+        repositoryId: 'repo-1',
+        path: '/worktrees/already-gone',
+        indexNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      const result = await service.removeWorktree('/repo-missing', '/worktrees/already-gone');
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+      // deleteByPath still ran, record removed
+      expect(mockRepo.records.length).toBe(0);
+      expect(mockGit.removeWorktree).not.toHaveBeenCalled();
+    });
+
+    // ④ Orphaned existing row is recoverable when primary missing.
+    it('should remove the orphaned DB row when primary missing', async () => {
+      fs.mkdirSync('/worktrees/orphaned', { recursive: true });
+      mockRepo.records.push({
+        id: 'wt-orphan',
+        repositoryId: 'repo-1',
+        path: '/worktrees/orphaned',
+        indexNumber: 2,
+        createdAt: new Date().toISOString(),
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      await service.removeWorktree('/repo-missing', '/worktrees/orphaned');
+
+      expect(mockRepo.records.find((r) => r.path === '/worktrees/orphaned')).toBeUndefined();
     });
   });
 

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, afterAll } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, afterAll, spyOn } from 'bun:test';
 import * as fs from 'fs';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { mockGit, GitError } from '../../__tests__/utils/mock-git-helper.js';
@@ -482,6 +482,42 @@ detached
       await service.removeWorktree('/repo-missing', '/worktrees/orphaned');
 
       expect(mockRepo.records.find((r) => r.path === '/worktrees/orphaned')).toBeUndefined();
+    });
+
+    // ⑤ Non-ENOENT stat error (EACCES/EPERM/IO) on the primary repo dir must NOT
+    //    route to destructive recovery. It should surface as { success: false }
+    //    without running git or deleting the DB row.
+    it('should fail without destructive recovery when stat(repoPath) rejects with EACCES', async () => {
+      // DB record present; must remain present after the failed call.
+      mockRepo.records.push({
+        id: 'wt-1',
+        repositoryId: 'repo-1',
+        path: '/worktrees/feature',
+        indexNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
+
+      // Force stat() to reject with a coded permission error (not ENOENT/ENOTDIR).
+      const statSpy = spyOn(fs.promises, 'stat').mockImplementation((() =>
+        Promise.reject(Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }))
+      ) as typeof fs.promises.stat);
+
+      try {
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+        const result = await service.removeWorktree('/repo', '/worktrees/feature');
+
+        // Surfaced as a failure, not a silent destructive recovery.
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+        // Git removal was NOT attempted.
+        expect(mockGit.removeWorktree).not.toHaveBeenCalled();
+        // DB row was NOT deleted (record still present).
+        expect(mockRepo.records.find((r) => r.path === '/worktrees/feature')).toBeDefined();
+      } finally {
+        statSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -319,6 +319,34 @@ export class WorktreeService {
     worktreePath: string,
     force: boolean = false
   ): Promise<{ success: boolean; error?: string }> {
+    // Detect the orphaned-worktree case where the primary repo dir was deleted
+    // out-of-band. Every git op in the removal path runs with cwd = repoPath, and
+    // a nonexistent cwd makes Bun.spawn throw ENOENT (not a GitError with parseable
+    // stderr), so the normal git path — including the force fallback's prune — cannot
+    // recover. A real-fs existence pre-check on repoPath is the reliable detector.
+    let repoExists = false;
+    try {
+      await fsPromises.stat(repoPath);
+      repoExists = true;
+    } catch {
+      repoExists = false;
+    }
+
+    if (!repoExists) {
+      // Primary repo is gone: the worktree is already orphaned. Recover without
+      // git, unconditionally (no `force` required) — recovery of an orphaned
+      // worktree is always defensible, and this also satisfies "at minimum force
+      // must work". rm on a missing path and deleteByPath on a missing row are
+      // both no-ops, so this branch is idempotent.
+      await fsPromises.rm(worktreePath, { recursive: true, force: true });
+      await this.worktreeRepository.deleteByPath(worktreePath);
+      logger.warn(
+        { worktreePath, repoPath },
+        'Primary repo dir missing; removed orphaned worktree without git'
+      );
+      return { success: true };
+    }
+
     try {
       await gitRemoveWorktree(worktreePath, repoPath, { force });
 

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -319,35 +319,44 @@ export class WorktreeService {
     worktreePath: string,
     force: boolean = false
   ): Promise<{ success: boolean; error?: string }> {
-    // Detect the orphaned-worktree case where the primary repo dir was deleted
-    // out-of-band. Every git op in the removal path runs with cwd = repoPath, and
-    // a nonexistent cwd makes Bun.spawn throw ENOENT (not a GitError with parseable
-    // stderr), so the normal git path — including the force fallback's prune — cannot
-    // recover. A real-fs existence pre-check on repoPath is the reliable detector.
-    let repoExists = false;
     try {
-      await fsPromises.stat(repoPath);
-      repoExists = true;
-    } catch {
-      repoExists = false;
-    }
+      // Detect the orphaned-worktree case where the primary repo dir was deleted
+      // out-of-band. Every git op in the removal path runs with cwd = repoPath, and
+      // a nonexistent cwd makes Bun.spawn throw ENOENT (not a GitError with parseable
+      // stderr), so the normal git path — including the force fallback's prune — cannot
+      // recover. A real-fs existence pre-check on repoPath is the reliable detector.
+      //
+      // Only ENOENT/ENOTDIR means "missing" — other stat errors (EACCES/EPERM/IO)
+      // must NOT route to destructive recovery; let them surface as a failure via
+      // the outer catch below.
+      let repoExists = false;
+      try {
+        const stat = await fsPromises.stat(repoPath);
+        repoExists = stat.isDirectory();
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException | undefined)?.code;
+        if (code === 'ENOENT' || code === 'ENOTDIR') {
+          repoExists = false;
+        } else {
+          throw error; // caught by the outer catch → { success: false, error }
+        }
+      }
 
-    if (!repoExists) {
-      // Primary repo is gone: the worktree is already orphaned. Recover without
-      // git, unconditionally (no `force` required) — recovery of an orphaned
-      // worktree is always defensible, and this also satisfies "at minimum force
-      // must work". rm on a missing path and deleteByPath on a missing row are
-      // both no-ops, so this branch is idempotent.
-      await fsPromises.rm(worktreePath, { recursive: true, force: true });
-      await this.worktreeRepository.deleteByPath(worktreePath);
-      logger.warn(
-        { worktreePath, repoPath },
-        'Primary repo dir missing; removed orphaned worktree without git'
-      );
-      return { success: true };
-    }
+      if (!repoExists) {
+        // Primary repo is gone: the worktree is already orphaned. Recover without
+        // git, unconditionally (no `force` required) — recovery of an orphaned
+        // worktree is always defensible, and this also satisfies "at minimum force
+        // must work". rm on a missing path and deleteByPath on a missing row are
+        // both no-ops, so this branch is idempotent.
+        await fsPromises.rm(worktreePath, { recursive: true, force: true });
+        await this.worktreeRepository.deleteByPath(worktreePath);
+        logger.warn(
+          { worktreePath, repoPath },
+          'Primary repo dir missing; removed orphaned worktree without git'
+        );
+        return { success: true };
+      }
 
-    try {
       await gitRemoveWorktree(worktreePath, repoPath, { force });
 
       // Remove DB record


### PR DESCRIPTION
## Summary

Fixes #811 — when a worktree's **primary repository directory** (the original checkout owning the common `.git` dir) is deleted out-of-band, the linked worktree could not be removed from AgentConsole — not even with `force: true`. The DB row orphaned and showed as an un-removable entry.

Closes #811

## Root cause

Every git op in the removal path runs with `cwd = repoPath` (the primary). Once the primary is gone:
- `git()` does `Bun.spawn(['git', ...], { cwd: repoPath })`. **A nonexistent cwd makes `Bun.spawn` throw `ENOENT` — not a `GitError` with parseable stderr.** So stderr-string detection alone cannot catch the reported case; a real-fs existence pre-check on `repoPath` is the reliable detector.
- The `force` fallback was also broken: after `fs.rm`-ing the worktree dir it ran `git worktree prune` with the same dead `cwd`, which threw.
- The DB row (`deleteByPath`) was only deleted on git success, so the row orphaned.

## Fix

- **`worktree-service.ts` `removeWorktree`**: top-of-method pre-check of `repoPath` existence (`fsPromises.stat` in try/catch, the existing idiom in this file). When the primary is missing, recover **without git** — `fsPromises.rm(worktreePath, {recursive, force})` then `worktreeRepository.deleteByPath(worktreePath)` — and return success. Runs **unconditionally** (no `force` required): an orphaned worktree is always safe to reclaim, and this also guarantees the `force` path works. Idempotent — `rm` on a missing path and `deleteByPath` on a missing row are both no-ops.
- **`git.ts` `removeWorktree`** force fallback: guard `git worktree prune` so it is **skipped when `cwd` no longer exists** (prune against an absent common dir is a no-op anyway).
- `worktree-deletion-service.ts` needs **no change** — once `removeWorktree` returns `{success:true}` for the recovery path, the existing flow deletes sessions normally.

## Design decision (per issue AC)

Primary-missing cleanup is allowed **unconditionally (no `force` required)**. The worktree is already orphaned, so reclaiming it is defensible; this also satisfies the AC's "at minimum `force` must work" (today neither worked).

## Boundary-value coverage (TDD)

| Case | Behavior |
|---|---|
| ① Primary present + clean | Normal git removal — unchanged |
| ② Primary MISSING + worktree dir present | Git-independent recovery; dir removed, DB row + session deleted, git not invoked |
| ③ Primary MISSING + worktree dir also gone | Idempotent — DB row still cleaned up, no throw |
| ④ Existing orphaned row | Reclaimed/removable after the fix |

**Polarity verified**: stashing only the production hunks (keeping the new tests) makes the discriminating recovery tests (② and ③) and the git.ts prune-skip test FAIL against unmodified production; restoring makes them pass.

## Verification

- `bun run test` — full suite green (server 2578 pass / 1 skip / 0 fail, client 1396, shared 324, integration 29, scripts/hooks 362). **TEST_EXIT: 0**
- `bun run typecheck` — **0 errors**
- `coderabbit review --agent --base origin/main` — `findings: 0` (no CRITICAL/HIGH/MEDIUM)

No UI changes — browser QA not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
