### PR TITLE
fix: gate UID-based default port on AUTH_MODE=multi-user (closes #813)

### DIFF
--- a/scripts/update-and-deploy-for-mac.sh
+++ b/scripts/update-and-deploy-for-mac.sh
@@ -11,7 +11,14 @@ bun install
 
 echo "==> Installing plist..."
 COMMAND_PATH=$(which bun)
-DEFAULT_PORT=$((6000 + $(id -u) % 1000))
+# UID-based port assignment is only useful when multiple users share the host
+# (AUTH_MODE=multi-user). For the single-user default (AUTH_MODE unset or 'none')
+# fall back to the historical fixed default so existing bookmarks keep working.
+if [ "${AUTH_MODE:-none}" = "multi-user" ]; then
+    DEFAULT_PORT=$((6000 + $(id -u) % 1000))
+else
+    DEFAULT_PORT=6340
+fi
 PORT=${PORT:-$DEFAULT_PORT}
 APP_URL=${APP_URL:-"http://localhost:$PORT"}
 

--- a/scripts/update-and-deploy-for-ubuntu.sh
+++ b/scripts/update-and-deploy-for-ubuntu.sh
@@ -4,9 +4,11 @@
 #
 # Notes:
 #   - Requires `rsync` (checked below). Install with: sudo apt-get install -y rsync
-#   - The service port defaults to 6000 + (uid % 1000). Known caveat: users whose
-#     UIDs differ by a multiple of 1000 (e.g. 1000 and 2000) collide on the same
-#     port. Set PORT explicitly to override.
+#   - The service port defaults to 6340 in single-user mode (AUTH_MODE unset or
+#     'none'), and to 6000 + (uid % 1000) when AUTH_MODE=multi-user is set, since
+#     UID-based assignment only matters when multiple users share the host.
+#   - Multi-user caveat: users whose UIDs differ by a multiple of 1000 (e.g. 1000
+#     and 2000) collide on the same port. Set PORT explicitly to override.
 #   - Base 6000 overlaps the X11 TCP range (6000-6063), but impact is low: this
 #     targets headless servers (no X server), and modern X11 defaults to
 #     `-nolisten tcp` (desktops default to Wayland). Override with PORT if needed.
@@ -32,7 +34,11 @@ bun install
 
 echo "==> Installing systemd user service..."
 COMMAND_PATH=$(which bun)
-DEFAULT_PORT=$((6000 + $(id -u) % 1000))
+if [ "${AUTH_MODE:-none}" = "multi-user" ]; then
+    DEFAULT_PORT=$((6000 + $(id -u) % 1000))
+else
+    DEFAULT_PORT=6340
+fi
 PORT=${PORT:-$DEFAULT_PORT}
 APP_URL=${APP_URL:-"http://localhost:$PORT"}
 


### PR DESCRIPTION
## Summary

- Restore the historical `6340` default port for the single-user case (AUTH_MODE unset or `none`) in `scripts/update-and-deploy-for-{mac,ubuntu}.sh`.
- Keep the `6000 + (uid % 1000)` scheme introduced in #260 behind `AUTH_MODE=multi-user`, where it actually matters.
- Explicit `PORT=...` still overrides both branches.

Behaviour matrix:

| `AUTH_MODE` | `PORT` env | Effective port |
|---|---|---|
| unset / `none` | unset | **6340** (restored default) |
| `multi-user` | unset | `6000 + (uid % 1000)` |
| any | set | `\$PORT` |

The UID-based default is meaningful only when multiple users share the host. For the default single-user deploy, the silent shift broke existing bookmarks and shortcuts (e.g. UID 501 → 6501 instead of 6340).

Closes #813

## Test plan

Logic was probed in isolation (the deploy script itself touches the live LaunchAgent / systemd unit, so was not executed end-to-end):

- [x] \`bash -n\` syntax check on both scripts
- [x] Inline probe of the port-decision block across 5 cases — all match expectations:
  - AUTH_MODE unset, no PORT → 6340
  - AUTH_MODE=multi-user, no PORT → 6000 + uid%1000 (6501 here with uid 501)
  - AUTH_MODE unset, PORT=7000 → 7000
  - AUTH_MODE=multi-user, PORT=7000 → 7000
  - AUTH_MODE='' (empty) → 6340 (\`\${VAR:-default}\` treats empty as default)
- [x] \`bun run typecheck\` — 0 errors
- [x] \`bun run test\` — 2581 pass / 1 skip / 0 fail (server) + 362 pass / 0 fail (scripts/hooks/skills); exit 0
- [x] \`bun run check:lang\` — clean
- [x] \`node .claude/skills/orchestrator/preflight-check.js\` — coverage / duplication / language all clean
- [ ] CodeRabbit CLI not installed locally — skipped per workflow.md (recommend installation: \`curl -fsSL https://cli.coderabbit.ai/install.sh | sh\`); CodeRabbit GitHub bot will review on the PR.
- [ ] Owner dogfood: re-deploy with \`./scripts/update-and-deploy-for-mac.sh\` (no env) and confirm the LaunchAgent listens on 6340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)