### PR TITLE
feat(server): run description generation as requesting user via runAsUser

### DIFF
--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -131,6 +131,32 @@ describe('Repositories API', () => {
   // =========================================================================
 
   describe('POST /api/repositories/:id/generate-description', () => {
+    it('should thread the authenticated username as requestUser (Issue #835)', async () => {
+      // In multi-user mode the generator must run the agent's headless command
+      // as the requesting user (via runAsUser). The route is responsible for
+      // forwarding `authUser.username` -> `requestUser`. The default test app
+      // wires SingleUserMode with TEST_AUTH_USER ('testuser'), so we assert
+      // the value lands on the generator call.
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      agentManager.getAgent.mockReturnValue({ id: 'claude-code-builtin', command: 'claude' });
+      mockGenerateDescription.mockImplementationOnce(() =>
+        Promise.resolve({ description: 'A test description.' })
+      );
+
+      const res = await app.request('/api/repositories/repo1/generate-description', {
+        method: 'POST',
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockGenerateDescription).toHaveBeenCalledTimes(1);
+      const call = mockGenerateDescription.mock.calls[0][0] as {
+        repositoryPath: string;
+        requestUser: string | null;
+      };
+      expect(call.repositoryPath).toBe('/repo');
+      expect(call.requestUser).toBe('testuser');
+    });
+
     it('should return 400 for concurrent description generation', async () => {
       let resolveGeneration!: (value: any) => void;
       mockGenerateDescription.mockImplementationOnce(

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import type { GenerateRepositoryDescriptionFn } from '../../services/repository-description-generator.js';
 
-const mockGenerateDescription = mock(() => Promise.resolve({ description: 'test' }));
+const mockGenerateDescription = mock<GenerateRepositoryDescriptionFn>(() =>
+  Promise.resolve({ description: 'test' })
+);
 
 import type { Hono } from 'hono';
 import type { AppBindings } from '../../app-context.js';
@@ -149,12 +152,9 @@ describe('Repositories API', () => {
 
       expect(res.status).toBe(200);
       expect(mockGenerateDescription).toHaveBeenCalledTimes(1);
-      const call = mockGenerateDescription.mock.calls[0][0] as {
-        repositoryPath: string;
-        requestUser: string | null;
-      };
-      expect(call.repositoryPath).toBe('/repo');
-      expect(call.requestUser).toBe('testuser');
+      const firstArg = mockGenerateDescription.mock.calls[0][0];
+      expect(firstArg.repositoryPath).toBe('/repo');
+      expect(firstArg.requestUser).toBe('testuser');
     });
 
     it('should return 400 for concurrent description generation', async () => {

--- a/packages/server/src/routes/repositories.ts
+++ b/packages/server/src/routes/repositories.ts
@@ -158,6 +158,7 @@ const repositories = new Hono<AppBindings>()
   .post('/:id/generate-description', async (c) => {
     const repoId = c.req.param('id');
     const { repositoryManager, agentManager, generateRepositoryDescription } = c.get('appContext');
+    const authUser = c.get('authUser');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {
@@ -176,9 +177,14 @@ const repositories = new Hono<AppBindings>()
 
     descriptionGenerationsInProgress.add(repoId);
     try {
+      // Thread the authenticated username so multi-user mode runs the agent's
+      // headless command (e.g. `claude -p ...`) as the requesting user via
+      // `runAsUser` (Issue #835). In single-user mode `runAsUser` bypasses
+      // sudo because the username matches the server-process user.
       const result = await generateRepositoryDescription({
         repositoryPath: repo.path,
         agent,
+        requestUser: authUser.username,
       });
 
       if (result.error) {

--- a/packages/server/src/services/__tests__/repository-description-generator.test.ts
+++ b/packages/server/src/services/__tests__/repository-description-generator.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
+import { describe, it, expect, beforeEach, afterAll, afterEach } from 'bun:test';
+import * as os from 'node:os';
 import type { AgentDefinition } from '@agent-console/shared';
 
 // Mock Bun.spawn for agent command execution
@@ -56,10 +57,16 @@ const mockAgentWithoutHeadless: AgentDefinition = {
 
 let importCounter = 0;
 
+const originalAuthMode = process.env.AUTH_MODE;
+
 describe('repository-description-generator', () => {
   beforeEach(() => {
     spawnCalls = [];
     mockFileContents = new Map();
+    // Default to single-user mode for the existing test set; the
+    // multi-user tests below set AUTH_MODE explicitly and rely on
+    // afterEach to restore the original value.
+    delete process.env.AUTH_MODE;
 
     // Reset mock spawn result
     mockSpawnResult = {
@@ -100,6 +107,14 @@ describe('repository-description-generator', () => {
       }
       return originalBunFile(...(args as Parameters<typeof Bun.file>));
     }) as typeof Bun.file;
+  });
+
+  afterEach(() => {
+    if (originalAuthMode === undefined) {
+      delete process.env.AUTH_MODE;
+    } else {
+      process.env.AUTH_MODE = originalAuthMode;
+    }
   });
 
   // Restore originals after all tests
@@ -143,6 +158,7 @@ describe('repository-description-generator', () => {
       const result = await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.description).toBe('A web application for managing AI agents.');
@@ -161,6 +177,7 @@ describe('repository-description-generator', () => {
       const result = await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgentWithoutHeadless,
+        requestUser: null,
       });
 
       expect(result.description).toBeUndefined();
@@ -174,6 +191,7 @@ describe('repository-description-generator', () => {
       const result = await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.description).toBeUndefined();
@@ -190,6 +208,7 @@ describe('repository-description-generator', () => {
       const result = await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.description).toBe('A plain text project.');
@@ -206,6 +225,7 @@ describe('repository-description-generator', () => {
       await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       // Verify the prompt uses the README.md content
@@ -225,6 +245,7 @@ describe('repository-description-generator', () => {
       await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       const options = spawnCalls[0].options as { env?: Record<string, string> };
@@ -244,6 +265,7 @@ describe('repository-description-generator', () => {
       await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       const options = spawnCalls[0].options as { env?: Record<string, string> };
@@ -261,6 +283,7 @@ describe('repository-description-generator', () => {
       const result = await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.description).toBeUndefined();
@@ -276,6 +299,7 @@ describe('repository-description-generator', () => {
       const result = await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.description).toBeUndefined();
@@ -291,6 +315,7 @@ describe('repository-description-generator', () => {
       const result = await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.description).toBe('A project description.');
@@ -305,6 +330,7 @@ describe('repository-description-generator', () => {
       await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       // Verify env contains the prompt
@@ -324,6 +350,7 @@ describe('repository-description-generator', () => {
       await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       const options = spawnCalls[0].options as { env?: Record<string, string> };
@@ -340,6 +367,7 @@ describe('repository-description-generator', () => {
       await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       const options = spawnCalls[0].options as { env?: Record<string, string> };
@@ -365,6 +393,7 @@ describe('repository-description-generator', () => {
       const result = await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: agentMissingTemplate,
+        requestUser: null,
       });
 
       expect(result.description).toBeUndefined();
@@ -414,6 +443,7 @@ describe('repository-description-generator', () => {
         const result = await generateRepositoryDescription({
           repositoryPath: '/repo',
           agent: mockAgent,
+          requestUser: null,
         });
 
         expect(killCalled).toBe(true);
@@ -434,9 +464,116 @@ describe('repository-description-generator', () => {
       const result = await generateRepositoryDescription({
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.description).toBe('An rst project.');
+    });
+
+    // -- Privilege-elevation branch (Issue #835) --
+    //
+    // The runAsUser helper inspects AUTH_MODE + requestUser to decide whether
+    // to elevate via sudo. These assertions exercise the resulting spawn argv
+    // shape so a regression in routing back to the elevated branch fails the
+    // test rather than only manifesting at runtime in multi-user deployments.
+
+    it('AUTH_MODE=none: bypasses elevation even when requestUser is set', async () => {
+      process.env.AUTH_MODE = 'none';
+      mockFileContents.set('/repo/README.md', '# Project');
+      setMockSpawnResult('A project.');
+
+      const { generateRepositoryDescription } = await getModule();
+
+      const result = await generateRepositoryDescription({
+        repositoryPath: '/repo',
+        agent: mockAgent,
+        requestUser: 'alice',
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args[0]).toBe('sh');
+      expect(spawnCalls[0].args[1]).toBe('-c');
+      expect(spawnCalls[0].args[2]).toContain('test-cli -p --format text');
+    });
+
+    it('AUTH_MODE=multi-user with non-server requestUser: elevates via sudo as that user', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const targetUser = `${os.userInfo().username}-someone-else`;
+      mockFileContents.set('/repo/README.md', '# Project');
+      setMockSpawnResult('A project.');
+
+      const { generateRepositoryDescription } = await getModule();
+
+      const result = await generateRepositoryDescription({
+        repositoryPath: '/repo',
+        agent: mockAgent,
+        requestUser: targetUser,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(spawnCalls.length).toBe(1);
+      // Elevated argv: ['sudo', '-u', <user>, '--preserve-env=FORCE_COLOR', '-i', 'sh', '-c', <inner>]
+      const args = spawnCalls[0].args;
+      expect(args[0]).toBe('sudo');
+      expect(args[1]).toBe('-u');
+      expect(args[2]).toBe(targetUser);
+      expect(args[3]).toBe('--preserve-env=FORCE_COLOR');
+      expect(args[4]).toBe('-i');
+      expect(args[5]).toBe('sh');
+      expect(args[6]).toBe('-c');
+      // `sudo -i` resets env + chdirs to target HOME, so cwd / env MUST be
+      // interpolated into the inner command. The inner shell should contain
+      // the cd to the repo path, the agent command, and the env exports
+      // (`export K1=v1 K2=v2; <command>`) carrying both __AGENT_PROMPT__ and
+      // TERM=dumb.
+      const inner = args[7];
+      expect(inner).toContain("cd '/repo'");
+      expect(inner).toMatch(/export\b[^;]*\bTERM='dumb'/);
+      expect(inner).toContain("__AGENT_PROMPT__=");
+      expect(inner).toContain('test-cli -p --format text');
+    });
+
+    it('AUTH_MODE=multi-user with requestUser == server user: bypasses elevation', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      mockFileContents.set('/repo/README.md', '# Project');
+      setMockSpawnResult('A project.');
+
+      const { generateRepositoryDescription } = await getModule();
+
+      const result = await generateRepositoryDescription({
+        repositoryPath: '/repo',
+        agent: mockAgent,
+        requestUser: os.userInfo().username,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(spawnCalls.length).toBe(1);
+      // Direct spawn, no sudo prefix.
+      expect(spawnCalls[0].args[0]).toBe('sh');
+      expect(spawnCalls[0].args[1]).toBe('-c');
+      expect(spawnCalls[0].args[2]).toContain('test-cli -p --format text');
+    });
+
+    it('AUTH_MODE=multi-user with non-server requestUser: surfaces stderr when sudo exits non-zero', async () => {
+      // Real-world failure shape: `claude` not on the elevated user's PATH.
+      // The helper returns a non-zero exitCode and captured stderr; the
+      // description generator surfaces it via the error path.
+      process.env.AUTH_MODE = 'multi-user';
+      mockFileContents.set('/repo/README.md', '# Project');
+      setMockSpawnResult('', 127, 'sh: 1: claude: not found');
+
+      const { generateRepositoryDescription } = await getModule();
+
+      const result = await generateRepositoryDescription({
+        repositoryPath: '/repo',
+        agent: mockAgent,
+        requestUser: `${os.userInfo().username}-someone-else`,
+      });
+
+      expect(result.description).toBeUndefined();
+      expect(result.error).toContain('Agent command failed');
+      expect(result.error).toContain('claude: not found');
     });
   });
 });

--- a/packages/server/src/services/repository-description-generator.ts
+++ b/packages/server/src/services/repository-description-generator.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 import type { AgentDefinition } from '@agent-console/shared';
 import { expandTemplate, TemplateExpansionError } from '../lib/template.js';
 import { createLogger } from '../lib/logger.js';
+import { runAsUser } from './privilege-elevation.js';
 
 const logger = createLogger('service:description-generator');
 
@@ -18,6 +19,15 @@ const TIMEOUT_MS = 30000;
 interface RepositoryDescriptionRequest {
   repositoryPath: string;
   agent: AgentDefinition;
+  /**
+   * The OS username that requested the generation. In multi-user mode this is
+   * threaded down so the agent's headless command (e.g. `claude -p ...`) runs
+   * with the requesting user's PATH and per-user auth credentials via the
+   * `runAsUser` privilege-elevation helper. In single-user mode `runAsUser`
+   * bypasses elevation regardless of this value; pass the authenticated
+   * username (auth middleware always provides one).
+   */
+  requestUser: string | null;
 }
 
 interface RepositoryDescriptionResponse {
@@ -67,7 +77,7 @@ Rules:
 export async function generateRepositoryDescription(
   request: RepositoryDescriptionRequest,
 ): Promise<RepositoryDescriptionResponse> {
-  const { repositoryPath, agent } = request;
+  const { repositoryPath, agent, requestUser } = request;
 
   // Check if agent supports headless mode
   if (!agent.capabilities.supportsHeadlessMode) {
@@ -101,29 +111,23 @@ export async function generateRepositoryDescription(
       cwd: repositoryPath,
     });
 
-    // Spawn via shell with the expanded command
-    // The prompt is safely passed via environment variable to prevent injection
-    const proc = Bun.spawn(['sh', '-c', command], {
+    // Route through the privilege-elevation helper so multi-user mode runs the
+    // agent's headless command (e.g. `claude -p ...`) as the requesting user --
+    // i.e. with that user's PATH and per-user auth credentials. The prompt is
+    // safely passed via environment variable to prevent injection.
+    // In single-user mode (or when requestUser equals the server user) the
+    // helper bypasses sudo and spawns directly, preserving prior behavior.
+    const { stdout, stderr, exitCode, timedOut } = await runAsUser({
+      username: requestUser,
+      command,
       cwd: repositoryPath,
-      stdout: 'pipe',
-      stderr: 'pipe',
       env: {
-        ...process.env,
         ...templateEnv,
         // Ensure we don't inherit any interactive settings
         TERM: 'dumb',
       },
+      timeoutMs: TIMEOUT_MS,
     });
-
-    // Set up timeout with a flag to distinguish timeout from other failures
-    let timedOut = false;
-    const timeoutId = setTimeout(() => {
-      timedOut = true;
-      proc.kill();
-    }, TIMEOUT_MS);
-
-    const exitCode = await proc.exited;
-    clearTimeout(timeoutId);
 
     if (exitCode !== 0) {
       if (timedOut) {
@@ -131,14 +135,12 @@ export async function generateRepositoryDescription(
           error: `Description generation timed out after ${TIMEOUT_MS / 1000} seconds`,
         };
       }
-      const stderr = await new Response(proc.stderr).text();
       return {
         error: `Agent command failed: ${stderr.trim() || `exit code ${exitCode}`}`,
       };
     }
 
-    const result = await new Response(proc.stdout).text();
-    const trimmedResult = result.trim();
+    const trimmedResult = stdout.trim();
 
     if (!trimmedResult) {
       return {


### PR DESCRIPTION
## Summary

Routes repository description generation through the `runAsUser` privilege-elevation helper landed in PR #840 so that, in multi-user mode (`AUTH_MODE=multi-user`), the agent's headless command (e.g. `claude -p ...`) runs as the user who requested the operation. The user's PATH and per-user auth credentials are inherited, eliminating the `claude: not found` error reported in Issue #835.

In single-user mode (`AUTH_MODE=none`) or when the requesting user equals the server-process user, `runAsUser` bypasses elevation and spawns directly via `sh -c <command>`, preserving prior behavior with no regression risk.

Closes #835
Refs umbrella #837

## Changes

- `packages/server/src/services/repository-description-generator.ts`
  - Adds `requestUser: string | null` to `RepositoryDescriptionRequest`.
  - Replaces the direct `Bun.spawn(['sh', '-c', command], ...)` block with a single `runAsUser({...})` call. Timeout handling, env merging, and cwd are now delegated to the helper. `templateEnv` (carrying `__AGENT_PROMPT__`) and `TERM=dumb` flow through `opts.env`, which the helper merges with `process.env` in the non-elevated branch and interpolates as `export K=v` statements inside the inner shell in the elevated branch.
- `packages/server/src/routes/repositories.ts`
  - The `POST /:id/generate-description` handler reads `c.get('authUser').username` (always present after the route's auth middleware) and threads it as `requestUser` to the generator.
- Sibling tests
  - `packages/server/src/services/__tests__/repository-description-generator.test.ts`: 4 new tests covering both branches (direct spawn vs elevated argv shape), the same-user bypass, and the multi-user non-zero-exit stderr surface path (the `claude: not found` failure shape). All existing tests updated with `requestUser: null` to compile against the new request type.
  - `packages/server/src/routes/__tests__/repositories.test.ts`: 1 new test asserting the route forwards `authUser.username` (`'testuser'` from `TEST_AUTH_USER`) as `requestUser`. The mock's signature is now typed against `GenerateRepositoryDescriptionFn` so `mock.calls[0][0]` infers `{ repositoryPath, requestUser, ... }` directly.

## Verification

Full local pipeline run from the worktree root:

```
$ bun run typecheck
@agent-console/shared typecheck: Exited with code 0
@agent-console/server typecheck: Exited with code 0
@agent-console/client typecheck: Exited with code 0
```

```
$ bun run test  (server / shared / client / scripts / hooks / skills)
@agent-console/server test:  2683 pass, 1 skip, 0 fail (Ran 2684 tests across 129 files)
@agent-console/client test:  1397 pass, 2 skip, 0 fail (Ran 1399 tests across 88 files)
scripts / hooks / skills:    362 pass,  0 fail            (Ran 362 tests across 11 files)
TEST_EXIT: 0
```

```
$ bun run check:lang
OK -- language check clean (103 files scanned).

$ node .claude/skills/orchestrator/preflight-check.js
- Test Coverage Check: Covered (2): repositories.ts, repository-description-generator.ts
- Rule/Skill Duplication: clean
- Language Check: clean
EXIT: 0
```

CodeRabbit CLI is not installed locally; the GitHub-side bot will review.

## TDD polarity check

Verified by stashing only the production change in `repository-description-generator.ts` while keeping the new tests, then re-running the sibling suite: the new elevated-branch test `AUTH_MODE=multi-user with non-server requestUser: elevates ...` fails (expected `'sudo'` / received `'sh'`). Restoring the production change resolves the failure.

## 7-question gap-scan

- **Q1 (existing mechanism):** `runAsUser` is the existing mechanism; this PR is its first consumer migration per umbrella #837. The previous implementation used a direct `Bun.spawn(['sh', '-c', ...])` block that does not satisfy multi-user requirements (the bug in #835).
- **Q1.5 (cross-doc citation):** Verified against the actual `privilege-elevation.ts` code from PR #840 -- specifically the `buildSpawnArgs` argv shape and the cwd / env interpolation rule (the elevated shell resets the environment, so cwd / env MUST live inside the inner command, not on the outer spawn options).
- **Q3 (failure paths tested):** Yes. The sibling generator tests cover the happy path (both branches), the same-user bypass, and the realistic failure shape (`claude: not found` -> non-zero exit -> stderr surfaced through the error response). The route-level test verifies the username threading.
- **Q3 (sibling test diff):** Yes -- both production files in this PR have changed sibling test files in the same diff (preflight verified).
- **Q6 (cross-runtime spawn):** N / A. No new cross-runtime spawn introduced; `runAsUser` is the existing helper.
- **Q7 (shared-resource lifetime):** N / A. No new persistent artifacts.
- **Q8 (signature shape change):** `generateRepositoryDescription` gains one new field (`requestUser: string | null`). Call sites: 1 production (`routes/repositories.ts`) + 16 test sites in the sibling test file. Test-site churn was mechanical (added `requestUser: null` to each existing call to keep them in the non-elevated branch).

## Integration test note

Preflight surfaces a `route changed without integration test diff` warning. This is intentional: the change does not alter the `/api/repositories/:id/generate-description` client-server contract (request body, response shape, status codes are unchanged); it only changes how the server executes the underlying command. Existing integration coverage of this endpoint continues to apply.

## Out of scope / parallel work

- Parallel work on umbrella #837: another agent is migrating `worktree-service.ts` / `worktree-creation-service.ts` for Issue #838. This PR intentionally does not touch those files.
- `#834` (clone-as-user) is the remaining umbrella constituent, owned by a separate effort.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` (full suite) passes (server 2683 / client 1397 / scripts 362, 0 failures)
- [x] `bun run check:lang` passes
- [x] `node .claude/skills/orchestrator/preflight-check.js` passes
- [x] TDD polarity verified (new tests fail when production change is stashed)
- [ ] Dogfood verification on a multi-user host (request owner / Orchestrator -- this environment cannot exercise the elevation path end-to-end)
