### PR TITLE
chore: add opt-in PTY_PROVIDER slot to mac deploy plist (#824 dogfood)

### DIFF
--- a/scripts/com.agent-console.plist.template
+++ b/scripts/com.agent-console.plist.template
@@ -23,6 +23,7 @@
         <string>{{APP_URL}}</string>
         <key>PATH</key>
         <string>{{PATH}}</string>
+        <!-- PTY_PROVIDER_BLOCK_PLACEHOLDER -->
     </dict>
 
     <key>RunAtLoad</key>

--- a/scripts/update-and-deploy-for-mac.sh
+++ b/scripts/update-and-deploy-for-mac.sh
@@ -26,11 +26,28 @@ echo ""
 echo "  Port: $PORT"
 echo "  URL:  $APP_URL"
 echo ""
+
+# Opt-in: emit a PTY_PROVIDER env entry only when the operator explicitly sets it.
+# Unset -> the placeholder line is replaced by an empty string (no entry), so the
+# server falls back to its compiled default. Used for dogfooding bun-terminal
+# before stage-2 default flip (issues #824 / #827).
+if [ -n "${PTY_PROVIDER:-}" ]; then
+    # Single-line XML: literal newlines in the sed substitution pattern are
+    # rejected by BSD sed (macOS). The plist parser is whitespace-insensitive,
+    # so the collapsed form is semantically identical.
+    PTY_PROVIDER_BLOCK="<key>PTY_PROVIDER</key><string>$PTY_PROVIDER</string>"
+    echo "  PTY_PROVIDER: $PTY_PROVIDER"
+    echo ""
+else
+    PTY_PROVIDER_BLOCK=""
+fi
+
 sed -e "s|{{HOME}}|$HOME|g" \
     -e "s|{{COMMAND_PATH}}|$COMMAND_PATH|g" \
     -e "s|{{PORT}}|$PORT|g" \
     -e "s|{{APP_URL}}|$APP_URL|g" \
     -e "s|{{PATH}}|$PATH|g" \
+    -e "s|<!-- PTY_PROVIDER_BLOCK_PLACEHOLDER -->|${PTY_PROVIDER_BLOCK}|" \
     "$SCRIPT_DIR/com.agent-console.plist.template" \
     > ~/Library/LaunchAgents/com.agent-console.plist
 


### PR DESCRIPTION
## Summary

Lets the owner dogfood `bun-terminal` locally (issue #824 / PR #826 follow-up) without re-injecting `PTY_PROVIDER` into the plist after every `update-and-deploy-for-mac.sh` run.

- `scripts/com.agent-console.plist.template` gains a `<!-- PTY_PROVIDER_BLOCK_PLACEHOLDER -->` slot.
- `scripts/update-and-deploy-for-mac.sh` expands it into a `<key>PTY_PROVIDER</key><string>...</string>` entry **only when** `$PTY_PROVIDER` is set; unset leaves the placeholder replaced by an empty string (no entry, server falls back to its compiled default — currently `bun-pty`, flipped to `bun-terminal` in stage 2 / #827).

Usage:

```bash
PTY_PROVIDER=bun-terminal ./scripts/update-and-deploy-for-mac.sh
```

## Scope choices

- **mac plist template + mac deploy only.** The ubuntu service template (Model A) is untouched: the stage-2 default flip (#827) will make the opt-in unnecessary there.
- **Single-line XML for the injected block.** BSD sed (macOS) rejects literal newlines inside an `s|...|...|` substitution. Plist parsing is whitespace-insensitive, so the collapsed form is semantically identical. Verified locally — `plutil -lint` clean for all three cases (unset / `bun-terminal` / `bun-pty`).
- **Temporary mechanism.** Stage 3 (#828) removes this placeholder and the `PTY_PROVIDER`-related sed branch entirely once `bun-pty` is retired (reminder comment added on #828).

## Verification (local, BSD sed on macOS)

```
unset           -> plist OK, 0 PTY_PROVIDER lines (server default applies)
bun-terminal    -> plist OK, EnvironmentVariables contains PTY_PROVIDER=bun-terminal
bun-pty         -> plist OK, EnvironmentVariables contains PTY_PROVIDER=bun-pty
```

Each case passed `plutil -lint` and round-tripped via `PlistBuddy -c Print`. No `bun run typecheck` / `bun run test` impact (scripts only).

## Risk

- mac dogfood deploy only. Other deployment paths unchanged.
- Empty placeholder substitution leaves no trailing whitespace inside the `EnvironmentVariables` dict.

Refs #824 #826 #827 #828