### PR TITLE
feat(server): plumb OS username through MCP delegate_to_worktree

### DIFF
--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -14,6 +14,7 @@ import type { Kysely } from 'kysely';
 import type { Database } from './database/schema.js';
 import type { JobQueue } from './jobs/job-queue.js';
 import type { SessionRepository } from './repositories/session-repository.js';
+import type { UserRepository } from './repositories/user-repository.js';
 import type { SessionManager } from './services/session-manager.js';
 import type { RepositoryManager } from './services/repository-manager.js';
 import type { NotificationManager } from './services/notifications/notification-manager.js';
@@ -112,6 +113,14 @@ export interface AppContext {
 
   /** User authentication and PTY spawning mode */
   userMode: UserMode;
+
+  /**
+   * User identity repository — resolves a `users.id` UUID back to an OS
+   * username / home dir. Exposed on AppContext so that MCP `delegate_to_worktree`
+   * can resolve the parent session's `createdBy` for `runAsUser`
+   * elevation (Issue #844).
+   */
+  userRepository: UserRepository;
 
   /** Registry of configured shared OS accounts (for shared-session creation) */
   sharedAccountRegistry: SharedAccountRegistry;
@@ -479,6 +488,7 @@ export async function createAppContext(
     interSessionMessageService,
     suggestSessionMetadata,
     userMode,
+    userRepository,
     sharedAccountRegistry,
     timerManager,
     conditionalWakeupManager,
@@ -663,6 +673,7 @@ export async function createTestContext(
     interSessionMessageService,
     suggestSessionMetadata,
     userMode,
+    userRepository,
     sharedAccountRegistry,
     timerManager,
     conditionalWakeupManager,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -143,6 +143,7 @@ const mcpApp = createMcpApp({
   suggestSessionMetadata: appContext.suggestSessionMetadata,
   createWorktreeWithSession,
   deleteWorktree,
+  userRepository: appContext.userRepository,
   broadcastToApp: appContext.broadcastToApp,
   fetchPullRequestUrl: appContext.fetchPullRequestUrl,
   findOpenPullRequest: appContext.findOpenPullRequest,

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -20,6 +20,7 @@ import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repositor
 import { JsonSessionRepository } from '../../repositories/index.js';
 import { SqliteRepositoryRepository } from '../../repositories/sqlite-repository-repository.js';
 import { SqliteWorktreeRepository } from '../../repositories/sqlite-worktree-repository.js';
+import { SqliteUserRepository } from '../../repositories/sqlite-user-repository.js';
 import { WorktreeService } from '../../services/worktree-service.js';
 import type { PtySpawnOptions } from '../../lib/pty-provider.js';
 import { TimerManager } from '../../services/timer-manager.js';
@@ -148,6 +149,7 @@ describe('MCP Server Tools', () => {
   let interactiveProcessManager: InteractiveProcessManager;
   let worktreeService: WorktreeService;
   let annotationService: AnnotationService;
+  let userRepository: SqliteUserRepository;
   let testJobQueue: JobQueue;
   let mcpSessionId: string;
   // Track unique IDs for tool calls to avoid collisions in the shared transport
@@ -177,7 +179,7 @@ describe('MCP Server Tools', () => {
    * the MCP tools see the updated dependencies.
    */
   async function remountMcpApp(): Promise<void> {
-    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, conditionalWakeupManager, interactiveProcessManager, worktreeService, annotationService, interSessionMessageService: new InterSessionMessageService(), suggestSessionMetadata: mockSuggestSessionMetadata, createWorktreeWithSession, deleteWorktree, broadcastToApp: () => {}, findOpenPullRequest: mockFindOpenPullRequest, fetchPullRequestUrl: mockFetchPullRequestUrl });
+    const mcpApp = createMcpApp({ sessionManager, repositoryManager, agentManager, timerManager, conditionalWakeupManager, interactiveProcessManager, worktreeService, annotationService, interSessionMessageService: new InterSessionMessageService(), suggestSessionMetadata: mockSuggestSessionMetadata, createWorktreeWithSession, deleteWorktree, userRepository, broadcastToApp: () => {}, findOpenPullRequest: mockFindOpenPullRequest, fetchPullRequestUrl: mockFetchPullRequestUrl });
     app = new Hono();
     app.route('', mcpApp);
     mcpSessionId = await initializeMcp(app);
@@ -237,6 +239,12 @@ describe('MCP Server Tools', () => {
     // Create AgentManager for dependency injection
     const db = getDatabase();
     agentManager = await AgentManager.create(new SqliteAgentRepository(db));
+
+    // Create UserRepository for delegate_to_worktree's username resolution.
+    // Tests that exercise the resolved-username path seed entries via
+    // `userRepository.upsertByOsUid(...)`; tests that exercise the null
+    // fallback rely on findById returning null for unknown UUIDs.
+    userRepository = new SqliteUserRepository(db);
 
     // Create AnnotationService
     annotationService = new AnnotationService();
@@ -1972,6 +1980,141 @@ describe('MCP Server Tools', () => {
       const childSession = sessionManager.getSession(data.sessionId);
       expect(childSession).toBeDefined();
       expect(childSession!.createdBy).toBe('parent-user-abc');
+    });
+
+    // -------------------------------------------------------------------------
+    // Issue #844: OS username plumbing through delegate_to_worktree
+    // -------------------------------------------------------------------------
+    //
+    // delegate_to_worktree must resolve the parent session's createdBy (a
+    // users.id UUID) to its OS `username` via `userRepository.findById` and
+    // pass that username down to `worktreeService.createWorktree` as the
+    // `requestUsername` parameter. `runAsUser` then either elevates (multi-user
+    // mode) or bypasses elevation (AUTH_MODE=none / null username).
+    //
+    // The tests below spy on `worktreeService.createWorktree` to capture the
+    // exact `requestUsername` argument the MCP path passes through, covering:
+    //   1. Resolved username path (parent user exists in userRepository)
+    //   2. No parentSessionId -> null
+    //   3. Parent exists but createdBy is null/undefined -> null
+    //   4. Parent createdBy is a UUID that does not resolve -> null
+    describe('Issue #844: OS username plumbing', () => {
+      /**
+       * Spy on `worktreeService.createWorktree` and return the spy so tests
+       * can read the captured arguments. The wrapped implementation delegates
+       * to the real method so the rest of the orchestration still runs.
+       */
+      function spyCreateWorktree(): ReturnType<typeof jest.spyOn> {
+        return jest.spyOn(worktreeService, 'createWorktree');
+      }
+
+      it('plumbs resolved OS username when parent createdBy resolves to a registered user', async () => {
+        await setupDelegateEnvironment('feat/username-resolved');
+
+        // Seed userRepository with an OS user; upsertByOsUid returns the
+        // assigned UUID which we then thread through as the parent session's
+        // createdBy. This mirrors the production wiring where authentication
+        // assigns the same UUID and stores it on `sessions.created_by`.
+        const aliceOsUid = 9001;
+        const alice = await userRepository.upsertByOsUid(aliceOsUid, 'alice', '/home/alice');
+
+        const parentSession = await sessionManager.createSession({
+          type: 'quick',
+          locationPath: TEST_REPO_PATH,
+        }, { createdBy: alice.id });
+
+        const createWorktreeSpy = spyCreateWorktree();
+
+        const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+          repositoryId: 'test-repo',
+          prompt: 'Test username plumbing',
+          branch: 'feat/username-resolved',
+          parentSessionId: parentSession.id,
+          parentWorkerId: 'parent-worker-id',
+        }, nextId++);
+
+        expect(response.result?.isError).toBeUndefined();
+
+        // createWorktree(repoPath, branch, repositoryId, baseBranch?, requestUsername?)
+        expect(createWorktreeSpy).toHaveBeenCalledTimes(1);
+        const callArgs = createWorktreeSpy.mock.calls[0] as unknown[];
+        expect(callArgs[4]).toBe('alice');
+      });
+
+      it('passes null requestUsername when delegate_to_worktree is called without parentSessionId', async () => {
+        await setupDelegateEnvironment('feat/no-parent-username');
+
+        const createWorktreeSpy = spyCreateWorktree();
+
+        const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+          repositoryId: 'test-repo',
+          prompt: 'Direct delegation with no parent context',
+          branch: 'feat/no-parent-username',
+          // parentSessionId intentionally omitted
+        }, nextId++);
+
+        expect(response.result?.isError).toBeUndefined();
+
+        expect(createWorktreeSpy).toHaveBeenCalledTimes(1);
+        const callArgs = createWorktreeSpy.mock.calls[0] as unknown[];
+        expect(callArgs[4]).toBeNull();
+      });
+
+      it('passes null requestUsername when parent session has no createdBy (legacy)', async () => {
+        await setupDelegateEnvironment('feat/legacy-parent');
+
+        // Create a parent session WITHOUT createdBy - legacy / pre-multi-user
+        // sessions saved before `sessions.created_by` was populated.
+        const parentSession = await sessionManager.createSession({
+          type: 'quick',
+          locationPath: TEST_REPO_PATH,
+        });
+
+        const createWorktreeSpy = spyCreateWorktree();
+
+        const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+          repositoryId: 'test-repo',
+          prompt: 'Delegation from a legacy parent',
+          branch: 'feat/legacy-parent',
+          parentSessionId: parentSession.id,
+          parentWorkerId: 'parent-worker-id',
+        }, nextId++);
+
+        expect(response.result?.isError).toBeUndefined();
+
+        expect(createWorktreeSpy).toHaveBeenCalledTimes(1);
+        const callArgs = createWorktreeSpy.mock.calls[0] as unknown[];
+        expect(callArgs[4]).toBeNull();
+      });
+
+      it('passes null requestUsername when parent createdBy UUID does not resolve to a user', async () => {
+        await setupDelegateEnvironment('feat/orphan-uuid');
+
+        // Parent has a createdBy that does not correspond to any
+        // userRepository entry. This is the orphan case — the foreign-key-
+        // less DB layout permits a session whose createdBy was deleted from
+        // (or never inserted into) the users table.
+        const parentSession = await sessionManager.createSession({
+          type: 'quick',
+          locationPath: TEST_REPO_PATH,
+        }, { createdBy: 'orphan-uuid-not-in-users-table' });
+
+        const createWorktreeSpy = spyCreateWorktree();
+
+        const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+          repositoryId: 'test-repo',
+          prompt: 'Delegation from an orphan parent',
+          branch: 'feat/orphan-uuid',
+          parentSessionId: parentSession.id,
+          parentWorkerId: 'parent-worker-id',
+        }, nextId++);
+
+        expect(response.result?.isError).toBeUndefined();
+
+        expect(createWorktreeSpy).toHaveBeenCalledTimes(1);
+        const callArgs = createWorktreeSpy.mock.calls[0] as unknown[];
+        expect(callArgs[4]).toBeNull();
+      });
     });
 
     it('should accept optional templateVars parameter and create session successfully', async () => {

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -24,6 +24,7 @@ import { sendAnnotationsToClient } from '../websocket/git-diff-handler.js';
 import type { DeleteWorktreeFn } from '../services/worktree-deletion-service.js';
 import type { CreateWorktreeWithSessionFn } from '../services/worktree-creation-service.js';
 import type { OpenPrInfo } from '../services/github-pr-service.js';
+import type { UserRepository } from '../repositories/user-repository.js';
 import { getCurrentBranch } from '../lib/git.js';
 import { CLAUDE_CODE_AGENT_ID } from '../services/agent-manager.js';
 import type { SuggestSessionMetadataFn } from '../services/session-metadata-suggester.js';
@@ -166,6 +167,14 @@ export interface McpDependencies {
   suggestSessionMetadata: SuggestSessionMetadataFn;
   createWorktreeWithSession: CreateWorktreeWithSessionFn;
   deleteWorktree: DeleteWorktreeFn;
+  /**
+   * User repository used by `delegate_to_worktree` to resolve the parent
+   * session's `createdBy` (a user UUID) to its OS `username`, which is then
+   * threaded down to `createWorktreeWithSession` as `requestUsername` so that
+   * `git worktree add` runs as the requesting user in multi-user mode
+   * (Issue #844, extending the REST path established by Issue #838 / PR #843).
+   */
+  userRepository: UserRepository;
   broadcastToApp: (msg: AppServerMessage) => void;
   fetchPullRequestUrl: (branch: string, cwd: string) => Promise<string | null>;
   findOpenPullRequest: (branch: string, cwd: string) => Promise<OpenPrInfo | null>;
@@ -179,7 +188,7 @@ export interface McpDependencies {
  * All MCP tool handlers use the provided dependencies instead of singleton getters.
  */
 export function createMcpApp(deps: McpDependencies): Hono {
-  const { sessionManager, repositoryManager, agentManager, timerManager, conditionalWakeupManager, interactiveProcessManager, worktreeService, annotationService, interSessionMessageService, suggestSessionMetadata, createWorktreeWithSession, deleteWorktree, broadcastToApp, findOpenPullRequest } = deps;
+  const { sessionManager, repositoryManager, agentManager, timerManager, conditionalWakeupManager, interactiveProcessManager, worktreeService, annotationService, interSessionMessageService, suggestSessionMetadata, createWorktreeWithSession, deleteWorktree, userRepository, broadcastToApp, findOpenPullRequest } = deps;
 
   /**
    * Map a public Session to the worker info format used by MCP tool responses.
@@ -643,18 +652,25 @@ export function createMcpApp(deps: McpDependencies): Hono {
           ? sessionManager.getSession(parentSessionId)?.createdBy
           : undefined;
 
-        // NOTE: Issue #838 routes `git worktree add` through `runAsUser` so
-        // worktree files become user-owned. The MCP delegation path does
-        // not currently resolve `parentCreatedBy` (a user UUID) back to an
-        // OS username — that requires plumbing `userRepository` through
-        // `McpDependencies`. In multi-user mode, MCP-delegated worktrees
-        // are therefore created with `runAsUser({ username: undefined })`
-        // -> server user ownership. The subsequent agent worker still
-        // spawns as the parent session's user via `resolveSpawnUsername`
-        // in SessionManager, so the user will hit `dubious ownership` on
-        // git commands inside MCP-delegated worktrees. Tracked as a
-        // follow-up; the REST `/api/repositories/:id/worktrees` path is
-        // the primary user-visible entry point and is covered by this PR.
+        // Resolve parent's createdBy (a users.id UUID) to its OS username so
+        // `git worktree add` runs as the requesting user in multi-user mode
+        // (Issue #844, extending Issue #838 / PR #843 from REST to MCP).
+        // When `parentCreatedBy` is unset, or the UUID does not resolve
+        // (legacy / orphan sessions), `requestUsername` is null and
+        // `runAsUser` bypasses elevation — current behaviour preserved.
+        let requestUsername: string | null = null;
+        if (parentCreatedBy) {
+          const parentUser = await userRepository.findById(parentCreatedBy);
+          if (parentUser) {
+            requestUsername = parentUser.username;
+          } else {
+            logger.warn(
+              { parentCreatedBy, repositoryId },
+              'delegate_to_worktree: parent createdBy does not resolve to a user; running git worktree add without elevation',
+            );
+          }
+        }
+
         const result = await createWorktreeWithSession({
           repoPath: repo.path,
           repoId: repositoryId,
@@ -673,6 +689,7 @@ export function createMcpApp(deps: McpDependencies): Hono {
             createdBy: parentCreatedBy,
             templateVars,
           },
+          requestUsername,
         }, sessionManager, worktreeService);
 
         if (!result.success) {


### PR DESCRIPTION
Closes #844

## Summary

Extend Issue #838 / PR #843's worktree-as-user behaviour from the REST path
to the MCP path, so MCP-delegated worktrees are also owned by the requesting
user in `AUTH_MODE=multi-user`. Without this change, MCP-delegated worktrees
are created with server-user ownership and the user hits
`fatal: detected dubious ownership in repository` on every git command
inside that worktree.

## Implementation

- **Add `userRepository` to `McpDependencies`** (`packages/server/src/mcp/mcp-server.ts`).
  Mirrors the existing repository-dependency wiring shape.
- **Wire `userRepository` through `AppContext`** (`packages/server/src/app-context.ts`)
  and pass it to `createMcpApp` in `packages/server/src/index.ts`. The
  `SqliteUserRepository` was already constructed inside `app-context.ts`
  for the `userMode` / `sessionManager` wiring; this PR exposes it on
  `AppContext`.
- **Resolve UUID -> OS username** in `delegate_to_worktree` and pass it as
  `requestUsername` to `createWorktreeWithSession`. The parent session's
  `createdBy` is a `users.id` UUID; `userRepository.findById(...)` returns
  the `AuthUser` with the `username` field used by `runAsUser`.
- **Null-safe fallback** — when `parentCreatedBy` is unset, parent has no
  `createdBy` (legacy sessions), or the UUID does not resolve to a registered
  user, `requestUsername` is `null` and `runAsUser` bypasses elevation.
  Current behaviour preserved. A warn log fires when a UUID is present but
  does not resolve.
- **Remove the `NOTE` comment** at the former line 643 in `mcp-server.ts`
  that documented the gap (the comment was added explicitly so future
  contributors would discover this gap).

## Verification

```
# bun run typecheck
@agent-console/shared typecheck: Exited with code 0
@agent-console/server typecheck: Exited with code 0
@agent-console/client typecheck: Exited with code 0

# bun run test
@agent-console/shared test:  324 pass / 0 fail   (Ran 324 tests across 10 files)
@agent-console/integration test:  29 pass / 0 fail   (Ran 29 tests across 8 files)
@agent-console/server test:  2701 pass / 0 fail   (Ran 2702 tests across 129 files; +4 new for #844)
@agent-console/client test:  1397 pass / 0 fail   (Ran 1399 tests across 88 files; 2 skip)
scripts / hooks / skills tests:  362 pass / 0 fail   (Ran 362 tests across 11 files)
TEST_EXIT: 0

# bun run check:lang
OK — language check clean (103 files scanned).

# node .claude/skills/orchestrator/preflight-check.js
✅ No rule paragraphs found verbatim in any skill file.
✅ All public artifacts use Latin / Greek / Cyrillic scripts only.
```

### Test polarity check

To verify the new tests would have caught the missing plumbing, I stashed
`packages/server/src/mcp/mcp-server.ts` (the production diff) while keeping
the test diff intact. All 4 new tests failed against unmodified production
code (`callArgs[4]` was `undefined`, not the expected resolved username or
`null`). Restoring the production change made them all pass.

## 7-question gap-scan

1. **Similar mechanism?** Yes — the REST path in `routes/worktrees.ts`
   threads `authUser.username` to `createWorktreeWithSession` exactly the
   same way (PR #843). This PR closes the MCP-side gap that was explicitly
   documented in the now-removed `NOTE` comment.
2. **Canonical invocation documented?** Not applicable — no new canonical
   procedure is introduced; the MCP entry point (`delegate_to_worktree`)
   already existed.
3. **Failure paths tested?** Yes — 4 sibling tests cover all four branches
   per the boundary-value rule:
   - Resolved username path (parent → registered user → `'alice'`)
   - No `parentSessionId` → `null`
   - Parent has no `createdBy` (legacy sessions) → `null`
   - Parent `createdBy` is an orphan UUID that does not resolve → `null`
   The sibling test file (`__tests__/mcp-server.test.ts`) was modified in
   the same PR per pre-pr-completeness §3.
4. **New file type / directory?** No.
5. **Rule clarity?** No rule text changed.
6. **Cross-runtime spawn?** No new spawn boundary; this PR plumbs username
   through an existing call chain.
7. **Shared-resource artifact?** No new persistent artifact.
8. **Signature shape change?** Yes — `McpDependencies` gained a required
   `userRepository` field. Two call sites updated:
   `packages/server/src/index.ts` (production) and the test file's
   `remountMcpApp` helper.

## Related

- Umbrella: #837 — privilege-elevation pattern across server-side ops.
- REST counterpart: PR #843 / Issue #838 — same shape on `/api/repositories/:id/worktrees`.
- The previously-removed in-code `NOTE` comment that documented this gap.

## Out of scope

Per Issue #844 "Out of Scope":
- No broader `McpDependencies` refactor.
- No migration of pre-existing MCP-delegated worktrees (operators chown manually per `multi-user-setup-guide.md`).
- No changes to `resolveSpawnUsername` (already user-aware).
- No new E2E for MCP path — the existing `verify-multiuser-docker.sh` Test 7 covers the REST shape; adding MCP-side E2E requires authenticating MCP, which is out of scope for this Issue's acceptance.