### PR TITLE
feat(server): add bunTerminalProvider gated by PTY_PROVIDER (Refs #824)

### DIFF
--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -51,7 +51,7 @@ import { SqliteUserRepository } from './repositories/sqlite-user-repository.js';
 import { SystemCapabilitiesService as SystemCapabilitiesServiceClass } from './services/system-capabilities-service.js';
 import { SingleUserMode, MultiUserMode } from './services/user-mode.js';
 import { SharedAccountRegistry } from './services/shared-account-registry.js';
-import { bunPtyProvider } from './lib/pty-provider.js';
+import { bunPtyProvider, getPtyProvider } from './lib/pty-provider.js';
 import { serverConfig } from './lib/server-config.js';
 import { createLogger } from './lib/logger.js';
 import { TimerManager as TimerManagerClass } from './services/timer-manager.js';
@@ -222,10 +222,14 @@ export async function createAppContext(
 
   // 5.5. Create user mode (determines auth + PTY spawning strategy)
   const userRepository = new SqliteUserRepository(db);
+  const ptyProvider = getPtyProvider(serverConfig.PTY_PROVIDER);
   const userMode = serverConfig.AUTH_MODE === 'multi-user'
-    ? await MultiUserMode.create(bunPtyProvider, userRepository)
-    : await SingleUserMode.create(bunPtyProvider, userRepository);
-  logger.info({ authMode: serverConfig.AUTH_MODE }, 'User mode initialized');
+    ? await MultiUserMode.create(ptyProvider, userRepository)
+    : await SingleUserMode.create(ptyProvider, userRepository);
+  logger.info(
+    { authMode: serverConfig.AUTH_MODE, ptyProvider: serverConfig.PTY_PROVIDER },
+    'User mode initialized',
+  );
 
   // 5.6. Create shared account registry. Only honours
   // AGENT_CONSOLE_SHARED_USERNAME when AUTH_MODE=multi-user; in AUTH_MODE=none

--- a/packages/server/src/lib/__tests__/pty-provider.test.ts
+++ b/packages/server/src/lib/__tests__/pty-provider.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import {
+  bunPtyProvider,
+  bunTerminalProvider,
+  getPtyProvider,
+  type PtyProvider,
+} from '../pty-provider.js';
+
+describe('pty-provider', () => {
+  describe('getPtyProvider', () => {
+    it("returns bunPtyProvider when name is 'bun-pty'", () => {
+      const provider = getPtyProvider('bun-pty');
+      expect(provider).toBe(bunPtyProvider);
+    });
+
+    it("returns bunTerminalProvider when name is 'bun-terminal'", () => {
+      const provider = getPtyProvider('bun-terminal');
+      expect(provider).toBe(bunTerminalProvider);
+    });
+
+    it('exposes both providers as distinct PtyProvider implementations', () => {
+      expect(bunPtyProvider).not.toBe(bunTerminalProvider);
+      expect(typeof bunPtyProvider.spawn).toBe('function');
+      expect(typeof bunTerminalProvider.spawn).toBe('function');
+    });
+  });
+
+  describe('bunTerminalProvider', () => {
+    type SpawnArgs = {
+      cmd: string[];
+      options: {
+        cwd?: string;
+        env?: Record<string, string>;
+        terminal?: {
+          cols?: number;
+          rows?: number;
+          name?: string;
+          data?: (terminal: unknown, chunk: Uint8Array) => void;
+          exit?: (terminal: unknown, exitCode: number, signal: string | null) => void;
+        };
+      };
+    };
+
+    let originalSpawn: typeof Bun.spawn;
+    let lastSpawn: SpawnArgs | null;
+    let mockTerminal: {
+      write: ReturnType<typeof mock>;
+      resize: ReturnType<typeof mock>;
+      close: ReturnType<typeof mock>;
+    };
+    let mockSubprocess: {
+      pid: number;
+      exitCode: number | null;
+      signalCode: NodeJS.Signals | null;
+      kill: ReturnType<typeof mock>;
+      terminal: typeof mockTerminal;
+      exited: Promise<number>;
+      _resolveExited: (code: number) => void;
+    };
+
+    function makeMockSubprocess(pid: number): typeof mockSubprocess {
+      let resolveExited: (code: number) => void = () => {};
+      const exited = new Promise<number>((resolve) => {
+        resolveExited = resolve;
+      });
+      return {
+        pid,
+        exitCode: null,
+        signalCode: null,
+        kill: mock(() => {}),
+        terminal: mockTerminal,
+        exited,
+        _resolveExited: (code: number) => {
+          mockSubprocess.exitCode = code;
+          resolveExited(code);
+        },
+      };
+    }
+
+    beforeEach(() => {
+      originalSpawn = Bun.spawn;
+      lastSpawn = null;
+      mockTerminal = {
+        write: mock(() => 0),
+        resize: mock(() => {}),
+        close: mock(() => {}),
+      };
+      mockSubprocess = makeMockSubprocess(99999);
+
+      // Replace Bun.spawn for this test. The adapter calls Bun.spawn with a
+      // single options object containing `terminal`; capture both and return
+      // the mock subprocess so the adapter constructs against it.
+      const fakeSpawn = (cmd: string[], options: SpawnArgs['options']) => {
+        lastSpawn = { cmd, options };
+        return mockSubprocess;
+      };
+      (Bun as { spawn: typeof Bun.spawn }).spawn = fakeSpawn as unknown as typeof Bun.spawn;
+    });
+
+    afterEach(() => {
+      (Bun as unknown as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
+    });
+
+    it('spawns with terminal cols/rows/name and forwards cwd/env verbatim', () => {
+      const env = {
+        PATH: '/usr/bin',
+        HOME: '/tmp/home',
+        TERM: 'xterm-256color',
+        COLORTERM: 'truecolor',
+        FORCE_COLOR: '1',
+      };
+      bunTerminalProvider.spawn('bash', ['-l'], {
+        cols: 120,
+        rows: 30,
+        cwd: '/tmp',
+        env,
+        name: 'xterm-256color',
+      });
+
+      expect(lastSpawn).not.toBeNull();
+      expect(lastSpawn!.cmd).toEqual(['bash', '-l']);
+      expect(lastSpawn!.options.cwd).toBe('/tmp');
+      // env must be passed through unchanged so TERM/COLORTERM/FORCE_COLOR
+      // reach the child (Bun.spawn does NOT merge parent env when env is set).
+      expect(lastSpawn!.options.env).toBe(env);
+      expect(lastSpawn!.options.terminal).toBeDefined();
+      expect(lastSpawn!.options.terminal!.cols).toBe(120);
+      expect(lastSpawn!.options.terminal!.rows).toBe(30);
+      expect(lastSpawn!.options.terminal!.name).toBe('xterm-256color');
+      expect(typeof lastSpawn!.options.terminal!.data).toBe('function');
+    });
+
+    it('defaults cols/rows/name when not provided', () => {
+      bunTerminalProvider.spawn('sh', [], {});
+      expect(lastSpawn!.options.terminal!.cols).toBe(80);
+      expect(lastSpawn!.options.terminal!.rows).toBe(24);
+      expect(lastSpawn!.options.terminal!.name).toBe('xterm-256color');
+    });
+
+    it('adapter exposes pid from the subprocess', () => {
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      expect(pty.pid).toBe(99999);
+    });
+
+    it('adapter onData receives decoded string when terminal data callback fires', () => {
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      const received: string[] = [];
+      pty.onData((data) => received.push(data));
+
+      const dataCb = lastSpawn!.options.terminal!.data!;
+      dataCb(null, new TextEncoder().encode('hello '));
+      dataCb(null, new TextEncoder().encode('world'));
+
+      expect(received).toEqual(['hello ', 'world']);
+    });
+
+    it('adapter onData disposable detaches the listener', () => {
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      const received: string[] = [];
+      const disp = pty.onData((data) => received.push(data));
+      disp.dispose();
+
+      const dataCb = lastSpawn!.options.terminal!.data!;
+      dataCb(null, new TextEncoder().encode('ignored'));
+      expect(received).toEqual([]);
+    });
+
+    it('adapter onExit fires when subprocess.exited resolves', async () => {
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      const events: Array<{ exitCode: number; signal?: number | string }> = [];
+      pty.onExit((event) => events.push(event));
+
+      mockSubprocess._resolveExited(0);
+      await mockSubprocess.exited;
+      // exit listener fires asynchronously after `.then`. Flush microtasks.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(events.length).toBe(1);
+      expect(events[0]!.exitCode).toBe(0);
+    });
+
+    it('adapter onExit fires when subprocess.exited resolves with non-zero code', async () => {
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      const events: Array<{ exitCode: number; signal?: number | string }> = [];
+      pty.onExit((event) => events.push(event));
+
+      mockSubprocess._resolveExited(137);
+      await mockSubprocess.exited;
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(events[0]!.exitCode).toBe(137);
+    });
+
+    it('adapter onExit fires synchronously (via microtask) if process already exited before listener attached', async () => {
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      // Simulate the process exiting before any onExit listener is attached
+      mockSubprocess._resolveExited(2);
+      await mockSubprocess.exited;
+      await Promise.resolve();
+
+      // Now attach the listener after the fact (mirrors worker-manager kill
+      // path race where exit-wait listener is attached just before kill).
+      const events: Array<{ exitCode: number; signal?: number | string }> = [];
+      pty.onExit((event) => events.push(event));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(events.length).toBe(1);
+      expect(events[0]!.exitCode).toBe(2);
+    });
+
+    it('adapter write delegates to terminal.write', () => {
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      pty.write('echo hi\n');
+      expect(mockTerminal.write).toHaveBeenCalledTimes(1);
+      expect(mockTerminal.write.mock.calls[0]![0]).toBe('echo hi\n');
+    });
+
+    it('adapter resize delegates to terminal.resize with cols/rows', () => {
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      pty.resize(132, 50);
+      expect(mockTerminal.resize).toHaveBeenCalledTimes(1);
+      expect(mockTerminal.resize.mock.calls[0]).toEqual([132, 50]);
+    });
+
+    it('adapter kill defaults to SIGTERM when no signal is provided', () => {
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      pty.kill();
+      expect(mockSubprocess.kill).toHaveBeenCalledTimes(1);
+      expect(mockSubprocess.kill.mock.calls[0]![0]).toBe('SIGTERM');
+    });
+
+    it('adapter kill forwards the requested signal', () => {
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      pty.kill('SIGINT');
+      expect(mockSubprocess.kill.mock.calls[0]![0]).toBe('SIGINT');
+    });
+
+    it('adapter cols/rows reflect the requested terminal size', () => {
+      const pty = bunTerminalProvider.spawn('sh', [], { cols: 200, rows: 60 });
+      expect(pty.cols).toBe(200);
+      expect(pty.rows).toBe(60);
+    });
+
+    it('adapter process returns the command name', () => {
+      const pty = bunTerminalProvider.spawn('zsh', [], {});
+      expect(pty.process).toBe('zsh');
+    });
+
+    it('decoder preserves partial UTF-8 multi-byte sequences across data chunks', () => {
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      const received: string[] = [];
+      pty.onData((data) => received.push(data));
+
+      // U+1F600 "GRINNING FACE" is F0 9F 98 80. Split across two chunks.
+      const bytes = new Uint8Array([0xf0, 0x9f, 0x98, 0x80]);
+      const dataCb = lastSpawn!.options.terminal!.data!;
+      dataCb(null, bytes.slice(0, 2));
+      dataCb(null, bytes.slice(2));
+
+      // First chunk is incomplete -> decoder buffers it. Second chunk emits
+      // the full glyph.
+      expect(received.join('')).toBe('\u{1F600}');
+    });
+
+    it('PtyProvider interface is satisfied (compile-time check via assignment)', () => {
+      const _check: PtyProvider = bunTerminalProvider;
+      expect(typeof _check.spawn).toBe('function');
+    });
+  });
+});

--- a/packages/server/src/lib/__tests__/pty-provider.test.ts
+++ b/packages/server/src/lib/__tests__/pty-provider.test.ts
@@ -41,29 +41,40 @@ describe('pty-provider', () => {
       };
     };
 
-    let originalSpawn: typeof Bun.spawn;
-    let lastSpawn: SpawnArgs | null;
-    let mockTerminal: {
+    type MockTerminal = {
       write: ReturnType<typeof mock>;
       resize: ReturnType<typeof mock>;
       close: ReturnType<typeof mock>;
     };
-    let mockSubprocess: {
+    type MockSubprocess = {
       pid: number;
       exitCode: number | null;
       signalCode: NodeJS.Signals | null;
       kill: ReturnType<typeof mock>;
-      terminal: typeof mockTerminal;
+      terminal: MockTerminal;
       exited: Promise<number>;
       _resolveExited: (code: number) => void;
     };
+    /**
+     * Narrow Bun shape exposing only the (cmd[], options) spawn overload the
+     * adapter actually invokes. Used to install a typed test fake on the
+     * global Bun object without casting through `any`/`unknown as T`.
+     */
+    type SpawnableBun = {
+      spawn: (cmd: string[], options: SpawnArgs['options']) => MockSubprocess;
+    };
 
-    function makeMockSubprocess(pid: number): typeof mockSubprocess {
+    let originalSpawn: typeof Bun.spawn;
+    let lastSpawn: SpawnArgs | null;
+    let mockTerminal: MockTerminal;
+    let mockSubprocess: MockSubprocess;
+
+    function makeMockSubprocess(pid: number): MockSubprocess {
       let resolveExited: (code: number) => void = () => {};
       const exited = new Promise<number>((resolve) => {
         resolveExited = resolve;
       });
-      return {
+      const sub: MockSubprocess = {
         pid,
         exitCode: null,
         signalCode: null,
@@ -71,10 +82,11 @@ describe('pty-provider', () => {
         terminal: mockTerminal,
         exited,
         _resolveExited: (code: number) => {
-          mockSubprocess.exitCode = code;
+          sub.exitCode = code;
           resolveExited(code);
         },
       };
+      return sub;
     }
 
     beforeEach(() => {
@@ -87,17 +99,19 @@ describe('pty-provider', () => {
       };
       mockSubprocess = makeMockSubprocess(99999);
 
-      // Replace Bun.spawn for this test. The adapter calls Bun.spawn with a
-      // single options object containing `terminal`; capture both and return
-      // the mock subprocess so the adapter constructs against it.
-      const fakeSpawn = (cmd: string[], options: SpawnArgs['options']) => {
+      // View Bun through the narrow SpawnableBun shape so we can install a
+      // typed fake without `as unknown as typeof Bun.spawn`. The narrow shape
+      // matches the only overload the adapter calls; restoring in afterEach
+      // returns the full typed Bun.spawn.
+      const spawnable = Bun as unknown as SpawnableBun;
+      spawnable.spawn = (cmd, options) => {
         lastSpawn = { cmd, options };
         return mockSubprocess;
       };
-      (Bun as { spawn: typeof Bun.spawn }).spawn = fakeSpawn as unknown as typeof Bun.spawn;
     });
 
     afterEach(() => {
+      // Restore the original (fully-typed) Bun.spawn via the same narrow view.
       (Bun as unknown as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
     });
 
@@ -191,6 +205,27 @@ describe('pty-provider', () => {
       await Promise.resolve();
 
       expect(events[0]!.exitCode).toBe(137);
+    });
+
+    it('adapter onExit fires exactly once when listener attaches AFTER subprocess.exited resolves (double-fire race guard)', async () => {
+      // This is the race the exitFired flag guards against: the constructor's
+      // `.then(fireExit)` is enqueued on exit, and onExit()'s synchronous
+      // replay also enqueues fireExit for the same listener. Both targeting
+      // the same listener must NOT call it twice.
+      const pty = bunTerminalProvider.spawn('sh', [], {});
+      mockSubprocess._resolveExited(7);
+      await mockSubprocess.exited;
+      // Do NOT flush microtasks yet — attach the listener while .then() is
+      // still pending in the microtask queue.
+      const events: Array<{ exitCode: number; signal?: number | string }> = [];
+      pty.onExit((event) => events.push(event));
+      // Now flush.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(events.length).toBe(1);
+      expect(events[0]!.exitCode).toBe(7);
     });
 
     it('adapter onExit fires synchronously (via microtask) if process already exited before listener attached', async () => {

--- a/packages/server/src/lib/__tests__/server-config.test.ts
+++ b/packages/server/src/lib/__tests__/server-config.test.ts
@@ -116,6 +116,25 @@ describe('server-config', () => {
       expect(serverConfig.AGENT_CONSOLE_SHARED_USERNAME).toBe('agent-console-shared');
     });
 
+    it("should default PTY_PROVIDER to 'bun-pty' when not set", async () => {
+      delete process.env.PTY_PROVIDER;
+      const { serverConfig } = await importServerConfig();
+      expect(serverConfig.PTY_PROVIDER).toBe('bun-pty');
+    });
+
+    it("should accept PTY_PROVIDER='bun-terminal'", async () => {
+      process.env.PTY_PROVIDER = 'bun-terminal';
+      const { serverConfig } = await importServerConfig();
+      expect(serverConfig.PTY_PROVIDER).toBe('bun-terminal');
+    });
+
+    it('should throw for invalid PTY_PROVIDER value', async () => {
+      process.env.PTY_PROVIDER = 'wterm';
+      await expect(importServerConfig()).rejects.toThrow(
+        "Invalid PTY_PROVIDER: 'wterm'. Must be 'bun-pty' or 'bun-terminal'."
+      );
+    });
+
     it('should default AUTH_COOKIE_SECURE to undefined when not set', async () => {
       delete process.env.AUTH_COOKIE_SECURE;
 

--- a/packages/server/src/lib/pty-provider.ts
+++ b/packages/server/src/lib/pty-provider.ts
@@ -91,6 +91,13 @@ class BunTerminalPtyAdapter implements IPty {
   private readonly terminal: Bun.Terminal;
   private dataListener: ((data: string) => void) | null = null;
   private exitListener: ((event: IExitEvent) => void) | null = null;
+  /**
+   * Guards against double-fire of the exit listener when the listener is
+   * attached AFTER subprocess.exited has already resolved: in that race the
+   * constructor's `.then()` callback and `onExit()`'s synchronous-replay
+   * microtask both target the same listener. Set true on the first fire.
+   */
+  private exitFired = false;
 
   constructor(args: {
     subprocess: Bun.Subprocess;
@@ -110,16 +117,21 @@ class BunTerminalPtyAdapter implements IPty {
     // signals PTY stream close, not process exit. The real exit code lives on
     // subprocess.exited / subprocess.exitCode.
     void this.subprocess.exited.then((exitCode) => {
-      const listener = this.exitListener;
-      if (listener) {
-        const signal = this.subprocess.signalCode;
-        listener({
-          exitCode,
-          // IExitEvent.signal: number | string | undefined. signalCode is the
-          // POSIX signal name (e.g. 'SIGTERM') or null.
-          signal: signal ?? undefined,
-        });
-      }
+      this.fireExit(exitCode);
+    });
+  }
+
+  private fireExit(exitCode: number): void {
+    if (this.exitFired) return;
+    const listener = this.exitListener;
+    if (!listener) return;
+    this.exitFired = true;
+    const signal = this.subprocess.signalCode;
+    listener({
+      exitCode,
+      // IExitEvent.signal: number | string | undefined. signalCode is the
+      // POSIX signal name (e.g. 'SIGTERM') or null.
+      signal: signal ?? undefined,
     });
   }
 
@@ -143,13 +155,14 @@ class BunTerminalPtyAdapter implements IPty {
     // If the process has already exited before onExit was attached, fire
     // synchronously so callers (e.g. worker-manager's exit-wait race) don't
     // hang. Subprocess.exitCode is non-null after exit.
+    //
+    // fireExit() guards against double-fire: the constructor's `.then()`
+    // callback may also be queued for this same listener; the exitFired flag
+    // ensures only the first one wins.
     const code = this.subprocess.exitCode;
-    if (code !== null) {
-      const signal = this.subprocess.signalCode;
+    if (code !== null && !this.exitFired) {
       queueMicrotask(() => {
-        if (this.exitListener === listener) {
-          listener({ exitCode: code, signal: signal ?? undefined });
-        }
+        this.fireExit(code);
       });
     }
     return {

--- a/packages/server/src/lib/pty-provider.ts
+++ b/packages/server/src/lib/pty-provider.ts
@@ -1,4 +1,4 @@
-import type { IPty } from 'bun-pty';
+import type { IPty, IDisposable, IExitEvent } from 'bun-pty';
 
 /**
  * PTY spawn options (subset of bun-pty options)
@@ -20,7 +20,10 @@ export type PtyInstance = IPty;
  * PTY provider interface for dependency injection.
  * This abstraction enables:
  * 1. Easy mocking in tests without mock.module()
- * 2. Future migration to Bun.Terminal when available
+ * 2. Multiple implementations: bun-pty (native shared library) and Bun.Terminal (built-in PTY)
+ *
+ * Selection at runtime is controlled by `serverConfig.PTY_PROVIDER`.
+ * Use {@link getPtyProvider} to obtain the configured provider.
  */
 export interface PtyProvider {
   spawn(command: string, args: string[], options: PtySpawnOptions): PtyInstance;
@@ -40,20 +43,6 @@ export interface PtyProvider {
  *
  * By using dynamic require() inside the spawn() method, we defer loading until
  * the method is actually called, which never happens in tests that use mock providers.
- *
- * ## Future: Bun.Terminal migration
- *
- * When Bun's native Terminal API lands (https://github.com/oven-sh/bun/pull/25415),
- * we can replace bun-pty with Bun.spawn({ terminal: opts }). This will eliminate
- * the need for external native dependencies and simplify this code:
- *
- * ```typescript
- * export const bunTerminalProvider: PtyProvider = {
- *   spawn(command, args, options) {
- *     return Bun.spawn([command, ...args], { terminal: options });
- *   },
- * };
- * ```
  */
 export const bunPtyProvider: PtyProvider = {
   spawn(command, args, options) {
@@ -63,3 +52,216 @@ export const bunPtyProvider: PtyProvider = {
     return spawn(command, args, options);
   },
 };
+
+/**
+ * Decode a Uint8Array chunk to string with UTF-8 decoding that preserves
+ * partial multi-byte sequences across calls (`stream: true`).
+ *
+ * Bun.Terminal delivers raw bytes; consumers of `IPty.onData` expect strings
+ * matching bun-pty's behavior. A per-adapter TextDecoder instance keeps the
+ * boundary safe.
+ */
+function createStreamingDecoder(): (chunk: Uint8Array) => string {
+  const decoder = new TextDecoder('utf-8');
+  return (chunk) => decoder.decode(chunk, { stream: true });
+}
+
+/**
+ * Adapter that wraps a `Bun.spawn(..., { terminal: ... })` subprocess to
+ * conform to bun-pty's `IPty` shape.
+ *
+ * Behavioral notes:
+ * - `onData` / `onExit` accept a single listener each (matches bun-pty's
+ *   "Only one callback supported, subsequent calls replace" contract used by
+ *   existing consumers).
+ * - `onExit` fires when the child process exits (via `subprocess.exited`),
+ *   NOT when the PTY-side `exit` callback fires — the PTY callback reports
+ *   stream lifecycle (EOF/error), not the real exit code. See
+ *   `TerminalOptions.exit` doc in `@types/bun`.
+ * - `process` getter returns the command name. bun-pty's `process` reflects
+ *   the active foreground process; Bun.Terminal does not expose that, so we
+ *   fall back to the spawn command.
+ */
+class BunTerminalPtyAdapter implements IPty {
+  readonly pid: number;
+  readonly cols: number;
+  readonly rows: number;
+  private readonly commandName: string;
+  private readonly subprocess: Bun.Subprocess;
+  private readonly terminal: Bun.Terminal;
+  private dataListener: ((data: string) => void) | null = null;
+  private exitListener: ((event: IExitEvent) => void) | null = null;
+
+  constructor(args: {
+    subprocess: Bun.Subprocess;
+    terminal: Bun.Terminal;
+    cols: number;
+    rows: number;
+    commandName: string;
+  }) {
+    this.subprocess = args.subprocess;
+    this.terminal = args.terminal;
+    this.cols = args.cols;
+    this.rows = args.rows;
+    this.commandName = args.commandName;
+    this.pid = args.subprocess.pid;
+
+    // Bridge subprocess.exited -> IPty.onExit. Bun.Terminal's `exit` callback
+    // signals PTY stream close, not process exit. The real exit code lives on
+    // subprocess.exited / subprocess.exitCode.
+    void this.subprocess.exited.then((exitCode) => {
+      const listener = this.exitListener;
+      if (listener) {
+        const signal = this.subprocess.signalCode;
+        listener({
+          exitCode,
+          // IExitEvent.signal: number | string | undefined. signalCode is the
+          // POSIX signal name (e.g. 'SIGTERM') or null.
+          signal: signal ?? undefined,
+        });
+      }
+    });
+  }
+
+  get process(): string {
+    return this.commandName;
+  }
+
+  onData(listener: (data: string) => void): IDisposable {
+    this.dataListener = listener;
+    return {
+      dispose: () => {
+        if (this.dataListener === listener) {
+          this.dataListener = null;
+        }
+      },
+    };
+  }
+
+  onExit(listener: (event: IExitEvent) => void): IDisposable {
+    this.exitListener = listener;
+    // If the process has already exited before onExit was attached, fire
+    // synchronously so callers (e.g. worker-manager's exit-wait race) don't
+    // hang. Subprocess.exitCode is non-null after exit.
+    const code = this.subprocess.exitCode;
+    if (code !== null) {
+      const signal = this.subprocess.signalCode;
+      queueMicrotask(() => {
+        if (this.exitListener === listener) {
+          listener({ exitCode: code, signal: signal ?? undefined });
+        }
+      });
+    }
+    return {
+      dispose: () => {
+        if (this.exitListener === listener) {
+          this.exitListener = null;
+        }
+      },
+    };
+  }
+
+  /**
+   * @internal Exposed so the spawn() factory can route Terminal `data`
+   * callbacks into the adapter's listener. Not part of IPty.
+   */
+  _emitData(chunk: Uint8Array, decode: (c: Uint8Array) => string): void {
+    const listener = this.dataListener;
+    if (listener) {
+      listener(decode(chunk));
+    }
+  }
+
+  write(data: string): void {
+    this.terminal.write(data);
+  }
+
+  resize(columns: number, rows: number): void {
+    this.terminal.resize(columns, rows);
+  }
+
+  kill(signal?: string): void {
+    // Bun.Subprocess.kill accepts a signal name. bun-pty's IPty.kill signal
+    // defaults to SIGTERM; preserve that.
+    this.subprocess.kill((signal ?? 'SIGTERM') as NodeJS.Signals);
+  }
+}
+
+/**
+ * PtyProvider implementation using the built-in `Bun.spawn({ terminal: ... })`
+ * API (Bun >= 1.3.5). No native shared library is required.
+ *
+ * The adapter forwards `data` callbacks into `IPty.onData`, bridges
+ * `subprocess.exited` into `IPty.onExit`, and passes the caller-supplied
+ * `env` verbatim to `Bun.spawn` so callers' env routing (e.g.
+ * `getChildProcessEnv()` which sets TERM/COLORTERM/FORCE_COLOR) reaches the
+ * child unchanged.
+ *
+ * IMPORTANT: When the `env` option is provided to `Bun.spawn`, the parent
+ * process env is NOT merged — the child receives only the keys passed.
+ * Callers must pass a complete env including PATH, HOME, TERM, etc.
+ */
+export const bunTerminalProvider: PtyProvider = {
+  spawn(command, args, options) {
+    const cols = options.cols ?? 80;
+    const rows = options.rows ?? 24;
+    const decode = createStreamingDecoder();
+
+    // We need a reference to the adapter inside the `data` callback. Bun
+    // returns the Subprocess from spawn(), and Subprocess.terminal is the
+    // Terminal handle. The adapter is constructed after spawn returns.
+    let adapter: BunTerminalPtyAdapter | null = null;
+
+    const subprocess = Bun.spawn([command, ...args], {
+      cwd: options.cwd,
+      env: options.env,
+      terminal: {
+        cols,
+        rows,
+        name: options.name ?? 'xterm-256color',
+        data: (_terminal, chunk) => {
+          if (adapter) {
+            adapter._emitData(chunk, decode);
+          }
+        },
+      },
+    });
+
+    const terminal = subprocess.terminal;
+    if (!terminal) {
+      // Defensive: should never happen because we passed a terminal option.
+      // Kill the process to avoid leaking a zombie before throwing.
+      subprocess.kill();
+      throw new Error('Bun.spawn did not attach a terminal despite terminal option');
+    }
+
+    adapter = new BunTerminalPtyAdapter({
+      subprocess,
+      terminal,
+      cols,
+      rows,
+      commandName: command,
+    });
+
+    return adapter;
+  },
+};
+
+/**
+ * Identifier for the configured PTY backend.
+ */
+export type PtyProviderName = 'bun-pty' | 'bun-terminal';
+
+/**
+ * Resolve the configured `PtyProvider`. Defaults to {@link bunPtyProvider}
+ * for backward compatibility. Set `PTY_PROVIDER=bun-terminal` to use
+ * {@link bunTerminalProvider}.
+ */
+export function getPtyProvider(name: PtyProviderName): PtyProvider {
+  switch (name) {
+    case 'bun-terminal':
+      return bunTerminalProvider;
+    case 'bun-pty':
+      return bunPtyProvider;
+  }
+}

--- a/packages/server/src/lib/server-config.ts
+++ b/packages/server/src/lib/server-config.ts
@@ -106,6 +106,21 @@ export const serverConfig = {
       throw new Error(`Invalid AUTH_COOKIE_SECURE: ${(e as Error).message}`);
     }
   })(),
+  /**
+   * PTY backend selector.
+   * - 'bun-pty' (default): use the bun-pty native shared library.
+   * - 'bun-terminal': use `Bun.spawn({ terminal: ... })` (Bun >= 1.3.5).
+   *
+   * See docs in `lib/pty-provider.ts` and Issue #824 for the migration
+   * evaluation. Default preserves historical behavior.
+   */
+  PTY_PROVIDER: (() => {
+    const value = process.env.PTY_PROVIDER ?? 'bun-pty';
+    if (value !== 'bun-pty' && value !== 'bun-terminal') {
+      throw new Error(`Invalid PTY_PROVIDER: '${value}'. Must be 'bun-pty' or 'bun-terminal'.`);
+    }
+    return value as 'bun-pty' | 'bun-terminal';
+  })(),
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

- Adds `bunTerminalProvider` alongside the existing `bunPtyProvider` in `packages/server/src/lib/pty-provider.ts`. Selection via `PTY_PROVIDER` env var (`'bun-pty'` default | `'bun-terminal'`).
- Both providers coexist. Default behavior is unchanged.
- `bunTerminalProvider` wraps `Bun.spawn({ terminal: ... })` (Bun >= 1.3.5) with an adapter that satisfies bun-pty's `IPty` contract used by `worker-manager` (`pid`, `onData`/`onExit`, `write`, `resize`, `kill`, `cols`/`rows`/`process`). UTF-8 decoding is stream-aware so partial multi-byte sequences are preserved across data callbacks.
- `PTY_PROVIDER` added to `serverConfig` (validated, throws on unknown values) and therefore auto-included in `SERVER_ONLY_ENV_VARS` so it is stripped from child env.

## Why this exists

Per Issue #824, the prior `Bun.Terminal` migration attempt regressed TUI colors (Claude Code's orange rendered as white). This PR re-enters the migration as a flag-gated coexistence so the regression can be reproduced and diagnosed in isolation.

## Color regression root cause

`Bun.spawn` does **not** merge parent process env when `env` is provided. The prior attempt almost certainly passed an `env` that did not include `TERM` / `COLORTERM` / `FORCE_COLOR`, so the child fell back to `dumb` and color paths short-circuited. The new adapter passes `options.env` verbatim, so the existing `getChildProcessEnv()` (which already sets `TERM=xterm-256color`, `COLORTERM=truecolor`, `FORCE_COLOR=1`) reaches the child unchanged. `isatty(stdoutFd)` is true under `Bun.Terminal`, so hypothesis 1 (TTY gating) was a non-issue.

## Probe verification (PTY boundary)

Probe spawns the same color-producing shell pipeline through each provider with the same env (`getChildProcessEnv()`):

```
script: git log --color=always; git diff --color=always --stat; ls --color=always packages
```

| Provider | bytes | ANSI seqs | `isatty` | `TERM` | `COLORTERM` | `FORCE_COLOR` |
|---|---|---|---|---|---|---|
| `bun-pty` | 783 | 44 | true | xterm-256color | truecolor | 1 |
| `bun-terminal` | 783 | 44 | true | xterm-256color | truecolor | 1 |

Output is byte-identical at the PTY boundary, including every ANSI color sequence and the `\r\n` line endings.

## Shipping-path visual verification — Resolved by owner visual confirm

Owner ran the full shipping path (`MessagePanel/Terminal (xterm.js) -> WebSocket -> server -> getChildProcessEnv() -> provider.spawn -> child -> onData -> WebSocket -> xterm.js render`) in the `wt-003-1djw` worktree:

1. Baseline `PTY_PROVIDER=bun-pty bun run dev` — opened a terminal worker, launched `claude`, exchanged a test message.
2. `PTY_PROVIDER=bun-terminal bun run dev` — same flow.
3. Screenshots (owner-local) compared side-by-side: Claude Code logo (orange), "Opus 4.7 with high effort" colored text, message round-trip — **visually identical**.

This demonstrates that the byte-identical probe result holds all the way through to the xterm.js render boundary; the prior color regression does not reproduce with the new adapter.

## Adoption verdict

**adopt**. Probe + visual E2E both clean. The original "Claude orange → white" symptom is fixed by routing `options.env` verbatim through `Bun.spawn`'s `env` option (no parent-env merge, so the caller's env must be self-contained).

## Rollout plan

This PR deploys the flag, default unchanged. Adoption proceeds in three stages:

1. **This PR** (#826) — Flag-gated coexistence. Default remains `PTY_PROVIDER=bun-pty`; opt-in via `PTY_PROVIDER=bun-terminal`. Zero behavior change for existing users.
2. **Follow-up PR (default switch)** — Flip the default to `PTY_PROVIDER=bun-terminal`. Validates real-world compatibility (TUIs, signal handling, resize, kill semantics) by making it the production path. Easy revert via env var.
3. **Follow-up PR (cleanup)** — Remove `bun-pty` dependency, the #823 shim, the `dist/` lib copy, and (if still present) the systemd template `BUN_PTY_LIB`. Eliminates the entire #820 class of build/deploy friction.

## Test plan

- [x] `bun run typecheck` exit 0
- [x] `bun run test` exit 0 (full suite: server 2640 pass / shared 324 pass / client 1397 pass / integration 29 pass / orchestrator 362 pass, 1 skip, 0 fail)
- [x] `node .claude/skills/orchestrator/preflight-check.js` exit 0
- [x] `bun run check:lang` exit 0
- [x] Unit tests cover: provider selection, default options, env passthrough, `onData`/`onExit` listener semantics, `onExit` race when process exits before listener attaches, decoder boundary across multi-byte UTF-8 chunks, `write`/`resize`/`kill` delegation.
- [x] Shipping-path visual E2E (owner-local screenshots, `claude` color + message round-trip on both providers, byte-identical visual result).

## Out of scope

- Removing `bun-pty` dependency or the #823 shim. Those land in the follow-up cleanup PR (rollout stage 3).
- Touching `env-filter.ts` (already correct).

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lv6zsJU72o28yz2YfKNQBc
