### PR TITLE
fix: bundle bun-pty native lib into dist via shim entrypoint

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -38,6 +38,7 @@
     "packages/server": {
       "entry": [
         "src/index.ts!",
+        "src/shim.ts!",
         "build.ts",
         "src/app-context.ts",
         "src/**/__tests__/**/*.test.ts",

--- a/packages/server/build.ts
+++ b/packages/server/build.ts
@@ -1,5 +1,13 @@
-import { writeFileSync, readFileSync, mkdirSync, chmodSync } from 'fs';
+import {
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  chmodSync,
+  existsSync,
+  copyFileSync,
+} from 'fs';
 import { dirname, join } from 'path';
+import { getLibCandidateFilenames } from './src/lib/bun-pty-shim.ts';
 
 const __dirname = dirname(new URL(import.meta.url).pathname);
 const distDir = join(__dirname, '../../dist');
@@ -28,24 +36,93 @@ function getNativeDependencies(): Record<string, string> {
   return result;
 }
 
-// Bundle server with Bun's built-in bundler
-const result = await Bun.build({
+mkdirSync(distDir, { recursive: true });
+
+// 1. Bundle the actual server -> dist/server.js
+const serverBuild = await Bun.build({
   entrypoints: [join(__dirname, 'src/index.ts')],
   outdir: distDir,
   target: 'bun',
   format: 'esm',
   sourcemap: 'external',
+  naming: { entry: 'server.[ext]' },
 });
 
-if (!result.success) {
-  console.error('Build failed:');
-  for (const message of result.logs) {
+if (!serverBuild.success) {
+  console.error('Server build failed:');
+  for (const message of serverBuild.logs) {
     console.error(message);
   }
   process.exit(1);
 }
 
-// Generate dist/package.json for standalone distribution
+// 2. Bundle the shim entry -> dist/index.js.
+//    The shim uses a runtime-computed URL (`new URL('./server.js', ...)`)
+//    when dynamic-importing the real server bundle so Bun's bundler does not
+//    try to resolve and inline server.js into the shim.
+const shimBuild = await Bun.build({
+  entrypoints: [join(__dirname, 'src/shim.ts')],
+  outdir: distDir,
+  target: 'bun',
+  format: 'esm',
+  sourcemap: 'external',
+  naming: { entry: 'index.[ext]' },
+});
+
+if (!shimBuild.success) {
+  console.error('Shim build failed:');
+  for (const message of shimBuild.logs) {
+    console.error(message);
+  }
+  process.exit(1);
+}
+
+// 3. Copy the bun-pty native library for the current platform into dist/.
+//    bun-pty's resolveLibPath() will pick this up via process.env.BUN_PTY_LIB
+//    set by the shim. We copy via the workspace symlink which abstracts the
+//    .bun/bun-pty@<version> directory.
+const libSourceDir = join(
+  __dirname,
+  'node_modules',
+  'bun-pty',
+  'rust-pty',
+  'target',
+  'release'
+);
+if (!existsSync(libSourceDir)) {
+  console.error(
+    `bun-pty native library source directory not found: ${libSourceDir}\n` +
+      `Run \`bun install\` to populate the workspace symlink.`
+  );
+  process.exit(1);
+}
+
+const libDestDir = join(distDir, 'rust-pty', 'target', 'release');
+mkdirSync(libDestDir, { recursive: true });
+
+const candidateFilenames = getLibCandidateFilenames(process.platform, process.arch);
+const copiedLibs: string[] = [];
+for (const filename of candidateFilenames) {
+  const src = join(libSourceDir, filename);
+  if (existsSync(src)) {
+    const dest = join(libDestDir, filename);
+    copyFileSync(src, dest);
+    copiedLibs.push(filename);
+  }
+}
+
+if (copiedLibs.length === 0) {
+  console.error(
+    `No bun-pty native library candidates found in ${libSourceDir} for ` +
+      `platform=${process.platform} arch=${process.arch}.\n` +
+      `Expected one of: ${candidateFilenames.join(', ')}`
+  );
+  process.exit(1);
+}
+
+// 4. Generate dist/package.json for standalone distribution.
+//    bin/scripts still point at index.js — which is now the shim — so the
+//    on-disk contract for systemd / `bun run start` is unchanged.
 const distPackageJson = {
   name: 'agent-console',
   version: '0.1.0',
@@ -62,13 +139,13 @@ const distPackageJson = {
   dependencies: getNativeDependencies(),
 };
 
-mkdirSync(distDir, { recursive: true });
 writeFileSync(
   join(distDir, 'package.json'),
   JSON.stringify(distPackageJson, null, 2) + '\n'
 );
 
-// Add shebang to index.js for CLI execution
+// 5. Prepend the CLI shebang to the shim (not the server bundle — the server
+//    is loaded via dynamic import, never executed directly).
 const indexPath = join(distDir, 'index.js');
 const indexContent = readFileSync(indexPath, 'utf-8');
 if (!indexContent.startsWith('#!')) {
@@ -76,5 +153,8 @@ if (!indexContent.startsWith('#!')) {
   chmodSync(indexPath, 0o755);
 }
 
-console.log('Build complete: dist/index.js');
-console.log('Generated: dist/package.json');
+console.log('Build complete:');
+console.log('  dist/index.js   (shim, sets BUN_PTY_LIB and loads server.js)');
+console.log('  dist/server.js  (bundled server)');
+console.log(`  dist/rust-pty/target/release/  (copied: ${copiedLibs.join(', ')})`);
+console.log('  dist/package.json');

--- a/packages/server/src/__tests__/build-output.test.ts
+++ b/packages/server/src/__tests__/build-output.test.ts
@@ -1,0 +1,120 @@
+import { describe, test, expect } from 'bun:test';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getLibCandidateFilenames } from '../lib/bun-pty-shim.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// packages/server/src/__tests__/ -> packages/server/
+const serverPkgDir = join(__dirname, '..', '..');
+// build.ts writes to <repo-root>/dist (packages/server/../../dist)
+const distDir = join(serverPkgDir, '..', '..', 'dist');
+
+/**
+ * Reads real-fs file contents in a subprocess. Other tests in the same
+ * `bun test` run mock the `fs` module process-globally via `mock.module`
+ * (see `__tests__/utils/mock-fs-helper.ts`), which makes intra-process fs /
+ * `Bun.file()` calls non-deterministic when this suite is interleaved with
+ * memfs-using suites. Spawning a fresh subprocess sidesteps the mock.
+ */
+async function inspectDist(distPath: string): Promise<{
+  indexExists: boolean;
+  indexFirstLine: string;
+  indexContainsBunPtyLib: boolean;
+  indexContainsServerJs: boolean;
+  serverExists: boolean;
+  serverSize: number;
+  libDirEntries: string[];
+  pkgRaw: string;
+}> {
+  const probe = `
+    const { readFileSync, existsSync, statSync, readdirSync } = require('fs');
+    const { join } = require('path');
+    const dist = ${JSON.stringify(distPath)};
+    const indexPath = join(dist, 'index.js');
+    const serverPath = join(dist, 'server.js');
+    const libDir = join(dist, 'rust-pty', 'target', 'release');
+    const pkgPath = join(dist, 'package.json');
+
+    const indexExists = existsSync(indexPath);
+    const indexContent = indexExists ? readFileSync(indexPath, 'utf-8') : '';
+    const indexFirstLine = indexContent.split('\\n')[0] + '\\n';
+
+    const serverExists = existsSync(serverPath);
+    const serverSize = serverExists ? statSync(serverPath).size : 0;
+
+    const libDirEntries = existsSync(libDir) ? readdirSync(libDir) : [];
+    const pkgRaw = existsSync(pkgPath) ? readFileSync(pkgPath, 'utf-8') : '';
+
+    process.stdout.write(JSON.stringify({
+      indexExists,
+      indexFirstLine,
+      indexContainsBunPtyLib: indexContent.includes('BUN_PTY_LIB'),
+      indexContainsServerJs: indexContent.includes('./server.js'),
+      serverExists,
+      serverSize,
+      libDirEntries,
+      pkgRaw,
+    }));
+  `;
+  const proc = Bun.spawn(['bun', '-e', probe], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`inspectDist probe failed (exit ${exitCode}): ${stderr}`);
+  }
+  return JSON.parse(stdout) as Awaited<ReturnType<typeof inspectDist>>;
+}
+
+describe('build output (dist/) shape', () => {
+  test(
+    'bun run build produces a self-contained dist/ that satisfies the shim contract',
+    async () => {
+      const proc = Bun.spawn(['bun', 'run', 'build'], {
+        cwd: serverPkgDir,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      const exitCode = await proc.exited;
+      if (exitCode !== 0) {
+        const stderr = await new Response(proc.stderr).text();
+        const stdout = await new Response(proc.stdout).text();
+        console.error('build stdout:', stdout);
+        console.error('build stderr:', stderr);
+      }
+      expect(exitCode).toBe(0);
+
+      const info = await inspectDist(distDir);
+
+      // dist/index.js — the shim
+      expect(info.indexExists).toBe(true);
+      expect(info.indexFirstLine).toBe('#!/usr/bin/env bun\n');
+      expect(info.indexContainsBunPtyLib).toBe(true);
+      expect(info.indexContainsServerJs).toBe(true);
+
+      // dist/server.js — the real bundle (size sanity)
+      expect(info.serverExists).toBe(true);
+      expect(info.serverSize).toBeGreaterThan(1_000_000);
+
+      // dist/rust-pty/target/release/ — at least one candidate for this platform
+      const candidates = getLibCandidateFilenames(
+        process.platform,
+        process.arch
+      );
+      const found = info.libDirEntries.filter((e) => candidates.includes(e));
+      expect(found.length).toBeGreaterThan(0);
+
+      // dist/package.json — bin + start script point at the shim
+      const pkg = JSON.parse(info.pkgRaw) as {
+        bin: Record<string, string>;
+        scripts: Record<string, string>;
+      };
+      expect(pkg.bin['agent-console']).toBe('./index.js');
+      expect(pkg.scripts.start).toBe('bun index.js');
+    },
+    60_000
+  );
+});

--- a/packages/server/src/lib/__tests__/bun-pty-shim.test.ts
+++ b/packages/server/src/lib/__tests__/bun-pty-shim.test.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import {
+  getLibCandidateFilenames,
+  findLibPath,
+  formatLibNotFoundError,
+} from '../bun-pty-shim.js';
+
+describe('getLibCandidateFilenames', () => {
+  const cases: Array<{
+    platform: NodeJS.Platform;
+    arch: string;
+    expected: string[];
+  }> = [
+    {
+      platform: 'darwin',
+      arch: 'arm64',
+      expected: ['librust_pty_arm64.dylib', 'librust_pty.dylib'],
+    },
+    { platform: 'darwin', arch: 'x64', expected: ['librust_pty.dylib'] },
+    { platform: 'win32', arch: 'x64', expected: ['rust_pty.dll'] },
+    { platform: 'win32', arch: 'arm64', expected: ['rust_pty.dll'] },
+    {
+      platform: 'linux',
+      arch: 'arm64',
+      expected: ['librust_pty_arm64.so', 'librust_pty.so'],
+    },
+    { platform: 'linux', arch: 'x64', expected: ['librust_pty.so'] },
+  ];
+
+  for (const { platform, arch, expected } of cases) {
+    test(`${platform} + ${arch} → ${expected.join(', ')}`, () => {
+      expect(getLibCandidateFilenames(platform, arch)).toEqual(expected);
+    });
+  }
+});
+
+describe('findLibPath', () => {
+  const here = '/dist';
+  const baseDir = join(here, 'rust-pty', 'target', 'release');
+
+  test('returns envValue unchanged when set and existing (operator escape hatch)', () => {
+    const envPath = '/custom/path/to/librust_pty.dylib';
+    const calls: string[] = [];
+    const existsFn = (p: string): boolean => {
+      calls.push(p);
+      return p === envPath;
+    };
+    const result = findLibPath('/dist', 'darwin', 'arm64', envPath, existsFn);
+    expect(result).toBe(envPath);
+    // existsFn should have been called only with the env value, no fallthrough
+    expect(calls).toEqual([envPath]);
+  });
+
+  test('falls through to candidate search when envValue is undefined', () => {
+    const expected = join(baseDir, 'librust_pty_arm64.dylib');
+    const existsFn = (p: string): boolean => p === expected;
+    const result = findLibPath(here, 'darwin', 'arm64', undefined, existsFn);
+    expect(result).toBe(expected);
+  });
+
+  test('falls through to candidate search when envValue is an empty string', () => {
+    const expected = join(baseDir, 'librust_pty.dylib');
+    const existsFn = (p: string): boolean => p === expected;
+    const result = findLibPath(here, 'darwin', 'x64', '', existsFn);
+    expect(result).toBe(expected);
+  });
+
+  test('falls through when envValue is set but does not exist (broken override does not trap)', () => {
+    const brokenEnv = '/does/not/exist.dylib';
+    const expected = join(baseDir, 'librust_pty.dylib');
+    const existsFn = (p: string): boolean => p === expected;
+    const result = findLibPath(here, 'darwin', 'x64', brokenEnv, existsFn);
+    expect(result).toBe(expected);
+  });
+
+  test('darwin arm64 prefers librust_pty_arm64.dylib over librust_pty.dylib when both exist', () => {
+    const arm64Path = join(baseDir, 'librust_pty_arm64.dylib');
+    const fallbackPath = join(baseDir, 'librust_pty.dylib');
+    const existsFn = (p: string): boolean =>
+      p === arm64Path || p === fallbackPath;
+    const result = findLibPath(here, 'darwin', 'arm64', undefined, existsFn);
+    expect(result).toBe(arm64Path);
+  });
+
+  test('darwin arm64 returns non-arch fallback librust_pty.dylib when only fallback exists', () => {
+    const fallbackPath = join(baseDir, 'librust_pty.dylib');
+    const existsFn = (p: string): boolean => p === fallbackPath;
+    const result = findLibPath(here, 'darwin', 'arm64', undefined, existsFn);
+    expect(result).toBe(fallbackPath);
+  });
+
+  test('linux x64 returns <here>/rust-pty/target/release/librust_pty.so when present', () => {
+    const expected = join(baseDir, 'librust_pty.so');
+    const existsFn = (p: string): boolean => p === expected;
+    const result = findLibPath(here, 'linux', 'x64', undefined, existsFn);
+    expect(result).toBe(expected);
+  });
+
+  test('returns null when neither env nor any candidate exists', () => {
+    const existsFn = (): boolean => false;
+    const result = findLibPath(here, 'darwin', 'arm64', undefined, existsFn);
+    expect(result).toBeNull();
+  });
+
+  test('existsFn is called only with paths under <here>/rust-pty/target/release/ (when no env)', () => {
+    const calls: string[] = [];
+    const existsFn = (p: string): boolean => {
+      calls.push(p);
+      return false;
+    };
+    findLibPath(here, 'linux', 'arm64', undefined, existsFn);
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call.startsWith(baseDir + '/') || call === baseDir).toBe(true);
+    }
+  });
+});
+
+describe('formatLibNotFoundError', () => {
+  test('contains BUN_PTY_LIB=<value> when env is set', () => {
+    const msg = formatLibNotFoundError('/dist', 'darwin', 'arm64', '/x/y.dylib');
+    expect(msg).toContain('BUN_PTY_LIB=/x/y.dylib');
+  });
+
+  test('contains BUN_PTY_LIB=<unset> when env is undefined', () => {
+    const msg = formatLibNotFoundError('/dist', 'linux', 'x64', undefined);
+    expect(msg).toContain('BUN_PTY_LIB=<unset>');
+  });
+
+  test('lists each platform-appropriate candidate path under Checked:', () => {
+    const msg = formatLibNotFoundError('/dist', 'darwin', 'arm64', undefined);
+    const baseDir = join('/dist', 'rust-pty', 'target', 'release');
+    expect(msg).toContain('Checked:');
+    expect(msg).toContain(join(baseDir, 'librust_pty_arm64.dylib'));
+    expect(msg).toContain(join(baseDir, 'librust_pty.dylib'));
+  });
+
+  test('mentions dist/rust-pty/target/release/ so an operator knows where to look', () => {
+    const msg = formatLibNotFoundError('/dist', 'linux', 'x64', undefined);
+    expect(msg).toContain('dist/rust-pty/target/release/');
+  });
+});

--- a/packages/server/src/lib/bun-pty-shim.ts
+++ b/packages/server/src/lib/bun-pty-shim.ts
@@ -1,0 +1,104 @@
+/**
+ * Helper for the bundled dist/index.js shim that locates the bun-pty native
+ * library next to the bundled server and exposes it via BUN_PTY_LIB.
+ *
+ * bun-pty's own resolveLibPath() honors BUN_PTY_LIB above all other lookups,
+ * so setting it before importing the bundled server is enough to keep the
+ * library colocated with dist/ across both single-user (Model A) and
+ * multi-user (Model B) deployment shapes — they have different `here`
+ * derivations in bun-pty's resolver but neither matches a path inside dist/.
+ *
+ * The functions in this file are kept pure (no fs / process side effects)
+ * so they can be unit tested with an injected predicate and reused as the
+ * single source of truth for the shim runtime.
+ */
+
+import { join } from 'node:path';
+
+export type SupportedPlatform = 'darwin' | 'linux' | 'win32';
+export type SupportedArch = 'arm64' | 'x64';
+
+/**
+ * Returns the candidate native library filenames for a given platform/arch,
+ * in priority order (most specific first). Mirrors bun-pty's own resolver
+ * exactly so a future bun-pty bump only requires updating this table.
+ */
+export function getLibCandidateFilenames(
+  platform: NodeJS.Platform,
+  arch: string
+): string[] {
+  if (platform === 'darwin') {
+    return arch === 'arm64'
+      ? ['librust_pty_arm64.dylib', 'librust_pty.dylib']
+      : ['librust_pty.dylib'];
+  }
+  if (platform === 'win32') {
+    return ['rust_pty.dll'];
+  }
+  // linux + anything else falls through to the .so table
+  return arch === 'arm64'
+    ? ['librust_pty_arm64.so', 'librust_pty.so']
+    : ['librust_pty.so'];
+}
+
+/**
+ * Resolves the bun-pty native library path for the running platform.
+ *
+ * Order:
+ *   1. If process.env.BUN_PTY_LIB is set and points to an existing file, use it
+ *      (operator escape hatch — never overwritten).
+ *   2. Otherwise look under `<here>/rust-pty/target/release/<candidate>` for the
+ *      platform's candidate filenames, returning the first match.
+ *
+ * Returns the resolved absolute path, or null if nothing exists.
+ *
+ * @param here          Directory containing the shim (i.e. dist/).
+ * @param platform      process.platform value.
+ * @param arch          process.arch value.
+ * @param envValue      Current value of process.env.BUN_PTY_LIB (or undefined).
+ * @param existsFn      Predicate that returns true if a path exists. Injected
+ *                      so tests do not need to touch the real fs.
+ */
+export function findLibPath(
+  here: string,
+  platform: NodeJS.Platform,
+  arch: string,
+  envValue: string | undefined,
+  existsFn: (path: string) => boolean
+): string | null {
+  if (envValue && envValue.length > 0 && existsFn(envValue)) {
+    return envValue;
+  }
+  const candidates = getLibCandidateFilenames(platform, arch);
+  const baseDir = join(here, 'rust-pty', 'target', 'release');
+  for (const filename of candidates) {
+    const candidatePath = join(baseDir, filename);
+    if (existsFn(candidatePath)) {
+      return candidatePath;
+    }
+  }
+  return null;
+}
+
+/**
+ * Builds the human-readable error message used when no library can be found.
+ * Extracted so the shim's error formatting is covered by tests.
+ */
+export function formatLibNotFoundError(
+  here: string,
+  platform: NodeJS.Platform,
+  arch: string,
+  envValue: string | undefined
+): string {
+  const candidates = getLibCandidateFilenames(platform, arch);
+  const baseDir = join(here, 'rust-pty', 'target', 'release');
+  const checked = candidates.map((f) => `  - ${join(baseDir, f)}`).join('\n');
+  return (
+    `bun-pty native library not found next to the bundled server.\n` +
+    `  BUN_PTY_LIB=${envValue ?? '<unset>'}\n` +
+    `  platform=${platform} arch=${arch}\n` +
+    `Checked:\n${checked}\n\n` +
+    `The library should have been copied into dist/rust-pty/target/release/ at build time. ` +
+    `Re-run the build, or set BUN_PTY_LIB to an absolute path to the .dylib / .so / .dll.`
+  );
+}

--- a/packages/server/src/shim.ts
+++ b/packages/server/src/shim.ts
@@ -1,0 +1,47 @@
+/**
+ * Bundled entry point for dist/index.js.
+ *
+ * Responsibilities:
+ *   1. Locate the bun-pty native library that build.ts copied into
+ *      dist/rust-pty/target/release/ for the current platform.
+ *   2. Export the discovered path via process.env.BUN_PTY_LIB so that the
+ *      real server bundle (dist/server.js) — which transitively imports
+ *      bun-pty at module load time — can resolve the library regardless of
+ *      cwd or deployment shape (single-user / multi-user).
+ *   3. Dynamic-import the real server bundle.
+ *
+ * Kept intentionally tiny. All fs / platform logic lives in
+ * ./lib/bun-pty-shim.ts so it can be unit tested without the bundle.
+ *
+ * The dynamic import of './server.js' is marked external in build.ts so the
+ * bundler does not inline the server into the shim.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  findLibPath,
+  formatLibNotFoundError,
+} from './lib/bun-pty-shim.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const platform = process.platform;
+const arch = process.arch;
+const envValue = process.env.BUN_PTY_LIB;
+
+const resolved = findLibPath(here, platform, arch, envValue, existsSync);
+if (resolved === null) {
+  throw new Error(formatLibNotFoundError(here, platform, arch, envValue));
+}
+
+// Only set when we discovered it ourselves; preserve any operator override.
+if (resolved !== envValue) {
+  process.env.BUN_PTY_LIB = resolved;
+}
+
+// The sibling server bundle is loaded dynamically. The path is computed at
+// runtime so the bundler does not try to resolve and inline it during the
+// shim build step.
+const serverUrl = new URL('./server.js', import.meta.url).href;
+await import(serverUrl);


### PR DESCRIPTION
## Summary

- Adds a thin shim entrypoint `dist/index.js` that resolves the bun-pty native shared library relative to its own location and exposes it via `BUN_PTY_LIB` before loading the real server bundle (`dist/server.js`).
- `build.ts` copies the platform-matched library from the workspace `bun-pty` symlink into `dist/rust-pty/target/release/` at build time, so the resulting `dist/` is self-contained.
- Operators no longer need to set `BUN_PTY_LIB`. An existing `BUN_PTY_LIB` override is preserved (operator escape hatch).

## Why a shim, not a literal "lib at dist/rust-pty/" placement

bun-pty's resolver derives `here` from `import.meta.url`:

- Model A (`~/.agent-console/server/index.js`, `WorkingDirectory=~/.agent-console/server`): `dirName="server"`, so `here=~/.agent-console/server`. Path #1 = `~/.agent-console/server/rust-pty/...`. A copy of the library inside dist/ lands here after the rsync deploy, so path #1 hits.
- Model B (`~/agent-console/dist/index.js`, `WorkingDirectory=~/agent-console`): `dirName="dist"`, so `here=dirname(dist)=~/agent-console`. Path #1 = `~/agent-console/rust-pty/...`, outside dist/. A copy inside dist/ does not satisfy this.

The shim sidesteps both derivations by setting `BUN_PTY_LIB` from its own `import.meta.url` before bun-pty is loaded, which works in both shapes without changing the systemd templates or `bun run start`. (Owner-approved Option in Issue #820 triage.)

## Tests

- `packages/server/src/lib/__tests__/bun-pty-shim.test.ts` (19 tests): exhaustive table-driven coverage of `getLibCandidateFilenames` across all platform/arch combos; `findLibPath` covers env-set escape hatch, env-undefined / env-empty / env-broken fallthrough, darwin arm64 arch-specific priority, linux x64, all-missing null return, and hermeticity of `existsFn` calls; `formatLibNotFoundError` covers BUN_PTY_LIB rendering for both set and unset env, candidate listing, and operator-orientation string.
- `packages/server/src/__tests__/build-output.test.ts` (1 integration test): runs `bun run build`, then inspects `dist/index.js` (shebang, BUN_PTY_LIB token, dynamic `./server.js` reference), `dist/server.js` (existence + size > 1MB sanity), `dist/rust-pty/target/release/` (contains at least one platform-matched candidate from `getLibCandidateFilenames(process.platform, process.arch)`), and `dist/package.json` (bin + start script point at the shim). Real-fs inspection is done in a subprocess to avoid the process-global `mock.module('fs', ...)` from `__tests__/utils/mock-fs-helper.ts` interfering when this suite is interleaved with memfs-using suites.

## Polarity verification

1. With the lib-copy step in `build.ts` disabled (and the dist/rust-pty/target/release/ contents removed), `build-output.test.ts` fails with `Expected: > 0  Received: 0` on the candidate-file count assertion. Restoring lib-copy makes it pass.
2. With the libraries deleted from `dist/rust-pty/target/release/`, `env -u BUN_PTY_LIB bun dist/index.js` exits with the shim's error: `bun-pty native library not found next to the bundled server. BUN_PTY_LIB=<unset>  platform=darwin arch=arm64  Checked: ...`, listing the exact two candidate paths it tried. Restoring the libraries makes the server start cleanly with no `librust_pty` log.
3. With both restored, `env -u BUN_PTY_LIB bun dist/index.js` starts the server with no library-related warnings or errors.

## Verification

```
TYPECHECK_EXIT: 0
TEST_EXIT: 0 (server: 2614 pass / 1 skip / 0 fail; client: 1397 pass / 2 skip / 0 fail; shared: 324 pass; integration: 29 pass; scripts/hooks: 362 pass)
BUILD_EXIT: 0
LANG_EXIT: 0
PREFLIGHT_EXIT: 0
```

Integration smoke (real shipping path):
- `env -u BUN_PTY_LIB bun dist/index.js` -> server boots, "Server process starting" logged, no library-not-found error. PID killed after 4s. EXIT 0.

Closes #820