### PR TITLE
fix: clean up orphaned worktree when repository row is unregistered

### DIFF
--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -1751,13 +1751,21 @@ describe('API Routes Integration', () => {
     });
 
     describe('DELETE /api/repositories/:id/worktrees/*', () => {
-      it('should return 404 for non-existent repository', async () => {
+      it('should return 400 when repository is unregistered AND worktreePath is outside managed dir (orphan path, refs #815)', async () => {
+        // Refs #815. The previous "404 not-found" contract for an unknown
+        // repoId was the giving-up-partway pattern: the deletion service
+        // now routes into git-less orphan cleanup when the repo row is
+        // missing from the in-memory registry. The security boundary
+        // check still applies — a worktreePath outside getRepositoriesDir()
+        // returns a validation error (HTTP 400 on the sync path).
         const app = await createApp();
 
         const res = await app.request('/api/repositories/non-existent/worktrees/%2Fsome%2Fpath', {
           method: 'DELETE',
         });
-        expect(res.status).toBe(404);
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { error: string };
+        expect(body.error).toContain('outside managed directory');
       });
 
       it('should return 400 when worktree path is invalid for repository', async () => {
@@ -2468,14 +2476,27 @@ describe('API Routes Integration', () => {
         expect(body.error).toContain('Failed to check for open PRs');
       });
 
-      it('should broadcast worktree-deletion-failed with empty sessionIds when repository is not found (async path)', async () => {
+      it('should broadcast worktree-deletion-completed with empty sessionIds when repository is unregistered (orphan async path, refs #815)', async () => {
+        // Refs #815. When the repository row is missing from the in-memory
+        // registry but a worktree row / dir still references it, the deletion
+        // service routes into git-less orphan cleanup. The route must emit
+        // exactly one worktree-deletion-completed broadcast (NOT failed).
+        //
+        // Replaces an earlier PR #816 regression test which asserted the
+        // worktree-deletion-failed broadcast contract — that contract is
+        // now obsolete: the deletion service no longer gives up partway
+        // when the repo is unregistered.
         const app = await createApp();
-        // Do NOT register a repository — the route should treat it as not found.
+
+        // Do NOT register the repository. Use a worktreePath that resolves
+        // INSIDE getRepositoriesDir() so the orphan path's security
+        // boundary check passes. The path does not need to exist on disk —
+        // fs.rm with force is a no-op on missing paths.
         const missingRepoId = '00000000-0000-4000-8000-000000000000';
-        const worktreePath = '/test/missing-repo/wt-1';
+        const worktreePath = `${TEST_CONFIG_DIR}/repositories/orphan-repo/worktrees/wt-1`;
 
         const res = await app.request(
-          `/api/repositories/${missingRepoId}/worktrees/${encodeURIComponent(worktreePath)}?taskId=test-missing-repo&force=true`,
+          `/api/repositories/${missingRepoId}/worktrees/${encodeURIComponent(worktreePath)}?taskId=test-orphan-repo&force=true`,
           { method: 'DELETE' }
         );
 
@@ -2485,18 +2506,27 @@ describe('API Routes Integration', () => {
         // Wait for background operation to complete
         await new Promise((resolve) => setTimeout(resolve, 200));
 
-        // Exactly one worktree-deletion-failed broadcast must be emitted with empty sessionIds
         const broadcastSpy = mockBroadcastToApp;
+
+        // Exactly one worktree-deletion-completed broadcast must be emitted with empty sessionIds.
+        const completedCalls = broadcastSpy.mock.calls.filter(
+          (call: unknown[]) => {
+            const message = call[0] as { type: string; taskId?: string };
+            return message.type === 'worktree-deletion-completed' && message.taskId === 'test-orphan-repo';
+          }
+        );
+        expect(completedCalls.length).toBe(1);
+        const payload = completedCalls[0][0] as { sessionIds: string[] };
+        expect(payload.sessionIds).toEqual([]);
+
+        // No failed broadcasts for this task.
         const failedCalls = broadcastSpy.mock.calls.filter(
           (call: unknown[]) => {
             const message = call[0] as { type: string; taskId?: string };
-            return message.type === 'worktree-deletion-failed' && message.taskId === 'test-missing-repo';
+            return message.type === 'worktree-deletion-failed' && message.taskId === 'test-orphan-repo';
           }
         );
-        expect(failedCalls.length).toBe(1);
-        const payload = failedCalls[0][0] as { sessionIds: string[]; error: string };
-        expect(payload.sessionIds).toEqual([]);
-        expect(payload.error).toContain('Repository not found');
+        expect(failedCalls.length).toBe(0);
       });
     });
 

--- a/packages/server/src/__tests__/worktree-deletion-service.test.ts
+++ b/packages/server/src/__tests__/worktree-deletion-service.test.ts
@@ -16,12 +16,14 @@ const mockIsWorktreeOf = mock(() => Promise.resolve(true));
 const mockRemoveWorktree = mock(() => Promise.resolve({ success: true }));
 const mockListWorktrees = mock(() => Promise.resolve([]));
 const mockExecuteHookCommand = mock(() => Promise.resolve({ success: true }));
+const mockRemoveOrphanedWorktree = mock(() => Promise.resolve());
 
 const mockWorktreeService = {
   isWorktreeOf: mockIsWorktreeOf,
   removeWorktree: mockRemoveWorktree,
   listWorktrees: mockListWorktrees,
   executeHookCommand: mockExecuteHookCommand,
+  removeOrphanedWorktree: mockRemoveOrphanedWorktree,
 };
 
 function createMockSession(id: string, locationPath: string): Session {

--- a/packages/server/src/routes/__tests__/worktrees.test.ts
+++ b/packages/server/src/routes/__tests__/worktrees.test.ts
@@ -5,6 +5,7 @@ import { api } from '../api.js';
 import type { AppBindings } from '../../app-context.js';
 import type { WorktreeService } from '../../services/worktree-service.js';
 import type { RepositoryManager } from '../../services/repository-manager.js';
+import type { SessionManager } from '../../services/session-manager.js';
 import type { AppServerMessage, Repository } from '@agent-console/shared';
 import { asAppContext } from '../../__tests__/test-utils.js';
 import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
@@ -40,6 +41,7 @@ function createMockWorktreeService() {
     listRemoteBranches: mock(() => Promise.resolve([])),
     executeHookCommand: mock(() => Promise.resolve(null)),
     removeWorktree: mock(() => Promise.resolve({ success: true })),
+    removeOrphanedWorktree: mock(() => Promise.resolve()),
     getWorktreeIndexNumber: mock(() => Promise.resolve(null)),
   } as unknown as WorktreeService;
 }
@@ -410,18 +412,33 @@ describe('Worktrees API', () => {
       expect(body.error).toContain('required');
     });
 
-    it('should broadcast worktree-deletion-failed with empty sessionIds when repository is not found (async path)', async () => {
-      // Async DELETE for a repoId the registry does not know.
-      // The handler must emit exactly one worktree-deletion-failed broadcast
-      // with sessionIds: [] (rather than zero broadcasts, which would leave the
-      // client-side WorktreeDeletionTask stuck on 'deleting' forever).
+    it('should broadcast worktree-deletion-completed with empty sessionIds when repository is unregistered (orphan async path, refs #815)', async () => {
+      // Refs #815. When the repository row is missing from the in-memory
+      // registry (e.g., the primary repo dir was deleted out-of-band so
+      // RepositoryManager.initialize() skipped it), the worktree has lost
+      // its anchor. The deletion service routes into git-less orphan
+      // cleanup and the route must emit a SUCCESS broadcast — not failure
+      // — with the worktree's session IDs (here: [] because no sessions
+      // were registered against this orphaned worktree).
+      //
+      // This replaces an earlier regression test (PR #816) that asserted
+      // a worktree-deletion-failed broadcast. That contract is obsolete:
+      // the deletion service no longer gives up partway when the repo is
+      // unregistered.
       const broadcasts: AppServerMessage[] = [];
+
+      const mockSessionManager = {
+        getAllSessions: () => [],
+        killSessionWorkers: mock(() => Promise.resolve()),
+        deleteSession: mock(() => Promise.resolve(true)),
+      } as unknown as SessionManager;
 
       app = new Hono<AppBindings>();
       app.use('*', async (c, next) => {
         c.set('appContext', asAppContext({
           repositoryManager: mockRepositoryManager,
           worktreeService: mockWorktreeService,
+          sessionManager: mockSessionManager,
           broadcastToApp: (msg) => { broadcasts.push(msg); },
         }));
         await next();
@@ -431,7 +448,7 @@ describe('Worktrees API', () => {
 
       const unknownRepoId = 'non-existent-repo-id';
       const res = await app.request(
-        `/api/repositories/${unknownRepoId}/worktrees/${encodedPath(WORKTREE_PATH)}?taskId=test-not-found-task`,
+        `/api/repositories/${unknownRepoId}/worktrees/${encodedPath(WORKTREE_PATH)}?taskId=test-orphan-task`,
         { method: 'DELETE' },
       );
 
@@ -441,13 +458,22 @@ describe('Worktrees API', () => {
       // Wait for the background fire-and-forget task to complete
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      const failedBroadcasts = broadcasts.filter(
-        (b): b is Extract<AppServerMessage, { type: 'worktree-deletion-failed' }> =>
-          b.type === 'worktree-deletion-failed' && b.taskId === 'test-not-found-task',
+      const completedBroadcasts = broadcasts.filter(
+        (b): b is Extract<AppServerMessage, { type: 'worktree-deletion-completed' }> =>
+          b.type === 'worktree-deletion-completed' && b.taskId === 'test-orphan-task',
       );
-      expect(failedBroadcasts.length).toBe(1);
-      expect(failedBroadcasts[0].sessionIds).toEqual([]);
-      expect(failedBroadcasts[0].error).toContain('Repository not found');
+      expect(completedBroadcasts.length).toBe(1);
+      expect(completedBroadcasts[0].sessionIds).toEqual([]);
+
+      // No failure should be emitted for the orphan path.
+      const failedBroadcasts = broadcasts.filter(
+        (b) => b.type === 'worktree-deletion-failed' && b.taskId === 'test-orphan-task',
+      );
+      expect(failedBroadcasts.length).toBe(0);
+
+      // The git-less helper must be the one that ran (not the git-bound removeWorktree).
+      expect(mockWorktreeService.removeOrphanedWorktree).toHaveBeenCalledWith(WORKTREE_PATH);
+      expect(mockWorktreeService.removeWorktree).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/server/src/services/__tests__/worktree-deletion-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-deletion-service.test.ts
@@ -26,12 +26,16 @@ const mockExecuteHookCommand = mock<
 const mockIsWorktreeOf = mock<
   (repoPath: string, worktreePath: string, repoId: string) => Promise<boolean>
 >(() => Promise.resolve(true));
+const mockRemoveOrphanedWorktree = mock<(worktreePath: string) => Promise<void>>(
+  () => Promise.resolve(),
+);
 
 const mockWorktreeService = {
   listWorktrees: mockListWorktrees,
   removeWorktree: mockRemoveWorktree,
   executeHookCommand: mockExecuteHookCommand,
   isWorktreeOf: mockIsWorktreeOf,
+  removeOrphanedWorktree: mockRemoveOrphanedWorktree,
 };
 
 // --- Mock logger ---
@@ -110,10 +114,12 @@ describe('deleteWorktree', () => {
     mockRemoveWorktree.mockReset();
     mockExecuteHookCommand.mockReset();
     mockIsWorktreeOf.mockReset();
+    mockRemoveOrphanedWorktree.mockReset();
 
     mockRemoveWorktree.mockImplementation(() => Promise.resolve({ success: true }));
     mockExecuteHookCommand.mockImplementation(() => Promise.resolve({ success: true, output: 'ok' }));
     mockIsWorktreeOf.mockImplementation(() => Promise.resolve(true));
+    mockRemoveOrphanedWorktree.mockImplementation(() => Promise.resolve());
     mockListWorktrees.mockImplementation(() =>
       Promise.resolve([
         {
@@ -129,18 +135,153 @@ describe('deleteWorktree', () => {
 
   // --- Repository lookup ---
 
-  it('returns not-found error when repository does not exist', async () => {
-    const deps = createMockDeps({ repo: undefined as unknown as { name: string; path: string } });
+  it('orphan path: succeeds with git-less cleanup when repository row is unregistered (no sessions)', async () => {
+    // Refs #815. When the repository row is missing from the in-memory
+    // registry, the worktree has lost its anchor. Instead of returning
+    // "not-found" (which leaves the orphan stuck in 'deleting'), the
+    // deletion service must perform a git-less fs.rm + DB-row delete.
+    const deps = createMockDeps({ sessions: [] });
     (deps.repositoryManager as { getRepository: () => undefined }).getRepository = () => undefined;
 
     const result = await deleteWorktree(
-      { repoId: 'non-existent', worktreePath: WORKTREE_PATH, force: false },
+      { repoId: 'unregistered-repo', worktreePath: WORKTREE_PATH, force: false },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.sessionIds).toEqual([]);
+    expect(mockRemoveOrphanedWorktree).toHaveBeenCalledWith(WORKTREE_PATH);
+    expect(mockRemoveWorktree).not.toHaveBeenCalled();
+    expect(mockExecuteHookCommand).not.toHaveBeenCalled();
+    expect(deps.sessionManager.killSessionWorkers).not.toHaveBeenCalled();
+    expect(deps.sessionManager.deleteSession).not.toHaveBeenCalled();
+  });
+
+  it('orphan path: kills PTYs and deletes sessions when matching sessions exist', async () => {
+    const session2 = buildWorktreeSession({
+      id: 'sess-2',
+      repositoryName: 'my-repo',
+      worktreeId: 'feature-1',
+      locationPath: WORKTREE_PATH,
+    });
+    const deps = createMockDeps({ sessions: [DEFAULT_WORKTREE_SESSION, session2] });
+    (deps.repositoryManager as { getRepository: () => undefined }).getRepository = () => undefined;
+
+    const result = await deleteWorktree(
+      { repoId: 'unregistered-repo', worktreePath: WORKTREE_PATH, force: false },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.sessionIds).toEqual(['sess-1', 'sess-2']);
+    expect(deps.sessionManager.killSessionWorkers).toHaveBeenCalledWith('sess-1');
+    expect(deps.sessionManager.killSessionWorkers).toHaveBeenCalledWith('sess-2');
+    expect(mockRemoveOrphanedWorktree).toHaveBeenCalledWith(WORKTREE_PATH);
+    expect(deps.sessionManager.deleteSession).toHaveBeenCalledWith('sess-1');
+    expect(deps.sessionManager.deleteSession).toHaveBeenCalledWith('sess-2');
+    expect(mockRemoveWorktree).not.toHaveBeenCalled(); // git path not used
+  });
+
+  it('orphan path: idempotent — fs.rm and deleteByPath both no-op on missing artifacts', async () => {
+    // mockRemoveOrphanedWorktree default resolution simulates the no-op
+    // shape of removeOrphanedWorktree: rm with force does not throw on
+    // missing paths, deleteByPath does not throw on missing rows.
+    const deps = createMockDeps({ sessions: [] });
+    (deps.repositoryManager as { getRepository: () => undefined }).getRepository = () => undefined;
+
+    const result = await deleteWorktree(
+      { repoId: 'unregistered-repo', worktreePath: WORKTREE_PATH, force: false },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockRemoveOrphanedWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it('orphan path: rejects worktreePath outside getRepositoriesDir() (security boundary preserved)', async () => {
+    const deps = createMockDeps({ sessions: [] });
+    (deps.repositoryManager as { getRepository: () => undefined }).getRepository = () => undefined;
+
+    const result = await deleteWorktree(
+      { repoId: 'unregistered-repo', worktreePath: '/outside/path', force: false },
       deps,
     );
 
     expect(result.success).toBe(false);
-    expect(result.errorType).toBe('not-found');
-    expect(result.error).toContain('Repository not found');
+    expect(result.errorType).toBe('validation');
+    expect(result.error).toContain('outside managed directory');
+    expect(mockRemoveOrphanedWorktree).not.toHaveBeenCalled();
+  });
+
+  it('orphan path: rejects when a matching session is the main worktree (invariant preserved)', async () => {
+    const mainSession = buildWorktreeSession({
+      id: 'sess-main',
+      repositoryName: 'my-repo',
+      worktreeId: 'main',
+      locationPath: WORKTREE_PATH,
+      isMainWorktree: true,
+    });
+    const deps = createMockDeps({ sessions: [mainSession] });
+    (deps.repositoryManager as { getRepository: () => undefined }).getRepository = () => undefined;
+
+    const result = await deleteWorktree(
+      { repoId: 'unregistered-repo', worktreePath: WORKTREE_PATH, force: false },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errorType).toBe('validation');
+    expect(result.error).toContain('Cannot remove the main worktree');
+    expect(mockRemoveOrphanedWorktree).not.toHaveBeenCalled();
+  });
+
+  it('orphan path: returns conflict when deletion is already in progress for the same path', async () => {
+    _getDeletionsInProgress().add(WORKTREE_PATH);
+    const deps = createMockDeps({ sessions: [] });
+    (deps.repositoryManager as { getRepository: () => undefined }).getRepository = () => undefined;
+
+    const result = await deleteWorktree(
+      { repoId: 'unregistered-repo', worktreePath: WORKTREE_PATH, force: false },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errorType).toBe('conflict');
+    expect(mockRemoveOrphanedWorktree).not.toHaveBeenCalled();
+  });
+
+  it('orphan path: collects killErrors but still proceeds with cleanup', async () => {
+    const deps = createMockDeps({ sessions: [DEFAULT_WORKTREE_SESSION] });
+    (deps.repositoryManager as { getRepository: () => undefined }).getRepository = () => undefined;
+    deps.sessionManager.killSessionWorkers.mockImplementation(() =>
+      Promise.reject(new Error('kill failed')),
+    );
+
+    const result = await deleteWorktree(
+      { repoId: 'unregistered-repo', worktreePath: WORKTREE_PATH, force: false },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.killErrors).toEqual([{ sessionId: 'sess-1', error: 'kill failed' }]);
+    expect(mockRemoveOrphanedWorktree).toHaveBeenCalledTimes(1);
+    expect(deps.sessionManager.deleteSession).toHaveBeenCalledWith('sess-1');
+  });
+
+  it('orphan path: collects sessionDeleteError when deleteSession throws but still reports success', async () => {
+    const deps = createMockDeps({ sessions: [DEFAULT_WORKTREE_SESSION] });
+    (deps.repositoryManager as { getRepository: () => undefined }).getRepository = () => undefined;
+    deps.sessionManager.deleteSession.mockImplementation(() =>
+      Promise.reject(new Error('DB error')),
+    );
+
+    const result = await deleteWorktree(
+      { repoId: 'unregistered-repo', worktreePath: WORKTREE_PATH, force: false },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.sessionDeleteError).toBe('sess-1: DB error');
   });
 
   // --- Path validation ---

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -521,6 +521,74 @@ detached
     });
   });
 
+  describe('removeOrphanedWorktree', () => {
+    // Refs #815. The named helper is called directly by the deletion
+    // service when the repository row itself is unregistered. The helper
+    // must be pure best-effort (no git, idempotent).
+
+    it('should remove both the worktree directory and the DB row', async () => {
+      fs.mkdirSync('/worktrees/orphan-direct', { recursive: true });
+      mockRepo.records.push({
+        id: 'wt-direct',
+        repositoryId: 'repo-unregistered',
+        path: '/worktrees/orphan-direct',
+        indexNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      await service.removeOrphanedWorktree('/worktrees/orphan-direct');
+
+      expect(fs.existsSync('/worktrees/orphan-direct')).toBe(false);
+      expect(mockRepo.records.find((r) => r.path === '/worktrees/orphan-direct')).toBeUndefined();
+      expect(mockGit.removeWorktree).not.toHaveBeenCalled();
+    });
+
+    it('should be idempotent when the directory is already missing', async () => {
+      // No fs.mkdirSync — the directory does not exist on disk.
+      mockRepo.records.push({
+        id: 'wt-missing-dir',
+        repositoryId: 'repo-unregistered',
+        path: '/worktrees/no-dir',
+        indexNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      // Must not throw — fs.rm with force is a no-op on missing paths.
+      await service.removeOrphanedWorktree('/worktrees/no-dir');
+
+      expect(mockRepo.records.find((r) => r.path === '/worktrees/no-dir')).toBeUndefined();
+    });
+
+    it('should be idempotent when the DB row is already missing', async () => {
+      fs.mkdirSync('/worktrees/no-row', { recursive: true });
+      // No mockRepo.records.push — the row does not exist.
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      // Must not throw — deleteByPath is a no-op on missing rows.
+      await service.removeOrphanedWorktree('/worktrees/no-row');
+
+      expect(fs.existsSync('/worktrees/no-row')).toBe(false);
+    });
+
+    it('should be idempotent when both the directory and the DB row are already missing', async () => {
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      // Pure no-op call: nothing to remove.
+      await service.removeOrphanedWorktree('/worktrees/all-gone');
+
+      expect(mockRepo.records.length).toBe(0);
+    });
+  });
+
   describe('listBranches', () => {
     it('should list local and remote branches', async () => {
       const WorktreeService = await getWorktreeService();

--- a/packages/server/src/services/worktree-deletion-service.ts
+++ b/packages/server/src/services/worktree-deletion-service.ts
@@ -8,7 +8,7 @@ import type { WorktreeService } from './worktree-service.js';
 /** Narrow subset of WorktreeService methods needed by the deletion service. */
 type DeleteWorktreeServiceDeps = Pick<
   WorktreeService,
-  'isWorktreeOf' | 'listWorktrees' | 'executeHookCommand' | 'removeWorktree'
+  'isWorktreeOf' | 'listWorktrees' | 'executeHookCommand' | 'removeWorktree' | 'removeOrphanedWorktree'
 >;
 import type { SessionManager } from './session-manager.js';
 
@@ -125,6 +125,117 @@ export interface DeleteWorktreeResult {
   sessionIds?: string[];
 }
 
+// ---------- Orphan recovery ----------
+
+/**
+ * Clean up an orphaned worktree whose repository row is no longer registered
+ * in memory.
+ *
+ * Same shape as the main `deleteWorktree` path but git-less: no cleanup
+ * command (the repository row is gone, so there is no `cleanupCommand` to
+ * read), no open-PR check (no repo means no `gh` context), no main-worktree
+ * check based on the registry (we rely on the per-session invariant).
+ *
+ * Security boundary still applies: the worktreePath must resolve under
+ * `getRepositoriesDir()`. The main-worktree invariant still applies via the
+ * matching sessions' `isMainWorktree` flag. The concurrency guard still
+ * applies via `markDeletionInProgress`.
+ *
+ * `force` is intentionally not a parameter here: with no repository row,
+ * there is no data to protect, so unconditional cleanup is the correct
+ * default per #815.
+ */
+async function cleanupOrphanedWorktree(
+  params: { repoId: string; worktreePath: string },
+  deps: DeleteWorktreeDeps,
+): Promise<DeleteWorktreeResult> {
+  const { repoId, worktreePath } = params;
+  const { worktreeService, sessionManager } = deps;
+
+  // 1. Security boundary check — same as validateWorktreePath, but without
+  //    the repo-bound `isWorktreeOf` step (no registered repo to bind to).
+  const canonicalPath = resolvePath(worktreePath);
+  const repositoriesDir = resolvePath(getRepositoriesDir());
+  if (!canonicalPath.startsWith(repositoriesDir + pathSep)) {
+    return { success: false, error: 'Worktree path is outside managed directory', errorType: 'validation' };
+  }
+
+  // 2. Find matching sessions (same pattern as the registered path).
+  const matchingSessions = sessionManager.getAllSessions().filter(
+    (session: Session) => session.locationPath === worktreePath,
+  );
+  const sessionIds = matchingSessions.map(s => s.id);
+
+  // 2a. Main-worktree protection: even on the orphan path, do not allow
+  //     removing the main worktree of a registered worktree-session.
+  for (const session of matchingSessions) {
+    if (session.type === 'worktree' && session.isMainWorktree) {
+      return {
+        success: false,
+        error: 'Cannot remove the main worktree. Only added worktrees can be removed.',
+        errorType: 'validation',
+      };
+    }
+  }
+
+  // 3. Concurrency guard.
+  if (!markDeletionInProgress(worktreePath)) {
+    return { success: false, error: 'Deletion already in progress', errorType: 'conflict' };
+  }
+
+  try {
+    // 4. Kill PTYs — best-effort, do not fail the deletion on these errors.
+    const killResults = await Promise.allSettled(
+      sessionIds.map((sid) => sessionManager.killSessionWorkers(sid)),
+    );
+    const killErrors: Array<{ sessionId: string; error: string }> = [];
+    for (let i = 0; i < killResults.length; i++) {
+      const result = killResults[i];
+      if (result.status === 'rejected') {
+        const msg = result.reason instanceof Error ? result.reason.message : String(result.reason);
+        logger.warn({ sessionId: sessionIds[i], error: msg }, 'PTY kill failed, proceeding with orphan cleanup');
+        killErrors.push({ sessionId: sessionIds[i], error: msg });
+      }
+    }
+
+    // 5. Remove the worktree dir + DB row via the git-less helper.
+    //    Idempotent — fs.rm with force does not throw on missing paths,
+    //    and deleteByPath does not throw on missing rows.
+    await worktreeService.removeOrphanedWorktree(canonicalPath);
+
+    // 6. Delete sessions.
+    let sessionDeleteError: string | undefined;
+    if (sessionIds.length > 0) {
+      const deleteErrors: string[] = [];
+      for (const sid of sessionIds) {
+        try {
+          await sessionManager.deleteSession(sid);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          logger.error({ repoId, worktreePath, sessionId: sid, error }, 'Failed to delete session after orphan cleanup');
+          deleteErrors.push(`${sid}: ${msg}`);
+        }
+      }
+      if (deleteErrors.length > 0) {
+        sessionDeleteError = deleteErrors.join('; ');
+      }
+    }
+
+    logger.info(
+      { repoId, worktreePath, sessionIds },
+      'Orphaned worktree cleaned up (repository row unregistered)',
+    );
+    return {
+      success: true,
+      ...(killErrors.length > 0 ? { killErrors } : {}),
+      sessionDeleteError,
+      sessionIds,
+    };
+  } finally {
+    clearDeletionInProgress(worktreePath);
+  }
+}
+
 // ---------- Main entry point ----------
 
 export interface DeleteWorktreeParams {
@@ -151,10 +262,18 @@ export async function deleteWorktree(
   const { repoId, worktreePath, force } = params;
   const { worktreeService, sessionManager, repositoryManager, findOpenPullRequest, getCurrentBranch } = deps;
 
-  // 1. Look up repository
+  // 1. Look up repository.
+  //
+  // If the repository row is not in memory the worktree has lost its anchor:
+  // RepositoryManager.initialize() skips missing repository directories at
+  // startup, but persisted sessions and worktree DB rows referencing the
+  // missing repo can still load. Returning "not-found" here would leave the
+  // orphaned rows un-removable from the UI (see #815). Instead, route into
+  // the git-less orphan cleanup path — "if the underlying data doesn't
+  // exist, just clean up nicely rather than giving up partway".
   const repo = repositoryManager.getRepository(repoId);
   if (!repo) {
-    return { success: false, error: `Repository not found: ${repoId}`, errorType: 'not-found' };
+    return cleanupOrphanedWorktree({ repoId, worktreePath }, deps);
   }
 
   // 2. Validate worktree path

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -346,10 +346,9 @@ export class WorktreeService {
         // Primary repo is gone: the worktree is already orphaned. Recover without
         // git, unconditionally (no `force` required) — recovery of an orphaned
         // worktree is always defensible, and this also satisfies "at minimum force
-        // must work". rm on a missing path and deleteByPath on a missing row are
-        // both no-ops, so this branch is idempotent.
-        await fsPromises.rm(worktreePath, { recursive: true, force: true });
-        await this.worktreeRepository.deleteByPath(worktreePath);
+        // must work". The helper is idempotent and is also used by the deletion
+        // service when the repository row itself is unregistered (#815).
+        await this.removeOrphanedWorktree(worktreePath);
         logger.warn(
           { worktreePath, repoPath },
           'Primary repo dir missing; removed orphaned worktree without git'
@@ -369,6 +368,26 @@ export class WorktreeService {
       logger.error({ err: error, message, worktreePath }, 'Failed to remove worktree');
       return { success: false, error: message };
     }
+  }
+
+  /**
+   * Remove an orphaned worktree without invoking git.
+   *
+   * Used when a worktree has lost its anchor — either the primary repo
+   * directory is gone (see #811), or the repository row itself is no longer
+   * registered in memory (see #815). In both cases there is no git context
+   * to drive `git worktree remove`, so the recovery is a pure best-effort
+   * filesystem + DB cleanup:
+   *
+   * - `fs.rm` with `force: true` — no-op if the directory is already gone.
+   * - `worktreeRepository.deleteByPath` — no-op if the row is already gone.
+   *
+   * Idempotent. Callers are responsible for any concurrency guard and any
+   * security boundary check on `worktreePath`.
+   */
+  async removeOrphanedWorktree(worktreePath: string): Promise<void> {
+    await fsPromises.rm(worktreePath, { recursive: true, force: true });
+    await this.worktreeRepository.deleteByPath(worktreePath);
   }
 
   /**


### PR DESCRIPTION
## Summary

- When a repository's on-disk path is missing at server startup, `RepositoryManager.initialize()` logs `Skipped missing repository` and refuses to populate the in-memory registry, but persisted sessions and worktree DB rows referencing the missing repo still load. Previously, those orphaned worktrees were un-deletable from the UI: `worktree-deletion-service` early-returned `Repository not found` before any cleanup logic could run, and `force=true` did not change that.
- This PR routes the `!repo` branch into a **git-less orphan cleanup path** instead of giving up. The principle is "if the underlying data doesn't exist, just clean up nicely rather than abandoning halfway." Force delete is no longer required for this case — there is no data to protect once the registry row is gone.
- Dogfood-confirmed on macOS plist deployment: the previously stuck `chatboost-cv` orphan was cleaned successfully after deploying this branch (the same orphan that was also the trigger for the surfacing fix in #816).

## Design

- New `WorktreeService.removeOrphanedWorktree(worktreePath)` consolidates the two-line git-less cleanup (`fs.rm` + `worktreeRepository.deleteByPath`) into a named, idempotent method. Both #811's existing inline branch (primary repo dir missing) and the new #815 branch (repository row unregistered) now go through this single source of truth — no duplicated cleanup logic.
- New private helper `cleanupOrphanedWorktree()` in `worktree-deletion-service.ts` mirrors the shape of `deleteWorktree` but skips git operations, cleanup commands, and open-PR checks. Preserved invariants: security boundary check (path must resolve under `getRepositoriesDir()`), main-worktree protection (per-session `isMainWorktree` flag), concurrency guard (`markDeletionInProgress` with `try/finally`).
- `force` is intentionally dropped from the orphan signature. The repository row is gone; there is nothing whose accidental loss `force` would need to gate.
- The repository row itself is NOT deleted here. Multiple worktrees may reference the same orphaned repo, the path may return on a remount, and that decision belongs elsewhere. Out of scope.

## Changes

- `packages/server/src/services/worktree-service.ts` — extract `removeOrphanedWorktree`; #811's inline branch now delegates to it.
- `packages/server/src/services/worktree-deletion-service.ts` — branch `!repo` into `cleanupOrphanedWorktree` instead of returning failure; preserve all existing invariants on the orphan path.
- `packages/server/src/services/__tests__/worktree-deletion-service.test.ts` — 8 new orphan-path scenarios covering all boundary values from design-principles.md (empty sessions / N sessions / missing dir / out-of-bounds path / main-worktree / registered happy path / concurrency guard).
- `packages/server/src/services/__tests__/worktree-service.test.ts` — new `describe('removeOrphanedWorktree')` block (4 direct tests).
- `packages/server/src/routes/__tests__/worktrees.test.ts` — flipped the regression test from PR #816 from "Repository not found → emit `failed` broadcast" to "Repository not found → orphan cleanup → emit `completed` broadcast." Same scenario, new contract.
- `packages/server/src/__tests__/api.test.ts` — flipped 2 tests for the same reason (async broadcast + sync HTTP-status contract).

## Stacking

Stacks on #816 (still open). Base is `fix/worktree-deletion-stuck-deleting`. If #816 is squash-merged first, this branch will need a rebase onto main per `workflow.md` "Continuing Work after a Squash Merge."

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run test` — full suite green (server 2582 → 2594; +12 new tests)
- [x] `node .claude/skills/orchestrator/preflight-check.js` — exit 0 (sibling coverage satisfied for `worktree-service.ts`, `worktree-deletion-service.ts`, `worktrees.ts`)
- [x] Manual dogfood verification on macOS plist deployment — the orphan that triggered #815 was cleanly removed via the standard Delete action (no Force required)
- [ ] CodeRabbit review (GitHub-side bot)

Closes #815