### PR TITLE
fix: scope upload directory under /tmp/agent-console-uploads-<uid>/ with mode 0700 (#821)

### DIFF
--- a/packages/server/src/routes/__tests__/workers.test.ts
+++ b/packages/server/src/routes/__tests__/workers.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as os from 'os';
 import { join as pathJoin } from 'path';
-import { randomUUID } from 'crypto';
 import { Hono } from 'hono';
 import { onApiError } from '../../lib/error-handler.js';
 import { api } from '../api.js';
@@ -22,11 +21,13 @@ import { SessionManager } from '../../services/session-manager.js';
 import { JsonSessionRepository } from '../../repositories/index.js';
 import { MAX_MESSAGE_FILES, MAX_TOTAL_FILE_SIZE } from '@agent-console/shared';
 
-// Upload paths are resolved against real disk by Bun.write (native API, not
-// trapped by memfs). We therefore use a real per-test directory under
-// os.tmpdir() rather than a fixed memfs-only path.
-const TEST_CONFIG_BASE = pathJoin(os.tmpdir(), 'agent-console-workers-test');
-let TEST_CONFIG_DIR: string;
+// Config dir is memfs-only; uploads target a per-uid /tmp dir by spec (see #821).
+// memfs hooks fs/promises so the route's mkdir lands in memfs, which we then
+// inspect for the requested mode via memfs's `vol.statSync`. (Bun.write is
+// native and would land on real disk, but its parent-dir auto-creation uses
+// the default mode and would shadow the route's mkdir mode contract — so we
+// do not rely on real-disk stat for the mode assertion.)
+const TEST_CONFIG_DIR = '/test/config';
 
 const ptyFactory = createMockPtyFactory(20000);
 
@@ -37,8 +38,6 @@ describe('Workers API', () => {
 
   beforeEach(async () => {
     await closeDatabase();
-
-    TEST_CONFIG_DIR = pathJoin(TEST_CONFIG_BASE, randomUUID());
 
     resetGitMocks();
     setupMemfs({
@@ -88,8 +87,10 @@ describe('Workers API', () => {
     await closeDatabase();
     cleanupMemfs();
     resetProcessMock();
-    // Clean up the per-test upload directory written to real disk by Bun.write.
-    await Bun.spawn(['rm', '-rf', TEST_CONFIG_DIR]).exited;
+    // Note: per-uid upload dir under os.tmpdir() is intentionally NOT cleaned
+    // up here — the production design relies on OS-level /tmp reapers
+    // (systemd-tmpfiles / tmpwatch / reboot) and the path is shared across
+    // every test run for this uid. See #821.
   });
 
   // ===========================================================================
@@ -225,6 +226,79 @@ describe('Workers API', () => {
       expect(body.error).toContain('Total file size exceeds limit');
     });
 
+    // NOTE: This test must run BEFORE any other test that triggers an upload,
+    // because the route caches its `mkdir(..., { mode: 0o700 })` result in a
+    // process-level Map. Only the first upload in the process actually invokes
+    // mkdir; subsequent uploads short-circuit on the cache. We rely on that
+    // first call to leave a memfs entry whose mode we can inspect.
+    it('should save uploaded files under /tmp/agent-console-uploads-<uid>/ with mode 0700 (#821)', async () => {
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      const worker = await sessionManager.createWorker(session.id, {
+        type: 'agent',
+        agentId: 'claude-code',
+      });
+      expect(worker).not.toBeNull();
+
+      // Spy on Bun.write to capture the actual file path the route writes to.
+      // Bun.write is a native API and is not trapped by the memfs fs/promises
+      // mock, so a path-based assertion via the spy is the cleanest cross-check
+      // for the destination path.
+      const writtenPaths: string[] = [];
+      const originalBunWrite = Bun.write;
+      Bun.write = ((dest: unknown, input: unknown, options?: unknown) => {
+        if (typeof dest === 'string') {
+          writtenPaths.push(dest);
+        }
+        return originalBunWrite(
+          dest as Parameters<typeof originalBunWrite>[0],
+          input as Parameters<typeof originalBunWrite>[1],
+          options as Parameters<typeof originalBunWrite>[2],
+        );
+      }) as typeof Bun.write;
+
+      try {
+        const formData = new FormData();
+        formData.append('toWorkerId', worker!.id);
+        formData.append('content', 'msg');
+        formData.append('files', new File(['data'], 'test.txt', { type: 'text/plain' }));
+
+        const res = await app.request(`/api/sessions/${session.id}/messages`, {
+          method: 'POST',
+          body: formData,
+        });
+        expect(res.status).toBe(201);
+
+        expect(writtenPaths.length).toBeGreaterThan(0);
+
+        const euid: number | 'shared' =
+          typeof process.geteuid === 'function' ? process.geteuid() : 'shared';
+        const expectedUploadDir = pathJoin(os.tmpdir(), `agent-console-uploads-${euid}`);
+        const hostSharedLegacy = pathJoin(os.tmpdir(), 'agent-console-uploads');
+        for (const filePath of writtenPaths) {
+          // Path scoping: per-uid dir under os.tmpdir(), never the host-shared
+          // legacy bare dir.
+          expect(filePath.startsWith(expectedUploadDir + '/')).toBe(true);
+          expect(filePath === hostSharedLegacy).toBe(false);
+          expect(filePath.startsWith(hostSharedLegacy + '/')).toBe(false);
+        }
+
+        // Verify mode 0700 on the upload directory via memfs's vol — the
+        // route's `mkdir(..., { mode: 0o700 })` is intercepted by memfs and
+        // recorded with mode preserved.
+        const { vol } = await import('memfs');
+        const stat = vol.statSync(expectedUploadDir);
+        // mode includes the file-type bits; mask to perm bits only.
+        const perm = (stat.mode & 0o777).toString(8);
+        expect(perm).toBe('700');
+      } finally {
+        Bun.write = originalBunWrite;
+      }
+    });
+
     it('should sanitize path traversal in filenames', async () => {
       const session = await sessionManager.createSession({
         type: 'quick',
@@ -266,56 +340,6 @@ describe('Workers API', () => {
           expect(filePath).not.toContain('..');
           expect(filePath).not.toMatch(/[/\\]\.\.[/\\]/);
         }
-      }
-    });
-
-    it('should save uploaded files under AGENT_CONSOLE_HOME/uploads, not os.tmpdir() (#821)', async () => {
-      const session = await sessionManager.createSession({
-        type: 'quick',
-        locationPath: '/test/path',
-        agentId: 'claude-code',
-      });
-      const worker = await sessionManager.createWorker(session.id, {
-        type: 'agent',
-        agentId: 'claude-code',
-      });
-      expect(worker).not.toBeNull();
-
-      // Spy on Bun.write to capture the actual file path the route writes to.
-      // Bun.write is a native API and is not trapped by the memfs fs/promises mock,
-      // so a path-based assertion is the cleanest cross-check.
-      const writtenPaths: string[] = [];
-      const originalBunWrite = Bun.write;
-      Bun.write = ((dest: unknown, input: unknown, options?: unknown) => {
-        if (typeof dest === 'string') {
-          writtenPaths.push(dest);
-        }
-        return originalBunWrite(dest as Parameters<typeof originalBunWrite>[0], input as Parameters<typeof originalBunWrite>[1], options as Parameters<typeof originalBunWrite>[2]);
-      }) as typeof Bun.write;
-
-      try {
-        const formData = new FormData();
-        formData.append('toWorkerId', worker!.id);
-        formData.append('content', 'msg');
-        formData.append('files', new File(['data'], 'test.txt', { type: 'text/plain' }));
-
-        const res = await app.request(`/api/sessions/${session.id}/messages`, {
-          method: 'POST',
-          body: formData,
-        });
-        expect(res.status).toBe(201);
-
-        expect(writtenPaths.length).toBeGreaterThan(0);
-
-        const expectedUploadDir = pathJoin(TEST_CONFIG_DIR, 'uploads');
-        const hostSharedLegacy = pathJoin(os.tmpdir(), 'agent-console-uploads');
-        for (const filePath of writtenPaths) {
-          expect(filePath.startsWith(expectedUploadDir + '/')).toBe(true);
-          // Negative: must not regress to the old host-shared /tmp directory.
-          expect(filePath.startsWith(hostSharedLegacy + '/')).toBe(false);
-        }
-      } finally {
-        Bun.write = originalBunWrite;
       }
     });
 

--- a/packages/server/src/routes/__tests__/workers.test.ts
+++ b/packages/server/src/routes/__tests__/workers.test.ts
@@ -299,6 +299,155 @@ describe('Workers API', () => {
       }
     });
 
+    // TOCTOU defense (security review HIGH, #821 follow-up): a pre-created
+    // symlink at the upload-dir path would silently slip past
+    // `mkdir(..., { mode: 0o700 })`, so the route must lstat after mkdir and
+    // reject the symlink before any Bun.write touches real disk.
+    it('should reject a pre-existing symlink at the upload directory path (#821 TOCTOU defense)', async () => {
+      const { __TESTING__ } = await import('../workers.js');
+      __TESTING__.resetUploadDirCache();
+
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      const worker = await sessionManager.createWorker(session.id, {
+        type: 'agent',
+        agentId: 'claude-code',
+      });
+      expect(worker).not.toBeNull();
+
+      const euid: number | 'shared' =
+        typeof process.geteuid === 'function' ? process.geteuid() : 'shared';
+      const expectedUploadDir = pathJoin(os.tmpdir(), `agent-console-uploads-${euid}`);
+
+      const { vol } = await import('memfs');
+      // The earlier mode-0700 test may have created the dir; remove it before
+      // symlinking. Either way we end up with a symlink at the path.
+      try {
+        vol.rmdirSync(expectedUploadDir);
+      } catch {
+        // ignore: not present
+      }
+      // The symlink's parent directory must exist in memfs for symlinkSync to
+      // succeed. The OS tmpdir is real, but memfs is a separate volume.
+      vol.mkdirSync(os.tmpdir(), { recursive: true });
+      // The symlink target must also exist in memfs.
+      vol.symlinkSync(TEST_CONFIG_DIR, expectedUploadDir);
+
+      // Count Bun.write calls to assert the route rejected BEFORE any write —
+      // without this, a generic Bun.write failure (e.g. ENOENT) could pass an
+      // any-5xx assertion and the test would not actually exercise the lstat
+      // verification path.
+      const writtenPaths: string[] = [];
+      const originalBunWrite = Bun.write;
+      Bun.write = ((dest: unknown) => {
+        if (typeof dest === 'string') {
+          writtenPaths.push(dest);
+        }
+        // Return a rejected promise so that if verification fails to block
+        // the write, the route still surfaces a 5xx but our paths-count
+        // assertion exposes the bypass.
+        return Promise.reject(new Error('Bun.write must not be called'));
+      }) as typeof Bun.write;
+
+      try {
+        const formData = new FormData();
+        formData.append('toWorkerId', worker!.id);
+        formData.append('content', 'msg');
+        formData.append('files', new File(['data'], 'test.txt', { type: 'text/plain' }));
+
+        const res = await app.request(`/api/sessions/${session.id}/messages`, {
+          method: 'POST',
+          body: formData,
+        });
+
+        // Production code rejects with a thrown Error; the global error
+        // handler maps unhandled errors to 5xx.
+        expect(res.status).toBeGreaterThanOrEqual(500);
+        // The TOCTOU guard rejects before any file is written. Without the
+        // guard, Bun.write would be invoked once per attached file.
+        expect(writtenPaths).toEqual([]);
+      } finally {
+        Bun.write = originalBunWrite;
+        try {
+          vol.unlinkSync(expectedUploadDir);
+        } catch {
+          // ignore
+        }
+        __TESTING__.resetUploadDirCache();
+      }
+    });
+
+    // TOCTOU defense (security review HIGH, #821 follow-up): a pre-existing
+    // dir with a wider mode (e.g. 0o777) lets other users on the same host
+    // read buffered upload contents. mkdir is a no-op when the path exists,
+    // so the route must lstat-verify the actual mode.
+    it('should reject a pre-existing upload directory with the wrong mode (#821 TOCTOU defense)', async () => {
+      const { __TESTING__ } = await import('../workers.js');
+      __TESTING__.resetUploadDirCache();
+
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      const worker = await sessionManager.createWorker(session.id, {
+        type: 'agent',
+        agentId: 'claude-code',
+      });
+      expect(worker).not.toBeNull();
+
+      const euid: number | 'shared' =
+        typeof process.geteuid === 'function' ? process.geteuid() : 'shared';
+      const expectedUploadDir = pathJoin(os.tmpdir(), `agent-console-uploads-${euid}`);
+
+      const { vol } = await import('memfs');
+      try {
+        vol.rmdirSync(expectedUploadDir);
+      } catch {
+        // ignore
+      }
+      // Pre-create with world-writable mode. mkdir(..., {mode: 0o700}) is a
+      // POSIX no-op for an existing dir, so the mode stays 0o777.
+      vol.mkdirSync(os.tmpdir(), { recursive: true });
+      vol.mkdirSync(expectedUploadDir, { recursive: true, mode: 0o777 });
+
+      const writtenPaths: string[] = [];
+      const originalBunWrite = Bun.write;
+      Bun.write = ((dest: unknown) => {
+        if (typeof dest === 'string') {
+          writtenPaths.push(dest);
+        }
+        return Promise.reject(new Error('Bun.write must not be called'));
+      }) as typeof Bun.write;
+
+      try {
+        const formData = new FormData();
+        formData.append('toWorkerId', worker!.id);
+        formData.append('content', 'msg');
+        formData.append('files', new File(['data'], 'test.txt', { type: 'text/plain' }));
+
+        const res = await app.request(`/api/sessions/${session.id}/messages`, {
+          method: 'POST',
+          body: formData,
+        });
+
+        expect(res.status).toBeGreaterThanOrEqual(500);
+        // The TOCTOU guard rejects before any file is written.
+        expect(writtenPaths).toEqual([]);
+      } finally {
+        Bun.write = originalBunWrite;
+        try {
+          vol.rmdirSync(expectedUploadDir);
+        } catch {
+          // ignore
+        }
+        __TESTING__.resetUploadDirCache();
+      }
+    });
+
     it('should sanitize path traversal in filenames', async () => {
       const session = await sessionManager.createSession({
         type: 'quick',

--- a/packages/server/src/routes/__tests__/workers.test.ts
+++ b/packages/server/src/routes/__tests__/workers.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as os from 'os';
+import { join as pathJoin } from 'path';
+import { randomUUID } from 'crypto';
 import { Hono } from 'hono';
 import { onApiError } from '../../lib/error-handler.js';
 import { api } from '../api.js';
@@ -19,7 +22,11 @@ import { SessionManager } from '../../services/session-manager.js';
 import { JsonSessionRepository } from '../../repositories/index.js';
 import { MAX_MESSAGE_FILES, MAX_TOTAL_FILE_SIZE } from '@agent-console/shared';
 
-const TEST_CONFIG_DIR = '/test/config';
+// Upload paths are resolved against real disk by Bun.write (native API, not
+// trapped by memfs). We therefore use a real per-test directory under
+// os.tmpdir() rather than a fixed memfs-only path.
+const TEST_CONFIG_BASE = pathJoin(os.tmpdir(), 'agent-console-workers-test');
+let TEST_CONFIG_DIR: string;
 
 const ptyFactory = createMockPtyFactory(20000);
 
@@ -30,6 +37,8 @@ describe('Workers API', () => {
 
   beforeEach(async () => {
     await closeDatabase();
+
+    TEST_CONFIG_DIR = pathJoin(TEST_CONFIG_BASE, randomUUID());
 
     resetGitMocks();
     setupMemfs({
@@ -79,6 +88,8 @@ describe('Workers API', () => {
     await closeDatabase();
     cleanupMemfs();
     resetProcessMock();
+    // Clean up the per-test upload directory written to real disk by Bun.write.
+    await Bun.spawn(['rm', '-rf', TEST_CONFIG_DIR]).exited;
   });
 
   // ===========================================================================
@@ -255,6 +266,56 @@ describe('Workers API', () => {
           expect(filePath).not.toContain('..');
           expect(filePath).not.toMatch(/[/\\]\.\.[/\\]/);
         }
+      }
+    });
+
+    it('should save uploaded files under AGENT_CONSOLE_HOME/uploads, not os.tmpdir() (#821)', async () => {
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      const worker = await sessionManager.createWorker(session.id, {
+        type: 'agent',
+        agentId: 'claude-code',
+      });
+      expect(worker).not.toBeNull();
+
+      // Spy on Bun.write to capture the actual file path the route writes to.
+      // Bun.write is a native API and is not trapped by the memfs fs/promises mock,
+      // so a path-based assertion is the cleanest cross-check.
+      const writtenPaths: string[] = [];
+      const originalBunWrite = Bun.write;
+      Bun.write = ((dest: unknown, input: unknown, options?: unknown) => {
+        if (typeof dest === 'string') {
+          writtenPaths.push(dest);
+        }
+        return originalBunWrite(dest as Parameters<typeof originalBunWrite>[0], input as Parameters<typeof originalBunWrite>[1], options as Parameters<typeof originalBunWrite>[2]);
+      }) as typeof Bun.write;
+
+      try {
+        const formData = new FormData();
+        formData.append('toWorkerId', worker!.id);
+        formData.append('content', 'msg');
+        formData.append('files', new File(['data'], 'test.txt', { type: 'text/plain' }));
+
+        const res = await app.request(`/api/sessions/${session.id}/messages`, {
+          method: 'POST',
+          body: formData,
+        });
+        expect(res.status).toBe(201);
+
+        expect(writtenPaths.length).toBeGreaterThan(0);
+
+        const expectedUploadDir = pathJoin(TEST_CONFIG_DIR, 'uploads');
+        const hostSharedLegacy = pathJoin(os.tmpdir(), 'agent-console-uploads');
+        for (const filePath of writtenPaths) {
+          expect(filePath.startsWith(expectedUploadDir + '/')).toBe(true);
+          // Negative: must not regress to the old host-shared /tmp directory.
+          expect(filePath.startsWith(hostSharedLegacy + '/')).toBe(false);
+        }
+      } finally {
+        Bun.write = originalBunWrite;
       }
     });
 

--- a/packages/server/src/routes/workers.ts
+++ b/packages/server/src/routes/workers.ts
@@ -1,6 +1,5 @@
 import { Hono } from 'hono';
 import * as v from 'valibot';
-import { tmpdir } from 'os';
 import { join } from 'path';
 import { mkdir, unlink } from 'fs/promises';
 import { randomUUID } from 'crypto';
@@ -15,13 +14,32 @@ import type { AppBindings } from '../app-context.js';
 import { NotFoundError, ValidationError } from '../lib/errors.js';
 import { vValidator } from '../middleware/validation.js';
 import { createLogger } from '../lib/logger.js';
+import { getConfigDir } from '../lib/config.js';
 
 const logger = createLogger('api:workers');
 
-const FILE_UPLOAD_DIR = join(tmpdir(), 'agent-console-uploads');
-const uploadDirReady = mkdir(FILE_UPLOAD_DIR, { recursive: true }).catch((err) => {
-  logger.error({ err, dir: FILE_UPLOAD_DIR }, 'Failed to create upload directory');
-});
+// Upload directory is resolved lazily under AGENT_CONSOLE_HOME so that each
+// install (each Model B service user, each dev worktree) owns its own
+// directory instead of fighting over a host-wide path like /tmp/agent-console-uploads.
+// See issue #821.
+const uploadDirReady = new Map<string, Promise<void>>();
+
+async function ensureUploadDir(): Promise<string> {
+  const dir = join(getConfigDir(), 'uploads');
+  let ready = uploadDirReady.get(dir);
+  if (!ready) {
+    ready = mkdir(dir, { recursive: true })
+      .then(() => undefined)
+      .catch((err) => {
+        uploadDirReady.delete(dir);
+        logger.error({ err, dir }, 'Failed to create upload directory');
+        throw err;
+      });
+    uploadDirReady.set(dir, ready);
+  }
+  await ready;
+  return dir;
+}
 
 const workers = new Hono<AppBindings>()
   // Get workers for a session
@@ -87,7 +105,7 @@ const workers = new Hono<AppBindings>()
     }
 
     // Ensure upload directory is ready before writing files
-    await uploadDirReady;
+    const uploadDir = await ensureUploadDir();
 
     // Save files to disk
     const savedPaths: string[] = [];
@@ -95,7 +113,7 @@ const workers = new Hono<AppBindings>()
       // Sanitize filename: remove directory separators to prevent path traversal
       const sanitizedName = file.name.replace(/[/\\]/g, '_');
       const uniqueName = `${randomUUID()}-${sanitizedName}`;
-      const filePath = join(FILE_UPLOAD_DIR, uniqueName);
+      const filePath = join(uploadDir, uniqueName);
       const buffer = Buffer.from(await file.arrayBuffer());
       await Bun.write(filePath, buffer);
       savedPaths.push(filePath);

--- a/packages/server/src/routes/workers.ts
+++ b/packages/server/src/routes/workers.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import * as v from 'valibot';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { mkdir, unlink } from 'fs/promises';
 import { randomUUID } from 'crypto';
 import {
@@ -14,21 +15,31 @@ import type { AppBindings } from '../app-context.js';
 import { NotFoundError, ValidationError } from '../lib/errors.js';
 import { vValidator } from '../middleware/validation.js';
 import { createLogger } from '../lib/logger.js';
-import { getConfigDir } from '../lib/config.js';
 
 const logger = createLogger('api:workers');
 
-// Upload directory is resolved lazily under AGENT_CONSOLE_HOME so that each
-// install (each Model B service user, each dev worktree) owns its own
-// directory instead of fighting over a host-wide path like /tmp/agent-console-uploads.
+// Upload directory is per-uid under the OS temp directory so that:
+//   1. Different users on the same host (e.g. Model B service user `agentconsole`
+//      vs. an interactive dev user) do not collide on a single host-wide
+//      `/tmp/agent-console-uploads` (the original EACCES symptom of issue #821).
+//   2. Uploads remain transient: /tmp is reaped by the OS (systemd-tmpfiles,
+//      tmpwatch, reboot), so abandoned upload buffers do not accumulate. The
+//      server has no read-completion signal for `injectMessage`, so a
+//      persistent location (e.g. AGENT_CONSOLE_HOME) would leak disk over time.
+// Mode 0700 prevents other users from reading buffered file contents.
 // See issue #821.
 const uploadDirReady = new Map<string, Promise<void>>();
 
+function resolveUploadDir(): string {
+  const uid = typeof process.geteuid === 'function' ? process.geteuid() : 'shared';
+  return join(tmpdir(), `agent-console-uploads-${uid}`);
+}
+
 async function ensureUploadDir(): Promise<string> {
-  const dir = join(getConfigDir(), 'uploads');
+  const dir = resolveUploadDir();
   let ready = uploadDirReady.get(dir);
   if (!ready) {
-    ready = mkdir(dir, { recursive: true })
+    ready = mkdir(dir, { recursive: true, mode: 0o700 })
       .then(() => undefined)
       .catch((err) => {
         uploadDirReady.delete(dir);

--- a/packages/server/src/routes/workers.ts
+++ b/packages/server/src/routes/workers.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import * as v from 'valibot';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { mkdir, unlink } from 'fs/promises';
+import { lstat, mkdir, unlink } from 'fs/promises';
 import { randomUUID } from 'crypto';
 import {
   CreateWorkerRequestSchema,
@@ -39,18 +39,56 @@ async function ensureUploadDir(): Promise<string> {
   const dir = resolveUploadDir();
   let ready = uploadDirReady.get(dir);
   if (!ready) {
-    ready = mkdir(dir, { recursive: true, mode: 0o700 })
-      .then(() => undefined)
-      .catch((err) => {
-        uploadDirReady.delete(dir);
-        logger.error({ err, dir }, 'Failed to create upload directory');
-        throw err;
-      });
+    // TOCTOU defense (security review HIGH, #821 follow-up): POSIX mkdir is a
+    // no-op when the target already exists, so a pre-created symlink or a
+    // world-readable dir would silently slip past `mkdir(..., { mode: 0o700 })`.
+    // After mkdir, lstat the path (no symlink follow) and reject anything we
+    // did not just create ourselves with the expected owner and mode.
+    ready = (async () => {
+      await mkdir(dir, { recursive: true, mode: 0o700 });
+      const st = await lstat(dir);
+      if (st.isSymbolicLink()) {
+        throw new Error(`Upload directory is a symlink: ${dir}`);
+      }
+      if (!st.isDirectory()) {
+        throw new Error(`Upload directory path is not a directory: ${dir}`);
+      }
+      // POSIX-only ownership check; on Windows (or any platform without
+      // geteuid) the fallback path is the shared 'shared' suffix and there is
+      // no uid to compare against.
+      if (typeof process.geteuid === 'function' && st.uid !== process.geteuid()) {
+        throw new Error(
+          `Upload directory has unexpected owner uid=${st.uid} (expected ${process.geteuid()}): ${dir}`,
+        );
+      }
+      if ((st.mode & 0o777) !== 0o700) {
+        throw new Error(
+          `Upload directory has unexpected mode ${(st.mode & 0o777).toString(8)} (expected 700): ${dir}`,
+        );
+      }
+    })().catch((err) => {
+      uploadDirReady.delete(dir);
+      logger.error({ err, dir }, 'Upload directory verification failed');
+      throw err;
+    });
     uploadDirReady.set(dir, ready);
   }
   await ready;
   return dir;
 }
+
+/**
+ * @internal Exported for testing. The upload-directory readiness cache is
+ * process-global so that the route only pays the mkdir + verification cost
+ * once per uid per process. Tests need a way to invalidate the cache when
+ * they want to re-exercise the verification path with a different on-disk
+ * (memfs) state.
+ */
+export const __TESTING__ = {
+  resetUploadDirCache: (): void => {
+    uploadDirReady.clear();
+  },
+};
 
 const workers = new Hono<AppBindings>()
   // Get workers for a session


### PR DESCRIPTION
## Summary

Resolve issue #821 (Model B service-user `agentconsole` hitting EACCES on host-shared `/tmp/agent-console-uploads/`) by scoping the upload buffer directory to `/tmp/agent-console-uploads-<uid>/` with mode `0700`.

## Background — why the design evolved during review

The first push (commit `dbe668a`) routed uploads under `AGENT_CONSOLE_HOME/uploads`. Owner review surfaced a regression risk: the route is a transient buffer staged for `injectMessage`, which writes the path into the PTY but never confirms agent read-completion. There is no delete-after-read hook in either the route or the message pipeline, so moving the buffer to a persistent location (`AGENT_CONSOLE_HOME`, which lives across reboots) would accumulate orphan files indefinitely. The pre-#821 design on `/tmp` was implicitly rescued by OS-level reapers (`systemd-tmpfiles`, `tmpwatch`, reboot); `AGENT_CONSOLE_HOME` enjoys no such cleanup.

The current commit pivots to the uid-suffixed `/tmp` pattern, which solves both concerns at once.

## Adopted pattern

- **Path:** `os.tmpdir() + /agent-console-uploads-<euid>/` (e.g. `/tmp/agent-console-uploads-1000/`, `/tmp/agent-console-uploads-999/`). On systems without `process.geteuid` (Windows), falls back to a `-shared` suffix.
- **Mode:** `0o700` — only the owning uid can list / read buffered files.
- **Lifetime:** transient. The OS reaper sweeps `/tmp` per the system's policy. The server intentionally does NOT delete entries on success because `injectMessage` lacks a read-completion signal; a delete-on-success path would race the agent's open(2).
- **Cache:** the route memoizes the `mkdir(..., { mode: 0o700 })` promise per resolved path, so the mode contract is enforced exactly once per process per uid.

## Why each concern is addressed

| Concern | Before (#821 original) | First attempt (dbe668a) | Now |
|---|---|---|---|
| EACCES across users (Model B `agentconsole` + dev user) | Host-shared `/tmp/agent-console-uploads/` owned by whoever created it first | Per-install (no cross-user collision) | Per-uid (no cross-user collision) |
| Disk leak | None — OS reaper sweeps `/tmp` | Risk — `AGENT_CONSOLE_HOME` persists across reboots; no read-completion deletion | None — OS reaper sweeps `/tmp` |
| Other users reading buffered file contents | Possible (`0o755`) | N/A (`AGENT_CONSOLE_HOME` is already user-scoped) | Blocked (`0o700`) |

## Rejected alternative

- `AGENT_CONSOLE_HOME/uploads` (dbe668a) — solves EACCES but does not benefit from OS `/tmp` cleanup, so transient buffers leak. Reverted in favor of the per-uid `/tmp` pattern.

## Migration notes for operators

- Pre-#821 dir `/tmp/agent-console-uploads/` (mode `0755`, host-shared) is no longer used. Operators may `rm -rf` it at their convenience.
- The new dir `/tmp/agent-console-uploads-<uid>/` is auto-created with mode `0700` on the first upload by each uid. No manual provisioning is required.
- Existing buffered files (rare, since `/tmp` is reaped) under the old path are not migrated — they belonged to the agent runtime that wrote them and are no longer referenced.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 2595 server / 1397 client / 324 shared / 29 integration / 362 scripts pass, `TEST_EXIT: 0`
- [x] Polarity verification — stash `workers.ts` (keep test), new `with mode 0700` test fails (route 500s because the old code targets `/test/config/uploads` on real disk → EACCES); `git stash pop` → test passes
- [x] CodeRabbit CLI (`coderabbit review --agent --base origin/main`) — 0 findings
- [x] Preflight — coverage / language / mirror-drift / rule-duplication checks all pass (integration-test gap is a soft warning; no client-server contract change)
- [ ] Owner re-approval after design pivot — please confirm the per-uid `/tmp` pattern before merging

Closes #821