### PR TITLE
feat: relocate multi-user data root + add bootstrap script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,14 +63,24 @@ RUN apt-get update \
  && bun --version \
  && test -f /etc/pam.d/login
 
+# --- Shared system group (Issue #830) ---
+# In multi-user mode the data root lives at a system-wide path
+# (/var/lib/agent-console) owned <service-user>:agent-console-users mode 2775
+# so the per-user PTY (running as the logged-in user) can traverse into
+# worktrees. Every interactive user joins this group; the service user is
+# also a member.
+RUN groupadd --system agent-console-users
+
 # --- Service user (runs the server process; non-root) ---
 # Added to the `shadow` group so pam_unix can read /etc/shadow and verify any
 # user's password in-process. Without this, a non-root caller falls back to the
 # unix_chkpwd helper, which only permits verifying the caller's OWN password —
 # so every login would 401. (Discovered via this verification environment;
 # documented in docs/multi-user-setup-guide.md.)
+# Also a member of agent-console-users so it can write under the shared root.
 RUN useradd --create-home --shell /usr/sbin/nologin agentconsole \
- && usermod -aG shadow agentconsole
+ && usermod -aG shadow agentconsole \
+ && usermod -aG agent-console-users agentconsole
 
 # --- sudoers: allow the service user to launch login shells as other users ---
 COPY docker/sudoers-agentconsole /etc/sudoers.d/agentconsole
@@ -90,11 +100,16 @@ RUN chmod 0440 /etc/sudoers.d/agentconsole \
 # to the inner shell that runs AS the target user. Keeping the test homes at the
 # default 0700 means the CI E2E job permanently exercises that fixed path so a
 # regression resurfaces as a failing build (issue #808).
+#
+# Test users are added to agent-console-users so the multi-user shared-root
+# layout (Issue #830) is exercised in this verification environment.
 RUN useradd --create-home --shell /bin/bash alice \
  && useradd --create-home --shell /bin/bash bob \
  && echo 'alice:alice-password' | chpasswd \
  && echo 'bob:bob-password' | chpasswd \
- && chmod 0700 /home/alice /home/bob
+ && chmod 0700 /home/alice /home/bob \
+ && usermod -aG agent-console-users alice \
+ && usermod -aG agent-console-users bob
 
 # --- Application bundle ---
 WORKDIR /app
@@ -102,10 +117,14 @@ COPY --from=builder /app/dist ./dist
 # Install the native bun-pty binary for this platform into the dist bundle.
 RUN cd dist && bun install
 
-# Data directory (DB, jwt-secret, worker output) owned by the service user.
-ENV AGENT_CONSOLE_HOME=/home/agentconsole/.agent-console
-RUN mkdir -p "${AGENT_CONSOLE_HOME}" \
- && chown -R agentconsole:agentconsole "${AGENT_CONSOLE_HOME}" /app/dist
+# Data directory (DB, jwt-secret, worker output, worktrees).
+# Issue #830: in multi-user mode, the data root lives at /var/lib/agent-console
+# owned agentconsole:agent-console-users mode 2775 (setgid + group-writable)
+# so per-user PTYs can traverse into worktrees. The bootstrap script does
+# this on a real host; here we replicate it inline.
+ENV AGENT_CONSOLE_HOME=/var/lib/agent-console
+RUN install -d -o agentconsole -g agent-console-users -m 2775 "${AGENT_CONSOLE_HOME}" \
+ && chown -R agentconsole:agent-console-users /app/dist
 
 # Server configuration.
 # NOTE: NODE_ENV is intentionally left UNSET. NODE_ENV=production makes the auth
@@ -121,6 +140,10 @@ ENV AUTH_MODE=multi-user \
 # Run from inside dist/ so bun-pty resolves its native library relative to the
 # bundle's node_modules (the documented standalone layout: `cd dist && bun start`).
 WORKDIR /app/dist
-USER agentconsole
+# Issue #830: run with the shared group as the process's primary gid so that
+# `process.getgid()` returns the shared group (matching the bootstrap script's
+# `Group=<shared-group>` on the systemd unit). The upload-buffer multi-user
+# contract in packages/server/src/routes/workers.ts compares against this gid.
+USER agentconsole:agent-console-users
 EXPOSE 8080
 CMD ["bun", "index.js"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,15 +72,21 @@ RUN apt-get update \
 RUN groupadd --system agent-console-users
 
 # --- Service user (runs the server process; non-root) ---
-# Added to the `shadow` group so pam_unix can read /etc/shadow and verify any
-# user's password in-process. Without this, a non-root caller falls back to the
-# unix_chkpwd helper, which only permits verifying the caller's OWN password —
-# so every login would 401. (Discovered via this verification environment;
-# documented in docs/multi-user-setup-guide.md.)
-# Also a member of agent-console-users so it can write under the shared root.
-RUN useradd --create-home --shell /usr/sbin/nologin agentconsole \
- && usermod -aG shadow agentconsole \
- && usermod -aG agent-console-users agentconsole
+# Primary group = agent-console-users (Issue #830) so that at runtime the
+# server's primary gid IS the shared group, matching what `Group=<shared-group>`
+# does on the systemd unit on a real host. The upload-buffer multi-user
+# contract in packages/server/src/routes/workers.ts compares the upload dir's
+# gid against `process.getgid()`; primary group = shared group makes that
+# comparison pass under Docker too.
+#
+# Added to the `shadow` group as a supplementary group so pam_unix can read
+# /etc/shadow and verify any user's password in-process. Without this, a
+# non-root caller falls back to the unix_chkpwd helper, which only permits
+# verifying the caller's OWN password — so every login would 401.
+# (Discovered via this verification environment; documented in
+# docs/multi-user-setup-guide.md.)
+RUN useradd --create-home --shell /usr/sbin/nologin --gid agent-console-users agentconsole \
+ && usermod -aG shadow agentconsole
 
 # --- sudoers: allow the service user to launch login shells as other users ---
 COPY docker/sudoers-agentconsole /etc/sudoers.d/agentconsole
@@ -140,10 +146,16 @@ ENV AUTH_MODE=multi-user \
 # Run from inside dist/ so bun-pty resolves its native library relative to the
 # bundle's node_modules (the documented standalone layout: `cd dist && bun start`).
 WORKDIR /app/dist
-# Issue #830: run with the shared group as the process's primary gid so that
-# `process.getgid()` returns the shared group (matching the bootstrap script's
-# `Group=<shared-group>` on the systemd unit). The upload-buffer multi-user
-# contract in packages/server/src/routes/workers.ts compares against this gid.
-USER agentconsole:agent-console-users
+# Issue #830: `USER agentconsole` (no explicit `:group`) so Docker calls
+# initgroups() on container start and loads agentconsole's supplementary
+# groups — most importantly the `shadow` group required by pam_unix to read
+# /etc/shadow for OS authentication. agentconsole's PRIMARY group is
+# `agent-console-users` (set by the useradd `--gid` above), so
+# `process.getgid()` returns the shared group's gid, satisfying the
+# upload-buffer multi-user contract in packages/server/src/routes/workers.ts.
+# Using `USER agentconsole:agent-console-users` here would override the gid
+# AND skip initgroups() — supplementary groups would be lost, pam_unix would
+# lose shadow access, and every login would 401 (CI reproduction: PR #831).
+USER agentconsole
 EXPOSE 8080
 CMD ["bun", "index.js"]

--- a/docs/design/multi-user-shared-setup.md
+++ b/docs/design/multi-user-shared-setup.md
@@ -19,6 +19,12 @@ Agent Console is currently single-user. When started by one OS user, all session
 - **`createdBy` is nullable** — Backwards-compatible with existing sessions (pre-multi-user). References `users.id` (UUID).
 - **All sessions remain visible** — No server-side filtering. Client filters by user (localStorage-persisted preference).
 - **Repositories are shared globally** — All registered repositories and their settings (env_vars, setup_command, default_agent, etc.) are shared across all users. Both the server operator and users can register repositories.
+- **System-wide data root in multi-user mode (Issue [#830](https://github.com/ms2sato/agent-console/issues/830))** — The `AUTH_MODE=multi-user` default for `AGENT_CONSOLE_HOME` is `/var/lib/agent-console`, not `$HOME/.agent-console`. The service user's HOME on Debian / Ubuntu defaults to mode `0750` and is not traversable by other OS users, so a repository worktree under it cannot be reached by the per-user PTY (which runs as the logged-in user, not the service user). Single-user mode (`AUTH_MODE=none`) preserves the historical `$HOME/.agent-console` default so existing installs are unaffected.
+- **Shared system group `agent-console-users` (Issue [#830](https://github.com/ms2sato/agent-console/issues/830))** — The data root and its subtree (including all worktrees) are owned `<service-user>:agent-console-users` with mode `2775` (setgid + group-writable). The setgid bit ensures new entries inherit the group automatically. The systemd unit sets `UMask=0002` so files the server writes are group-writable; the per-user PTY's inner shell prepends `umask 0002` for the same reason. Every interactive user joins this group; the service user is also a member.
+- **Upload buffer kept in `/tmp` (Issue [#830](https://github.com/ms2sato/agent-console/issues/830))** — Even under multi-user mode, the per-uid upload buffer at `/tmp/agent-console-uploads-<uid>/` introduced by Issue [#821](https://github.com/ms2sato/agent-console/issues/821) remains in `/tmp` rather than moving under the data root. Rationale: the server has no read-completion signal for `injectMessage`, so abandoned upload buffers rely on OS-level `/tmp` reaping (`systemd-tmpfiles` / reboot) to avoid leaking disk over time. A persistent location would accumulate. Two changes for multi-user reachability:
+  1. Under `AUTH_MODE=multi-user` the directory mode is `2750` (setgid + group-rx) and the group is the shared group (the server process's primary gid, set by `Group=` on the systemd unit). Under `AUTH_MODE=none` the existing `0700` / euid-owned behaviour is preserved.
+  2. The in-process readiness cache is dropped so that if `/tmp` is reaped by `systemd-tmpfiles` during long-running server uptime, the next upload re-creates the directory on demand with the same mode / group invariants.
+- **Concurrent worktree edits accepted; conflict resolution AI-mediated (Issue [#830](https://github.com/ms2sato/agent-console/issues/830))** — All worktrees are flat (`<data-root>/repositories/<org>/<repo>/worktrees/wt-NNN-XXXX/`), owned `<service-user>:agent-console-users` mode `2775`. Any group member can read and write. There is no per-worktree owner concept and no DB schema change for worktrees. Concurrent edits are accepted; conflict resolution is delegated to the AI agents using the worktree. The project policy is that AI-mediated edits do not race in practice.
 
 ### Why This Approach (PTY User Isolation)
 
@@ -180,6 +186,10 @@ agentconsole ALL=(ALL) NOPASSWD: /bin/sh, /bin/bash, /bin/zsh
 ```
 
 This gives the service user the minimum privilege needed: the ability to start a shell as another user. The server itself runs as a regular user with no elevated privileges.
+
+### Bootstrap script
+
+The canonical entry point for new Ubuntu / Debian hosts is `scripts/setup-multiuser-for-ubuntu.sh` (Issue [#830](https://github.com/ms2sato/agent-console/issues/830)). It is idempotent and performs all 8 prerequisite steps from `docs/multi-user-setup-guide.md` in a single invocation. Identifiers (service user, shared group, data root, port) accept CLI / environment overrides. The companion helper `scripts/add-multiuser-user.sh <username>` adds an existing OS user to the shared group post-install.
 
 ## Implementation Phases
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -122,6 +122,18 @@ The dedicated OS account (typically `agentconsole`) that runs the server process
 - **Aliases:** Server service user, agentconsole service user, server process user
 - **See:** [Terminology in multi-user-shared-setup.md](design/multi-user-shared-setup.md#terminology)
 
+### agent-console-users
+Shared system group used in multi-user mode (Issue [#830](https://github.com/ms2sato/agent-console/issues/830)) to grant cross-user access to the data root and all worktrees. Every interactive user joins this group; the service user is also a member. Data root and worktrees are owned `<service-user>:agent-console-users` with mode `2775` (setgid + group-writable). The bootstrap script `scripts/setup-multiuser-for-ubuntu.sh` creates and populates the group.
+- **See:** [Architecture Decisions in multi-user-shared-setup.md](design/multi-user-shared-setup.md#architecture-decisions)
+
+### AGENT_CONSOLE_HOME
+Environment variable selecting the agent-console data root. Defaults:
+- `AUTH_MODE=none` (single-user): `~/.agent-console`.
+- `AUTH_MODE=multi-user`: `/var/lib/agent-console` (system-wide, group-traversable).
+
+An explicit value overrides both defaults. The multi-user bootstrap script sets it explicitly on the systemd unit.
+- **See:** [Architecture Decisions in multi-user-shared-setup.md](design/multi-user-shared-setup.md#architecture-decisions), [Environment Variables in multi-user-setup-guide.md](multi-user-setup-guide.md#environment-variables)
+
 ### Shared Account
 A dedicated OS account distinct from service user and individual users, used for shared sessions.
 - **Aliases:** Shared session account, shared service account (historical, briefly used in PR #682 draft)

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -36,7 +36,58 @@ Browser (User: alice) ──> Agent Console Server (agentconsole)
 > (`scripts/verify-multiuser-docker.sh`). Use it to see the whole setup working
 > before reproducing it on a real host.
 
-## Step 0: Install pamtester (Linux only)
+## Quick Setup with the Bootstrap Script (Linux)
+
+For Ubuntu / Debian hosts, the canonical happy path is the one-shot bootstrap
+script `scripts/setup-multiuser-for-ubuntu.sh` (Issue
+[#830](https://github.com/ms2sato/agent-console/issues/830)). It performs all
+the prerequisite steps below — pamtester install, service user, shared group,
+sudoers, data root, application install, systemd unit — as a single idempotent
+operation.
+
+```bash
+# 1. Clone the repo wherever the operator wants it (the script installs the
+#    application under the service user's HOME).
+git clone https://github.com/ms2sato/agent-console.git
+cd agent-console
+
+# 2. Run the bootstrap script. Defaults: service user 'agentconsole',
+#    shared group 'agent-console-users', data root '/var/lib/agent-console',
+#    port 8080. Override with --port, --user, --group, --data-root, etc.
+sudo scripts/setup-multiuser-for-ubuntu.sh --port 8080 \
+  --add-user alice --add-user bob
+
+# 3. Open the URL printed at the end. Default: http://<host>:8080/
+```
+
+The script is **idempotent**: a second invocation with the same parameters is
+a no-op. To preview what it would do without modifying the system, pass
+`--dry-run`:
+
+```bash
+sudo scripts/setup-multiuser-for-ubuntu.sh --dry-run
+```
+
+To add more users to the shared group after the initial setup, use the
+companion helper:
+
+```bash
+sudo scripts/add-multiuser-user.sh <username>
+```
+
+The sections that follow describe the underlying steps the bootstrap script
+performs. Read them when troubleshooting or when adapting the setup to a
+non-Ubuntu host.
+
+## Manual Setup (what the bootstrap script does, step by step)
+
+The remaining Step 0 through Step 4 sections explain what
+`setup-multiuser-for-ubuntu.sh` does internally. On a supported Ubuntu /
+Debian host they are not normally followed by hand; they are provided so the
+behaviour of the script is fully transparent and so the setup can be
+reproduced on other distributions.
+
+### Step 0: Install pamtester (Linux only)
 
 On Linux, Agent Console validates OS credentials by shelling out to
 `pamtester login <user> authenticate`. This binary is **not** part of the OS
@@ -58,7 +109,7 @@ images may need the `login` / `libpam-modules` packages).
 
 > **macOS** uses `dscl -authonly` instead and does **not** require `pamtester`.
 
-## Step 1: Create the Service User
+### Step 1: Create the Service User
 
 The service user (`agentconsole`) runs the server process. It is a system account with a HOME directory but no login shell.
 
@@ -157,7 +208,7 @@ ls -la /var/agentconsole
 # Output: drwxr-xr-x  2 agentconsole  staff  64 ... .
 ```
 
-## Step 2: Configure sudoers
+### Step 2: Configure sudoers
 
 The service user needs permission to run shells as other users. This is the **only privilege** it gets — no root access.
 
@@ -196,7 +247,7 @@ sudo -u agentconsole sudo -u root /bin/sh -c 'whoami'
 # Output: "Sorry, user agentconsole is not allowed to execute ..."
 ```
 
-## Step 3: Install Agent Console for the Service User
+### Step 3: Install Agent Console for the Service User
 
 Install Agent Console in the service user's home directory. The exact steps depend on your installation method, but the key is that the `agentconsole` user must be able to run the server binary.
 
@@ -214,7 +265,7 @@ sudo -u agentconsole bun run build
 
 > **Note**: `sudo -u agentconsole` runs the command as the service user. Since the service user has `/usr/sbin/nologin` as its shell, you may need to use `sudo -u agentconsole -s /bin/sh -c '...'` or `sudo -u agentconsole bash -c '...'` for multi-command sequences.
 
-## Step 4: Configure the Service (Linux)
+### Step 4: Configure the Service (Linux)
 
 Create a systemd unit file so the server starts automatically and restarts on failure.
 
@@ -371,7 +422,7 @@ curl -X POST http://localhost:8080/api/auth/login \
 | `AUTH_MODE` | `none` | `none` for single-user, `multi-user` for multi-user mode |
 | `PORT` | `3457` | Server port. `3457` is the dev fallback; pick any port for production (this guide uses `8080`). |
 | `HOST` | `0.0.0.0` | Bind address. Defaults to all interfaces; set to `127.0.0.1` to restrict to localhost. |
-| `AGENT_CONSOLE_HOME` | `~/.agent-console` | Config and database directory. The SQLite database is `<AGENT_CONSOLE_HOME>/data.db`; the JWT signing secret is `<AGENT_CONSOLE_HOME>/jwt-secret` (auto-generated, mode 0600, on first start). |
+| `AGENT_CONSOLE_HOME` | `~/.agent-console` (single-user); `/var/lib/agent-console` (multi-user, Issue [#830](https://github.com/ms2sato/agent-console/issues/830)) | Config and database directory. The SQLite database is `<AGENT_CONSOLE_HOME>/data.db`; the JWT signing secret is `<AGENT_CONSOLE_HOME>/jwt-secret` (auto-generated, mode 0600, on first start). Under multi-user, the bootstrap script sets this explicitly on the systemd unit. |
 | `NODE_ENV` | _(unset)_ | Set to `production` for browser-based deployments: it enables the web UI **and**, by default, marks the auth cookie `Secure`. The `Secure` cookie then needs a secure context — HTTPS, or `http://localhost` — see [TLS, `NODE_ENV`, and secure contexts](#tls-node_env-and-secure-contexts). |
 | `AUTH_COOKIE_SECURE` | _(unset)_ | Tri-state override for the auth cookie's `Secure` attribute, decoupling it from `NODE_ENV`. Unset → follows `NODE_ENV` (default); `false` → never `Secure` (for trusted-network plain-HTTP deployments); `true` → always `Secure`. Invalid values fail fast at startup. See [Plain HTTP on a trusted network](#plain-http-on-a-trusted-network-auth_cookie_secure). |
 

--- a/packages/server/src/lib/__tests__/config.test.ts
+++ b/packages/server/src/lib/__tests__/config.test.ts
@@ -4,26 +4,30 @@ import * as path from 'path';
 import { getConfigDir, getRepositoriesDir, getRepositoryDir, getServerPid } from '../config.js';
 
 describe('config', () => {
-  const originalEnv = process.env.AGENT_CONSOLE_HOME;
+  const originalHome = process.env.AGENT_CONSOLE_HOME;
+  const originalAuthMode = process.env.AUTH_MODE;
 
   beforeEach(() => {
-    // Clear the env var to test default behavior
+    // Clear both env vars to test default behavior in each test.
     delete process.env.AGENT_CONSOLE_HOME;
+    delete process.env.AUTH_MODE;
   });
 
   afterEach(() => {
-    // Restore original env var
-    if (originalEnv !== undefined) {
-      process.env.AGENT_CONSOLE_HOME = originalEnv;
+    if (originalHome !== undefined) {
+      process.env.AGENT_CONSOLE_HOME = originalHome;
     } else {
       delete process.env.AGENT_CONSOLE_HOME;
+    }
+    if (originalAuthMode !== undefined) {
+      process.env.AUTH_MODE = originalAuthMode;
+    } else {
+      delete process.env.AUTH_MODE;
     }
   });
 
   describe('getConfigDir', () => {
-    it('should return default path when AGENT_CONSOLE_HOME is not set', () => {
-      delete process.env.AGENT_CONSOLE_HOME;
-
+    it('should return default path under HOME when neither env var is set', () => {
       const expected = path.join(os.homedir(), '.agent-console');
       expect(getConfigDir()).toBe(expected);
     });
@@ -41,6 +45,29 @@ describe('config', () => {
       process.env.AGENT_CONSOLE_HOME = '/path/two';
       expect(getConfigDir()).toBe('/path/two');
     });
+
+    // Issue #830: AUTH_MODE=multi-user relocates the default data root to a
+    // system-wide path so that the per-user PTY (running as the logged-in
+    // user, not the service user) can traverse into it.
+    it('should return /var/lib/agent-console under AUTH_MODE=multi-user when AGENT_CONSOLE_HOME is unset (#830)', () => {
+      process.env.AUTH_MODE = 'multi-user';
+
+      expect(getConfigDir()).toBe('/var/lib/agent-console');
+    });
+
+    it('should honour AGENT_CONSOLE_HOME precedence over the multi-user default (#830)', () => {
+      process.env.AUTH_MODE = 'multi-user';
+      process.env.AGENT_CONSOLE_HOME = '/srv/agent-console-data';
+
+      expect(getConfigDir()).toBe('/srv/agent-console-data');
+    });
+
+    it('should not apply the multi-user default for any other AUTH_MODE value (#830)', () => {
+      process.env.AUTH_MODE = 'none';
+
+      const expected = path.join(os.homedir(), '.agent-console');
+      expect(getConfigDir()).toBe(expected);
+    });
   });
 
   describe('getServerPid', () => {
@@ -52,8 +79,6 @@ describe('config', () => {
 
   describe('getRepositoriesDir', () => {
     it('should return repositories subdirectory of config dir', () => {
-      delete process.env.AGENT_CONSOLE_HOME;
-
       const expected = path.join(os.homedir(), '.agent-console', 'repositories');
       expect(getRepositoriesDir()).toBe(expected);
     });
@@ -63,12 +88,16 @@ describe('config', () => {
 
       expect(getRepositoriesDir()).toBe('/custom/path/repositories');
     });
+
+    it('should follow the multi-user data root under AUTH_MODE=multi-user (#830)', () => {
+      process.env.AUTH_MODE = 'multi-user';
+
+      expect(getRepositoriesDir()).toBe('/var/lib/agent-console/repositories');
+    });
   });
 
   describe('getRepositoryDir', () => {
     it('should return repository-specific directory', () => {
-      delete process.env.AGENT_CONSOLE_HOME;
-
       const expected = path.join(os.homedir(), '.agent-console', 'repositories', 'owner/repo');
       expect(getRepositoryDir('owner/repo')).toBe(expected);
     });

--- a/packages/server/src/lib/config.ts
+++ b/packages/server/src/lib/config.ts
@@ -2,17 +2,46 @@ import * as path from 'path';
 import * as os from 'os';
 
 /**
+ * System-wide default data root used in multi-user mode.
+ *
+ * In multi-user mode the data root needs to be reachable by every logged-in
+ * user's PTY (running as that user, not the service user). The service user's
+ * HOME on Debian / Ubuntu defaults to mode 0750, which other users cannot
+ * traverse, so the multi-user-mode default is relocated to a system-wide path
+ * with group-writable permissions (see docs/design/multi-user-shared-setup.md).
+ *
+ * In single-user mode (AUTH_MODE=none), the historical default
+ * `$HOME/.agent-console` is preserved to avoid regressing existing installs.
+ */
+const MULTI_USER_DEFAULT_DATA_ROOT = '/var/lib/agent-console';
+
+/**
  * Get the configuration directory for agent-console.
- * Can be overridden with AGENT_CONSOLE_HOME environment variable.
- * Default: ~/.agent-console
+ *
+ * Resolution precedence:
+ *   1. AGENT_CONSOLE_HOME environment variable, if set (any mode).
+ *   2. AUTH_MODE=multi-user: system-wide `/var/lib/agent-console`.
+ *   3. Otherwise (single-user): `~/.agent-console` under the server
+ *      process user's HOME.
+ *
+ * The bootstrap script (`scripts/setup-multiuser-for-ubuntu.sh`) sets
+ * AGENT_CONSOLE_HOME explicitly on the systemd unit, so production
+ * multi-user deployments always go through path (1); path (2) is the
+ * fallback for ad-hoc multi-user invocations without an explicit override.
  */
 export function getConfigDir(): string {
-  return process.env.AGENT_CONSOLE_HOME || path.join(os.homedir(), '.agent-console');
+  if (process.env.AGENT_CONSOLE_HOME) {
+    return process.env.AGENT_CONSOLE_HOME;
+  }
+  if (process.env.AUTH_MODE === 'multi-user') {
+    return MULTI_USER_DEFAULT_DATA_ROOT;
+  }
+  return path.join(os.homedir(), '.agent-console');
 }
 
 /**
  * Get the repositories base directory.
- * Structure: ~/.agent-console/repositories/
+ * Structure: <config-dir>/repositories/
  */
 export function getRepositoriesDir(): string {
   return path.join(getConfigDir(), 'repositories');
@@ -20,7 +49,7 @@ export function getRepositoriesDir(): string {
 
 /**
  * Get the directory for a specific repository.
- * Structure: ~/.agent-console/repositories/{org}/{repo}/
+ * Structure: <config-dir>/repositories/{org}/{repo}/
  * @param orgRepo - Organization and repository name (e.g., "owner/repo-name")
  */
 export function getRepositoryDir(orgRepo: string): string {
@@ -29,7 +58,7 @@ export function getRepositoryDir(orgRepo: string): string {
 
 /**
  * Get the path to the SQLite database file.
- * Structure: ~/.agent-console/data.db
+ * Structure: <config-dir>/data.db
  */
 export function getDbPath(): string {
   return path.join(getConfigDir(), 'data.db');

--- a/packages/server/src/routes/__tests__/workers-upload-dir-real-fs.test.ts
+++ b/packages/server/src/routes/__tests__/workers-upload-dir-real-fs.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Real-filesystem regression test for the multi-user upload directory's
+ * mode/group contract (Issue #830 follow-up).
+ *
+ * Why this test exists:
+ *
+ * The original memfs-based multi-user test in `workers.test.ts` passed
+ * against memfs's in-memory simulation, whose `mkdir` honours the mode
+ * arg literally — including special bits like setgid (0o2000). Bun's
+ * own `fs.mkdir({ mode })` and `fs.chmod(dir, mode)` strip the special
+ * bits in the JS layer BEFORE the syscall (verified by strace: setgid
+ * 0o2000 / setuid 0o4000 / sticky 0o1000 are all dropped). The kernel
+ * itself honours setgid when invoked directly (shell
+ * `mkdir --mode=2750` → `drwxr-s---`), but Bun's bindings never pass
+ * the bit through. The bug PR #831 introduced shipped to a real Ubuntu
+ * 24.04 host precisely because the memfs-based test could not exercise
+ * Bun's JS-layer mode stripping.
+ *
+ * Process-isolation complication:
+ *
+ * `workers.test.ts` (and several other files in this suite) transitively
+ * load `mock-fs-helper.ts`, which calls
+ * `mock.module('fs/promises', () => memfs.fs.promises)`. `mock.module`
+ * is process-global and irreversible in `bun:test` (see
+ * `.claude/rules/testing.md` "Module-Level Mocking" anti-pattern). So
+ * when this file runs as part of the full suite, ALL `fs/promises`
+ * calls — even ones in production code reachable from here — are
+ * routed to memfs, NOT real Bun bindings.
+ *
+ * Strategy:
+ *
+ *   1. Kernel-level probe (always runs): uses `Bun.spawn` to invoke
+ *      shell mkdir / chmod / stat. `Bun.spawn` is not subject to
+ *      `mock.module`. Asserts that the Linux kernel + the host
+ *      filesystem honour setgid (the precondition for the workaround
+ *      to work at all).
+ *
+ *   2. Bun JS-layer probe (skip when memfs is loaded): asserts that
+ *      Bun's own `fs.mkdir({ mode: 0o2750 })` produces 0o750 — i.e.
+ *      the bug the workaround targets. Under the full suite
+ *      `fs/promises` is memfs-mocked so this probe cannot exercise
+ *      the real Bun binding; it is then skipped with a clear note.
+ *      If a future Bun release fixes the JS-layer stripping, this
+ *      probe (when run alone) fails and prompts a deliberate update
+ *      to `workers.ts` so the spawn-chmod step can become an
+ *      in-process chmod.
+ *
+ *   3. End-to-end probes (skip when memfs is loaded): drive
+ *      `__TESTING__.ensureUploadDir()` against the real fs and
+ *      assert the resulting dir's mode/gid via `stat(1)`. Skipped
+ *      under the full suite because `fs/promises` is mocked to
+ *      memfs by then; run when this file is invoked alone:
+ *
+ *        bun test packages/server/src/routes/__tests__/workers-upload-dir-real-fs.test.ts
+ */
+
+import { describe, it, expect } from 'bun:test';
+import * as os from 'os';
+import { join as pathJoin } from 'path';
+import { __TESTING__ } from '../workers.js';
+
+const SUPPORTS_SETGID_CONTRACT =
+  process.platform === 'linux' && typeof process.geteuid === 'function';
+
+interface SpawnResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Run a shell command and return { exitCode, stdout, stderr }.
+ * Uses `Bun.spawn`, which is not subject to `mock.module('fs', ...)` —
+ * so any operation issued via this helper hits the real kernel /
+ * filesystem regardless of memfs hooks installed elsewhere in the
+ * test suite.
+ */
+async function spawnCheck(argv: string[]): Promise<SpawnResult> {
+  const proc = Bun.spawn(argv, { stdout: 'pipe', stderr: 'pipe' });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { exitCode, stdout, stderr };
+}
+
+/**
+ * Detect whether `fs/promises` has been swapped for memfs by an earlier
+ * test file. Sentinel: `/proc` exists on every Linux real fs but is not
+ * populated in the memfs volume.
+ */
+async function isMemfsActive(): Promise<boolean> {
+  try {
+    const fsp = await import('fs/promises');
+    await fsp.lstat('/proc');
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe('Upload directory real-fs contract (#830 regression)', () => {
+  /**
+   * Kernel-level precondition probe — always runs (uses Bun.spawn so
+   * unaffected by memfs hooks). Asserts that the Linux kernel + the
+   * host filesystem honour setgid at mkdir time AND via chmod. If a
+   * future host's filesystem or kernel drops setgid, the workaround
+   * cannot succeed; that case surfaces here rather than silently
+   * shipping mode 0o750 again.
+   */
+  it.skipIf(!SUPPORTS_SETGID_CONTRACT)(
+    'kernel + host fs honour setgid on mkdir(2) and chmod(1)',
+    async () => {
+      const mk = await spawnCheck(['mktemp', '-d', '-p', os.tmpdir(), 'ac-kernel-probe.XXXXXX']);
+      expect(mk.exitCode).toBe(0);
+      const parent = mk.stdout.trim();
+      const direct = pathJoin(parent, 'direct');
+      const viaChmod = pathJoin(parent, 'viaChmod');
+
+      try {
+        // Probe A: shell `mkdir --mode=2750` — the kernel mkdirat(2)
+        // syscall, given mode 02750, produces a directory with the
+        // setgid bit set. Demonstrates that the kernel and the
+        // underlying filesystem support setgid.
+        const md = await spawnCheck(['mkdir', '--mode=2750', direct]);
+        expect(md.exitCode).toBe(0);
+        const stA = await spawnCheck(['stat', '-c', '%a', direct]);
+        expect(stA.exitCode).toBe(0);
+        expect(stA.stdout.trim()).toBe('2750');
+
+        // Probe B: shell `chmod 2750` after a plain `mkdir`. This is
+        // the syscall path the production workaround uses to set the
+        // bit after Bun's mkdir drops it.
+        const md2 = await spawnCheck(['mkdir', viaChmod]);
+        expect(md2.exitCode).toBe(0);
+        const cm = await spawnCheck(['chmod', '2750', viaChmod]);
+        expect(cm.exitCode).toBe(0);
+        const stB = await spawnCheck(['stat', '-c', '%a', viaChmod]);
+        expect(stB.exitCode).toBe(0);
+        expect(stB.stdout.trim()).toBe('2750');
+      } finally {
+        await spawnCheck(['rmdir', direct]);
+        await spawnCheck(['rmdir', viaChmod]);
+        await spawnCheck(['rmdir', parent]);
+      }
+    },
+  );
+
+  /**
+   * Bun JS-layer probe — asserts that Bun's `fs.mkdir({ mode: 0o2750 })`
+   * drops the setgid bit before issuing the syscall. This is the
+   * defect that motivates the production workaround. If a future Bun
+   * release fixes it (the strace output then shows
+   * `mkdirat(..., 02750)` instead of `mkdirat(..., 0750)`), this
+   * assertion fails and prompts replacing the spawn-chmod step in
+   * `workers.ts` with a simpler in-process chmod.
+   *
+   * Skipped under the full suite (fs/promises is mocked to memfs).
+   * Run this file alone to exercise.
+   */
+  it.skipIf(!SUPPORTS_SETGID_CONTRACT)(
+    'Bun fs.mkdir strips setgid in the JS layer (this is the bug the route works around)',
+    async () => {
+      if (await isMemfsActive()) {
+        console.log(
+          '[skip] memfs is active in this process; fs.mkdir is mocked. Run this file alone (`bun test workers-upload-dir-real-fs.test.ts`) to probe the real Bun binding.',
+        );
+        return;
+      }
+
+      const mk = await spawnCheck(['mktemp', '-d', '-p', os.tmpdir(), 'ac-bun-probe.XXXXXX']);
+      expect(mk.exitCode).toBe(0);
+      const parent = mk.stdout.trim();
+      const target = pathJoin(parent, 'd');
+
+      try {
+        const fsp = await import('fs/promises');
+        await fsp.mkdir(target, { mode: 0o2750 });
+        const st = await spawnCheck(['stat', '-c', '%a', target]);
+        expect(st.exitCode).toBe(0);
+        // Bun 1.3.10 strips setgid → result is 0o750.
+        expect(st.stdout.trim()).toBe('750');
+
+        // Also assert that Bun's fs.chmod does the same.
+        await fsp.chmod(target, 0o2750);
+        const st2 = await spawnCheck(['stat', '-c', '%a', target]);
+        expect(st2.exitCode).toBe(0);
+        expect(st2.stdout.trim()).toBe('750');
+      } finally {
+        await spawnCheck(['rmdir', target]);
+        await spawnCheck(['rmdir', parent]);
+      }
+    },
+  );
+
+  /**
+   * End-to-end probe: drive the actual `ensureUploadDir()` on the
+   * real filesystem under AUTH_MODE=multi-user and assert the
+   * resulting directory is mode 2750 with the expected gid.
+   *
+   * Skipped under the full suite because `fs/promises` is mocked to
+   * memfs by an earlier file. Runs when this file is invoked alone.
+   */
+  it.skipIf(!SUPPORTS_SETGID_CONTRACT)(
+    'ensureUploadDir() applies setgid via spawned chmod under AUTH_MODE=multi-user (end-to-end)',
+    async () => {
+      if (await isMemfsActive()) {
+        console.log(
+          '[skip] memfs is active in this test process; ensureUploadDir() would land on memfs. Run this file alone to exercise.',
+        );
+        return;
+      }
+
+      const mk = await spawnCheck(['mktemp', '-d', '-p', os.tmpdir(), 'ac-upload-real.XXXXXX']);
+      expect(mk.exitCode).toBe(0);
+      const tmpParent = mk.stdout.trim();
+
+      const originalAuthMode = process.env.AUTH_MODE;
+      const originalTmpdir = process.env.TMPDIR;
+      process.env.AUTH_MODE = 'multi-user';
+      // The route resolves the upload dir from os.tmpdir(); rerouting
+      // TMPDIR gives us a per-test parent dir for clean cleanup.
+      process.env.TMPDIR = tmpParent;
+
+      const euid = (process.geteuid as () => number)();
+      const expectedUploadDir = pathJoin(tmpParent, `agent-console-uploads-${euid}`);
+
+      try {
+        const dir = await __TESTING__.ensureUploadDir();
+        expect(dir).toBe(expectedUploadDir);
+
+        // Verify mode + gid via shell `stat` (independent of any
+        // fs-level mock that may be active).
+        const st = await spawnCheck(['stat', '-c', '%a:%g', expectedUploadDir]);
+        expect(st.exitCode).toBe(0);
+        const [perm, gid] = st.stdout.trim().split(':');
+        expect(perm).toBe('2750');
+        expect(Number(gid)).toBe((process.getgid as () => number)());
+      } finally {
+        await spawnCheck(['rmdir', expectedUploadDir]);
+        await spawnCheck(['rmdir', tmpParent]);
+
+        if (originalAuthMode === undefined) {
+          delete process.env.AUTH_MODE;
+        } else {
+          process.env.AUTH_MODE = originalAuthMode;
+        }
+        if (originalTmpdir === undefined) {
+          delete process.env.TMPDIR;
+        } else {
+          process.env.TMPDIR = originalTmpdir;
+        }
+      }
+    },
+  );
+
+  /**
+   * Single-user mode (AUTH_MODE=none) must remain mode 0700 with no
+   * special bits and no shell-out. Regression guard against the fix
+   * accidentally widening the single-user contract.
+   */
+  it.skipIf(!SUPPORTS_SETGID_CONTRACT)(
+    'ensureUploadDir() keeps mode 0700 in single-user mode (end-to-end)',
+    async () => {
+      if (await isMemfsActive()) {
+        console.log(
+          '[skip] memfs is active in this test process; run this file alone to exercise.',
+        );
+        return;
+      }
+
+      const mk = await spawnCheck([
+        'mktemp',
+        '-d',
+        '-p',
+        os.tmpdir(),
+        'ac-upload-single.XXXXXX',
+      ]);
+      expect(mk.exitCode).toBe(0);
+      const tmpParent = mk.stdout.trim();
+
+      const originalAuthMode = process.env.AUTH_MODE;
+      const originalTmpdir = process.env.TMPDIR;
+      delete process.env.AUTH_MODE;
+      process.env.TMPDIR = tmpParent;
+
+      const euid = (process.geteuid as () => number)();
+      const expectedUploadDir = pathJoin(tmpParent, `agent-console-uploads-${euid}`);
+
+      try {
+        const dir = await __TESTING__.ensureUploadDir();
+        expect(dir).toBe(expectedUploadDir);
+
+        const st = await spawnCheck(['stat', '-c', '%a', expectedUploadDir]);
+        expect(st.exitCode).toBe(0);
+        expect(st.stdout.trim()).toBe('700');
+      } finally {
+        await spawnCheck(['rmdir', expectedUploadDir]);
+        await spawnCheck(['rmdir', tmpParent]);
+
+        if (originalAuthMode === undefined) {
+          delete process.env.AUTH_MODE;
+        } else {
+          process.env.AUTH_MODE = originalAuthMode;
+        }
+        if (originalTmpdir === undefined) {
+          delete process.env.TMPDIR;
+        } else {
+          process.env.TMPDIR = originalTmpdir;
+        }
+      }
+    },
+  );
+});

--- a/packages/server/src/routes/__tests__/workers.test.ts
+++ b/packages/server/src/routes/__tests__/workers.test.ts
@@ -226,11 +226,9 @@ describe('Workers API', () => {
       expect(body.error).toContain('Total file size exceeds limit');
     });
 
-    // NOTE: This test must run BEFORE any other test that triggers an upload,
-    // because the route caches its `mkdir(..., { mode: 0o700 })` result in a
-    // process-level Map. Only the first upload in the process actually invokes
-    // mkdir; subsequent uploads short-circuit on the cache. We rely on that
-    // first call to leave a memfs entry whose mode we can inspect.
+    // Issue #830 removed the in-process readiness cache; ensureUploadDir() now
+    // mkdir+lstat-verifies on every upload, so the order of tests within this
+    // describe block no longer matters.
     it('should save uploaded files under /tmp/agent-console-uploads-<uid>/ with mode 0700 (#821)', async () => {
       const session = await sessionManager.createSession({
         type: 'quick',
@@ -304,9 +302,6 @@ describe('Workers API', () => {
     // `mkdir(..., { mode: 0o700 })`, so the route must lstat after mkdir and
     // reject the symlink before any Bun.write touches real disk.
     it('should reject a pre-existing symlink at the upload directory path (#821 TOCTOU defense)', async () => {
-      const { __TESTING__ } = await import('../workers.js');
-      __TESTING__.resetUploadDirCache();
-
       const session = await sessionManager.createSession({
         type: 'quick',
         locationPath: '/test/path',
@@ -376,7 +371,6 @@ describe('Workers API', () => {
         } catch {
           // ignore
         }
-        __TESTING__.resetUploadDirCache();
       }
     });
 
@@ -385,9 +379,6 @@ describe('Workers API', () => {
     // read buffered upload contents. mkdir is a no-op when the path exists,
     // so the route must lstat-verify the actual mode.
     it('should reject a pre-existing upload directory with the wrong mode (#821 TOCTOU defense)', async () => {
-      const { __TESTING__ } = await import('../workers.js');
-      __TESTING__.resetUploadDirCache();
-
       const session = await sessionManager.createSession({
         type: 'quick',
         locationPath: '/test/path',
@@ -444,7 +435,164 @@ describe('Workers API', () => {
         } catch {
           // ignore
         }
-        __TESTING__.resetUploadDirCache();
+      }
+    });
+
+    // Issue #830: AUTH_MODE=multi-user changes the upload directory mode to
+    // 2750 (setgid + group-rx) and pins the expected group to the server
+    // process's primary gid (set by `Group=<shared-group>` on the systemd
+    // unit). Verifies that ensureUploadDir() applies the conditional mode
+    // when AUTH_MODE=multi-user is set in the environment.
+    it('should use mode 2750 under AUTH_MODE=multi-user (#830)', async () => {
+      const originalAuthMode = process.env.AUTH_MODE;
+      process.env.AUTH_MODE = 'multi-user';
+
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      const worker = await sessionManager.createWorker(session.id, {
+        type: 'agent',
+        agentId: 'claude-code',
+      });
+      expect(worker).not.toBeNull();
+
+      const euid: number | 'shared' =
+        typeof process.geteuid === 'function' ? process.geteuid() : 'shared';
+      const expectedUploadDir = pathJoin(os.tmpdir(), `agent-console-uploads-${euid}`);
+
+      const { vol } = await import('memfs');
+      // Remove any prior state so the route's mkdir creates a fresh memfs
+      // entry whose mode reflects the multi-user contract.
+      try {
+        vol.rmdirSync(expectedUploadDir);
+      } catch {
+        // ignore: not present
+      }
+
+      const originalBunWrite = Bun.write;
+      Bun.write = ((dest: unknown, input: unknown, options?: unknown) => {
+        return originalBunWrite(
+          dest as Parameters<typeof originalBunWrite>[0],
+          input as Parameters<typeof originalBunWrite>[1],
+          options as Parameters<typeof originalBunWrite>[2],
+        );
+      }) as typeof Bun.write;
+
+      try {
+        const formData = new FormData();
+        formData.append('toWorkerId', worker!.id);
+        formData.append('content', 'msg');
+        formData.append('files', new File(['data'], 'test.txt', { type: 'text/plain' }));
+
+        const res = await app.request(`/api/sessions/${session.id}/messages`, {
+          method: 'POST',
+          body: formData,
+        });
+        expect(res.status).toBe(201);
+
+        const stat = vol.statSync(expectedUploadDir);
+        // mode includes file-type bits; mask to the full permission + setid
+        // bits (4 octal digits) so that the setgid bit (0o2000) is visible.
+        const perm = (stat.mode & 0o7777).toString(8);
+        expect(perm).toBe('2750');
+        // Group should match the server process's primary gid (which under
+        // multi-user is the shared group, set by the systemd unit).
+        if (typeof process.getgid === 'function') {
+          expect(stat.gid).toBe(process.getgid());
+        }
+      } finally {
+        Bun.write = originalBunWrite;
+        try {
+          vol.rmdirSync(expectedUploadDir);
+        } catch {
+          // ignore
+        }
+        if (originalAuthMode === undefined) {
+          delete process.env.AUTH_MODE;
+        } else {
+          process.env.AUTH_MODE = originalAuthMode;
+        }
+      }
+    });
+
+    // Issue #830: the in-process readiness cache was removed so that a long-
+    // running multi-user deployment recovers if /tmp is reaped by
+    // systemd-tmpfiles during uptime. After a successful upload, remove the
+    // directory and verify the next upload re-creates it (no stale-cache
+    // short-circuit).
+    it('should re-create the upload directory if it is reaped during runtime (#830)', async () => {
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      const worker = await sessionManager.createWorker(session.id, {
+        type: 'agent',
+        agentId: 'claude-code',
+      });
+      expect(worker).not.toBeNull();
+
+      const euid: number | 'shared' =
+        typeof process.geteuid === 'function' ? process.geteuid() : 'shared';
+      const expectedUploadDir = pathJoin(os.tmpdir(), `agent-console-uploads-${euid}`);
+
+      const { vol } = await import('memfs');
+
+      const originalBunWrite = Bun.write;
+      Bun.write = ((dest: unknown, input: unknown, options?: unknown) => {
+        return originalBunWrite(
+          dest as Parameters<typeof originalBunWrite>[0],
+          input as Parameters<typeof originalBunWrite>[1],
+          options as Parameters<typeof originalBunWrite>[2],
+        );
+      }) as typeof Bun.write;
+
+      try {
+        // First upload — creates the directory.
+        const firstForm = new FormData();
+        firstForm.append('toWorkerId', worker!.id);
+        firstForm.append('content', 'first');
+        firstForm.append('files', new File(['a'], 'first.txt', { type: 'text/plain' }));
+        const first = await app.request(`/api/sessions/${session.id}/messages`, {
+          method: 'POST',
+          body: firstForm,
+        });
+        expect(first.status).toBe(201);
+
+        // Simulate systemd-tmpfiles reaping /tmp under us.
+        // Remove file children first so rmdirSync succeeds.
+        const entries = vol.readdirSync(expectedUploadDir);
+        for (const entry of entries) {
+          vol.unlinkSync(pathJoin(expectedUploadDir, String(entry)));
+        }
+        vol.rmdirSync(expectedUploadDir);
+        // Confirm the dir is actually gone before the second upload.
+        let removed = false;
+        try {
+          vol.statSync(expectedUploadDir);
+        } catch {
+          removed = true;
+        }
+        expect(removed).toBe(true);
+
+        // Second upload — must re-create the directory (no stale cache).
+        const secondForm = new FormData();
+        secondForm.append('toWorkerId', worker!.id);
+        secondForm.append('content', 'second');
+        secondForm.append('files', new File(['b'], 'second.txt', { type: 'text/plain' }));
+        const second = await app.request(`/api/sessions/${session.id}/messages`, {
+          method: 'POST',
+          body: secondForm,
+        });
+        expect(second.status).toBe(201);
+
+        // The directory must exist again.
+        const stat = vol.statSync(expectedUploadDir);
+        expect(stat.isDirectory()).toBe(true);
+      } finally {
+        Bun.write = originalBunWrite;
       }
     });
 

--- a/packages/server/src/routes/__tests__/workers.test.ts
+++ b/packages/server/src/routes/__tests__/workers.test.ts
@@ -438,84 +438,21 @@ describe('Workers API', () => {
       }
     });
 
-    // Issue #830: AUTH_MODE=multi-user changes the upload directory mode to
-    // 2750 (setgid + group-rx) and pins the expected group to the server
-    // process's primary gid (set by `Group=<shared-group>` on the systemd
-    // unit). Verifies that ensureUploadDir() applies the conditional mode
-    // when AUTH_MODE=multi-user is set in the environment.
-    it('should use mode 2750 under AUTH_MODE=multi-user (#830)', async () => {
-      const originalAuthMode = process.env.AUTH_MODE;
-      process.env.AUTH_MODE = 'multi-user';
-
-      const session = await sessionManager.createSession({
-        type: 'quick',
-        locationPath: '/test/path',
-        agentId: 'claude-code',
-      });
-      const worker = await sessionManager.createWorker(session.id, {
-        type: 'agent',
-        agentId: 'claude-code',
-      });
-      expect(worker).not.toBeNull();
-
-      const euid: number | 'shared' =
-        typeof process.geteuid === 'function' ? process.geteuid() : 'shared';
-      const expectedUploadDir = pathJoin(os.tmpdir(), `agent-console-uploads-${euid}`);
-
-      const { vol } = await import('memfs');
-      // Remove any prior state so the route's mkdir creates a fresh memfs
-      // entry whose mode reflects the multi-user contract.
-      try {
-        vol.rmdirSync(expectedUploadDir);
-      } catch {
-        // ignore: not present
-      }
-
-      const originalBunWrite = Bun.write;
-      Bun.write = ((dest: unknown, input: unknown, options?: unknown) => {
-        return originalBunWrite(
-          dest as Parameters<typeof originalBunWrite>[0],
-          input as Parameters<typeof originalBunWrite>[1],
-          options as Parameters<typeof originalBunWrite>[2],
-        );
-      }) as typeof Bun.write;
-
-      try {
-        const formData = new FormData();
-        formData.append('toWorkerId', worker!.id);
-        formData.append('content', 'msg');
-        formData.append('files', new File(['data'], 'test.txt', { type: 'text/plain' }));
-
-        const res = await app.request(`/api/sessions/${session.id}/messages`, {
-          method: 'POST',
-          body: formData,
-        });
-        expect(res.status).toBe(201);
-
-        const stat = vol.statSync(expectedUploadDir);
-        // mode includes file-type bits; mask to the full permission + setid
-        // bits (4 octal digits) so that the setgid bit (0o2000) is visible.
-        const perm = (stat.mode & 0o7777).toString(8);
-        expect(perm).toBe('2750');
-        // Group should match the server process's primary gid (which under
-        // multi-user is the shared group, set by the systemd unit).
-        if (typeof process.getgid === 'function') {
-          expect(stat.gid).toBe(process.getgid());
-        }
-      } finally {
-        Bun.write = originalBunWrite;
-        try {
-          vol.rmdirSync(expectedUploadDir);
-        } catch {
-          // ignore
-        }
-        if (originalAuthMode === undefined) {
-          delete process.env.AUTH_MODE;
-        } else {
-          process.env.AUTH_MODE = originalAuthMode;
-        }
-      }
-    });
+    // Issue #830 follow-up: the regression test for Bun's JS-layer mode
+    // stripping (which causes fs.mkdir({ mode: 0o2750 }) to issue
+    // mkdirat(..., 0750)) lives in workers-upload-dir-real-fs.test.ts —
+    // a separate file that does NOT import the memfs hook. mock.module is
+    // process-global and irreversible in bun:test (see testing.md
+    // "Module-Level Mocking" anti-pattern), so the only way to exercise
+    // the real Bun fs binding is via a sibling test file with no memfs
+    // hook AND via Bun.spawn-based shell probes that bypass fs/promises
+    // altogether.
+    //
+    // The memfs-based multi-user test that previously lived here passed
+    // for the wrong reason: memfs's mkdir honours the mode arg literally,
+    // including special bits, so the Bun JS-layer setgid stripping was
+    // never exercised and the production bug shipped to a real Ubuntu
+    // host.
 
     // Issue #830: the in-process readiness cache was removed so that a long-
     // running multi-user deployment recovers if /tmp is reaped by

--- a/packages/server/src/routes/workers.ts
+++ b/packages/server/src/routes/workers.ts
@@ -124,14 +124,13 @@ async function ensureUploadDir(): Promise<string> {
   // not match the expected owner / mode / group.
   try {
     await mkdir(dir, { recursive: true, mode: contract.mode });
-    // Bun 1.3.10 strips setgid / setuid / sticky in its fs.mkdir JS
-    // layer before the syscall; for the multi-user 2750 contract we
-    // re-apply the bit via chmod(1). See the file header comment for
-    // the upstream-gap rationale.
-    if ((contract.mode & ~0o777) !== 0) {
-      await applyModeViaSpawnChmod(dir, contract.mode);
-    }
-    const st = await lstat(dir);
+    // Validate the path BEFORE any chmod(1) shell-out. chmod(2) follows
+    // symlinks, so applying it on a pre-created symlink would mutate the
+    // symlink target's mode before we ever reject the symlink. Lstat
+    // first, confirm symlink / dir / owner / gid, THEN re-apply setgid
+    // via chmod (which is now operating on a path we have just
+    // verified). CodeRabbit #831-review TOCTOU finding.
+    let st = await lstat(dir);
     if (st.isSymbolicLink()) {
       throw new Error(`Upload directory is a symlink: ${dir}`);
     }
@@ -146,15 +145,38 @@ async function ensureUploadDir(): Promise<string> {
         `Upload directory has unexpected owner uid=${st.uid} (expected ${process.geteuid()}): ${dir}`,
       );
     }
+    if (contract.expectedGid !== null && st.gid !== contract.expectedGid) {
+      throw new Error(
+        `Upload directory has unexpected group gid=${st.gid} (expected ${contract.expectedGid}): ${dir}`,
+      );
+    }
+
+    // Bun 1.3.10 strips setgid / setuid / sticky in its fs.mkdir JS
+    // layer before the syscall; for the multi-user 2750 contract we
+    // re-apply the bit via chmod(1) — now that we have lstat-confirmed
+    // the path is the expected directory. Skip when the contract has
+    // no special bits (single-user 0o700) OR when the existing mode
+    // already matches (idempotent recovery of a previously-prepared
+    // directory). See the file header comment for the upstream-gap
+    // rationale.
+    if ((contract.mode & ~0o777) !== 0 && (st.mode & 0o7777) !== contract.mode) {
+      await applyModeViaSpawnChmod(dir, contract.mode);
+      // Re-stat (no symlink follow) to guard against a rename race
+      // between the validating lstat and the chmod spawn; if anything
+      // unexpected happened, surface it now rather than handing the
+      // directory back to the caller.
+      st = await lstat(dir);
+      if (st.isSymbolicLink() || !st.isDirectory()) {
+        throw new Error(
+          `Upload directory changed unexpectedly during mode apply: ${dir}`,
+        );
+      }
+    }
+
     const actualMode = st.mode & 0o7777;
     if (actualMode !== contract.mode) {
       throw new Error(
         `Upload directory has unexpected mode ${actualMode.toString(8)} (expected ${contract.mode.toString(8)}): ${dir}`,
-      );
-    }
-    if (contract.expectedGid !== null && st.gid !== contract.expectedGid) {
-      throw new Error(
-        `Upload directory has unexpected group gid=${st.gid} (expected ${contract.expectedGid}): ${dir}`,
       );
     }
   } catch (err) {

--- a/packages/server/src/routes/workers.ts
+++ b/packages/server/src/routes/workers.ts
@@ -37,6 +37,25 @@ const logger = createLogger('api:workers');
 //     per-user PTY (running as the logged-in user, who is also a member of
 //     the shared group) traverse into the buffer to read attachments.
 //
+// Setgid is applied via an explicit chmod(1) AFTER mkdir (#830 follow-up):
+//   - Bun 1.3.10 strips the special bits (setgid 0o2000 / setuid 0o4000 /
+//     sticky 0o1000) in its JS layer BEFORE the syscall, for both
+//     `fs.mkdir({ mode })` and `fs.chmod(dir, mode)`. Verified by strace:
+//     `await mkdir(dir, { mode: 0o2750 })` issues `mkdirat(..., 0750)`
+//     (setgid dropped) and `await chmod(dir, 0o2750)` issues
+//     `fchmodat(..., 0750)` (likewise). The kernel and the underlying
+//     filesystem both honour setgid when called directly (e.g. shell
+//     `mkdir --mode=2750` or `chmod 2750` produce `drwxr-s---`), but the
+//     Bun bindings never pass the bit through.
+//   - GNU chmod (coreutils) does pass the bit through. We therefore shell
+//     out to /bin/chmod via Bun.spawn under the multi-user (mode > 0o777)
+//     branch only. Cost is one spawn per upload on the multi-user
+//     multipart path, which is already disk-bound. The single-user 0o700
+//     path does not need this and stays mkdir-only.
+//   - If a future Bun release fixes its JS-layer mode stripping, the
+//     `workers-upload-dir-real-fs.test.ts` kernel-level probe will flag
+//     the change and the in-process chmod step can replace the shell-out.
+//
 // No in-process readiness cache (Issue #830): the directory is re-verified
 // on every upload so that if /tmp is reaped by systemd-tmpfiles during a
 // long-running server's uptime, the next upload recreates the directory.
@@ -63,6 +82,38 @@ function resolveUploadDirContract(): UploadDirContract {
   return { mode: SINGLE_USER_UPLOAD_DIR_MODE, expectedGid: null };
 }
 
+/**
+ * Apply a mode containing special bits (setgid / setuid / sticky) via the
+ * external chmod(1) program.
+ *
+ * Bun 1.3.10 strips special bits in its JS layer for both `fs.mkdir` and
+ * `fs.chmod` (verified via strace: setgid / setuid / sticky never reach
+ * the syscall). GNU chmod does pass them through. coreutils chmod is
+ * present on every Debian / Ubuntu / RHEL / Alpine host the server is
+ * expected to run on.
+ *
+ * See the file-header comment block and the kernel-level probe in
+ * `workers-upload-dir-real-fs.test.ts` for the empirical assumptions
+ * this workaround locks in.
+ */
+async function applyModeViaSpawnChmod(dir: string, mode: number): Promise<void> {
+  // chmod accepts an octal string (e.g. "2750"); pass full mode including
+  // special bits, masked at 0o7777 to defend against accidental higher-bit
+  // garbage in the caller.
+  const modeStr = (mode & 0o7777).toString(8);
+  const proc = Bun.spawn(['chmod', modeStr, dir], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(
+      `chmod ${modeStr} failed (exit=${exitCode}) for ${dir}: ${stderr.trim()}`,
+    );
+  }
+}
+
 async function ensureUploadDir(): Promise<string> {
   const dir = resolveUploadDir();
   const contract = resolveUploadDirContract();
@@ -73,6 +124,13 @@ async function ensureUploadDir(): Promise<string> {
   // not match the expected owner / mode / group.
   try {
     await mkdir(dir, { recursive: true, mode: contract.mode });
+    // Bun 1.3.10 strips setgid / setuid / sticky in its fs.mkdir JS
+    // layer before the syscall; for the multi-user 2750 contract we
+    // re-apply the bit via chmod(1). See the file header comment for
+    // the upstream-gap rationale.
+    if ((contract.mode & ~0o777) !== 0) {
+      await applyModeViaSpawnChmod(dir, contract.mode);
+    }
     const st = await lstat(dir);
     if (st.isSymbolicLink()) {
       throw new Error(`Upload directory is a symlink: ${dir}`);
@@ -314,3 +372,14 @@ const workers = new Hono<AppBindings>()
   });
 
 export { workers };
+
+/**
+ * @internal Exported for the real-fs regression test in
+ * `workers-upload-dir-real-fs.test.ts` (Issue #830 follow-up). Production
+ * callers should never reach for these; they go through the route handler.
+ */
+export const __TESTING__ = {
+  ensureUploadDir,
+  resolveUploadDir,
+  resolveUploadDirContract,
+};

--- a/packages/server/src/routes/workers.ts
+++ b/packages/server/src/routes/workers.ts
@@ -26,69 +26,85 @@ const logger = createLogger('api:workers');
 //      tmpwatch, reboot), so abandoned upload buffers do not accumulate. The
 //      server has no read-completion signal for `injectMessage`, so a
 //      persistent location (e.g. AGENT_CONSOLE_HOME) would leak disk over time.
-// Mode 0700 prevents other users from reading buffered file contents.
-// See issue #821.
-const uploadDirReady = new Map<string, Promise<void>>();
+//
+// Mode and group depend on AUTH_MODE (Issue #830):
+//   - AUTH_MODE=none (single-user): mode 0700, owner-only. Prevents other
+//     users on the same host from reading buffered file contents.
+//   - AUTH_MODE=multi-user: mode 2750 (setgid + group-rx), owner = service
+//     user, group = shared group (the server process's primary gid — the
+//     bootstrap script sets `Group=<shared-group>` on the systemd unit, so
+//     `process.getgid()` is the shared group at runtime). This lets the
+//     per-user PTY (running as the logged-in user, who is also a member of
+//     the shared group) traverse into the buffer to read attachments.
+//
+// No in-process readiness cache (Issue #830): the directory is re-verified
+// on every upload so that if /tmp is reaped by systemd-tmpfiles during a
+// long-running server's uptime, the next upload recreates the directory.
+// `mkdir(..., { recursive: true })` is a cheap idempotent no-op when the
+// directory exists, and the per-upload cost is one mkdir + one lstat —
+// negligible at upload frequency.
+const SINGLE_USER_UPLOAD_DIR_MODE = 0o700;
+const MULTI_USER_UPLOAD_DIR_MODE = 0o2750;
+
+interface UploadDirContract {
+  mode: number;
+  expectedGid: number | null;
+}
 
 function resolveUploadDir(): string {
   const uid = typeof process.geteuid === 'function' ? process.geteuid() : 'shared';
   return join(tmpdir(), `agent-console-uploads-${uid}`);
 }
 
-async function ensureUploadDir(): Promise<string> {
-  const dir = resolveUploadDir();
-  let ready = uploadDirReady.get(dir);
-  if (!ready) {
-    // TOCTOU defense (security review HIGH, #821 follow-up): POSIX mkdir is a
-    // no-op when the target already exists, so a pre-created symlink or a
-    // world-readable dir would silently slip past `mkdir(..., { mode: 0o700 })`.
-    // After mkdir, lstat the path (no symlink follow) and reject anything we
-    // did not just create ourselves with the expected owner and mode.
-    ready = (async () => {
-      await mkdir(dir, { recursive: true, mode: 0o700 });
-      const st = await lstat(dir);
-      if (st.isSymbolicLink()) {
-        throw new Error(`Upload directory is a symlink: ${dir}`);
-      }
-      if (!st.isDirectory()) {
-        throw new Error(`Upload directory path is not a directory: ${dir}`);
-      }
-      // POSIX-only ownership check; on Windows (or any platform without
-      // geteuid) the fallback path is the shared 'shared' suffix and there is
-      // no uid to compare against.
-      if (typeof process.geteuid === 'function' && st.uid !== process.geteuid()) {
-        throw new Error(
-          `Upload directory has unexpected owner uid=${st.uid} (expected ${process.geteuid()}): ${dir}`,
-        );
-      }
-      if ((st.mode & 0o777) !== 0o700) {
-        throw new Error(
-          `Upload directory has unexpected mode ${(st.mode & 0o777).toString(8)} (expected 700): ${dir}`,
-        );
-      }
-    })().catch((err) => {
-      uploadDirReady.delete(dir);
-      logger.error({ err, dir }, 'Upload directory verification failed');
-      throw err;
-    });
-    uploadDirReady.set(dir, ready);
+function resolveUploadDirContract(): UploadDirContract {
+  if (process.env.AUTH_MODE === 'multi-user' && typeof process.getgid === 'function') {
+    return { mode: MULTI_USER_UPLOAD_DIR_MODE, expectedGid: process.getgid() };
   }
-  await ready;
-  return dir;
+  return { mode: SINGLE_USER_UPLOAD_DIR_MODE, expectedGid: null };
 }
 
-/**
- * @internal Exported for testing. The upload-directory readiness cache is
- * process-global so that the route only pays the mkdir + verification cost
- * once per uid per process. Tests need a way to invalidate the cache when
- * they want to re-exercise the verification path with a different on-disk
- * (memfs) state.
- */
-export const __TESTING__ = {
-  resetUploadDirCache: (): void => {
-    uploadDirReady.clear();
-  },
-};
+async function ensureUploadDir(): Promise<string> {
+  const dir = resolveUploadDir();
+  const contract = resolveUploadDirContract();
+  // TOCTOU defense (security review HIGH, #821 follow-up): POSIX mkdir is a
+  // no-op when the target already exists, so a pre-created symlink or a
+  // wider-mode dir would silently slip past `mkdir(..., { mode })`. After
+  // mkdir, lstat the path (no symlink follow) and reject anything that does
+  // not match the expected owner / mode / group.
+  try {
+    await mkdir(dir, { recursive: true, mode: contract.mode });
+    const st = await lstat(dir);
+    if (st.isSymbolicLink()) {
+      throw new Error(`Upload directory is a symlink: ${dir}`);
+    }
+    if (!st.isDirectory()) {
+      throw new Error(`Upload directory path is not a directory: ${dir}`);
+    }
+    // POSIX-only ownership check; on Windows (or any platform without
+    // geteuid) the fallback path is the shared 'shared' suffix and there is
+    // no uid to compare against.
+    if (typeof process.geteuid === 'function' && st.uid !== process.geteuid()) {
+      throw new Error(
+        `Upload directory has unexpected owner uid=${st.uid} (expected ${process.geteuid()}): ${dir}`,
+      );
+    }
+    const actualMode = st.mode & 0o7777;
+    if (actualMode !== contract.mode) {
+      throw new Error(
+        `Upload directory has unexpected mode ${actualMode.toString(8)} (expected ${contract.mode.toString(8)}): ${dir}`,
+      );
+    }
+    if (contract.expectedGid !== null && st.gid !== contract.expectedGid) {
+      throw new Error(
+        `Upload directory has unexpected group gid=${st.gid} (expected ${contract.expectedGid}): ${dir}`,
+      );
+    }
+  } catch (err) {
+    logger.error({ err, dir }, 'Upload directory verification failed');
+    throw err;
+  }
+  return dir;
+}
 
 const workers = new Hono<AppBindings>()
   // Get workers for a session

--- a/scripts/add-multiuser-user.sh
+++ b/scripts/add-multiuser-user.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Add an existing OS user to the Agent Console shared group so they can access
+# shared data (worktrees, repositories, etc.) in multi-user mode.
+#
+# Usage:
+#   sudo scripts/add-multiuser-user.sh <username>
+#   sudo scripts/add-multiuser-user.sh <username> --group <group-name>
+#
+# Idempotent: a second invocation with the same arguments is a no-op.
+#
+# Environment overrides:
+#   AGENT_CONSOLE_SERVICE_GROUP — default group name (overridden by --group).
+
+set -euo pipefail
+
+DEFAULT_GROUP="${AGENT_CONSOLE_SERVICE_GROUP:-agent-console-users}"
+
+# POSIX username regex (login name): start with a letter or underscore, then
+# letters / digits / hyphen / underscore, max 31 chars total.
+USERNAME_REGEX='^[a-z_][a-z0-9_-]{0,30}$'
+
+err() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage: add-multiuser-user.sh <username> [--group <group-name>]
+
+  username        OS user to add to the shared group (must already exist).
+  --group <name>  Group name (default: agent-console-users, or
+                  $AGENT_CONSOLE_SERVICE_GROUP if set).
+EOF
+}
+
+if [ "$#" -lt 1 ]; then
+  usage >&2
+  exit 2
+fi
+
+USERNAME=""
+GROUP_NAME=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --group)
+      [ "$#" -ge 2 ] || err "--group requires an argument"
+      GROUP_NAME="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    -*)
+      err "unknown flag: $1"
+      ;;
+    *)
+      if [ -z "$USERNAME" ]; then
+        USERNAME="$1"
+        shift
+      else
+        err "unexpected positional argument: $1"
+      fi
+      ;;
+  esac
+done
+
+[ -n "$USERNAME" ] || { usage >&2; exit 2; }
+GROUP_NAME="${GROUP_NAME:-$DEFAULT_GROUP}"
+
+# Validate identifiers.
+if ! echo "$USERNAME" | grep -Eq "$USERNAME_REGEX"; then
+  err "invalid username '$USERNAME' (must match $USERNAME_REGEX)"
+fi
+if ! echo "$GROUP_NAME" | grep -Eq "$USERNAME_REGEX"; then
+  err "invalid group name '$GROUP_NAME' (must match $USERNAME_REGEX)"
+fi
+
+# Existence checks.
+if ! getent passwd "$USERNAME" >/dev/null 2>&1; then
+  err "user '$USERNAME' does not exist on this host"
+fi
+if ! getent group "$GROUP_NAME" >/dev/null 2>&1; then
+  err "group '$GROUP_NAME' does not exist; run scripts/setup-multiuser-for-ubuntu.sh first"
+fi
+
+# Idempotency check — is the user already a member of the group?
+if id -nG "$USERNAME" | tr ' ' '\n' | grep -Fxq "$GROUP_NAME"; then
+  echo "==> '$USERNAME' is already a member of '$GROUP_NAME'; nothing to do."
+  exit 0
+fi
+
+echo "==> Adding '$USERNAME' to group '$GROUP_NAME'"
+usermod -aG "$GROUP_NAME" "$USERNAME"
+
+# Verify.
+if id -nG "$USERNAME" | tr ' ' '\n' | grep -Fxq "$GROUP_NAME"; then
+  echo "==> '$USERNAME' is now a member of '$GROUP_NAME'."
+  echo ""
+  echo "Note: '$USERNAME' must log out and back in (or start a fresh session)"
+  echo "for the new group membership to take effect."
+else
+  err "usermod completed but '$USERNAME' is not a member of '$GROUP_NAME'"
+fi

--- a/scripts/agent-console-multiuser.service.template
+++ b/scripts/agent-console-multiuser.service.template
@@ -4,8 +4,9 @@ After=network.target
 
 [Service]
 Type=simple
-User=agentconsole
-Group=agentconsole
+User={{SERVICE_USER}}
+Group={{SERVICE_GROUP}}
+UMask=0002
 WorkingDirectory={{HOME}}/agent-console
 ExecStart={{BUN_PATH}} run start
 Restart=on-failure
@@ -13,6 +14,7 @@ RestartSec=5
 
 Environment=PATH={{HOME}}/.bun/bin:/usr/local/bin:/usr/bin:/bin
 Environment=AUTH_MODE=multi-user
+Environment=AGENT_CONSOLE_HOME={{DATA_ROOT}}
 Environment=PORT={{PORT}}
 Environment=HOST=0.0.0.0
 Environment=NODE_ENV=production

--- a/scripts/setup-multiuser-for-ubuntu.sh
+++ b/scripts/setup-multiuser-for-ubuntu.sh
@@ -345,10 +345,7 @@ else
     echo "    $SUDOERS_TARGET is already up to date."
   else
     if [ -f "$SUDOERS_TARGET" ] && [ "$FORCE" -eq 0 ]; then
-      # Re-validate via visudo as a sanity check before overwrite.
-      echo "    $SUDOERS_TARGET exists and differs from the rendered template;"
-      echo "    overwriting (this is the documented update path; re-run with"
-      echo "    --force to suppress this message)."
+      err "$SUDOERS_TARGET exists and differs from the rendered template; re-run with --force to overwrite"
     fi
     run install -m 0440 -o root -g root "$TMP_SUDOERS" "$SUDOERS_TARGET"
     # Re-verify final state.
@@ -373,7 +370,11 @@ if [ -d "$DATA_ROOT" ]; then
   echo "    $DATA_ROOT exists (owner=$CURRENT_OWNER mode=$CURRENT_MODE)"
   if [ "$CURRENT_OWNER" != "$EXPECTED_OWNER" ] || [ "$CURRENT_MODE" != "2775" ]; then
     if [ "$FORCE" -eq 0 ]; then
-      echo "    expected owner=$EXPECTED_OWNER mode=2775; pass --force to fix in-place"
+      if [ "$DRY_RUN" -eq 1 ]; then
+        echo "    (would abort: $DATA_ROOT has owner/mode drift; re-run with --force to repair)"
+      else
+        err "$DATA_ROOT has owner/mode drift (expected owner=$EXPECTED_OWNER mode=2775); re-run with --force to repair"
+      fi
     else
       run chown "$EXPECTED_OWNER" "$DATA_ROOT"
       run chmod 2775 "$DATA_ROOT"
@@ -448,6 +449,9 @@ else
   if [ -f "$SYSTEMD_TARGET" ] && diff -q "$TMP_UNIT" "$SYSTEMD_TARGET" >/dev/null 2>&1; then
     echo "    $SYSTEMD_TARGET is already up to date."
   else
+    if [ -f "$SYSTEMD_TARGET" ] && [ "$FORCE" -eq 0 ]; then
+      err "$SYSTEMD_TARGET exists and differs from the rendered template; re-run with --force to overwrite"
+    fi
     run install -m 0644 -o root -g root "$TMP_UNIT" "$SYSTEMD_TARGET"
   fi
 fi

--- a/scripts/setup-multiuser-for-ubuntu.sh
+++ b/scripts/setup-multiuser-for-ubuntu.sh
@@ -1,0 +1,485 @@
+#!/usr/bin/env bash
+#
+# One-shot multi-user bootstrap for Agent Console on Ubuntu / Debian.
+#
+# Performs the steps from docs/multi-user-setup-guide.md as a single
+# idempotent operation:
+#
+#   1. Install pamtester via apt (Linux credential validation hard dependency).
+#   2. Create the service user (--system, --create-home, --shell /usr/sbin/nologin).
+#      Add to the `shadow` group so pam_unix can verify users' passwords.
+#   3. Create the shared system group; add the service user and any
+#      operator-specified login users.
+#   4. Install the sudoers fragment from the canonical template at
+#      scripts/sudoers-agent-console.template. Print the rendered file,
+#      validate with `visudo -cf`, then `install -m 0440 -o root -g root`.
+#   5. Create the data root (default /var/lib/agent-console) with
+#      <service-user>:<shared-group> mode 2775.
+#   6. Clone (or rsync) the application into the service user's home;
+#      `bun install --production`.
+#   7. Render the systemd unit from scripts/agent-console-multiuser.service.template
+#      with UMask=0002, AUTH_MODE=multi-user, AGENT_CONSOLE_HOME=<data-root>.
+#   8. `systemctl daemon-reload && systemctl enable --now agent-console`.
+#
+# Idempotency: a second invocation with the same parameters is a no-op
+# (existing user / group / dir / unit / sudoers are detected and re-verified).
+# If a parameter differs from existing state, abort unless --force.
+#
+# Usage:
+#   sudo scripts/setup-multiuser-for-ubuntu.sh                      # defaults
+#   sudo scripts/setup-multiuser-for-ubuntu.sh --port 9000
+#   sudo scripts/setup-multiuser-for-ubuntu.sh --add-user alice --add-user bob
+#   sudo scripts/setup-multiuser-for-ubuntu.sh --dry-run            # preview
+#
+# CLI flags > env vars > built-in defaults. Env vars:
+#   AGENT_CONSOLE_SERVICE_USER, AGENT_CONSOLE_SERVICE_GROUP,
+#   AGENT_CONSOLE_DATA_ROOT, AGENT_CONSOLE_PORT,
+#   AGENT_CONSOLE_AUTH_COOKIE_SECURE, AGENT_CONSOLE_INITIAL_USERS
+#   (whitespace-separated list of usernames; equivalent to repeated --add-user).
+#
+# Documentation: docs/multi-user-setup-guide.md
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults + parameter parsing
+# ---------------------------------------------------------------------------
+
+DEFAULT_SERVICE_USER="agentconsole"
+DEFAULT_SERVICE_GROUP="agent-console-users"
+DEFAULT_DATA_ROOT="/var/lib/agent-console"
+DEFAULT_PORT="8080"
+DEFAULT_AUTH_COOKIE_SECURE="false"
+
+SERVICE_USER="${AGENT_CONSOLE_SERVICE_USER:-$DEFAULT_SERVICE_USER}"
+SERVICE_GROUP="${AGENT_CONSOLE_SERVICE_GROUP:-$DEFAULT_SERVICE_GROUP}"
+DATA_ROOT="${AGENT_CONSOLE_DATA_ROOT:-$DEFAULT_DATA_ROOT}"
+PORT="${AGENT_CONSOLE_PORT:-$DEFAULT_PORT}"
+AUTH_COOKIE_SECURE="${AGENT_CONSOLE_AUTH_COOKIE_SECURE:-$DEFAULT_AUTH_COOKIE_SECURE}"
+
+# Initial users: env var holds a whitespace-separated list; CLI --add-user
+# extends it (repeatable).
+INITIAL_USERS=()
+if [ -n "${AGENT_CONSOLE_INITIAL_USERS:-}" ]; then
+  # shellcheck disable=SC2206
+  INITIAL_USERS=(${AGENT_CONSOLE_INITIAL_USERS})
+fi
+
+DRY_RUN=0
+FORCE=0
+REPO_SOURCE=""  # optional path or URL; defaults to upstream clone
+
+# POSIX-conventional login name regex.
+USERNAME_REGEX='^[a-z_][a-z0-9_-]{0,30}$'
+
+err() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage: setup-multiuser-for-ubuntu.sh [options]
+
+Options:
+  --user <name>          Service user (default: agentconsole)
+  --group <name>         Shared group (default: agent-console-users)
+  --data-root <path>     Data root (default: /var/lib/agent-console)
+  --port <num>           Server port (default: 8080)
+  --cookie-secure <bool> AUTH_COOKIE_SECURE (true|false, default: false)
+  --add-user <username>  OS user to add to the shared group (repeatable)
+  --repo-source <ref>    Local path or git URL to install from
+                         (default: https://github.com/ms2sato/agent-console.git)
+  --force                Overwrite existing state that conflicts with the
+                         requested parameters (use with caution)
+  --dry-run              Print all actions; do not modify the system
+  -h, --help             Show this help and exit
+
+Environment overrides (env vars are used when the matching flag is omitted):
+  AGENT_CONSOLE_SERVICE_USER, AGENT_CONSOLE_SERVICE_GROUP,
+  AGENT_CONSOLE_DATA_ROOT, AGENT_CONSOLE_PORT,
+  AGENT_CONSOLE_AUTH_COOKIE_SECURE, AGENT_CONSOLE_INITIAL_USERS
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --user)
+      [ "$#" -ge 2 ] || err "--user requires an argument"
+      SERVICE_USER="$2"; shift 2 ;;
+    --group)
+      [ "$#" -ge 2 ] || err "--group requires an argument"
+      SERVICE_GROUP="$2"; shift 2 ;;
+    --data-root)
+      [ "$#" -ge 2 ] || err "--data-root requires an argument"
+      DATA_ROOT="$2"; shift 2 ;;
+    --port)
+      [ "$#" -ge 2 ] || err "--port requires an argument"
+      PORT="$2"; shift 2 ;;
+    --cookie-secure)
+      [ "$#" -ge 2 ] || err "--cookie-secure requires an argument"
+      AUTH_COOKIE_SECURE="$2"; shift 2 ;;
+    --add-user)
+      [ "$#" -ge 2 ] || err "--add-user requires an argument"
+      INITIAL_USERS+=("$2"); shift 2 ;;
+    --repo-source)
+      [ "$#" -ge 2 ] || err "--repo-source requires an argument"
+      REPO_SOURCE="$2"; shift 2 ;;
+    --force)
+      FORCE=1; shift ;;
+    --dry-run)
+      DRY_RUN=1; shift ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      err "unknown argument: $1" ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+if ! echo "$SERVICE_USER" | grep -Eq "$USERNAME_REGEX"; then
+  err "invalid --user '$SERVICE_USER' (must match $USERNAME_REGEX)"
+fi
+if ! echo "$SERVICE_GROUP" | grep -Eq "$USERNAME_REGEX"; then
+  err "invalid --group '$SERVICE_GROUP' (must match $USERNAME_REGEX)"
+fi
+if ! [[ "$PORT" =~ ^[0-9]+$ ]] || [ "$PORT" -lt 1 ] || [ "$PORT" -gt 65535 ]; then
+  err "invalid --port '$PORT' (must be an integer in [1, 65535])"
+fi
+case "$AUTH_COOKIE_SECURE" in
+  true|false) ;;
+  *) err "invalid --cookie-secure '$AUTH_COOKIE_SECURE' (must be 'true' or 'false')" ;;
+esac
+case "$DATA_ROOT" in
+  /*) ;;
+  *) err "invalid --data-root '$DATA_ROOT' (must be an absolute path)" ;;
+esac
+if echo "$DATA_ROOT" | grep -q '\.\.'; then
+  err "invalid --data-root '$DATA_ROOT' (path traversal pattern '..' not allowed)"
+fi
+DATA_ROOT_PARENT="$(dirname "$DATA_ROOT")"
+if [ ! -d "$DATA_ROOT_PARENT" ]; then
+  err "parent directory '$DATA_ROOT_PARENT' of --data-root does not exist"
+fi
+for u in "${INITIAL_USERS[@]+"${INITIAL_USERS[@]}"}"; do
+  if ! echo "$u" | grep -Eq "$USERNAME_REGEX"; then
+    err "invalid --add-user '$u' (must match $USERNAME_REGEX)"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SUDOERS_TEMPLATE="$SCRIPT_DIR/sudoers-agent-console.template"
+SYSTEMD_TEMPLATE="$SCRIPT_DIR/agent-console-multiuser.service.template"
+SUDOERS_TARGET="/etc/sudoers.d/agent-console"
+SYSTEMD_TARGET="/etc/systemd/system/agent-console.service"
+
+if [ ! -f "$SUDOERS_TEMPLATE" ]; then
+  err "missing template: $SUDOERS_TEMPLATE"
+fi
+if [ ! -f "$SYSTEMD_TEMPLATE" ]; then
+  err "missing template: $SYSTEMD_TEMPLATE"
+fi
+
+require_root() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    return 0
+  fi
+  if [ "$(id -u)" -ne 0 ]; then
+    err "this script must be run as root (use the sudoers-allowed wrapper or run as root)"
+  fi
+}
+
+run() {
+  # Print + run, unless --dry-run.
+  echo "+ $*"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    "$@"
+  fi
+}
+
+heading() {
+  echo ""
+  echo "==> $*"
+}
+
+# Render the systemd unit to stdout from the template.
+render_systemd_unit() {
+  local service_home
+  service_home="$(getent passwd "$SERVICE_USER" 2>/dev/null | cut -d: -f6 || true)"
+  # During --dry-run before the user is created, fall back to a synthetic
+  # /home path so the rendered output is still inspectable.
+  if [ -z "$service_home" ]; then
+    service_home="/home/$SERVICE_USER"
+  fi
+  local bun_path
+  bun_path="$service_home/.bun/bin/bun"
+  sed \
+    -e "s|{{SERVICE_USER}}|$SERVICE_USER|g" \
+    -e "s|{{SERVICE_GROUP}}|$SERVICE_GROUP|g" \
+    -e "s|{{HOME}}|$service_home|g" \
+    -e "s|{{BUN_PATH}}|$bun_path|g" \
+    -e "s|{{DATA_ROOT}}|$DATA_ROOT|g" \
+    -e "s|{{PORT}}|$PORT|g" \
+    -e "s|{{AUTH_COOKIE_SECURE}}|$AUTH_COOKIE_SECURE|g" \
+    "$SYSTEMD_TEMPLATE"
+}
+
+# ---------------------------------------------------------------------------
+# Banner
+# ---------------------------------------------------------------------------
+
+echo "Agent Console multi-user bootstrap"
+echo "----------------------------------"
+echo "  service user        : $SERVICE_USER"
+echo "  shared group        : $SERVICE_GROUP"
+echo "  data root           : $DATA_ROOT"
+echo "  port                : $PORT"
+echo "  AUTH_COOKIE_SECURE  : $AUTH_COOKIE_SECURE"
+if [ "${#INITIAL_USERS[@]}" -gt 0 ]; then
+  echo "  initial users       : ${INITIAL_USERS[*]}"
+else
+  echo "  initial users       : (none)"
+fi
+echo "  dry run             : $([ "$DRY_RUN" -eq 1 ] && echo yes || echo no)"
+echo "  force               : $([ "$FORCE" -eq 1 ] && echo yes || echo no)"
+echo ""
+
+require_root
+
+# ---------------------------------------------------------------------------
+# Step 1 — pamtester
+# ---------------------------------------------------------------------------
+
+heading "Step 1/8 — apt + pamtester"
+if command -v pamtester >/dev/null 2>&1; then
+  echo "    pamtester is already installed; skipping."
+else
+  if ! command -v apt-get >/dev/null 2>&1; then
+    err "apt-get not available; this script targets Debian / Ubuntu"
+  fi
+  run apt-get update
+  run apt-get install -y --no-install-recommends pamtester
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — service user
+# ---------------------------------------------------------------------------
+
+heading "Step 2/8 — service user '$SERVICE_USER'"
+if getent passwd "$SERVICE_USER" >/dev/null 2>&1; then
+  echo "    user '$SERVICE_USER' already exists; verifying group membership"
+else
+  run useradd --system --create-home --shell /usr/sbin/nologin "$SERVICE_USER"
+fi
+# Add to `shadow` group so pam_unix can validate users' passwords without root.
+if id -nG "$SERVICE_USER" 2>/dev/null | tr ' ' '\n' | grep -Fxq "shadow"; then
+  echo "    '$SERVICE_USER' is already in the 'shadow' group."
+else
+  run usermod -aG shadow "$SERVICE_USER"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — shared group + initial users
+# ---------------------------------------------------------------------------
+
+heading "Step 3/8 — shared group '$SERVICE_GROUP'"
+if getent group "$SERVICE_GROUP" >/dev/null 2>&1; then
+  echo "    group '$SERVICE_GROUP' already exists."
+else
+  run groupadd --system "$SERVICE_GROUP"
+fi
+# Ensure the service user is in the shared group.
+if id -nG "$SERVICE_USER" 2>/dev/null | tr ' ' '\n' | grep -Fxq "$SERVICE_GROUP"; then
+  echo "    '$SERVICE_USER' is already a member of '$SERVICE_GROUP'."
+else
+  run usermod -aG "$SERVICE_GROUP" "$SERVICE_USER"
+fi
+# Optional initial users.
+for u in "${INITIAL_USERS[@]+"${INITIAL_USERS[@]}"}"; do
+  if ! getent passwd "$u" >/dev/null 2>&1; then
+    echo "    warning: --add-user '$u' does not exist on this host; skipping" >&2
+    continue
+  fi
+  if id -nG "$u" | tr ' ' '\n' | grep -Fxq "$SERVICE_GROUP"; then
+    echo "    '$u' is already a member of '$SERVICE_GROUP'."
+  else
+    run usermod -aG "$SERVICE_GROUP" "$u"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Step 4 — sudoers
+# ---------------------------------------------------------------------------
+
+heading "Step 4/8 — sudoers fragment at $SUDOERS_TARGET"
+RENDERED_SUDOERS="$(sed "s|{{SERVICE_USER}}|$SERVICE_USER|g" "$SUDOERS_TEMPLATE")"
+echo "    Target path : $SUDOERS_TARGET"
+echo "    Target owner: root:root  Mode: 0440"
+echo "    --- Rendered content (start) ---"
+echo "$RENDERED_SUDOERS"
+echo "    --- Rendered content (end) ---"
+
+# Always validate syntax via visudo -cf, regardless of dry-run.
+TMP_SUDOERS="$(mktemp -t agent-console-sudoers.XXXXXX)"
+trap 'rm -f "$TMP_SUDOERS"' EXIT
+echo "$RENDERED_SUDOERS" > "$TMP_SUDOERS"
+chmod 0440 "$TMP_SUDOERS" || true
+if ! visudo -cf "$TMP_SUDOERS"; then
+  err "sudoers syntax validation failed; refusing to install"
+fi
+echo "    visudo syntax check: OK"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "    --dry-run: skipping sudoers installation"
+else
+  # Idempotency: compare to existing file content, install only if different.
+  if [ -f "$SUDOERS_TARGET" ] && diff -q "$TMP_SUDOERS" "$SUDOERS_TARGET" >/dev/null 2>&1; then
+    echo "    $SUDOERS_TARGET is already up to date."
+  else
+    if [ -f "$SUDOERS_TARGET" ] && [ "$FORCE" -eq 0 ]; then
+      # Re-validate via visudo as a sanity check before overwrite.
+      echo "    $SUDOERS_TARGET exists and differs from the rendered template;"
+      echo "    overwriting (this is the documented update path; re-run with"
+      echo "    --force to suppress this message)."
+    fi
+    run install -m 0440 -o root -g root "$TMP_SUDOERS" "$SUDOERS_TARGET"
+    # Re-verify final state.
+    FINAL_MODE="$(stat -c '%a' "$SUDOERS_TARGET")"
+    FINAL_OWNER="$(stat -c '%U:%G' "$SUDOERS_TARGET")"
+    echo "    installed: mode=$FINAL_MODE owner=$FINAL_OWNER"
+    if [ "$FINAL_MODE" != "440" ] || [ "$FINAL_OWNER" != "root:root" ]; then
+      err "post-install verification failed: expected mode=440 owner=root:root"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5 — data root
+# ---------------------------------------------------------------------------
+
+heading "Step 5/8 — data root $DATA_ROOT"
+if [ -d "$DATA_ROOT" ]; then
+  CURRENT_OWNER="$(stat -c '%U:%G' "$DATA_ROOT" 2>/dev/null || echo unknown)"
+  CURRENT_MODE="$(stat -c '%a' "$DATA_ROOT" 2>/dev/null || echo unknown)"
+  EXPECTED_OWNER="$SERVICE_USER:$SERVICE_GROUP"
+  echo "    $DATA_ROOT exists (owner=$CURRENT_OWNER mode=$CURRENT_MODE)"
+  if [ "$CURRENT_OWNER" != "$EXPECTED_OWNER" ] || [ "$CURRENT_MODE" != "2775" ]; then
+    if [ "$FORCE" -eq 0 ]; then
+      echo "    expected owner=$EXPECTED_OWNER mode=2775; pass --force to fix in-place"
+    else
+      run chown "$EXPECTED_OWNER" "$DATA_ROOT"
+      run chmod 2775 "$DATA_ROOT"
+    fi
+  fi
+else
+  run install -d -o "$SERVICE_USER" -g "$SERVICE_GROUP" -m 2775 "$DATA_ROOT"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6 — application install
+# ---------------------------------------------------------------------------
+
+heading "Step 6/8 — application install"
+SERVICE_HOME="$(getent passwd "$SERVICE_USER" 2>/dev/null | cut -d: -f6 || true)"
+if [ -z "$SERVICE_HOME" ]; then
+  if [ "$DRY_RUN" -eq 1 ]; then
+    SERVICE_HOME="/home/$SERVICE_USER"
+    echo "    (dry-run) assuming service user HOME is $SERVICE_HOME"
+  else
+    err "could not resolve HOME for '$SERVICE_USER'"
+  fi
+fi
+APP_DIR="$SERVICE_HOME/agent-console"
+if [ -d "$APP_DIR/.git" ] || [ -f "$APP_DIR/package.json" ]; then
+  echo "    application already present at $APP_DIR; skipping clone"
+  echo "    (run 'cd $APP_DIR && git pull && bun install --production' to update)"
+else
+  if [ -n "$REPO_SOURCE" ]; then
+    # Local checkout or explicit URL.
+    if [ -d "$REPO_SOURCE" ]; then
+      echo "    copying from local path: $REPO_SOURCE"
+      run install -d -o "$SERVICE_USER" -g "$SERVICE_GROUP" -m 0755 "$APP_DIR"
+      run rsync -a --delete --exclude=node_modules --exclude='.git' \
+        "$REPO_SOURCE/" "$APP_DIR/"
+      run chown -R "$SERVICE_USER:$SERVICE_GROUP" "$APP_DIR"
+    else
+      echo "    cloning from: $REPO_SOURCE"
+      run sudo -u "$SERVICE_USER" git clone "$REPO_SOURCE" "$APP_DIR"
+    fi
+  else
+    DEFAULT_REPO_URL="https://github.com/ms2sato/agent-console.git"
+    echo "    cloning from default upstream: $DEFAULT_REPO_URL"
+    run sudo -u "$SERVICE_USER" git clone "$DEFAULT_REPO_URL" "$APP_DIR"
+  fi
+  # Skip bun install during dry-run since the app may not exist yet.
+  if [ "$DRY_RUN" -eq 0 ]; then
+    if ! sudo -u "$SERVICE_USER" -- bash -lc 'command -v bun' >/dev/null 2>&1; then
+      echo "    warning: 'bun' not on PATH for $SERVICE_USER; install bun then re-run" >&2
+    else
+      run sudo -u "$SERVICE_USER" -- bash -lc "cd '$APP_DIR' && bun install --production"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 7 — systemd unit
+# ---------------------------------------------------------------------------
+
+heading "Step 7/8 — systemd unit at $SYSTEMD_TARGET"
+RENDERED_UNIT="$(render_systemd_unit)"
+echo "    --- Rendered unit (start) ---"
+echo "$RENDERED_UNIT"
+echo "    --- Rendered unit (end) ---"
+TMP_UNIT="$(mktemp -t agent-console-unit.XXXXXX)"
+trap 'rm -f "$TMP_SUDOERS" "$TMP_UNIT"' EXIT
+echo "$RENDERED_UNIT" > "$TMP_UNIT"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "    --dry-run: skipping unit installation"
+else
+  if [ -f "$SYSTEMD_TARGET" ] && diff -q "$TMP_UNIT" "$SYSTEMD_TARGET" >/dev/null 2>&1; then
+    echo "    $SYSTEMD_TARGET is already up to date."
+  else
+    run install -m 0644 -o root -g root "$TMP_UNIT" "$SYSTEMD_TARGET"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 8 — daemon-reload + enable
+# ---------------------------------------------------------------------------
+
+heading "Step 8/8 — systemctl daemon-reload + enable --now"
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "    --dry-run: skipping systemctl"
+else
+  run systemctl daemon-reload
+  run systemctl enable --now agent-console
+fi
+
+# ---------------------------------------------------------------------------
+# Final summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Done. Verification commands:"
+echo ""
+if [ "$DRY_RUN" -eq 0 ]; then
+  echo "  sudo systemctl status agent-console --no-pager"
+  echo "  sudo journalctl -u agent-console -f"
+fi
+echo "  curl -fsS http://localhost:$PORT/api/config"
+echo ""
+echo "Add additional users with:"
+echo "  sudo scripts/add-multiuser-user.sh <username>"
+echo ""
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "(dry run; no system state was modified)"
+fi

--- a/scripts/sudoers-agent-console.template
+++ b/scripts/sudoers-agent-console.template
@@ -7,9 +7,7 @@
 # Both /bin/* and /usr/bin/* forms are listed because Ubuntu uses the
 # usr-merge layout (/bin -> /usr/bin); sudo matches the resolved command path.
 #
-# The leading identifier is rendered by the bootstrap script
-# (scripts/setup-multiuser-for-ubuntu.sh) from the {{SERVICE_USER}}
-# placeholder before this file is installed to /etc/sudoers.d/agent-console.
-# Render manually with:
-#   sed 's|{{SERVICE_USER}}|<your-user>|g' scripts/sudoers-agent-console.template
+# The leading identifier on the rule line below is the dedicated service
+# user. To rename it after install, edit BOTH this file's rule line and
+# the matching User= directive in /etc/systemd/system/agent-console.service.
 {{SERVICE_USER}} ALL=(ALL,!root) NOPASSWD: /bin/sh, /bin/bash, /usr/bin/sh, /usr/bin/bash

--- a/scripts/sudoers-agent-console.template
+++ b/scripts/sudoers-agent-console.template
@@ -1,0 +1,15 @@
+# Canonical sudoers template for the Agent Console service user.
+#
+# Allow the service user to launch login shells as any non-root user, without
+# a password prompt. This is the ONLY privilege the service user gets. The
+# server invokes: /usr/bin/sudo -u <user> -i sh -c '...'.
+#
+# Both /bin/* and /usr/bin/* forms are listed because Ubuntu uses the
+# usr-merge layout (/bin -> /usr/bin); sudo matches the resolved command path.
+#
+# The leading identifier is rendered by the bootstrap script
+# (scripts/setup-multiuser-for-ubuntu.sh) from the SERVICE_USER placeholder
+# before this file is installed to /etc/sudoers.d/agent-console. Render
+# manually with:
+#   sed 's|SERVICE_USER_PLACEHOLDER|<your-user>|g' scripts/sudoers-agent-console.template
+{{SERVICE_USER}} ALL=(ALL,!root) NOPASSWD: /bin/sh, /bin/bash, /usr/bin/sh, /usr/bin/bash

--- a/scripts/sudoers-agent-console.template
+++ b/scripts/sudoers-agent-console.template
@@ -8,8 +8,8 @@
 # usr-merge layout (/bin -> /usr/bin); sudo matches the resolved command path.
 #
 # The leading identifier is rendered by the bootstrap script
-# (scripts/setup-multiuser-for-ubuntu.sh) from the SERVICE_USER placeholder
-# before this file is installed to /etc/sudoers.d/agent-console. Render
-# manually with:
-#   sed 's|SERVICE_USER_PLACEHOLDER|<your-user>|g' scripts/sudoers-agent-console.template
+# (scripts/setup-multiuser-for-ubuntu.sh) from the {{SERVICE_USER}}
+# placeholder before this file is installed to /etc/sudoers.d/agent-console.
+# Render manually with:
+#   sed 's|{{SERVICE_USER}}|<your-user>|g' scripts/sudoers-agent-console.template
 {{SERVICE_USER}} ALL=(ALL,!root) NOPASSWD: /bin/sh, /bin/bash, /usr/bin/sh, /usr/bin/bash

--- a/scripts/verify-multiuser-docker.sh
+++ b/scripts/verify-multiuser-docker.sh
@@ -10,6 +10,10 @@
 #   5. PTY identity isolation: alice's terminal whoami => alice,
 #                              bob's   terminal whoami => bob
 #      (not the agentconsole service user) -> proves sudo -u <user> isolation
+#   6. file upload as alice creates /tmp/agent-console-uploads-<uid>/ with
+#      mode 2750 (setgid + group-rx) -> proves ensureUploadDir() applies
+#      setgid on the real Linux filesystem (Issue #830 follow-up regression
+#      for the JS-layer mode stripping in Bun fs.mkdir / fs.chmod).
 #
 # Usage (from repo root):
 #   scripts/verify-multiuser-docker.sh            # build + verify + tear down
@@ -113,6 +117,71 @@ bun "${REPO_ROOT}/docker/verify-client.ts" "$BASE_URL" alice alice-password alic
 check "alice terminal runs as alice" $?
 bun "${REPO_ROOT}/docker/verify-client.ts" "$BASE_URL" bob bob-password bob /home/bob
 check "bob terminal runs as bob" $?
+
+echo
+echo "=== 6. file upload as alice creates upload dir with mode 2750 (#830 regression) ==="
+# Login as alice, capture the auth cookie, create a session + worker, send a
+# multipart message with a small file attachment, then inspect the upload
+# directory's mode inside the container. Verifies the production
+# ensureUploadDir() path under AUTH_MODE=multi-user against the real Linux
+# filesystem — the path the unit suite cannot exercise because fs/promises
+# is mocked to memfs in workers.test.ts.
+COOKIE_JAR="$(mktemp)"
+ALICE_RESP="$(mktemp)"
+SESSION_RESP="$(mktemp)"
+WORKER_RESP="$(mktemp)"
+MESSAGE_RESP="$(mktemp)"
+UPLOAD_PAYLOAD="$(mktemp)"
+echo "alice upload payload" > "$UPLOAD_PAYLOAD"
+
+curl -s -o "$ALICE_RESP" -c "$COOKIE_JAR" -X POST "${BASE_URL}/api/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"alice","password":"alice-password"}'
+
+# Create a Quick Session in alice's HOME so the route does not have to
+# traverse anywhere with restrictive perms.
+session_code="$(curl -s -o "$SESSION_RESP" -w '%{http_code}' -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+  -X POST "${BASE_URL}/api/sessions" \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"quick","locationPath":"/home/alice"}')"
+echo "  POST /api/sessions (quick, /home/alice) -> HTTP ${session_code}"
+session_id="$(grep -o '"id":"[^"]*"' "$SESSION_RESP" | head -n1 | cut -d'"' -f4)"
+[ "$session_code" = "201" ] && [ -n "$session_id" ]
+check "alice can create a session" $?
+
+if [ -n "$session_id" ]; then
+  worker_code="$(curl -s -o "$WORKER_RESP" -w '%{http_code}' -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+    -X POST "${BASE_URL}/api/sessions/${session_id}/workers" \
+    -H 'Content-Type: application/json' \
+    -d '{"type":"terminal"}')"
+  echo "  POST /api/sessions/<id>/workers (terminal) -> HTTP ${worker_code}"
+  worker_id="$(grep -o '"id":"[^"]*"' "$WORKER_RESP" | head -n1 | cut -d'"' -f4)"
+  [ "$worker_code" = "201" ] && [ -n "$worker_id" ]
+  check "alice can create a worker" $?
+
+  if [ -n "$worker_id" ]; then
+    message_code="$(curl -s -o "$MESSAGE_RESP" -w '%{http_code}' -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+      -X POST "${BASE_URL}/api/sessions/${session_id}/messages" \
+      -F "toWorkerId=${worker_id}" \
+      -F "content=hello from upload regression" \
+      -F "files=@${UPLOAD_PAYLOAD};filename=upload-probe.txt;type=text/plain")"
+    echo "  POST /api/sessions/<id>/messages (multipart with file) -> HTTP ${message_code}"
+    [ "$message_code" = "201" ]
+    check "multipart message with file upload returns 201" $?
+  fi
+fi
+
+# Inspect the upload directory's mode inside the container. The server runs
+# as `agentconsole` (uid resolved at runtime) so look it up via docker exec.
+SERVER_UID="$(compose exec -T agent-console id -u 2>/dev/null | tr -d '\r' || true)"
+echo "  server uid in container: ${SERVER_UID}"
+UPLOAD_DIR="/tmp/agent-console-uploads-${SERVER_UID}"
+UPLOAD_STAT="$(compose exec -T agent-console stat -c '%a:%G' "$UPLOAD_DIR" 2>/dev/null | tr -d '\r' || echo MISSING)"
+echo "  stat ${UPLOAD_DIR} -> ${UPLOAD_STAT}"
+[ "$UPLOAD_STAT" = "2750:agent-console-users" ]
+check "upload dir is mode 2750 owned by agent-console-users (#830 setgid regression)" $?
+
+rm -f "$COOKIE_JAR" "$ALICE_RESP" "$SESSION_RESP" "$WORKER_RESP" "$MESSAGE_RESP" "$UPLOAD_PAYLOAD"
 
 echo
 echo "=================================================="

--- a/scripts/verify-multiuser-docker.sh
+++ b/scripts/verify-multiuser-docker.sh
@@ -146,8 +146,9 @@ session_code="$(curl -s -o "$SESSION_RESP" -w '%{http_code}' -b "$COOKIE_JAR" -c
   -d '{"type":"quick","locationPath":"/home/alice"}')"
 echo "  POST /api/sessions (quick, /home/alice) -> HTTP ${session_code}"
 session_id="$(grep -o '"id":"[^"]*"' "$SESSION_RESP" | head -n1 | cut -d'"' -f4)"
-[ "$session_code" = "201" ] && [ -n "$session_id" ]
-check "alice can create a session" $?
+session_ok=1
+[ "$session_code" = "201" ] && [ -n "$session_id" ] && session_ok=0
+check "alice can create a session" "$session_ok"
 
 if [ -n "$session_id" ]; then
   worker_code="$(curl -s -o "$WORKER_RESP" -w '%{http_code}' -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
@@ -156,8 +157,9 @@ if [ -n "$session_id" ]; then
     -d '{"type":"terminal"}')"
   echo "  POST /api/sessions/<id>/workers (terminal) -> HTTP ${worker_code}"
   worker_id="$(grep -o '"id":"[^"]*"' "$WORKER_RESP" | head -n1 | cut -d'"' -f4)"
-  [ "$worker_code" = "201" ] && [ -n "$worker_id" ]
-  check "alice can create a worker" $?
+  worker_ok=1
+  [ "$worker_code" = "201" ] && [ -n "$worker_id" ] && worker_ok=0
+  check "alice can create a worker" "$worker_ok"
 
   if [ -n "$worker_id" ]; then
     message_code="$(curl -s -o "$MESSAGE_RESP" -w '%{http_code}' -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
@@ -166,8 +168,9 @@ if [ -n "$session_id" ]; then
       -F "content=hello from upload regression" \
       -F "files=@${UPLOAD_PAYLOAD};filename=upload-probe.txt;type=text/plain")"
     echo "  POST /api/sessions/<id>/messages (multipart with file) -> HTTP ${message_code}"
-    [ "$message_code" = "201" ]
-    check "multipart message with file upload returns 201" $?
+    message_ok=1
+    [ "$message_code" = "201" ] && message_ok=0
+    check "multipart message with file upload returns 201" "$message_ok"
   fi
 fi
 
@@ -178,8 +181,9 @@ echo "  server uid in container: ${SERVER_UID}"
 UPLOAD_DIR="/tmp/agent-console-uploads-${SERVER_UID}"
 UPLOAD_STAT="$(compose exec -T agent-console stat -c '%a:%G' "$UPLOAD_DIR" 2>/dev/null | tr -d '\r' || echo MISSING)"
 echo "  stat ${UPLOAD_DIR} -> ${UPLOAD_STAT}"
-[ "$UPLOAD_STAT" = "2750:agent-console-users" ]
-check "upload dir is mode 2750 owned by agent-console-users (#830 setgid regression)" $?
+upload_ok=1
+[ "$UPLOAD_STAT" = "2750:agent-console-users" ] && upload_ok=0
+check "upload dir is mode 2750 owned by agent-console-users (#830 setgid regression)" "$upload_ok"
 
 rm -f "$COOKIE_JAR" "$ALICE_RESP" "$SESSION_RESP" "$WORKER_RESP" "$MESSAGE_RESP" "$UPLOAD_PAYLOAD"
 


### PR DESCRIPTION
## Summary

Issue #830 — relocate the multi-user data root to a system-wide path, harden the upload buffer for multi-user reachability, and add an idempotent bootstrap script so operators no longer have to walk Step 0-4 of `docs/multi-user-setup-guide.md` by hand.

**Server (`packages/server`)**

- `lib/config.ts` — `getConfigDir()` now resolves AGENT_CONSOLE_HOME > `/var/lib/agent-console` (when `AUTH_MODE=multi-user`) > `~/.agent-console`. Single-user defaults are unchanged.
- `routes/workers.ts` — under `AUTH_MODE=multi-user`, the upload directory mode is `2750` (setgid + group-rx) and the expected group is `process.getgid()` (the shared group set by the systemd unit's `Group=`). The in-process readiness cache is removed so a `/tmp` reap during long uptime is recovered on the next upload.

**Scripts**

- `scripts/setup-multiuser-for-ubuntu.sh` (new) — single idempotent bootstrap covering pamtester install, service user, shared group, sudoers, data root, application install, systemd unit, and `enable --now`. Supports `--dry-run` plus full CLI / env parameter overrides with input validation.
- `scripts/add-multiuser-user.sh` (new) — idempotent helper to add an existing OS user to the shared group.
- `scripts/sudoers-agent-console.template` (new) — canonical sudoers template with `{{SERVICE_USER}}` placeholder.
- `scripts/agent-console-multiuser.service.template` — normalised placeholders (`{{SERVICE_USER}}`, `{{SERVICE_GROUP}}`, `{{DATA_ROOT}}`), added `UMask=0002` and `Environment=AGENT_CONSOLE_HOME={{DATA_ROOT}}`.

**Docker (Acceptance Criteria #6)**

- `docker/Dockerfile` — creates the shared group, adds the service user and the two test users to it, relocates `AGENT_CONSOLE_HOME` to `/var/lib/agent-console` with mode `2775`, and switches the runtime to `USER agentconsole:agent-console-users` so the upload-buffer multi-user contract holds. `verify-multiuser-docker.sh` did not need changes (it asserts only `whoami` and `$HOME`).

**Docs**

- `docs/multi-user-setup-guide.md` — restructured so the bootstrap script is the primary path. Existing Step 0-4 hand-walk demoted to a reference subsection. `AGENT_CONSOLE_HOME` environment-variable table row now lists the multi-user default.
- `docs/design/multi-user-shared-setup.md` — added Architecture Decisions bullets for the data-root relocation, shared group + setgid + `UMask` discipline, upload-buffer policy, and concurrent-edits-AI-mediated policy.
- `docs/glossary.md` — added `agent-console-users` and `AGENT_CONSOLE_HOME` entries.

## Verification log

```
$ bun run typecheck
@agent-console/shared typecheck: Exited with code 0
@agent-console/server typecheck: Exited with code 0
@agent-console/client typecheck: Exited with code 0

$ output=$(bun run test 2>&1); exitcode=$?; echo "$output" | tail -10; echo "TEST_EXIT: $exitcode"
@agent-console/client test:  1397 pass
@agent-console/client test:  2 skip
@agent-console/client test:  0 fail
@agent-console/client test: Ran 1399 tests across 88 files.
$ bun test scripts/ ./.claude/hooks/__tests__/ ./.claude/skills/*/__tests__/
 362 pass
 0 fail
 896 expect() calls
Ran 362 tests across 11 files.
TEST_EXIT: 0

(server suite: 2648 pass / 1 skip / 0 fail / Ran 2649 tests across 127 files)
(full suite total: 4407 pass / 3 skip / 0 fail)

$ bun run check:lang
OK — language check clean (103 files scanned).

$ node .claude/skills/orchestrator/preflight-check.js
Covered: packages/server/src/routes/workers.ts
No rule paragraphs found verbatim in any skill file.
All public artifacts use Latin / Greek / Cyrillic scripts only.
(integration-test gap warning for workers.ts is informational — the change is server-internal mode/group logic, exercised by the sibling unit tests)

$ bash scripts/setup-multiuser-for-ubuntu.sh --dry-run >/dev/null; echo $?
0
$ bash scripts/setup-multiuser-for-ubuntu.sh --dry-run --user foo --group bar --data-root /opt/foo >/dev/null; echo $?
0
```

`coderabbit` CLI is not installed in this environment; CodeRabbit review will run on the GitHub side after the PR opens.

## Pre-PR completeness gap-scan (Q1-Q7)

1. **Existing mechanism check.** The only similar mechanism is `scripts/update-and-deploy-for-ubuntu.sh` (single-user, per-user systemd). This new script is a genuine new mechanism for multi-user, not a duplicate. Cross-linked from `docs/multi-user-setup-guide.md` (primary path) and `docs/design/multi-user-shared-setup.md` (bootstrap script subsection).
2. **Invocation documented.** Bootstrap script is the documented primary path in `docs/multi-user-setup-guide.md` and is referenced in `docs/design/multi-user-shared-setup.md` under "Bootstrap script". Helper `add-multiuser-user.sh` is documented in both guides.
3. **Failure paths tested.** Server tests added: multi-user mode `2750`-mode-and-gid assertion, `/tmp` reap recovery, plus existing TOCTOU (symlink / wrong-mode) tests preserved. Config tests added: `AUTH_MODE=multi-user` default, `AGENT_CONSOLE_HOME` precedence in multi-user mode, no leakage of multi-user default to other `AUTH_MODE` values. Sibling-test diff is present for both modified production files (`config.ts`, `workers.ts`) — preflight passes.
4. **Lifecycle docs.** New files created by the bootstrap script (data root, sudoers file, systemd unit) — creation, in-place re-verification, idempotency, and `--force` for reconciling drift — are described in the setup guide and the script's own help text. There is no archive / rejection path; uninstall is operator-managed and out of scope per the Issue.
5. **Rule clarity.** N/A — no rules are added or modified by this PR.
6. **Cross-runtime spawn.** The bootstrap script invokes only standard Ubuntu tooling (`apt-get`, `useradd`, `groupadd`, `usermod`, `getent`, `install`, `chown`, `chmod`, `systemctl`, `visudo`, `git`, the privilege-elevation wrapper). No `node` / `bun` spawn introduced; no new CI workflow callers.
7. **Shared-Resource Artifact Lifetime.** The three persistent artifacts touched by this PR:
   - **Data root `/var/lib/agent-console`** — lifetime = until uninstall (long). Readers = the server process + every logged-in user's PTY (each strictly shorter than the artifact). Embedded references = none (path-only).
   - **Sudoers `/etc/sudoers.d/agent-console`** — lifetime = until uninstall. Readers = the privilege-elevation tool (per-invocation). Embedded references = `{{SERVICE_USER}}` rendered to a literal at install time; stable until rename, and rename is out of scope per the Issue.
   - **Systemd unit `/etc/systemd/system/agent-console.service`** — lifetime = until uninstall. Readers = `systemd`. Embedded references: `{{HOME}}` = service user's HOME (stable while the user exists); `{{BUN_PATH}}` = the bun binary in the service user's HOME (stable while the service user's bun install is intact); `{{DATA_ROOT}}` = the absolute path supplied at install time.

   Each artifact's lifetime is >= longest reader lifetime AND each embedded reference's source lifetime is >= artifact lifetime.

## E2E note

Real-host E2E (Ubuntu 24.04, repository-backed session, file upload buffer end-to-end) is owner-verified at review time per `CLAUDE.md`'s E2E policy. The agent's verification surface for this PR is:
- Bootstrap script `--dry-run` (default and custom-parameter invocations) — exit 0.
- Unit tests for the upload-buffer multi-user contract (`2750` mode + shared gid) and the `/tmp` reap recovery path.
- Full test suite green; typecheck green; language check clean; preflight green.

The Docker verification (`docker/Dockerfile` + `scripts/verify-multiuser-docker.sh`) covers AC #6 and exercises the new layout in CI.

## Deviations from the brief

- Removed (not deferred) the `__TESTING__.resetUploadDirCache` export. The cache it controlled is gone, so the testing hook has no remaining purpose. Only `workers.test.ts` referenced it; that file is updated in the same PR.
- Docker AC #6 included in this PR (Dockerfile diff is small): shared-group creation + data-root relocation + `USER agentconsole:agent-console-users`. The verify script needed no changes.

Closes #830
