### PR TITLE
fix: emit worktree-deletion broadcasts per task, not per session

### DIFF
--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -1999,12 +1999,13 @@ describe('API Routes Integration', () => {
           expect(bunSpawnCalls.length).toBe(1);
           expect(bunSpawnCalls[0].args[2]).toBe('docker compose down');
 
-          // No sessions exist for this worktree, so no broadcast should occur
+          // Exactly one broadcast is emitted per task, even when no sessions exist.
           const broadcastSpy = mockBroadcastToApp;
           const completedCalls = broadcastSpy.mock.calls.filter(
             (call: unknown[]) => (call[0] as { type: string }).type === 'worktree-deletion-completed'
           );
-          expect(completedCalls.length).toBe(0);
+          expect(completedCalls.length).toBe(1);
+          expect((completedCalls[0][0] as { sessionIds: string[] }).sessionIds).toEqual([]);
         } finally {
           restoreBunSpawn();
         }
@@ -2224,15 +2225,17 @@ describe('API Routes Integration', () => {
         // Session was NOT deleted (preserved for retry)
         expect(deleteSpy).not.toHaveBeenCalled();
 
-        // broadcastToApp was called with worktree-deletion-failed
+        // broadcastToApp was called exactly once with worktree-deletion-failed
         const broadcastSpy = mockBroadcastToApp;
-        const failedCall = broadcastSpy.mock.calls.find(
+        const failedCalls = broadcastSpy.mock.calls.filter(
           (call: unknown[]) => {
             const message = call[0] as { type: string; taskId?: string };
             return message.type === 'worktree-deletion-failed' && message.taskId === 'test-fail-task';
           }
         );
-        expect(failedCall).toBeDefined();
+        expect(failedCalls.length).toBe(1);
+        const failedPayload = failedCalls[0][0] as { sessionIds: string[] };
+        expect(Array.isArray(failedPayload.sessionIds)).toBe(true);
 
         // Session still exists
         const sessions = testSessionManager!.getAllSessions();
@@ -2240,7 +2243,7 @@ describe('API Routes Integration', () => {
         expect(sessionStillExists).toBe(true);
       });
 
-      it('should broadcast worktree-deletion-completed for all deleted sessions', async () => {
+      it('should broadcast worktree-deletion-completed exactly once with all deleted session ids', async () => {
         const app = await createApp();
         const { repo, repoPath } = await registerTestRepo(app);
         const { worktreePath } = await setupWorktreeForDeletion(repo, repoPath);
@@ -2284,7 +2287,8 @@ describe('API Routes Integration', () => {
         // Wait for background operation to complete
         await new Promise((resolve) => setTimeout(resolve, 200));
 
-        // Verify broadcastToApp was called with worktree-deletion-completed for EACH session ID
+        // Verify broadcastToApp was called exactly once with worktree-deletion-completed,
+        // and the payload contains ALL deleted session IDs.
         const broadcastSpy = mockBroadcastToApp;
         const completedCalls = broadcastSpy.mock.calls.filter(
           (call: unknown[]) => {
@@ -2292,16 +2296,15 @@ describe('API Routes Integration', () => {
             return message.type === 'worktree-deletion-completed' && message.taskId === 'test-broadcast-all';
           }
         );
-        expect(completedCalls.length).toBe(2);
+        expect(completedCalls.length).toBe(1);
 
-        const broadcastSessionIds = completedCalls.map(
-          (call: unknown[]) => (call[0] as { sessionId: string }).sessionId
-        );
+        const broadcastSessionIds = (completedCalls[0][0] as { sessionIds: string[] }).sessionIds;
         expect(broadcastSessionIds).toContain(session1.id);
         expect(broadcastSessionIds).toContain(session2.id);
+        expect(broadcastSessionIds.length).toBe(2);
       });
 
-      it('should not broadcast worktree-deletion-completed when no sessions exist for deleted worktree', async () => {
+      it('should broadcast worktree-deletion-completed with empty sessionIds when no sessions exist for deleted worktree', async () => {
         const app = await createApp();
         const { repo, repoPath } = await registerTestRepo(app);
         const { worktreePath } = await setupWorktreeForDeletion(repo, repoPath);
@@ -2319,7 +2322,8 @@ describe('API Routes Integration', () => {
         // Wait for background operation to complete
         await new Promise((resolve) => setTimeout(resolve, 200));
 
-        // Verify broadcastToApp was NOT called with worktree-deletion-completed for this taskId
+        // Verify broadcastToApp WAS called exactly once with worktree-deletion-completed
+        // and sessionIds is an empty array (one-broadcast-per-task contract).
         const broadcastSpy = mockBroadcastToApp;
         const completedCalls = broadcastSpy.mock.calls.filter(
           (call: unknown[]) => {
@@ -2327,10 +2331,11 @@ describe('API Routes Integration', () => {
             return message.type === 'worktree-deletion-completed' && message.taskId === 'test-no-sessions';
           }
         );
-        expect(completedCalls.length).toBe(0);
+        expect(completedCalls.length).toBe(1);
+        expect((completedCalls[0][0] as { sessionIds: string[] }).sessionIds).toEqual([]);
       });
 
-      it('should broadcast worktree-deletion-failed for all sessions when deletion fails', async () => {
+      it('should broadcast worktree-deletion-failed exactly once with all session ids when deletion fails', async () => {
         const app = await createApp();
         const { repo, repoPath } = await registerTestRepo(app);
         const { worktreePath } = await setupWorktreeForDeletion(repo, repoPath);
@@ -2379,7 +2384,8 @@ describe('API Routes Integration', () => {
         // Wait for background operation to complete
         await new Promise((resolve) => setTimeout(resolve, 200));
 
-        // Verify broadcastToApp was called with worktree-deletion-failed for EACH session ID
+        // Verify broadcastToApp was called exactly once with worktree-deletion-failed,
+        // and the payload contains ALL associated session IDs.
         const broadcastSpy = mockBroadcastToApp;
         const failedCalls = broadcastSpy.mock.calls.filter(
           (call: unknown[]) => {
@@ -2387,13 +2393,12 @@ describe('API Routes Integration', () => {
             return message.type === 'worktree-deletion-failed' && message.taskId === 'test-fail-broadcast-all';
           }
         );
-        expect(failedCalls.length).toBe(2);
+        expect(failedCalls.length).toBe(1);
 
-        const broadcastSessionIds = failedCalls.map(
-          (call: unknown[]) => (call[0] as { sessionId: string }).sessionId
-        );
+        const broadcastSessionIds = (failedCalls[0][0] as { sessionIds: string[] }).sessionIds;
         expect(broadcastSessionIds).toContain(session1.id);
         expect(broadcastSessionIds).toContain(session2.id);
+        expect(broadcastSessionIds.length).toBe(2);
       });
 
       it('should block deletion when branch has an open PR (sync path)', async () => {
@@ -2461,6 +2466,37 @@ describe('API Routes Integration', () => {
         expect(res.status).toBe(409);
         const body = (await res.json()) as { error: string };
         expect(body.error).toContain('Failed to check for open PRs');
+      });
+
+      it('should broadcast worktree-deletion-failed with empty sessionIds when repository is not found (async path)', async () => {
+        const app = await createApp();
+        // Do NOT register a repository — the route should treat it as not found.
+        const missingRepoId = '00000000-0000-4000-8000-000000000000';
+        const worktreePath = '/test/missing-repo/wt-1';
+
+        const res = await app.request(
+          `/api/repositories/${missingRepoId}/worktrees/${encodeURIComponent(worktreePath)}?taskId=test-missing-repo&force=true`,
+          { method: 'DELETE' }
+        );
+
+        // Async path returns 202 Accepted immediately, even when the repo is missing.
+        expect(res.status).toBe(202);
+
+        // Wait for background operation to complete
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        // Exactly one worktree-deletion-failed broadcast must be emitted with empty sessionIds
+        const broadcastSpy = mockBroadcastToApp;
+        const failedCalls = broadcastSpy.mock.calls.filter(
+          (call: unknown[]) => {
+            const message = call[0] as { type: string; taskId?: string };
+            return message.type === 'worktree-deletion-failed' && message.taskId === 'test-missing-repo';
+          }
+        );
+        expect(failedCalls.length).toBe(1);
+        const payload = failedCalls[0][0] as { sessionIds: string[]; error: string };
+        expect(payload.sessionIds).toEqual([]);
+        expect(payload.error).toContain('Repository not found');
       });
     });
 

--- a/packages/server/src/routes/__tests__/worktrees.test.ts
+++ b/packages/server/src/routes/__tests__/worktrees.test.ts
@@ -5,7 +5,7 @@ import { api } from '../api.js';
 import type { AppBindings } from '../../app-context.js';
 import type { WorktreeService } from '../../services/worktree-service.js';
 import type { RepositoryManager } from '../../services/repository-manager.js';
-import type { Repository } from '@agent-console/shared';
+import type { AppServerMessage, Repository } from '@agent-console/shared';
 import { asAppContext } from '../../__tests__/test-utils.js';
 import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
@@ -408,6 +408,46 @@ describe('Worktrees API', () => {
 
       const body = (await res.json()) as { error: string };
       expect(body.error).toContain('required');
+    });
+
+    it('should broadcast worktree-deletion-failed with empty sessionIds when repository is not found (async path)', async () => {
+      // Async DELETE for a repoId the registry does not know.
+      // The handler must emit exactly one worktree-deletion-failed broadcast
+      // with sessionIds: [] (rather than zero broadcasts, which would leave the
+      // client-side WorktreeDeletionTask stuck on 'deleting' forever).
+      const broadcasts: AppServerMessage[] = [];
+
+      app = new Hono<AppBindings>();
+      app.use('*', async (c, next) => {
+        c.set('appContext', asAppContext({
+          repositoryManager: mockRepositoryManager,
+          worktreeService: mockWorktreeService,
+          broadcastToApp: (msg) => { broadcasts.push(msg); },
+        }));
+        await next();
+      });
+      app.onError(onApiError);
+      app.route('/api', api);
+
+      const unknownRepoId = 'non-existent-repo-id';
+      const res = await app.request(
+        `/api/repositories/${unknownRepoId}/worktrees/${encodedPath(WORKTREE_PATH)}?taskId=test-not-found-task`,
+        { method: 'DELETE' },
+      );
+
+      // Async path returns 202 immediately even when the repo is missing
+      expect(res.status).toBe(202);
+
+      // Wait for the background fire-and-forget task to complete
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const failedBroadcasts = broadcasts.filter(
+        (b): b is Extract<AppServerMessage, { type: 'worktree-deletion-failed' }> =>
+          b.type === 'worktree-deletion-failed' && b.taskId === 'test-not-found-task',
+      );
+      expect(failedBroadcasts.length).toBe(1);
+      expect(failedBroadcasts[0].sessionIds).toEqual([]);
+      expect(failedBroadcasts[0].error).toContain('Repository not found');
     });
   });
 });

--- a/packages/server/src/routes/worktrees.ts
+++ b/packages/server/src/routes/worktrees.ts
@@ -326,29 +326,25 @@ const worktrees = new Hono<AppBindings>()
           const sessionIds = result.sessionIds ?? [];
 
           if (!result.success) {
-            for (const sid of sessionIds) {
-              broadcastToApp({
-                type: 'worktree-deletion-failed',
-                taskId,
-                sessionId: sid,
-                error: result.error || 'Failed to remove worktree',
-                gitStatus: result.gitStatus,
-              });
-            }
+            broadcastToApp({
+              type: 'worktree-deletion-failed',
+              taskId,
+              sessionIds,
+              error: result.error || 'Failed to remove worktree',
+              gitStatus: result.gitStatus,
+            });
             logger.error({ taskId, repoId, worktreePath, error: result.error }, 'Worktree deletion failed');
             return;
           }
 
-          for (const sid of sessionIds) {
-            broadcastToApp({
-              type: 'worktree-deletion-completed',
-              taskId,
-              sessionId: sid,
-              cleanupCommandResult: result.cleanupCommandResult,
-              killErrors: result.killErrors,
-            });
-          }
-          logger.info({ taskId, repoId, worktreePath, sessionIds: result.sessionIds }, 'Worktree and session deletion completed');
+          broadcastToApp({
+            type: 'worktree-deletion-completed',
+            taskId,
+            sessionIds,
+            cleanupCommandResult: result.cleanupCommandResult,
+            killErrors: result.killErrors,
+          });
+          logger.info({ taskId, repoId, worktreePath, sessionIds }, 'Worktree and session deletion completed');
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error during worktree deletion';
           logger.error({ taskId, repoId, worktreePath, error: errorMessage }, 'Worktree deletion failed');
@@ -357,7 +353,7 @@ const worktrees = new Hono<AppBindings>()
             broadcastToApp({
               type: 'worktree-deletion-failed',
               taskId,
-              sessionId: '',
+              sessionIds: [],
               error: errorMessage,
             });
           } catch {

--- a/packages/shared/src/schemas/__tests__/app-server-message.test.ts
+++ b/packages/shared/src/schemas/__tests__/app-server-message.test.ts
@@ -389,7 +389,7 @@ describe('AppServerMessageSchema', () => {
       expectValid({
         type: 'worktree-deletion-completed',
         taskId: 'task-1',
-        sessionId: 'session-1',
+        sessionIds: ['session-1'],
       });
     });
 
@@ -397,7 +397,7 @@ describe('AppServerMessageSchema', () => {
       expectValid({
         type: 'worktree-deletion-failed',
         taskId: 'task-1',
-        sessionId: 'session-1',
+        sessionIds: ['session-1'],
         error: 'Uncommitted changes',
         gitStatus: 'M file.ts',
       });

--- a/packages/shared/src/schemas/app-server-message.ts
+++ b/packages/shared/src/schemas/app-server-message.ts
@@ -303,7 +303,7 @@ const WorktreeCreationFailedSchema = v.object({
 const WorktreeDeletionCompletedSchema = v.object({
   type: v.literal('worktree-deletion-completed'),
   taskId: v.string(),
-  sessionId: v.string(),
+  sessionIds: v.array(v.string()),
   cleanupCommandResult: v.optional(HookCommandResultSchema),
   killErrors: v.optional(v.array(v.object({
     sessionId: v.string(),
@@ -314,7 +314,7 @@ const WorktreeDeletionCompletedSchema = v.object({
 const WorktreeDeletionFailedSchema = v.object({
   type: v.literal('worktree-deletion-failed'),
   taskId: v.string(),
-  sessionId: v.string(),
+  sessionIds: v.array(v.string()),
   error: v.string(),
   gitStatus: v.optional(v.string()),
 });

--- a/packages/shared/src/types/worktree-deletion.ts
+++ b/packages/shared/src/types/worktree-deletion.ts
@@ -42,7 +42,8 @@ export interface WorktreeDeletionTask {
 export interface WorktreeDeletionCompletedPayload {
   /** Client-generated task ID for correlation */
   taskId: string;
-  sessionId: string;
+  /** Sessions that were cleaned up — may be empty. */
+  sessionIds: string[];
   /** Present when cleanup command was executed before deletion */
   cleanupCommandResult?: HookCommandResult;
   /** Per-session PTY kill errors (non-blocking — deletion proceeded despite these) */
@@ -55,7 +56,8 @@ export interface WorktreeDeletionCompletedPayload {
 export interface WorktreeDeletionFailedPayload {
   /** Client-generated task ID for correlation */
   taskId: string;
-  sessionId: string;
+  /** Sessions that were cleaned up — may be empty. */
+  sessionIds: string[];
   error: string;
   /** Git status output to help users understand what files are causing the issue */
   gitStatus?: string;


### PR DESCRIPTION
## Summary

- Switched `worktree-deletion-completed` / `worktree-deletion-failed` payloads from scalar `sessionId: string` to `sessionIds: string[]`, so exactly one broadcast is emitted per task regardless of how many sessions are tied to the worktree (0, 1, or N).
- Fixes the dogfood-surfaced bug where the UI WorktreeDeletionTask stays stuck on `deleting` forever — most reliably reproduced via the `Repository not found` path, which returns an empty `sessionIds` and previously sent no broadcast at all.
- Aligns with the already task-centric `worktree-creation-*` and `worktree-pull-*` message shapes, and removes the `sessionId: ''` sentinel in the catch path.

The companion data-integrity follow-up (orphaned sessions when a repo path is missing at startup) is tracked separately in #815 and is intentionally out of scope here.

## Changes

- `packages/shared/src/types/worktree-deletion.ts` — `WorktreeDeletion{Completed,Failed}Payload` now use `sessionIds: string[]`.
- `packages/shared/src/schemas/app-server-message.ts` — matching valibot schema updates.
- `packages/server/src/routes/worktrees.ts` (async DELETE branch) — removed the per-session for-loops; one broadcast per task on both success and failure; catch path emits `sessionIds: []` instead of the empty-string sentinel.
- `packages/server/src/__tests__/api.test.ts` — updated 4 existing tests to expect a single broadcast with the new array shape; added 1 new regression test for the `Repository not found` path (empty sessionIds + 1 broadcast).
- `packages/shared/src/schemas/__tests__/app-server-message.test.ts` — updated 2 schema fixtures.

Note: per `design-principles.md` "Avoid backwards-compatibility hacks", this is a straight replacement — no dual support / shim. Both client and server are in the same repo, so the type system catches every consumer at build time.

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run test` — full suite passes (client 1396, shared 324, integration 29, server 2582 incl. the new regression test, scripts 362)
- [x] `node .claude/skills/orchestrator/preflight-check.js` — passes (no production patterns changed beyond covered files; test coverage / language / duplication checks green)
- [x] New regression test: async DELETE against a non-registered `repoId` returns 202 immediately and a single `worktree-deletion-failed` broadcast with `sessionIds: []` and `error` containing `Repository not found`
- [ ] CodeRabbit review (deferred to GitHub-side bot; local CLI not installed)

Related: #815 (data-integrity follow-up — not closed by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)