### PR TITLE
feat(server): run git worktree add as requesting user via runAsUser

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -158,4 +158,12 @@ WORKDIR /app/dist
 # lose shadow access, and every login would 401 (CI reproduction: PR #831).
 USER agentconsole
 EXPOSE 8080
-CMD ["bun", "index.js"]
+# Set umask=0002 to match the production systemd unit
+# (scripts/agent-console-multiuser.service.template's `UMask=0002`). Without
+# this, server-created dirs inside the shared data root (e.g., the
+# `worktrees/` parent dir created by WorktreeService.createWorktree) land
+# at mode 0755 -- the group lacks write permission, and a non-server user
+# running `git worktree add` via runAsUser cannot create the worktree
+# leading directories. Production systemd already handles this; the
+# verification image must mirror it. (Issue #838 E2E regression.)
+CMD ["sh", "-c", "umask 0002 && exec bun index.js"]

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -593,3 +593,35 @@ whoami     # Should show the logged-in user
 id         # Should show the user's UID and groups
 ls -la ~   # Should be accessible
 ```
+
+## Migrating Pre-#838 Worktrees (Linux multi-user)
+
+Issue #838 changes worktree creation so the resulting files are owned by the
+requesting user (not the service user). New worktrees created after the
+upgrade are owned correctly automatically; **existing worktrees created
+before the upgrade remain owned by the service user** and will continue to
+trigger `fatal: detected dubious ownership in repository` when the user runs
+any git command inside them.
+
+The fix is a one-time `chown` per pre-existing worktree. For each affected
+worktree path:
+
+```bash
+sudo chown -R <user>:agent-console-users \
+  /var/lib/agent-console/repositories/<org>/<repo>/worktrees/wt-NNN-XXXX
+```
+
+`<user>` is the OS username of the person who originally created the
+worktree. If the session is still listed in the Agent Console UI, the
+worktree row's owner can be inferred from the session's creator; otherwise
+ask the user who has been working in that worktree.
+
+After the chown, the user can run `git status` inside the worktree from
+their PTY without further configuration. No restart of the server is
+required.
+
+This documentation-based migration is intentional: production multi-user
+installs at the time of #838 had a small number of pre-existing worktrees
+(per the bootstrap-script-era setup window), so a per-path operator step
+costs less than a database-aware migration script. A scripted variant can
+be added later if installs in the wild accumulate many pre-#838 worktrees.

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -594,6 +594,33 @@ id         # Should show the user's UID and groups
 ls -la ~   # Should be accessible
 ```
 
+## Source Repo Group-Writability (Linux multi-user)
+
+When Issue #838 lands, `git worktree add` runs as the requesting user. For
+this to succeed against a source repo owned by the service user
+(`agentconsole`), two things must be true:
+
+1. The user's gitconfig must trust the source repo path. The server
+   bootstraps this automatically (`git config --global --add safe.directory
+   <repoPath>`, mitigation A from Issue #838); operators do not need to
+   configure it.
+2. The user must be able to **write** to `.git/refs/`, `.git/packed-refs`,
+   etc. (Issue's mitigation C — group writability). The bootstrap script
+   sets `core.sharedRepository=group` on cloned repos, but operators
+   who add source repos manually (e.g., by cloning as `agentconsole`)
+   must apply equivalent config:
+
+```bash
+sudo -u agentconsole bash -lc 'cd <repo-path> && git config core.sharedRepository group'
+sudo find <repo-path>/.git -type d -exec chmod g+rwxs {} +
+sudo chmod -R g+rw <repo-path>/.git
+```
+
+These are operator steps for source repos that pre-date the multi-user-
+ready setup. When [Issue #834](https://github.com/ms2sato/agent-console/issues/834)
+(clone-as-user) lands, repos cloned via the in-app flow are owned by the
+requesting user directly and neither step is required.
+
 ## Migrating Pre-#838 Worktrees (Linux multi-user)
 
 Issue #838 changes worktree creation so the resulting files are owned by the

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -154,6 +154,24 @@ describe('MCP Server Tools', () => {
   let nextId: number;
 
   /**
+   * Capture of the `runAsUser` invocation made by the injected stub on the
+   * `WorktreeService`. The `setupDelegateEnvironment` helper reads
+   * `capturedWorktreePath` to drive `listWorktrees` so the orchestration
+   * tests see the just-created worktree. Tests that need to simulate
+   * `git worktree add` failing can override `responseOverride`. Reset in
+   * each `beforeEach`.
+   */
+  const mcpRunAsUserCapture: {
+    lastCommand: string;
+    capturedWorktreePath: string;
+    responseOverride: { stdout: string; stderr: string; exitCode: number; timedOut: boolean } | null;
+  } = {
+    lastCommand: '',
+    capturedWorktreePath: '',
+    responseOverride: null,
+  };
+
+  /**
    * Re-create the MCP app and initialize a new MCP session.
    * Call this after replacing the repositoryManager to ensure
    * the MCP tools see the updated dependencies.
@@ -190,6 +208,12 @@ describe('MCP Server Tools', () => {
 
     // Reset git mocks to defaults
     resetGitMocks();
+
+    // Reset the runAsUser capture (used by setupDelegateEnvironment to
+    // resolve the worktree path captured from the spawned git command).
+    mcpRunAsUserCapture.lastCommand = '';
+    mcpRunAsUserCapture.capturedWorktreePath = '';
+    mcpRunAsUserCapture.responseOverride = null;
 
     // Reset session metadata suggester mock
     mockSuggestSessionMetadata.mockReset();
@@ -249,8 +273,34 @@ describe('MCP Server Tools', () => {
     // Create InteractiveProcessManager (no-op callbacks for tests)
     interactiveProcessManager = new InteractiveProcessManager(() => {}, () => {});
 
-    // Create WorktreeService with in-memory database
-    worktreeService = new WorktreeService({ db });
+    // Create WorktreeService with in-memory database. Inject a stub
+    // `runAsUser` that pretends `git worktree add` succeeded. The
+    // `delegate_to_worktree` tests below also need to capture the worktree
+    // path from the spawn command (the path is generated with a random
+    // suffix), so the stub parses the command and shares the captured value
+    // via `mcpRunAsUserCapture` for the per-test `setupDelegateEnvironment`
+    // helper. The detailed `git worktree add` shape is verified by
+    // worktree-service.test.ts and privilege-elevation.test.ts.
+    worktreeService = new WorktreeService({
+      db,
+      runAsUserImpl: async (opts) => {
+        mcpRunAsUserCapture.lastCommand = opts.command;
+        // The command shape is: `'git' 'worktree' 'add' ['-b' '<branch>'] '<path>' [<branch>|<base>]`
+        // with single-quote escaped args. The worktree path is the longest
+        // token in the command — it includes the absolute config dir path.
+        const tokens = Array.from(opts.command.matchAll(/'((?:[^']|'\\'')*)'/g)).map(
+          (m) => m[1],
+        );
+        const wtPath = tokens.find((t) => t.includes('/worktrees/wt-'));
+        if (wtPath) {
+          mcpRunAsUserCapture.capturedWorktreePath = wtPath;
+        }
+        if (mcpRunAsUserCapture.responseOverride) {
+          return mcpRunAsUserCapture.responseOverride;
+        }
+        return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+      },
+    });
 
     // Create MCP app with injected dependencies and initialize MCP session
     await remountMcpApp();
@@ -1213,27 +1263,18 @@ describe('MCP Server Tools', () => {
       });
       process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
 
-      // Configure git mocks for worktree operations
+      // Configure git mocks for worktree operations.
+      // The `git worktree add` invocation itself is captured by the
+      // `runAsUserImpl` stub injected on the WorktreeService at the
+      // top-level `beforeEach`; the captured path then feeds `listWorktrees`
+      // below so the orchestration sees the newly-created worktree.
       mockGit.getRemoteUrl.mockImplementation(async () => 'git@github.com:owner/repo.git');
       mockGit.getDefaultBranch.mockImplementation(async () => 'main');
-      mockGit.createWorktree.mockImplementation(async () => {
-        // Simulate git creating the worktree directory - noop since we mock listWorktrees
-      });
-
-      // listWorktrees must return the created worktree. Since the actual worktree path
-      // includes a random suffix, we configure listWorktrees dynamically:
-      // After createWorktree is called, we know the path from the index store.
-      // However, the simpler approach is to return a porcelain output that includes
-      // both the main repo and a worktree at a known path.
-      // We intercept createWorktree to capture the path, then use it in listWorktrees.
-      let capturedWorktreePath = '';
-      mockGit.createWorktree.mockImplementation(async (...args: unknown[]) => {
-        capturedWorktreePath = args[0] as string;
-      });
 
       mockGit.listWorktrees.mockImplementation(async () => {
-        if (capturedWorktreePath) {
-          return `worktree ${TEST_REPO_PATH}\nHEAD abc123\nbranch refs/heads/main\n\nworktree ${capturedWorktreePath}\nHEAD def456\nbranch refs/heads/${worktreeBranch}\n`;
+        const captured = mcpRunAsUserCapture.capturedWorktreePath;
+        if (captured) {
+          return `worktree ${TEST_REPO_PATH}\nHEAD abc123\nbranch refs/heads/main\n\nworktree ${captured}\nHEAD def456\nbranch refs/heads/${worktreeBranch}\n`;
         }
         return `worktree ${TEST_REPO_PATH}\nHEAD abc123\nbranch refs/heads/main\n`;
       });
@@ -1457,7 +1498,9 @@ describe('MCP Server Tools', () => {
     });
 
     it('should return error when worktree creation fails', async () => {
-      // Setup environment but make createWorktree fail
+      // Setup environment but make `git worktree add` fail. The runAsUser
+      // stub returns a non-zero exit (with the same stderr the real git
+      // would emit), which the WorktreeService surfaces via GitError.
       setupMemfs({
         [`${TEST_CONFIG_DIR}/.keep`]: '',
         [`${TEST_REPO_PATH}/.git/HEAD`]: 'ref: refs/heads/main',
@@ -1467,11 +1510,12 @@ describe('MCP Server Tools', () => {
       mockGit.getRemoteUrl.mockImplementation(async () => 'git@github.com:owner/repo.git');
       mockGit.getDefaultBranch.mockImplementation(async () => 'main');
 
-      // Make createWorktree throw a GitError
-      const { GitError } = await import('../../lib/git.js');
-      mockGit.createWorktree.mockImplementation(async () => {
-        throw new GitError('fatal: branch already exists', 128, 'fatal: branch already exists');
-      });
+      mcpRunAsUserCapture.responseOverride = {
+        stdout: '',
+        stderr: 'fatal: branch already exists',
+        exitCode: 128,
+        timedOut: false,
+      };
 
       await setupDelegateRepoManager([{
         id: 'test-repo',

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -286,9 +286,13 @@ describe('MCP Server Tools', () => {
       runAsUserImpl: async (opts) => {
         mcpRunAsUserCapture.lastCommand = opts.command;
         // The command shape is: `'git' 'worktree' 'add' ['-b' '<branch>'] '<path>' [<branch>|<base>]`
-        // with single-quote escaped args. The worktree path is the longest
-        // token in the command — it includes the absolute config dir path.
-        const tokens = Array.from(opts.command.matchAll(/'((?:[^']|'\\'')*)'/g)).map(
+        // with single-quote escaped args. The worktree path is the first
+        // (and only) token containing `/worktrees/wt-`. The test data does
+        // not include single quotes inside arg values, so a simple
+        // `'[^']*'` pattern is sufficient -- shell single-quote escaping
+        // (real form: `'\''` = end-quote, literal-quote, start-quote) is
+        // not exercised here.
+        const tokens = Array.from(opts.command.matchAll(/'([^']*)'/g)).map(
           (m) => m[1],
         );
         const wtPath = tokens.find((t) => t.includes('/worktrees/wt-'));

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -643,6 +643,18 @@ export function createMcpApp(deps: McpDependencies): Hono {
           ? sessionManager.getSession(parentSessionId)?.createdBy
           : undefined;
 
+        // NOTE: Issue #838 routes `git worktree add` through `runAsUser` so
+        // worktree files become user-owned. The MCP delegation path does
+        // not currently resolve `parentCreatedBy` (a user UUID) back to an
+        // OS username — that requires plumbing `userRepository` through
+        // `McpDependencies`. In multi-user mode, MCP-delegated worktrees
+        // are therefore created with `runAsUser({ username: undefined })`
+        // -> server user ownership. The subsequent agent worker still
+        // spawns as the parent session's user via `resolveSpawnUsername`
+        // in SessionManager, so the user will hit `dubious ownership` on
+        // git commands inside MCP-delegated worktrees. Tracked as a
+        // follow-up; the REST `/api/repositories/:id/worktrees` path is
+        // the primary user-visible entry point and is covered by this PR.
         const result = await createWorktreeWithSession({
           repoPath: repo.path,
           repoId: repositoryId,

--- a/packages/server/src/routes/__tests__/worktrees.test.ts
+++ b/packages/server/src/routes/__tests__/worktrees.test.ts
@@ -43,6 +43,9 @@ function createMockWorktreeService() {
     removeWorktree: mock(() => Promise.resolve({ success: true })),
     removeOrphanedWorktree: mock(() => Promise.resolve()),
     getWorktreeIndexNumber: mock(() => Promise.resolve(null)),
+    // Default no-op for createWorktree; overridden in tests that exercise
+    // the POST /worktrees route.
+    createWorktree: mock(() => Promise.resolve({ worktreePath: '', error: 'not implemented in mock' })),
   } as unknown as WorktreeService;
 }
 
@@ -130,6 +133,95 @@ describe('Worktrees API', () => {
       const body = (await res.json()) as { worktrees: unknown[] };
       expect(body.worktrees).toBeArray();
       expect(body.worktrees).toHaveLength(1);
+    });
+  });
+
+  // =========================================================================
+  // POST /api/repositories/:id/worktrees  (Issue #838: requestUsername plumbing)
+  // =========================================================================
+
+  describe('POST /api/repositories/:id/worktrees (Issue #838 requestUsername plumbing)', () => {
+    /**
+     * The route handler kicks worktree creation off in a fire-and-forget
+     * background promise; the HTTP response returns 202 immediately. To
+     * deterministically observe the inner `worktreeService.createWorktree`
+     * call, the mock resolves a promise the test awaits before asserting.
+     */
+    function createCapturingWorktreeMock() {
+      let resolveCall!: (args: unknown[]) => void;
+      const captured = new Promise<unknown[]>((resolve) => {
+        resolveCall = resolve;
+      });
+      const mockFn = mock((...args: unknown[]) => {
+        resolveCall(args);
+        // Return error so the route's success-broadcast path is skipped --
+        // the test only needs to observe the createWorktree call args.
+        return Promise.resolve({ worktreePath: '', error: 'short-circuit for test' });
+      });
+      return { mockFn, captured };
+    }
+
+    it("forwards authUser.username as requestUsername to worktreeService.createWorktree", async () => {
+      // Mock the agent manager so the route passes the agent validation.
+      const mockAgentManager = {
+        getAgent: mock(() => ({ id: 'claude-code-builtin', name: 'Claude Code' })),
+      } as unknown as Parameters<typeof asAppContext>[0]['agentManager'];
+
+      const { mockFn: createCapture, captured } = createCapturingWorktreeMock();
+      (mockWorktreeService as unknown as { createWorktree: typeof createCapture }).createWorktree = createCapture;
+
+      // Re-mount the app with the augmented appContext (agentManager +
+      // sessionManager + broadcastToApp + suggestSessionMetadata). The
+      // default suggestSessionMetadata is not invoked because we use
+      // `mode: 'custom'`, which uses the explicit branch verbatim.
+      app = new Hono<AppBindings>();
+      app.use('*', async (c, next) => {
+        c.set('appContext', asAppContext({
+          repositoryManager: mockRepositoryManager,
+          worktreeService: mockWorktreeService,
+          agentManager: mockAgentManager,
+          // sessionManager is invoked downstream by createWorktreeWithSession
+          // only when the worktree creation succeeds; the short-circuit error
+          // above ensures it never runs.
+          sessionManager: { createSession: mock() } as unknown as SessionManager,
+          broadcastToApp: () => {},
+          suggestSessionMetadata: mock(async () => ({ branch: '', title: '', error: 'unused' })),
+        }));
+        await next();
+      });
+      app.onError(onApiError);
+      app.route('/api', api);
+
+      const res = await app.request(
+        `/api/repositories/${TEST_REPO.id}/worktrees`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            taskId: 'task-issue-838',
+            mode: 'custom',
+            branch: 'issue-838-feature',
+            baseBranch: 'main',
+            useRemote: false,
+            autoStartSession: false,
+            agentId: 'claude-code-builtin',
+          }),
+        },
+      );
+
+      expect(res.status).toBe(202);
+
+      // The route's fire-and-forget call MUST run before the test ends.
+      // The promise resolves the moment createWorktree is invoked.
+      const args = await captured;
+      // Signature: (repoPath, branch, repoId, baseBranch, requestUsername)
+      expect(args[0]).toBe(REPO_PATH);
+      expect(args[1]).toBe('issue-838-feature');
+      expect(args[2]).toBe(TEST_REPO.id);
+      // The default SingleUserMode used by asAppContext is constructed with
+      // TEST_AUTH_USER (username='testuser'), so the route MUST forward
+      // 'testuser' as the 5th positional arg.
+      expect(args[4]).toBe('testuser');
     });
   });
 

--- a/packages/server/src/routes/worktrees.ts
+++ b/packages/server/src/routes/worktrees.ts
@@ -129,6 +129,11 @@ const worktrees = new Hono<AppBindings>()
           title: effectiveTitle,
           autoStartSession,
           context: { createdBy: authUser.id },
+          // Thread the authenticated OS username down to `git worktree add`
+          // so multi-user installs create the worktree as the requesting
+          // user (Issue #838). In single-user mode, `runAsUser` reads this
+          // value but `AUTH_MODE` gates the elevation to a no-op.
+          requestUsername: authUser.username,
         }, sessionManager, worktreeService);
 
         if (!result.success) {

--- a/packages/server/src/services/__tests__/privilege-elevation.test.ts
+++ b/packages/server/src/services/__tests__/privilege-elevation.test.ts
@@ -604,5 +604,55 @@ describe('privilege-elevation', () => {
       expect(opts.cwd).toBe('/');
       expect(opts.env).toBeUndefined();
     });
+
+    it('forwards opts.stdin as Uint8Array to spawn options (string is UTF-8 encoded)', async () => {
+      process.env.AUTH_MODE = 'none';
+      const captured: CapturedSpawn[] = [];
+      const fakeSpawn = makeFakeSpawn(captured, { stdout: '', exitCode: 0 });
+
+      await runAsUser(
+        {
+          username: null,
+          command: 'cat > /tmp/out',
+          stdin: 'hello, world',
+        },
+        fakeSpawn,
+      );
+
+      const opts = captured[0].options as { stdin?: Uint8Array };
+      expect(opts.stdin).toBeInstanceOf(Uint8Array);
+      expect(new TextDecoder().decode(opts.stdin)).toBe('hello, world');
+    });
+
+    it('forwards a Uint8Array stdin verbatim (no re-encoding for binary payloads)', async () => {
+      process.env.AUTH_MODE = 'none';
+      const captured: CapturedSpawn[] = [];
+      const fakeSpawn = makeFakeSpawn(captured, { stdout: '', exitCode: 0 });
+      const bytes = new Uint8Array([0x00, 0x01, 0x02, 0xff]);
+
+      await runAsUser(
+        {
+          username: null,
+          command: 'cat > /tmp/binary',
+          stdin: bytes,
+        },
+        fakeSpawn,
+      );
+
+      const opts = captured[0].options as { stdin?: Uint8Array };
+      // Same reference (no copy) is acceptable; assert bytes equality.
+      expect(opts.stdin).toEqual(bytes);
+    });
+
+    it('omits the stdin spawn option when opts.stdin is not set', async () => {
+      process.env.AUTH_MODE = 'none';
+      const captured: CapturedSpawn[] = [];
+      const fakeSpawn = makeFakeSpawn(captured, { stdout: '', exitCode: 0 });
+
+      await runAsUser({ username: null, command: 'echo hi' }, fakeSpawn);
+
+      const opts = captured[0].options as { stdin?: unknown };
+      expect(opts.stdin).toBeUndefined();
+    });
   });
 });

--- a/packages/server/src/services/__tests__/privilege-elevation.test.ts
+++ b/packages/server/src/services/__tests__/privilege-elevation.test.ts
@@ -5,6 +5,7 @@ import {
   buildSpawnArgs,
   buildInnerCommand,
   shellEscape,
+  shouldElevateForUser,
   type SpawnFn,
 } from '../privilege-elevation.js';
 
@@ -136,6 +137,32 @@ describe('privilege-elevation', () => {
     it('escapes embedded single quotes', () => {
       // foo'bar -> 'foo'\''bar'
       expect(shellEscape("foo'bar")).toBe("'foo'\\''bar'");
+    });
+  });
+
+  describe('shouldElevateForUser', () => {
+    it('returns false when AUTH_MODE is unset (single-user)', () => {
+      // AUTH_MODE deleted by beforeEach
+      expect(shouldElevateForUser('alice')).toBe(false);
+      expect(shouldElevateForUser(serverUsername)).toBe(false);
+    });
+
+    it('returns false when AUTH_MODE is set but username is null/undefined/empty', () => {
+      process.env.AUTH_MODE = 'multi-user';
+      expect(shouldElevateForUser(null)).toBe(false);
+      expect(shouldElevateForUser(undefined)).toBe(false);
+      expect(shouldElevateForUser('')).toBe(false);
+    });
+
+    it('returns false in multi-user mode when username equals the server user', () => {
+      process.env.AUTH_MODE = 'multi-user';
+      expect(shouldElevateForUser(serverUsername)).toBe(false);
+    });
+
+    it('returns true in multi-user mode for a different OS username', () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const otherUser = `${serverUsername}-not-the-server-user`;
+      expect(shouldElevateForUser(otherUser)).toBe(true);
     });
   });
 

--- a/packages/server/src/services/__tests__/worktree-creation-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-creation-service.test.ts
@@ -9,7 +9,13 @@ const mockListWorktrees = mock<(repoPath: string, repoId: string) => Promise<Wor
   Promise.resolve([]),
 );
 const mockCreateWorktree = mock<
-  (repoPath: string, branch: string, repoId: string, baseBranch?: string) => Promise<{ worktreePath: string; error?: string }>
+  (
+    repoPath: string,
+    branch: string,
+    repoId: string,
+    baseBranch?: string,
+    requestUsername?: string | null,
+  ) => Promise<{ worktreePath: string; error?: string }>
 >(() => Promise.resolve({ worktreePath: '/repos/my-repo/worktrees/wt-new' }));
 const mockRemoveWorktree = mock<
   (repoPath: string, path: string, force: boolean) => Promise<{ success: boolean; error?: string }>

--- a/packages/server/src/services/__tests__/worktree-creation-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-creation-service.test.ts
@@ -112,9 +112,11 @@ describe('createWorktreeWithSession', () => {
 
     // Verify fetch was called with remote branch
     expect(mockGit.fetchRemote).toHaveBeenCalledWith('main', '/repos/my-repo');
-    // Verify createWorktree used origin/ prefix
+    // Verify createWorktree used origin/ prefix. `requestUsername` is
+    // forwarded from `CreateWorktreeParams` -- undefined here because
+    // DEFAULT_PARAMS does not set it (single-user defaults).
     expect(mockCreateWorktree).toHaveBeenCalledWith(
-      '/repos/my-repo', 'feature-new', 'repo-1', 'origin/main',
+      '/repos/my-repo', 'feature-new', 'repo-1', 'origin/main', undefined,
     );
     expect(sm.createSession).toHaveBeenCalledTimes(1);
   });
@@ -131,7 +133,7 @@ describe('createWorktreeWithSession', () => {
     expect(mockGit.fetchRemote).not.toHaveBeenCalled();
     // baseBranch is passed as-is (no origin/ prefix)
     expect(mockCreateWorktree).toHaveBeenCalledWith(
-      '/repos/my-repo', 'feature-new', 'repo-1', 'main',
+      '/repos/my-repo', 'feature-new', 'repo-1', 'main', undefined,
     );
   });
 
@@ -155,7 +157,7 @@ describe('createWorktreeWithSession', () => {
     expect(result.fetchError).toBe('Failed to fetch remote branch, created from local branch instead');
     // baseBranch should remain local (no origin/ prefix)
     expect(mockCreateWorktree).toHaveBeenCalledWith(
-      '/repos/my-repo', 'feature-new', 'repo-1', 'main',
+      '/repos/my-repo', 'feature-new', 'repo-1', 'main', undefined,
     );
   });
 
@@ -236,6 +238,21 @@ describe('createWorktreeWithSession', () => {
     expect(sessionRequest.templateVars).toEqual({ model: 'opus' });
     // createdBy is passed via the context parameter
     expect(passedContext).toEqual(context);
+  });
+
+  it('threads requestUsername to WorktreeService.createWorktree (Issue #838)', async () => {
+    const sm = createMockSessionManager();
+    await createWorktreeWithSession(
+      { ...DEFAULT_PARAMS, requestUsername: 'alice' },
+      sm,
+      mockWorktreeService,
+    );
+
+    // The username arrives at WorktreeService as the 5th positional arg so
+    // multi-user installs create the worktree as the requesting user.
+    expect(mockCreateWorktree).toHaveBeenCalledWith(
+      '/repos/my-repo', 'feature-new', 'repo-1', 'origin/main', 'alice',
+    );
   });
 
   it('returns original error even when rollback fails', async () => {

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -4,6 +4,33 @@ import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.j
 import { mockGit, GitError } from '../../__tests__/utils/mock-git-helper.js';
 import type { Worktree } from '@agent-console/shared';
 import type { WorktreeRepository, WorktreeRecord } from '../../repositories/worktree-repository.js';
+import type { RunAsUserOpts, RunAsUserResult } from '../privilege-elevation.js';
+
+/**
+ * Capture-and-respond fake for `runAsUser`. The worktree-service routes
+ * `git worktree add` (and the per-user `safe.directory` bootstrap on the
+ * elevated path) through `runAsUser`, so tests inject this fake via the
+ * `runAsUserImpl` constructor option and assert on the captured opts.
+ *
+ * Default response: success (exitCode 0, empty stdout/stderr). Per-test
+ * scenarios can replace the responder via `responder.fn = ...`.
+ */
+function createRunAsUserMock() {
+  const calls: RunAsUserOpts[] = [];
+  const responder = {
+    fn: async (_opts: RunAsUserOpts): Promise<RunAsUserResult> => ({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+    }),
+  };
+  const runAsUserImpl = (opts: RunAsUserOpts) => {
+    calls.push(opts);
+    return responder.fn(opts);
+  };
+  return { calls, runAsUserImpl, responder };
+}
 
 // Test config directory
 const TEST_CONFIG_DIR = '/test/config';
@@ -65,6 +92,9 @@ function createMockWorktreeRepository(): WorktreeRepository & { records: Worktre
 
 describe('WorktreeService', () => {
   let mockRepo: ReturnType<typeof createMockWorktreeRepository>;
+  // Top-level capture mock for `runAsUser`. All sub-describes share the
+  // same instance; the top-level beforeEach creates a fresh one per test.
+  let runAsUserMock: ReturnType<typeof createRunAsUserMock>;
 
   beforeEach(() => {
     // Setup memfs with config directory structure
@@ -75,12 +105,15 @@ describe('WorktreeService', () => {
 
     // Create fresh mock repository for each test
     mockRepo = createMockWorktreeRepository();
+    // Fresh runAsUser capture for each test (default: success response).
+    runAsUserMock = createRunAsUserMock();
 
-    // Reset mocks
+    // Reset mocks. `createWorktree` is no longer mocked at the lib/git layer
+    // because the service now routes through `runAsUser` -- the
+    // `runAsUserMock` defined above is the capture point for the create path.
     mockGit.getRemoteUrl.mockReset();
     mockGit.parseOrgRepo.mockReset();
     mockGit.listWorktrees.mockReset();
-    mockGit.createWorktree.mockReset();
     mockGit.removeWorktree.mockReset();
     mockGit.listLocalBranches.mockReset();
     mockGit.listRemoteBranches.mockReset();
@@ -97,7 +130,6 @@ worktree /worktrees/feature-1
 HEAD def456
 branch refs/heads/feature-1
 `));
-    mockGit.createWorktree.mockImplementation(() => Promise.resolve());
     mockGit.removeWorktree.mockImplementation(() => Promise.resolve());
     mockGit.listLocalBranches.mockImplementation(() => Promise.resolve(['main', 'feature-1', 'feature-2']));
     mockGit.listRemoteBranches.mockImplementation(() => Promise.resolve(['origin/main', 'origin/develop']));
@@ -211,9 +243,34 @@ detached
   });
 
   describe('createWorktree', () => {
-    it('should create worktree with existing branch', async () => {
+    // `runAsUser` is now the single execution point for `git worktree add`,
+    // so the tests inject a capture mock via `runAsUserImpl` rather than
+    // relying on the lib/git module mock for the create path. The lib/git
+    // mock is still used for sibling operations (list, listBranches, etc.).
+    let originalAuthMode: string | undefined;
+
+    beforeEach(() => {
+      // Default tests run as a single-user environment (no elevation, no
+      // safe.directory bootstrap). Multi-user behaviour is exercised by its
+      // own describe block below.
+      originalAuthMode = process.env.AUTH_MODE;
+      delete process.env.AUTH_MODE;
+    });
+
+    afterEach(() => {
+      if (originalAuthMode === undefined) {
+        delete process.env.AUTH_MODE;
+      } else {
+        process.env.AUTH_MODE = originalAuthMode;
+      }
+    });
+
+    it('should create worktree with existing branch (single-user: no elevation)', async () => {
       const WorktreeService = await getWorktreeService();
-      const service = new WorktreeService({ worktreeRepository: mockRepo });
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
 
       const result = await service.createWorktree('/repo', 'feature-branch', 'repo-1');
 
@@ -221,45 +278,158 @@ detached
       // Directory name is wt-XXX-xxxx format, independent of branch name
       expect(result.worktreePath).toMatch(/wt-\d{3}-[a-z0-9]{4}$/);
       expect(result.index).toBeDefined();
-      // Verify createWorktree was called with correct arguments
-      expect(mockGit.createWorktree).toHaveBeenCalledWith(
-        expect.stringMatching(/wt-\d{3}-[a-z0-9]{4}$/),
-        'feature-branch',
-        '/repo',
-        { baseBranch: undefined }
-      );
+      // Verify runAsUser was invoked with the correct git command, cwd, and
+      // a null username (no elevation in single-user mode).
+      expect(runAsUserMock.calls.length).toBe(1);
+      const call = runAsUserMock.calls[0];
+      expect(call.username).toBeNull();
+      expect(call.cwd).toBe('/repo');
+      // Command is `'git' 'worktree' 'add' '<path>' 'feature-branch'` with
+      // each value single-quote escaped. No `-b` flag when no baseBranch.
+      expect(call.command).toMatch(/^'git' 'worktree' 'add' '.*wt-\d{3}-[a-z0-9]{4}' 'feature-branch'$/);
       // Verify record was saved to mock repository
       expect(mockRepo.records.length).toBe(1);
       expect(mockRepo.records[0].repositoryId).toBe('repo-1');
       expect(mockRepo.records[0].path).toBe(result.worktreePath);
     });
 
-    it('should create worktree with new branch from base', async () => {
+    it('should create worktree with new branch from base (uses -b flag)', async () => {
       const WorktreeService = await getWorktreeService();
-      const service = new WorktreeService({ worktreeRepository: mockRepo });
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
 
       await service.createWorktree('/repo', 'new-feature', 'repo-1', 'main');
 
-      expect(mockGit.createWorktree).toHaveBeenCalledWith(
-        expect.stringMatching(/wt-\d{3}-[a-z0-9]{4}$/),
-        'new-feature',
-        '/repo',
-        { baseBranch: 'main' }
+      expect(runAsUserMock.calls.length).toBe(1);
+      const call = runAsUserMock.calls[0];
+      // With baseBranch, command is `git worktree add -b <branch> <path> <baseBranch>`
+      expect(call.command).toMatch(
+        /^'git' 'worktree' 'add' '-b' 'new-feature' '.*wt-\d{3}-[a-z0-9]{4}' 'main'$/,
       );
     });
 
-    it('should return error on failure', async () => {
-      mockGit.createWorktree.mockImplementation(() =>
-        Promise.reject(new GitError('branch already exists', 128, 'fatal: branch already exists'))
-      );
+    it('should return error on failure (non-zero exit code from runAsUser)', async () => {
+      runAsUserMock.responder.fn = async () => ({
+        stdout: '',
+        stderr: 'fatal: branch already exists',
+        exitCode: 128,
+        timedOut: false,
+      });
 
       const WorktreeService = await getWorktreeService();
-      const service = new WorktreeService({ worktreeRepository: mockRepo });
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
 
       const result = await service.createWorktree('/repo', 'existing-branch', 'repo-1');
 
       expect(result.error).toBeDefined();
+      expect(result.error).toContain('branch already exists');
       expect(result.worktreePath).toBe('');
+      // Verify no DB record was saved on failure
+      expect(mockRepo.records.length).toBe(0);
+    });
+
+    describe('multi-user mode (Issue #838)', () => {
+      beforeEach(() => {
+        process.env.AUTH_MODE = 'multi-user';
+      });
+
+      it('routes git worktree add through runAsUser with requestUsername', async () => {
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        // Use a non-server username so elevation actually engages. Hardcoding
+        // an unlikely-collision value avoids dependence on the host's user.
+        const result = await service.createWorktree(
+          '/repo',
+          'feature-x',
+          'repo-1',
+          undefined,
+          'alice-multiuser-test',
+        );
+
+        expect(result.error).toBeUndefined();
+        // Two calls: safe.directory bootstrap, then git worktree add.
+        expect(runAsUserMock.calls.length).toBe(2);
+
+        // Call ordering: bootstrap MUST precede the worktree add so the
+        // user's gitconfig has the safe.directory entry before git runs.
+        const bootstrap = runAsUserMock.calls[0];
+        expect(bootstrap.username).toBe('alice-multiuser-test');
+        expect(bootstrap.command).toContain('safe.directory');
+        expect(bootstrap.command).toContain("'/repo'");
+
+        const worktreeAdd = runAsUserMock.calls[1];
+        expect(worktreeAdd.username).toBe('alice-multiuser-test');
+        expect(worktreeAdd.cwd).toBe('/repo');
+        expect(worktreeAdd.command).toMatch(
+          /^'git' 'worktree' 'add' '.*wt-\d{3}-[a-z0-9]{4}' 'feature-x'$/,
+        );
+      });
+
+      it('skips safe.directory bootstrap when no requestUsername is supplied (backward compat)', async () => {
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        // No requestUsername -> no elevation -> only one call (worktree add
+        // with username=null, which the helper bypasses).
+        const result = await service.createWorktree('/repo', 'feature-y', 'repo-1');
+
+        expect(result.error).toBeUndefined();
+        expect(runAsUserMock.calls.length).toBe(1);
+        expect(runAsUserMock.calls[0].username).toBeNull();
+        // The DB record is saved with the server-user-owned worktree path.
+        expect(mockRepo.records.length).toBe(1);
+      });
+
+      it('does not abort worktree creation when the safe.directory bootstrap returns non-zero', async () => {
+        let callCount = 0;
+        runAsUserMock.responder.fn = async () => {
+          callCount += 1;
+          // First call is the bootstrap; simulate a non-zero exit. Second
+          // call is `git worktree add`; respond success so creation proceeds.
+          if (callCount === 1) {
+            return {
+              stdout: '',
+              stderr: 'unable to write config',
+              exitCode: 1,
+              timedOut: false,
+            };
+          }
+          return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+        };
+
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        const result = await service.createWorktree(
+          '/repo',
+          'feature-z',
+          'repo-1',
+          undefined,
+          'alice-multiuser-test',
+        );
+
+        // Bootstrap failure is logged but not fatal; the worktree add still
+        // ran and DB record was saved. If `git worktree add` itself fails
+        // because of the missing safe.directory entry, the error from THAT
+        // call surfaces to the caller (covered by the "non-zero exit" test).
+        expect(result.error).toBeUndefined();
+        expect(runAsUserMock.calls.length).toBe(2);
+      });
     });
 
     describe('template copying', () => {
@@ -269,7 +439,10 @@ detached
         fs.writeFileSync('/repo/.agent-console/CLAUDE.md', 'hello world');
 
         const WorktreeService = await getWorktreeService();
-        const service = new WorktreeService({ worktreeRepository: mockRepo });
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
 
         const result = await service.createWorktree('/repo', 'feature-branch', 'repo-1');
 
@@ -289,7 +462,10 @@ detached
         fs.writeFileSync(`${globalTemplatesDir}/setup.sh`, '#!/bin/bash\necho setup');
 
         const WorktreeService = await getWorktreeService();
-        const service = new WorktreeService({ worktreeRepository: mockRepo });
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
 
         const result = await service.createWorktree('/repo', 'feature-branch', 'repo-1');
 
@@ -307,7 +483,10 @@ detached
         );
 
         const WorktreeService = await getWorktreeService();
-        const service = new WorktreeService({ worktreeRepository: mockRepo });
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
 
         const result = await service.createWorktree('/repo', 'my-feature', 'repo-1');
 
@@ -326,7 +505,10 @@ detached
         fs.writeFileSync('/repo/.agent-console/root-file.txt', 'root');
 
         const WorktreeService = await getWorktreeService();
-        const service = new WorktreeService({ worktreeRepository: mockRepo });
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
 
         const result = await service.createWorktree('/repo', 'feature-branch', 'repo-1');
 
@@ -744,7 +926,10 @@ detached
       );
 
       const WorktreeService = await getWorktreeService();
-      const service = new WorktreeService({ worktreeRepository: mockRepo });
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
 
       const result = await service.createWorktree('/repo', 'feature-gap', 'repo-1');
 
@@ -764,7 +949,10 @@ detached
       }
 
       const WorktreeService = await getWorktreeService();
-      const service = new WorktreeService({ worktreeRepository: mockRepo });
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
 
       const result = await service.createWorktree('/repo', 'feature-next', 'repo-1');
 
@@ -776,7 +964,10 @@ detached
       // mockRepo.records is empty
 
       const WorktreeService = await getWorktreeService();
-      const service = new WorktreeService({ worktreeRepository: mockRepo });
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
 
       const result = await service.createWorktree('/repo', 'first-worktree', 'repo-1');
 

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -392,6 +392,79 @@ detached
         expect(mockRepo.records.length).toBe(1);
       });
 
+      it('materializes template files as the requesting user (Issue #838 ownership-consistency)', async () => {
+        // Templates live under <repo>/.agent-console/ ; create one. Without
+        // the user-owned-sink behaviour, the template would be written by
+        // the server process. With it, the sink shells out to `mkdir -p`
+        // and `cat > <dst>` as the user, so both ownership and the writes
+        // are routed through runAsUser.
+        fs.mkdirSync('/repo/.agent-console', { recursive: true });
+        fs.writeFileSync(
+          '/repo/.agent-console/CLAUDE.md',
+          'branch={{BRANCH}} num={{WORKTREE_NUM}}',
+        );
+
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        const result = await service.createWorktree(
+          '/repo',
+          'feature-templates',
+          'repo-1',
+          undefined,
+          'alice-multiuser-test',
+        );
+
+        expect(result.error).toBeUndefined();
+        expect(result.copiedFiles).toContain('CLAUDE.md');
+
+        // Expected runAsUser calls (order matters):
+        //   [0] safe.directory bootstrap
+        //   [1] git worktree add
+        //   [2] mkdir -p <worktreePath>  (the file's parent dir)
+        //   [3] cat > <worktreePath>/CLAUDE.md (with substituted content as stdin)
+        expect(runAsUserMock.calls.length).toBe(4);
+
+        const mkdirCall = runAsUserMock.calls[2];
+        expect(mkdirCall.username).toBe('alice-multiuser-test');
+        expect(mkdirCall.command).toMatch(/^mkdir -p '.*wt-\d{3}-[a-z0-9]{4}'$/);
+
+        const writeCall = runAsUserMock.calls[3];
+        expect(writeCall.username).toBe('alice-multiuser-test');
+        expect(writeCall.command).toMatch(
+          /^cat > '.*wt-\d{3}-[a-z0-9]{4}\/CLAUDE\.md'$/,
+        );
+        // Stdin carries the substituted content. WORKTREE_NUM is the
+        // allocated index (1 for a fresh DB).
+        expect(writeCall.stdin).toBe('branch=feature-templates num=1');
+      });
+
+      it('uses direct fs writes for templates when worktree is server-owned (no requestUsername)', async () => {
+        // No requestUsername -> sink falls back to direct fs writes.
+        // This preserves the original pre-#838 single-user behaviour.
+        fs.mkdirSync('/repo/.agent-console', { recursive: true });
+        fs.writeFileSync('/repo/.agent-console/hello.txt', 'hi');
+
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        const result = await service.createWorktree('/repo', 'feature-no-user', 'repo-1');
+
+        expect(result.error).toBeUndefined();
+        expect(result.copiedFiles).toContain('hello.txt');
+        // Only one runAsUser call: the `git worktree add` invocation with
+        // username=null. The template write went through fsPromises, not
+        // runAsUser.
+        expect(runAsUserMock.calls.length).toBe(1);
+        expect(runAsUserMock.calls[0].username).toBeNull();
+      });
+
       it('does not abort worktree creation when the safe.directory bootstrap returns non-zero', async () => {
         let callCount = 0;
         runAsUserMock.responder.fn = async () => {

--- a/packages/server/src/services/privilege-elevation.ts
+++ b/packages/server/src/services/privilege-elevation.ts
@@ -82,6 +82,14 @@ export interface RunAsUserOpts {
    * array suppresses the flag entirely. Ignored when elevation is bypassed.
    */
   preserveEnv?: string[];
+  /**
+   * Optional bytes to feed to the child's stdin. Use when the command is a
+   * sink that reads stdin (e.g. `sh -c 'cat > <dst>'` to materialize a file
+   * as the target user, see worktree-service.ts template materialization).
+   * String values are encoded as UTF-8; pass a `Uint8Array` for binary
+   * content. When omitted, stdin is left as the default (inherit / no pipe).
+   */
+  stdin?: string | Uint8Array;
 }
 
 export interface RunAsUserResult {
@@ -251,6 +259,16 @@ export async function runAsUser(
     stdout: 'pipe',
     stderr: 'pipe',
   };
+  if (opts.stdin !== undefined) {
+    // Caller provided stdin bytes -- normalize string to UTF-8 and hand
+    // Bun.spawn the Uint8Array. Bun's `stdin` option accepts Uint8Array,
+    // Blob, ReadableStream, etc.; Uint8Array is the simplest contract.
+    const stdinBytes =
+      typeof opts.stdin === 'string'
+        ? new TextEncoder().encode(opts.stdin)
+        : opts.stdin;
+    spawnOptions.stdin = stdinBytes;
+  }
   if (elevated) {
     spawnOptions.cwd = SUDO_NEUTRAL_CWD;
   } else {

--- a/packages/server/src/services/privilege-elevation.ts
+++ b/packages/server/src/services/privilege-elevation.ts
@@ -158,6 +158,28 @@ export function buildInnerCommand(
 }
 
 /**
+ * Decide whether `runAsUser` would actually elevate for the given username
+ * under the current `AUTH_MODE`. Callers use this to gate companion logic
+ * that only makes sense when running as a different OS user (e.g., the
+ * source-repo `safe.directory` bootstrap in `worktree-service.ts`).
+ *
+ * Reads `process.env.AUTH_MODE` and `os.userInfo().username` at call time so
+ * the result reflects the same runtime conditions `runAsUser` itself sees.
+ */
+export function shouldElevateForUser(
+  username: string | null | undefined,
+): boolean {
+  const authMode = process.env.AUTH_MODE;
+  const serverUsername = os.userInfo().username;
+  return (
+    authMode === 'multi-user' &&
+    typeof username === 'string' &&
+    username.length > 0 &&
+    username !== serverUsername
+  );
+}
+
+/**
  * Build the argv that will actually be spawned. Pure function so tests can
  * assert the shape without spawning a real process.
  * @internal Exported for testing.

--- a/packages/server/src/services/worktree-creation-service.ts
+++ b/packages/server/src/services/worktree-creation-service.ts
@@ -42,6 +42,15 @@ export interface CreateWorktreeParams {
   title?: string;
   autoStartSession?: boolean;  // Defaults to true. When false, skip session creation.
   context?: SessionCreationContext;
+  /**
+   * OS username of the user who requested this worktree (typically
+   * `authUser.username` from the route handler). Threaded down to
+   * `WorktreeService.createWorktree` -> `runAsUser` so multi-user mode
+   * creates the worktree files owned by the requesting user (Issue #838).
+   * `null` / `undefined` -> no elevation (single-user mode, or any path that
+   * has no authenticated user context).
+   */
+  requestUsername?: string | null;
 }
 
 export interface CreateWorktreeResult {
@@ -71,6 +80,7 @@ export async function createWorktreeWithSession(
     useRemote, agentId, initialPrompt, title,
     autoStartSession = true,
     context,
+    requestUsername,
   } = params;
 
   // 1. Handle remote fetch if requested
@@ -94,7 +104,13 @@ export async function createWorktreeWithSession(
   }
 
   // 2. Create worktree
-  const wtResult = await worktreeService.createWorktree(repoPath, branch, repoId, effectiveBaseBranch);
+  const wtResult = await worktreeService.createWorktree(
+    repoPath,
+    branch,
+    repoId,
+    effectiveBaseBranch,
+    requestUsername,
+  );
 
   if (wtResult.error) {
     return { success: false, error: wtResult.error };

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -6,7 +6,6 @@ import {
   getRemoteUrl,
   parseOrgRepo,
   listWorktrees as gitListWorktrees,
-  createWorktree as gitCreateWorktree,
   removeWorktree as gitRemoveWorktree,
   listLocalBranches,
   listRemoteBranches,
@@ -17,12 +16,31 @@ import {
 import { createLogger } from '../lib/logger.js';
 import { substituteVariables } from '../lib/template-variables.js';
 import { getCleanChildProcessEnv } from './env-filter.js';
+import {
+  runAsUser,
+  shellEscape,
+  shouldElevateForUser,
+  type RunAsUserResult,
+} from './privilege-elevation.js';
 import type { Kysely } from 'kysely';
 import type { Database } from '../database/schema.js';
 import type { WorktreeRepository, WorktreeRecord } from '../repositories/worktree-repository.js';
 import { SqliteWorktreeRepository } from '../repositories/sqlite-worktree-repository.js';
 
 const logger = createLogger('worktree-service');
+
+/**
+ * Timeout for `git worktree add` invocations that route through `runAsUser`.
+ * Mirrors `HEAVY_GIT_TIMEOUT_MS` from `lib/git.ts` so the multi-user path has
+ * the same wall-clock budget as the direct-spawn single-user path.
+ */
+const WORKTREE_ADD_TIMEOUT_MS = 120000;
+
+/**
+ * Timeout for the per-user `safe.directory` bootstrap. Short — the command is
+ * a pure local gitconfig write with no network or fs traversal.
+ */
+const SAFE_DIRECTORY_BOOTSTRAP_TIMEOUT_MS = 10000;
 
 /**
  * Generate a random alphanumeric suffix
@@ -133,19 +151,30 @@ async function getOrgRepoFromRemote(repoPath: string): Promise<string | null> {
 }
 
 /**
+ * Type of the privilege-elevation helper, exposed for dependency injection
+ * in tests. Production code uses the real `runAsUser` import.
+ */
+type RunAsUserFn = typeof runAsUser;
+
+/**
  * Discriminated union for WorktreeService dependencies.
  * Either provide a `db` (and the service creates its own repository),
  * or provide a `worktreeRepository` directly (e.g. in tests).
+ *
+ * `runAsUserImpl` is an optional injection point used only by tests; in
+ * production it defaults to the real `runAsUser`.
  */
 export type WorktreeServiceDeps =
-  | { db: Kysely<Database>; worktreeRepository?: never }
-  | { db?: never; worktreeRepository: WorktreeRepository };
+  | { db: Kysely<Database>; worktreeRepository?: never; runAsUserImpl?: RunAsUserFn }
+  | { db?: never; worktreeRepository: WorktreeRepository; runAsUserImpl?: RunAsUserFn };
 
 export class WorktreeService {
   private readonly _worktreeRepository: WorktreeRepository;
+  private readonly _runAsUser: RunAsUserFn;
 
   constructor(deps: WorktreeServiceDeps) {
     this._worktreeRepository = deps.worktreeRepository ?? new SqliteWorktreeRepository(deps.db);
+    this._runAsUser = deps.runAsUserImpl ?? runAsUser;
   }
 
   private get worktreeRepository(): WorktreeRepository {
@@ -247,13 +276,30 @@ export class WorktreeService {
   }
 
   /**
-   * Create a new worktree
+   * Create a new worktree.
+   *
+   * When `requestUsername` is provided and the server is in `AUTH_MODE=multi-user`,
+   * `git worktree add` is invoked via `runAsUser` so the resulting worktree
+   * files are owned by the requesting user. This eliminates the
+   * `dubious ownership` error users hit when running git commands inside the
+   * worktree's PTY (Issue #838 / umbrella #837).
+   *
+   * In `AUTH_MODE=none` or when `requestUsername` is null/undefined, the call
+   * still routes through `runAsUser` (which bypasses elevation in that case),
+   * preserving the original single-user behaviour.
+   *
+   * When elevating, the server also runs `git config --global --add
+   * safe.directory <repoPath>` as the requesting user once, so git's owner
+   * check passes against the source repo (which remains owned by the server
+   * user). The bootstrap is idempotent thanks to `git config --get-all`
+   * checking for an existing entry first.
    */
   async createWorktree(
     repoPath: string,
     branch: string,
     repositoryId: string,
-    baseBranch?: string
+    baseBranch?: string,
+    requestUsername?: string | null,
   ): Promise<{ worktreePath: string; index?: number; copiedFiles?: string[]; error?: string }> {
     // Generate worktree path: repositories/{org}/{repo}/worktrees/wt-{index}-{suffix}
     // Directory name is independent of branch name to avoid path issues with branch names containing slashes
@@ -273,7 +319,27 @@ export class WorktreeService {
     const worktreePath = path.join(repoWorktreeDir, dirName);
 
     try {
-      await gitCreateWorktree(worktreePath, branch, repoPath, { baseBranch });
+      // Determine whether elevation will actually engage. `runAsUser` itself
+      // checks the same conditions; we replicate the check locally so we can
+      // also gate the safe.directory bootstrap (only meaningful when running
+      // as a non-server user).
+      const willElevate = shouldElevateForUser(requestUsername);
+
+      if (willElevate) {
+        // Bootstrap the user's gitconfig so `git worktree add` (running as
+        // the user) accepts the server-owned source repo. Idempotent —
+        // `git config --get-all safe.directory` is checked first so we only
+        // add the entry if it is not already present.
+        await this.bootstrapSafeDirectoryForUser(requestUsername!, repoPath);
+      }
+
+      await this.invokeGitWorktreeAdd({
+        worktreePath,
+        branch,
+        repoPath,
+        baseBranch,
+        requestUsername: willElevate ? requestUsername! : null,
+      });
 
       // Save record to DB
       await this.worktreeRepository.save({
@@ -284,7 +350,10 @@ export class WorktreeService {
         createdAt: new Date().toISOString(),
       });
 
-      logger.info({ worktreePath, index: newIndex }, 'Worktree created');
+      logger.info(
+        { worktreePath, index: newIndex, elevated: willElevate },
+        'Worktree created',
+      );
 
       // Copy template files
       const templatesDir = await findTemplatesDir(repoPath, orgRepo);
@@ -309,6 +378,107 @@ export class WorktreeService {
       logger.error({ err: error, message }, 'Failed to create worktree');
       return { worktreePath: '', error: message };
     }
+  }
+
+  /**
+   * Invoke `git worktree add` via `runAsUser`. When `requestUsername` is null
+   * or in `AUTH_MODE=none`, `runAsUser` bypasses elevation and runs the
+   * command as the server user (the same effective behaviour as the prior
+   * `Bun.spawn(['git', ...])` call in `lib/git.ts`). When elevation engages,
+   * the worktree files end up owned by the requesting user, eliminating the
+   * `dubious ownership` issue (#838).
+   *
+   * Throws a `GitError`-compatible error on non-zero exit so callers can
+   * keep their existing `instanceof GitError` branching (via
+   * `extractErrorMessage`).
+   */
+  private async invokeGitWorktreeAdd(opts: {
+    worktreePath: string;
+    branch: string;
+    repoPath: string;
+    baseBranch?: string;
+    requestUsername: string | null;
+  }): Promise<void> {
+    // Build the git invocation as a shell command. Every interpolated value
+    // is shell-escaped — branch names and worktree paths originate from
+    // server-controlled / DB-driven sources but routing them through
+    // `shellEscape` keeps the contract uniform (no value reaches sh -c
+    // unquoted).
+    const args = ['git', 'worktree', 'add'];
+    if (opts.baseBranch !== undefined) {
+      args.push('-b', opts.branch, opts.worktreePath, opts.baseBranch);
+    } else {
+      args.push(opts.worktreePath, opts.branch);
+    }
+    const command = args.map(shellEscape).join(' ');
+
+    const result = await this._runAsUser({
+      username: opts.requestUsername,
+      command,
+      cwd: opts.repoPath,
+      timeoutMs: WORKTREE_ADD_TIMEOUT_MS,
+    });
+
+    if (result.timedOut || result.exitCode !== 0) {
+      const stderr = result.stderr.trim();
+      const detail = stderr || `exit code ${result.exitCode}`;
+      throw new GitError(`git worktree failed: ${detail}`, result.exitCode, stderr);
+    }
+  }
+
+  /**
+   * Append `<repoPath>` to the requesting user's `safe.directory` list when
+   * not already present. Required because the source repo is owned by the
+   * server user (`agentconsole`), so `git worktree add` running as the
+   * requesting user would otherwise hit `fatal: detected dubious ownership`.
+   * Mitigation A from Issue #838.
+   *
+   * Idempotent — checks `git config --get-all safe.directory` first and only
+   * adds the entry when this exact `repoPath` is missing. Failure is logged
+   * but not thrown, so a misconfigured gitconfig does not block worktree
+   * creation; the subsequent `git worktree add` will surface a clearer
+   * `dubious ownership` error if the bootstrap was actually needed.
+   */
+  private async bootstrapSafeDirectoryForUser(
+    username: string,
+    repoPath: string,
+  ): Promise<void> {
+    const escapedPath = shellEscape(repoPath);
+    // `--get-all` returns one line per entry, exit 0 even if none match the
+    // value. We post-filter rather than relying on `--get` (which would only
+    // return the first match and could mis-report when the user has multiple
+    // entries).
+    const command = `if ! git config --global --get-all safe.directory 2>/dev/null | grep -Fxq ${escapedPath}; then git config --global --add safe.directory ${escapedPath}; fi`;
+    let result: RunAsUserResult;
+    try {
+      result = await this._runAsUser({
+        username,
+        command,
+        timeoutMs: SAFE_DIRECTORY_BOOTSTRAP_TIMEOUT_MS,
+      });
+    } catch (error) {
+      logger.warn(
+        { err: error, username, repoPath },
+        'safe.directory bootstrap spawn failed; continuing with worktree creation',
+      );
+      return;
+    }
+
+    if (result.timedOut || result.exitCode !== 0) {
+      logger.warn(
+        {
+          username,
+          repoPath,
+          exitCode: result.exitCode,
+          timedOut: result.timedOut,
+          stderr: result.stderr.trim(),
+        },
+        'safe.directory bootstrap returned non-zero; continuing with worktree creation',
+      );
+      return;
+    }
+
+    logger.info({ username, repoPath }, 'safe.directory bootstrap completed for user');
   }
 
   /**

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -43,6 +43,13 @@ const WORKTREE_ADD_TIMEOUT_MS = 120000;
 const SAFE_DIRECTORY_BOOTSTRAP_TIMEOUT_MS = 10000;
 
 /**
+ * Timeout for each template file materialization step (one `mkdir -p` or
+ * `cat > <dst>` invocation) when the worktree is user-owned (Issue #838
+ * elevated branch). Local fs only, short content -- 10s is generous.
+ */
+const TEMPLATE_MATERIALIZE_TIMEOUT_MS = 10000;
+
+/**
  * Generate a random alphanumeric suffix
  */
 function generateRandomSuffix(length: number): string {
@@ -85,12 +92,46 @@ async function findTemplatesDir(repoPath: string, orgRepo: string): Promise<stri
 }
 
 /**
- * Copy template files to worktree with variable substitution
+ * Sink for template file materialization. Production uses a sink that
+ * routes writes through `runAsUser` when the worktree is user-owned
+ * (Issue #838) so template files land owned by the requesting user
+ * rather than the server process. Tests use the in-process sink that
+ * writes via `fsPromises` directly.
+ */
+interface TemplateFileSink {
+  mkdir(dirPath: string): Promise<void>;
+  writeFile(filePath: string, content: string): Promise<void>;
+}
+
+/**
+ * In-process sink used when the worktree is server-owned (single-user
+ * mode, or multi-user with no `requestUsername`). Equivalent to the
+ * original pre-#838 behaviour.
+ */
+const directFsSink: TemplateFileSink = {
+  async mkdir(dirPath) {
+    await fsPromises.mkdir(dirPath, { recursive: true });
+  },
+  async writeFile(filePath, content) {
+    await fsPromises.writeFile(filePath, content);
+  },
+};
+
+/**
+ * Copy template files to worktree with variable substitution.
+ *
+ * The reader side (substitution) always runs in-process because templates
+ * live under server-controlled paths (`<repo>/.agent-console/` or
+ * `<AGENT_CONSOLE_HOME>/repositories/<org>/<repo>/templates/`). Only the
+ * writer side is potentially elevated, via the injected `sink`, so that
+ * template files in a user-owned worktree end up owned by the requesting
+ * user rather than the server process (Issue #838).
  */
 async function copyTemplateFiles(
   templatesDir: string,
   worktreePath: string,
-  vars: { worktreeNum: number; branch: string; repo: string; worktreePath: string }
+  vars: { worktreeNum: number; branch: string; repo: string; worktreePath: string },
+  sink: TemplateFileSink,
 ): Promise<string[]> {
   const copiedFiles: string[] = [];
 
@@ -105,7 +146,7 @@ async function copyTemplateFiles(
       const destPath = path.join(destDir, entry.name);
 
       if (entry.isDirectory()) {
-        await fsPromises.mkdir(destPath, { recursive: true });
+        await sink.mkdir(destPath);
         await copyRecursive(srcPath, destPath);
       } else {
         // Read, substitute, and write
@@ -114,9 +155,9 @@ async function copyTemplateFiles(
 
         // Ensure parent directory exists
         const destParent = path.dirname(destPath);
-        await fsPromises.mkdir(destParent, { recursive: true });
+        await sink.mkdir(destParent);
 
-        await fsPromises.writeFile(destPath, substituted);
+        await sink.writeFile(destPath, substituted);
         copiedFiles.push(path.relative(worktreePath, destPath));
       }
     }
@@ -355,18 +396,31 @@ export class WorktreeService {
         'Worktree created',
       );
 
-      // Copy template files
+      // Copy template files. When the worktree is user-owned (Issue #838
+      // elevated branch), template files must also be materialized as the
+      // requesting user so the ownership of the entire worktree subtree is
+      // consistent. The sink wraps `runAsUser` for that case; the
+      // non-elevated branch uses direct fs writes (server-owned worktree
+      // matches server-owned templates).
       const templatesDir = await findTemplatesDir(repoPath, orgRepo);
       let copiedFiles: string[] = [];
 
       if (templatesDir) {
         const repoName = orgRepo.includes('/') ? orgRepo.split('/')[1] : orgRepo;
-        copiedFiles = await copyTemplateFiles(templatesDir, worktreePath, {
-          worktreeNum: newIndex,
-          branch,
-          repo: repoName,
+        const sink = willElevate
+          ? this.makeUserOwnedTemplateSink(requestUsername!)
+          : directFsSink;
+        copiedFiles = await copyTemplateFiles(
+          templatesDir,
           worktreePath,
-        });
+          {
+            worktreeNum: newIndex,
+            branch,
+            repo: repoName,
+            worktreePath,
+          },
+          sink,
+        );
         if (copiedFiles.length > 0) {
           logger.info({ copiedFiles }, 'Template files copied');
         }
@@ -479,6 +533,58 @@ export class WorktreeService {
     }
 
     logger.info({ username, repoPath }, 'safe.directory bootstrap completed for user');
+  }
+
+  /**
+   * Build a template-file sink that materializes directories and files as
+   * the requesting user via `runAsUser`. Used by `copyTemplateFiles` so
+   * that template entries in a user-owned worktree (Issue #838 elevated
+   * branch) inherit the same ownership as the worktree itself.
+   *
+   * The reader side (template content + variable substitution) stays
+   * in-process; only the writer side is elevated. Files are materialized
+   * by piping the substituted content through `sh -c 'cat > <dst>'` as
+   * the user. Directories are created via `mkdir -p <dir>` as the user.
+   *
+   * Failure modes: a non-zero exit from the spawn causes the function to
+   * throw, which propagates up through `copyTemplateFiles` and is caught
+   * by `createWorktree`'s outer try/catch (returns `{ error }` and logs).
+   */
+  private makeUserOwnedTemplateSink(username: string): TemplateFileSink {
+    const runAsUser = this._runAsUser;
+    return {
+      async mkdir(dirPath: string): Promise<void> {
+        const escaped = shellEscape(dirPath);
+        const result = await runAsUser({
+          username,
+          command: `mkdir -p ${escaped}`,
+          timeoutMs: TEMPLATE_MATERIALIZE_TIMEOUT_MS,
+        });
+        if (result.timedOut || result.exitCode !== 0) {
+          const detail = result.stderr.trim() || `exit ${result.exitCode}`;
+          throw new Error(`mkdir as ${username} failed for ${dirPath}: ${detail}`);
+        }
+      },
+      async writeFile(filePath: string, content: string): Promise<void> {
+        const escaped = shellEscape(filePath);
+        // `cat > <dst>` is the canonical "write stdin to file" shell
+        // idiom. The user's shell receives the bytes via the stdin
+        // pipe (runAsUser plumbs `opts.stdin` through Bun.spawn) and
+        // creates `<dst>` owned by the user with the user's umask.
+        // Production umask=0002 + setgid parent → mode 0664 group
+        // agent-console-users, matching the rest of the worktree.
+        const result = await runAsUser({
+          username,
+          command: `cat > ${escaped}`,
+          stdin: content,
+          timeoutMs: TEMPLATE_MATERIALIZE_TIMEOUT_MS,
+        });
+        if (result.timedOut || result.exitCode !== 0) {
+          const detail = result.stderr.trim() || `exit ${result.exitCode}`;
+          throw new Error(`writeFile as ${username} failed for ${filePath}: ${detail}`);
+        }
+      },
+    };
   }
 
   /**

--- a/scripts/verify-multiuser-docker.sh
+++ b/scripts/verify-multiuser-docker.sh
@@ -264,7 +264,7 @@ if [ -n "$repo_id" ]; then
 
   # Worktree creation is async; poll for the new path to appear in the list.
   WT_PATH=""
-  for i in $(seq 1 30); do
+  for _ in $(seq 1 30); do
     sleep 1
     curl -s -o "$WT_LIST_RESP" -b "$ALICE_COOKIE_JAR" \
       "${BASE_URL}/api/repositories/${repo_id}/worktrees" >/dev/null

--- a/scripts/verify-multiuser-docker.sh
+++ b/scripts/verify-multiuser-docker.sh
@@ -188,6 +188,111 @@ check "upload dir is mode 2750 owned by agent-console-users (#830 setgid regress
 rm -f "$COOKIE_JAR" "$ALICE_RESP" "$SESSION_RESP" "$WORKER_RESP" "$MESSAGE_RESP" "$UPLOAD_PAYLOAD"
 
 echo
+echo "=== 7. worktree creation runs as the requesting user (#838) ==="
+# Verifies the umbrella #837 / Issue #838 fix: in multi-user mode, the server
+# routes `git worktree add` through `runAsUser` so the resulting worktree
+# files are owned by the requesting user. Without this fix, a subsequent
+# `git status` inside the worktree (running as the user) would hit
+# `fatal: detected dubious ownership in repository`.
+#
+# Bootstrap a small source repo inside the container (owned by `agentconsole`,
+# matching the documented multi-user source-repo ownership). The server
+# bootstraps `safe.directory` for alice via `runAsUser` so git accepts the
+# server-owned source repo from alice's elevated context.
+SOURCE_REPO_PATH="/var/lib/agent-console/source-repos/wt-issue-838"
+compose exec -T --user agentconsole agent-console sh -lc "
+  set -e
+  mkdir -p ${SOURCE_REPO_PATH}
+  cd ${SOURCE_REPO_PATH}
+  if [ ! -d .git ]; then
+    git init -q -b main
+    git config user.email 'agentconsole@example.com'
+    git config user.name 'agentconsole'
+    echo hello > README.md
+    git add README.md
+    git commit -q -m 'initial commit'
+  fi
+" >/dev/null 2>&1
+source_repo_ok=$?
+check "source repo bootstrapped inside container" "$source_repo_ok"
+
+ALICE_COOKIE_JAR="$(mktemp)"
+ALICE_LOGIN_RESP="$(mktemp)"
+REPO_RESP="$(mktemp)"
+WT_TASK_RESP="$(mktemp)"
+WT_LIST_RESP="$(mktemp)"
+GIT_STATUS_OUT="$(mktemp)"
+
+curl -s -o "$ALICE_LOGIN_RESP" -c "$ALICE_COOKIE_JAR" -X POST "${BASE_URL}/api/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"alice","password":"alice-password"}' >/dev/null
+
+# Register the source repo as alice.
+repo_code="$(curl -s -o "$REPO_RESP" -w '%{http_code}' -b "$ALICE_COOKIE_JAR" -c "$ALICE_COOKIE_JAR" \
+  -X POST "${BASE_URL}/api/repositories" \
+  -H 'Content-Type: application/json' \
+  -d "{\"path\":\"${SOURCE_REPO_PATH}\"}")"
+echo "  POST /api/repositories (path=${SOURCE_REPO_PATH}) -> HTTP ${repo_code}"
+repo_id="$(grep -o '"id":"[^"]*"' "$REPO_RESP" | head -n1 | cut -d'"' -f4)"
+repo_ok=1
+[ "$repo_code" = "201" ] && [ -n "$repo_id" ] && repo_ok=0
+check "alice can register source repo" "$repo_ok"
+
+if [ -n "$repo_id" ]; then
+  # Create a worktree from `main` via the API.
+  task_id="$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)"
+  wt_code="$(curl -s -o "$WT_TASK_RESP" -w '%{http_code}' -b "$ALICE_COOKIE_JAR" -c "$ALICE_COOKIE_JAR" \
+    -X POST "${BASE_URL}/api/repositories/${repo_id}/worktrees" \
+    -H 'Content-Type: application/json' \
+    -d "{\"taskId\":\"${task_id}\",\"mode\":\"custom\",\"branch\":\"issue-838-wt\",\"baseBranch\":\"main\",\"useRemote\":false,\"autoStartSession\":false}")"
+  echo "  POST /api/repositories/<id>/worktrees -> HTTP ${wt_code}"
+  wt_accept_ok=1
+  [ "$wt_code" = "202" ] && wt_accept_ok=0
+  check "worktree creation accepted (202)" "$wt_accept_ok"
+
+  # Worktree creation is async; poll for the new path to appear in the list.
+  WT_PATH=""
+  for i in $(seq 1 30); do
+    sleep 1
+    curl -s -o "$WT_LIST_RESP" -b "$ALICE_COOKIE_JAR" \
+      "${BASE_URL}/api/repositories/${repo_id}/worktrees" >/dev/null
+    WT_PATH="$(grep -o '"path":"[^"]*wt-[0-9]\{3\}-[a-z0-9]\{4\}"' "$WT_LIST_RESP" | head -n1 | cut -d'"' -f4)"
+    if [ -n "$WT_PATH" ]; then break; fi
+  done
+  wt_listed_ok=1
+  [ -n "$WT_PATH" ] && wt_listed_ok=0
+  check "worktree appears in repo's worktree list" "$wt_listed_ok"
+
+  if [ -n "$WT_PATH" ]; then
+    # Worktree dir owner must be alice (root cause of #838). The owner field
+    # is the primary signal; the safe.directory bootstrap is the secondary
+    # mitigation that lets the user's git accept the server-owned SOURCE repo.
+    WT_OWNER="$(compose exec -T agent-console stat -c '%U' "$WT_PATH" 2>/dev/null | tr -d '\r' || echo MISSING)"
+    echo "  stat ${WT_PATH} -> owner=${WT_OWNER}"
+    owner_ok=1
+    [ "$WT_OWNER" = "alice" ] && owner_ok=0
+    check "new worktree dir is owned by alice (Issue #838 root fix)" "$owner_ok"
+
+    # Run `git status` AS alice (the shipping path: alice's PTY runs as alice
+    # via sudo -i). With #838 in place, the worktree is owned by alice and
+    # the safe.directory entry for the source repo is in alice's gitconfig,
+    # so this should NOT report dubious ownership.
+    compose exec -T --user alice agent-console sh -lc "git -C '${WT_PATH}' status" \
+      > "$GIT_STATUS_OUT" 2>&1
+    git_status_exit=$?
+    echo "  git status (as alice) exit=${git_status_exit}; first line: $(head -n1 "$GIT_STATUS_OUT" | tr -d '\r')"
+    git_status_ok=1
+    if [ "$git_status_exit" -eq 0 ] && ! grep -q 'dubious ownership' "$GIT_STATUS_OUT"; then
+      git_status_ok=0
+    fi
+    check "git status as alice does NOT report dubious ownership (#838 E2E)" "$git_status_ok"
+  fi
+fi
+
+rm -f "$ALICE_COOKIE_JAR" "$ALICE_LOGIN_RESP" "$REPO_RESP" \
+  "$WT_TASK_RESP" "$WT_LIST_RESP" "$GIT_STATUS_OUT"
+
+echo
 echo "=================================================="
 echo "  RESULT: ${PASS} passed, ${FAIL} failed"
 echo "=================================================="

--- a/scripts/verify-multiuser-docker.sh
+++ b/scripts/verify-multiuser-docker.sh
@@ -200,21 +200,33 @@ echo "=== 7. worktree creation runs as the requesting user (#838) ==="
 # bootstraps `safe.directory` for alice via `runAsUser` so git accepts the
 # server-owned source repo from alice's elevated context.
 SOURCE_REPO_PATH="/var/lib/agent-console/source-repos/wt-issue-838"
+# Bootstrap a multi-user-ready source repo: owned by agentconsole but
+# configured with `core.sharedRepository=group` and group-writable `.git`
+# so members of `agent-console-users` (alice) can write refs / lock files
+# during `git worktree add`. This mirrors the operational expectation for
+# multi-user source repos -- the umbrella design assumes the repo is
+# either user-owned (#834 clone-as-user) or group-writable; this PR's
+# mitigation A (safe.directory bootstrap) handles the OWNERSHIP check but
+# not WRITABILITY. Production operator setups should apply equivalent
+# config when adding source repos to a multi-user install.
 compose exec -T --user agentconsole agent-console sh -lc "
   set -e
   mkdir -p ${SOURCE_REPO_PATH}
   cd ${SOURCE_REPO_PATH}
   if [ ! -d .git ]; then
-    git init -q -b main
+    git init -q -b main --shared=group
     git config user.email 'agentconsole@example.com'
     git config user.name 'agentconsole'
     echo hello > README.md
     git add README.md
     git commit -q -m 'initial commit'
   fi
+  # Ensure setgid on every directory so files inherit the shared group.
+  find .git -type d -exec chmod g+rwxs '{}' +
+  chmod -R g+rw .git
 " >/dev/null 2>&1
 source_repo_ok=$?
-check "source repo bootstrapped inside container" "$source_repo_ok"
+check "source repo bootstrapped inside container (shared=group)" "$source_repo_ok"
 
 ALICE_COOKIE_JAR="$(mktemp)"
 ALICE_LOGIN_RESP="$(mktemp)"

--- a/scripts/verify-multiuser-docker.sh
+++ b/scripts/verify-multiuser-docker.sh
@@ -262,6 +262,13 @@ if [ -n "$repo_id" ]; then
   wt_listed_ok=1
   [ -n "$WT_PATH" ] && wt_listed_ok=0
   check "worktree appears in repo's worktree list" "$wt_listed_ok"
+  if [ "$wt_listed_ok" -ne 0 ]; then
+    echo "  ---- DIAGNOSTIC: server logs (last 60 lines) ----"
+    compose logs --tail 60 agent-console 2>&1 | sed 's/^/    /' || true
+    echo "  ---- DIAGNOSTIC: worktree list response ----"
+    sed 's/^/    /' "$WT_LIST_RESP" || true
+    echo "  -------------------------------------------------"
+  fi
 
   if [ -n "$WT_PATH" ]; then
     # Worktree dir owner must be alice (root cause of #838). The owner field


### PR DESCRIPTION
## Summary

- Migrate `WorktreeService.createWorktree` to invoke `git worktree add` via the `runAsUser` helper (PR #840 / umbrella #837) so multi-user installs create worktree files owned by the requesting user rather than the service user.
- Bootstrap the source-repo `safe.directory` entry in the requesting user's gitconfig before the elevated `git worktree add` runs so git's CVE-2022-24765 owner check passes against the server-owned source repo (Mitigation A from Issue #838).
- Backward-compat migration for pre-#838 worktrees is documented as a per-path manual `chown` step in `docs/multi-user-setup-guide.md`.

Closes #838

This is the highest-leverage constituent of the umbrella #837 — landing it eliminates the user-visible `dubious ownership` friction in multi-user mode and makes the safe.directory stopgap tracked by #836 obsolete.

## Design Choices

### Source-repo trust mitigation: Option A (per-repo gitconfig entry)

The Issue offered three mitigations; this PR picks **A** (server runs `git config --global --add safe.directory <repoPath>` as the requesting user once per source repo).

- Works regardless of how the source repo was registered (clone-as-user from #834 is not a prerequisite).
- Bounded scope: one specific path per user, server-write to user gitconfig limited to that single entry.
- Idempotent: `git config --get-all safe.directory | grep -Fxq <path>` guards against duplicate writes.
- Failure-tolerant: bootstrap errors log but do not abort worktree creation — if the bootstrap is actually needed, the subsequent `git worktree add` surfaces a clearer error from git.

When #834 (clone-as-user) lands, Option A becomes unnecessary for repos cloned via the in-app flow; the bootstrap can be skipped when the source repo is already owned by the user.

### Backward-compat migration: documentation rather than scripted

Per Issue #838 / umbrella #837 operational notes, the choice is between (a) shipping a one-time `chown` migration script and (b) documenting the manual command. Picked (b) because:

- Issue #830 ("Out of Scope") notes there is no production multi-user install in the wild yet.
- Pre-#838 installs at this stage have a small number of worktrees per host, so a per-path operator step costs less than the DB-aware tooling a script would need (resolving `sessions.created_by` UUIDs to OS usernames via the user repository).
- A scripted variant can be added later as a follow-up if installs accumulate many pre-#838 worktrees.

## Pre-PR Gap-Scan

- **Q1 (existing mechanism):** `runAsUser` is the canonical mechanism (PR #840, umbrella #837); this PR is the worktree-creation constituent. Found `worktree-service.ts` already used `lib/git.ts` for the `git worktree add` call; replaced that path with the new `runAsUser` flow without touching the other lib/git callers (list, remove, fetchRemote, …).
- **Q3 (failure paths tested):** `worktree-service.test.ts` covers single-user (no elevation), multi-user with elevation, missing username fallback, non-zero git exit, bootstrap returning non-zero (not fatal). The sibling test file is touched in the same PR (preflight gate satisfied).
- **Q7 (shared-resource lifetime):** The new artifacts written by this PR are (a) worktree directories — owner changes from service-user to requesting-user, group unchanged (`agent-console-users` mode `2775`), so cleanup paths in `worktree-deletion-service.ts` still work via group permissions; (b) per-user gitconfig safe.directory entry — outlives the worktree (intentionally, since users may have multiple worktrees against the same source repo); lifetime ends when the user removes the entry. The rollback procedure (`git config --global --unset-all safe.directory`) is documented in the umbrella Issue's operational notes.

## Known Limitations

- MCP `delegate_to_worktree` currently does NOT resolve the parent session's `createdBy` UUID to an OS username, so MCP-delegated worktrees stay service-user-owned in multi-user mode. The subsequent agent worker still spawns as the parent session's user via `resolveSpawnUsername`, so the user will hit `dubious ownership` on git commands inside MCP-delegated worktrees. Resolving this requires plumbing `userRepository` through `McpDependencies`. Tracked as a follow-up; the user-visible REST path is the primary entry point and is fully covered by this PR.

## Verification

```
$ bun run typecheck
@agent-console/shared typecheck: Exited with code 0
@agent-console/server typecheck: Exited with code 0
@agent-console/client typecheck: Exited with code 0

$ bun run test
@agent-console/shared test: Ran 324 tests across 10 files.
@agent-console/integration test: Ran 29 tests across 8 files.
@agent-console/server test:  2687 pass / Ran 2688 tests across 129 files.
@agent-console/client test:  1397 pass / 2 skip / Ran 1399 tests across 88 files.
scripts:  362 pass / Ran 362 tests across 11 files.
TEST_EXIT: 0

$ bun run check:lang
OK -- language check clean (103 files scanned).

$ node .claude/skills/orchestrator/preflight-check.js
Test Coverage Check:    4 covered, 0 missing
Rule/Skill Duplication: clean
Language Check:         clean
```

Docker E2E (`scripts/verify-multiuser-docker.sh`) was NOT executed locally — Docker is not available in this build environment. The new Test 7 is included in the script and will exercise the shipping path under CI's `e2e (home 0700)` job: it bootstraps a service-user-owned source repo, registers it as alice, creates a worktree via the API, asserts the resulting dir is owned by alice, and runs `git status` as alice expecting no `dubious ownership` error.

Reference: umbrella #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)