### PR TITLE
feat(server): auto-apply sharedRepository=group + group-writable .git at registration

### DIFF
--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -596,30 +596,59 @@ ls -la ~   # Should be accessible
 
 ## Source Repo Group-Writability (Linux multi-user)
 
-When Issue #838 lands, `git worktree add` runs as the requesting user. For
-this to succeed against a source repo owned by the service user
-(`agentconsole`), two things must be true:
+When `git worktree add` runs as the requesting user (Issue #838 / PR #843),
+two things must be true for it to succeed against a source repo owned by
+the service user (`agentconsole`):
 
 1. The user's gitconfig must trust the source repo path. The server
    bootstraps this automatically (`git config --global --add safe.directory
    <repoPath>`, mitigation A from Issue #838); operators do not need to
    configure it.
 2. The user must be able to **write** to `.git/refs/`, `.git/packed-refs`,
-   etc. (Issue's mitigation C — group writability). The bootstrap script
-   sets `core.sharedRepository=group` on cloned repos, but operators
-   who add source repos manually (e.g., by cloning as `agentconsole`)
-   must apply equivalent config:
+   etc. (Issue #838's mitigation C — group writability).
+   **As of Issue #845, `registerRepository` automatically applies this
+   configuration in multi-user mode** at repository-registration time. The
+   server runs the equivalent of the four commands below as the service
+   user, idempotently (re-registering a configured repo is a no-op):
+
+```bash
+# Applied automatically by the server in multi-user mode (Issue #845).
+git -C <repo-path> config core.sharedRepository group
+find <repo-path>/.git -type d -exec chmod g+rwxs {} +
+chmod -R g+rw <repo-path>/.git
+chgrp -R agent-console-users <repo-path>/.git
+```
+
+### Manual fallback (operator step)
+
+The auto-apply step requires the server process (`agentconsole`) to either
+own the repo or be in its group. When neither holds — e.g., the repo was
+cloned by a different operator account whose primary group differs — the
+auto-apply logs a `WARN` (with the exact remediation commands embedded)
+and proceeds with registration. Apply the same commands manually as a
+privileged user:
 
 ```bash
 sudo -u agentconsole bash -lc 'cd <repo-path> && git config core.sharedRepository group'
 sudo find <repo-path>/.git -type d -exec chmod g+rwxs {} +
 sudo chmod -R g+rw <repo-path>/.git
+sudo chgrp -R agent-console-users <repo-path>/.git
 ```
 
-These are operator steps for source repos that pre-date the multi-user-
-ready setup. When [Issue #834](https://github.com/ms2sato/agent-console/issues/834)
+### Pre-#845 source repos
+
+Source repos registered before Issue #845 landed retain the registration
+record but were not touched by the auto-apply step. Two options:
+
+- **Re-register**: unregister and re-register through the UI (or
+  `DELETE /api/repositories/:id` + `POST /api/repositories`) to trigger the
+  new auto-apply.
+- **Run the manual fallback commands** above once per affected repo.
+
+When [Issue #834](https://github.com/ms2sato/agent-console/issues/834)
 (clone-as-user) lands, repos cloned via the in-app flow are owned by the
-requesting user directly and neither step is required.
+requesting user directly and neither the auto-apply nor the manual fallback
+is required.
 
 ## Migrating Pre-#838 Worktrees (Linux multi-user)
 

--- a/packages/server/src/services/__tests__/repository-manager.test.ts
+++ b/packages/server/src/services/__tests__/repository-manager.test.ts
@@ -8,6 +8,7 @@ import { JobQueue } from '../../jobs/index.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { SqliteRepositoryRepository } from '../../repositories/index.js';
 import type { RunAsUserOpts, RunAsUserResult } from '../privilege-elevation.js';
+import { buildManualFallbackCommands } from '../repository-manager.js';
 
 /**
  * Capture-and-respond fake for `runAsUser`. Mirrors the pattern used by
@@ -161,8 +162,44 @@ describe('RepositoryManager', () => {
     describe('multi-user mode shared-repo auto-apply (Issue #845)', () => {
       let originalAuthMode: string | undefined;
 
+      // Synthetic shared-group gid used by tests to drive the `getent group`
+      // resolution. Real production reads this from /etc/group; tests stub
+      // the responder to return this value via the `getent group <name>`
+      // wire format `name:x:<gid>:members`.
+      const FAKE_SHARED_GID = 9876;
+
+      /**
+       * Default multi-user responder: simulates a freshly-cloned source
+       * repo whose `.git/` does NOT yet have the shared-group gid /
+       * core.sharedRepository setting, so the apply step runs. `getent`
+       * resolves the shared group's gid to `FAKE_SHARED_GID`; the lstat
+       * probe sees a mismatch (memfs gid != FAKE_SHARED_GID), so the
+       * `git config --get` probe is never attempted. The apply call
+       * succeeds.
+       */
+      function defaultFreshRepoResponder(opts: RunAsUserOpts): Promise<RunAsUserResult> {
+        if (opts.command.startsWith('getent group ')) {
+          // Wire format: `name:x:gid:members`. Extract name from the
+          // shell-escaped second token.
+          return Promise.resolve({
+            stdout: `agent-console-users:x:${FAKE_SHARED_GID}:agentconsole\n`,
+            stderr: '',
+            exitCode: 0,
+            timedOut: false,
+          });
+        }
+        // Apply / git config probe / anything else: success.
+        return Promise.resolve({
+          stdout: '',
+          stderr: '',
+          exitCode: 0,
+          timedOut: false,
+        });
+      }
+
       beforeEach(() => {
         originalAuthMode = process.env.AUTH_MODE;
+        runAsUserMock.responder.fn = defaultFreshRepoResponder;
       });
 
       afterEach(() => {
@@ -179,9 +216,10 @@ describe('RepositoryManager', () => {
 
         await manager.registerRepository(TEST_REPO_DIR);
 
-        // Single-user mode must not chmod / chgrp / set core.sharedRepository
-        // on the source repo. The whole multi-user branch is gated on
-        // AUTH_MODE so a single spawn would already be a regression.
+        // Single-user mode must not resolve the shared group, chmod, chgrp,
+        // or set core.sharedRepository on the source repo. The whole
+        // multi-user branch is gated on AUTH_MODE so even a single spawn
+        // would already be a regression.
         expect(runAsUserMock.calls.length).toBe(0);
       });
 
@@ -189,91 +227,80 @@ describe('RepositoryManager', () => {
         process.env.AUTH_MODE = 'multi-user';
         const manager = await getRepositoryManager();
 
-        // memfs-backed `.git` does not have a realistic gid, so the
-        // idempotent-skip probe sees a mismatch and the apply step runs.
+        // memfs-backed `.git`'s gid does not match FAKE_SHARED_GID, so the
+        // lstat short-circuit fails and the apply step runs.
         const repo = await manager.registerRepository(TEST_REPO_DIR);
         expect(repo.path).toBe(TEST_REPO_DIR);
 
-        // Exactly one runAsUser call covering all four legs of the chain
-        // (`git config && find -exec chmod g+rwxs && chmod -R g+rw && chgrp`).
-        // Single spawn is intentional: fewer process invocations = fewer
-        // sudo prompts in real multi-user installs (PR brief step 5).
-        expect(runAsUserMock.calls.length).toBe(1);
-        const call = runAsUserMock.calls[0];
+        // Two runAsUser calls: (1) `getent group` to resolve the shared
+        // group's gid, (2) the combined apply command. The git-config
+        // probe is NOT attempted because the lstat short-circuit fails on
+        // gid mismatch in memfs. Apply remains a single spawn covering
+        // all four legs.
+        const applyCalls = runAsUserMock.calls.filter((c) =>
+          c.command.includes('chgrp -R '),
+        );
+        expect(applyCalls.length).toBe(1);
+        const apply = applyCalls[0];
         // Run as the server process (username: null => no elevation).
-        expect(call.username).toBeNull();
+        expect(apply.username).toBeNull();
         // Verify the command shape covers all four operations and references
         // the registered repo path + the shared group name. Single-quote
         // escaping is from `shellEscape`.
-        expect(call.command).toContain(
+        expect(apply.command).toContain(
           `git -C '${TEST_REPO_DIR}' config core.sharedRepository group`,
         );
-        expect(call.command).toContain(
+        expect(apply.command).toContain(
           `find '${TEST_REPO_DIR}/.git' -type d -exec chmod g+rwxs {} +`,
         );
-        expect(call.command).toContain(`chmod -R g+rw '${TEST_REPO_DIR}/.git'`);
-        expect(call.command).toContain(
+        expect(apply.command).toContain(`chmod -R g+rw '${TEST_REPO_DIR}/.git'`);
+        expect(apply.command).toContain(
           `chgrp -R 'agent-console-users' '${TEST_REPO_DIR}/.git'`,
         );
         // Steps chained with `&&` so a failing earlier step aborts the rest
         // and the failing stderr surfaces clearly.
-        expect(call.command).toContain(' && ');
+        expect(apply.command).toContain(' && ');
+
+        // Confirm `getent group` was invoked to resolve the shared gid.
+        const getentCalls = runAsUserMock.calls.filter((c) =>
+          c.command.startsWith('getent group '),
+        );
+        expect(getentCalls.length).toBe(1);
+        expect(getentCalls[0].command).toContain(`'agent-console-users'`);
       });
 
       it('skips apply when already configured (idempotent no-op via git config probe)', async () => {
         process.env.AUTH_MODE = 'multi-user';
 
-        // Track lstat/probe-vs-apply distinction via the probe responder:
-        // when the lstat-based mode/gid check passes (the test fs cannot
-        // realistically simulate that, so we force it from the probe side
-        // instead), the production code issues a `git config --local --get
-        // core.sharedRepository` probe -- when that returns `group` on
-        // stdout, no apply call follows.
-        //
-        // The probe code path requires the lstat short-circuit to succeed
-        // first. memfs reports gid=0 (or process.getgid() in some setups),
-        // mode bits without setgid -- so the probe path is not entered in
-        // memfs.  We exercise the apply branch (covered above) and the
-        // permission-denied branch (covered below); the idempotent-skip
-        // branch is verified by direct invocation of the probe responder
-        // sequence below.
-        //
-        // To exercise the skip branch without depending on memfs gid/mode
-        // realism, force the probe responder to claim 'group' and stub the
-        // mode probe by hijacking the apply responder to fail-loudly: if
-        // the apply runs, the test fails. The skip branch ONLY runs after a
-        // successful lstat short-circuit + a 'group' probe, so we cannot
-        // reach it without lstat returning the right gid/mode. The
-        // production behaviour is captured by the assertion shape: when
-        // already-configured we expect zero runAsUser calls following the
-        // probe.
-        //
-        // Note: we cover the apply / permission-denied / single-user
-        // branches in dedicated tests; the idempotent-skip path is
-        // explicitly verified via the probe contract here -- the probe
-        // returns 'group' AND the next call must NOT be an apply.
+        // Align memfs `.git/` mode bits + gid to what the apply step would
+        // produce: setgid + group-rwx (octal 2775), gid = FAKE_SHARED_GID.
+        // memfs honours both `chmod` and `chown` for owned files / dirs,
+        // so `lstat` will report these values.
+        const gitDirAbs = `${TEST_REPO_DIR}/.git`;
+        const beforeStat = fs.statSync(gitDirAbs);
+        fs.chmodSync(gitDirAbs, 0o2775);
+        fs.chownSync(gitDirAbs, beforeStat.uid, FAKE_SHARED_GID);
 
-        // Make lstat appear to match: synthesise a `.git` directory whose
-        // mode bits include setgid + group-write and whose gid equals the
-        // current process gid. memfs preserves the mode bits we set.
-        const gidNow = typeof process.getgid === 'function' ? process.getgid() : 0;
-        // memfs does not honour setgid bits the same way real fs does, but
-        // `lstat` will still report them. Set them explicitly:
-        try {
-          fs.chmodSync(`${TEST_REPO_DIR}/.git`, 0o2775);
-          // Best-effort gid alignment; memfs may not honour chown but we try.
-          fs.chownSync(`${TEST_REPO_DIR}/.git`, fs.statSync(`${TEST_REPO_DIR}/.git`).uid, gidNow);
-        } catch {
-          // ignore -- if memfs cannot align these, the probe code path
-          // will fall through to apply and the next assertion below would
-          // need to adapt. But memfs does honour chmod, so this works.
-        }
-
-        // Wire the probe responder to return `group` for the git-config
-        // probe, and fail loudly if any apply runs.
+        // Replace the responder so `getent group` returns FAKE_SHARED_GID
+        // (matching the synthesised dir gid) AND the `git config --get
+        // core.sharedRepository` probe returns 'group'. The apply call
+        // MUST NOT run -- enforce by throwing if it's invoked.
         runAsUserMock.responder.fn = async (opts) => {
+          if (opts.command.startsWith('getent group ')) {
+            return {
+              stdout: `agent-console-users:x:${FAKE_SHARED_GID}:agentconsole\n`,
+              stderr: '',
+              exitCode: 0,
+              timedOut: false,
+            };
+          }
           if (opts.command.includes('--get core.sharedRepository')) {
-            return { stdout: 'group\n', stderr: '', exitCode: 0, timedOut: false };
+            return {
+              stdout: 'group\n',
+              stderr: '',
+              exitCode: 0,
+              timedOut: false,
+            };
           }
           throw new Error(
             `apply should not run when already configured; got command: ${opts.command}`,
@@ -281,21 +308,20 @@ describe('RepositoryManager', () => {
         };
 
         const manager = await getRepositoryManager();
-        // Registration must succeed without invoking apply. If lstat skip
-        // is not reached (memfs limitation), the responder throws above
-        // and registration would fail loudly -- exercising the negative
-        // case still has value.
         const repo = await manager.registerRepository(TEST_REPO_DIR);
         expect(repo.path).toBe(TEST_REPO_DIR);
 
-        // Either zero calls (skip path skipped probe too -- impossible
-        // shape; just guards against accidental regressions) or one call
-        // (the probe) but no apply call. Concretely: at most one call,
-        // and if one call, it is the probe.
-        expect(runAsUserMock.calls.length).toBeLessThanOrEqual(1);
-        if (runAsUserMock.calls.length === 1) {
-          expect(runAsUserMock.calls[0].command).toContain('--get core.sharedRepository');
-        }
+        // Exactly two runAsUser calls -- the `getent` resolve + the
+        // `git config --get core.sharedRepository` probe -- AND no apply
+        // call. The probe-first contract ensures we tightly assert the
+        // idempotent-skip path was actually taken (not bypassed early).
+        expect(runAsUserMock.calls.length).toBe(2);
+        expect(runAsUserMock.calls[0].command).toContain('getent group ');
+        expect(runAsUserMock.calls[1].command).toContain('--get core.sharedRepository');
+        const applyCalls = runAsUserMock.calls.filter((c) =>
+          c.command.includes('chgrp -R '),
+        );
+        expect(applyCalls.length).toBe(0);
       });
 
       it('registration succeeds with a warn log when apply hits permission denied', async () => {
@@ -303,17 +329,24 @@ describe('RepositoryManager', () => {
 
         // Simulate the chgrp / chmod failing because the server does not
         // own the repo (chmod g+rwxs and chgrp would emit EPERM). The
-        // production code logs a WARN with the manual remediation commands
-        // and proceeds with registration.
+        // production code logs a WARN containing the manual remediation
+        // commands and proceeds with registration.
         runAsUserMock.responder.fn = async (opts) => {
+          if (opts.command.startsWith('getent group ')) {
+            return {
+              stdout: `agent-console-users:x:${FAKE_SHARED_GID}:agentconsole\n`,
+              stderr: '',
+              exitCode: 0,
+              timedOut: false,
+            };
+          }
           if (opts.command.includes('--get core.sharedRepository')) {
-            // Probe: report 'not configured' so the apply step runs.
             return { stdout: '', stderr: '', exitCode: 1, timedOut: false };
           }
           // Apply: simulate EPERM from chgrp.
           return {
             stdout: '',
-            stderr: "chgrp: changing group of '/test/repo/.git': Operation not permitted",
+            stderr: `chgrp: changing group of '${TEST_REPO_DIR}/.git': Operation not permitted`,
             exitCode: 1,
             timedOut: false,
           };
@@ -332,12 +365,24 @@ describe('RepositoryManager', () => {
 
         // Verify the apply step was attempted (so this test fails if the
         // multi-user branch is removed). The apply call is identified by
-        // the `chgrp` substring; the count is >= 1 (probe may or may not
-        // fire depending on the lstat short-circuit outcome in memfs).
+        // the `chgrp` substring.
         const applyCalls = runAsUserMock.calls.filter((c) =>
           c.command.includes('chgrp -R '),
         );
         expect(applyCalls.length).toBe(1);
+
+        // The WARN-log embeds `buildManualFallbackCommands(...)` as a
+        // structured array operators can copy-paste. Assert the exported
+        // helper produces a non-empty list and that every command shape
+        // present in the docs section is in the output. This pins the
+        // contract the production WARN log delivers without depending on
+        // pino-internal log-capture plumbing.
+        const fallback = buildManualFallbackCommands(TEST_REPO_DIR, 'agent-console-users');
+        expect(fallback.length).toBe(4);
+        expect(fallback.some((c) => c.includes('git config core.sharedRepository group'))).toBe(true);
+        expect(fallback.some((c) => c.includes('chmod g+rwxs'))).toBe(true);
+        expect(fallback.some((c) => c.includes('chmod -R g+rw'))).toBe(true);
+        expect(fallback.some((c) => c.includes('chgrp -R agent-console-users'))).toBe(true);
       });
 
       it('honours AGENT_CONSOLE_SERVICE_GROUP override for the chgrp target group', async () => {
@@ -348,9 +393,14 @@ describe('RepositoryManager', () => {
           const manager = await getRepositoryManager();
           await manager.registerRepository(TEST_REPO_DIR);
 
-          // The runAsUser command should reference the overridden group.
-          // Either one call (apply only, when probe is skipped) or two
-          // calls (probe + apply); the apply call is the one with `chgrp`.
+          // The runAsUser command should reference the overridden group in
+          // BOTH legs: the `getent group` lookup and the apply chain.
+          const getentCalls = runAsUserMock.calls.filter((c) =>
+            c.command.startsWith('getent group '),
+          );
+          expect(getentCalls.length).toBe(1);
+          expect(getentCalls[0].command).toContain(`'custom-shared-group'`);
+
           const applyCalls = runAsUserMock.calls.filter((c) =>
             c.command.includes('chgrp -R '),
           );
@@ -358,6 +408,10 @@ describe('RepositoryManager', () => {
           expect(applyCalls[0].command).toContain(
             `chgrp -R 'custom-shared-group' '${TEST_REPO_DIR}/.git'`,
           );
+
+          // The fallback helper also threads the override through.
+          const fallback = buildManualFallbackCommands(TEST_REPO_DIR, 'custom-shared-group');
+          expect(fallback.some((c) => c.includes('chgrp -R custom-shared-group'))).toBe(true);
         } finally {
           if (originalGroup === undefined) {
             delete process.env.AGENT_CONSOLE_SERVICE_GROUP;

--- a/packages/server/src/services/__tests__/repository-manager.test.ts
+++ b/packages/server/src/services/__tests__/repository-manager.test.ts
@@ -7,6 +7,32 @@ import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-proces
 import { JobQueue } from '../../jobs/index.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { SqliteRepositoryRepository } from '../../repositories/index.js';
+import type { RunAsUserOpts, RunAsUserResult } from '../privilege-elevation.js';
+
+/**
+ * Capture-and-respond fake for `runAsUser`. Mirrors the pattern used by
+ * `worktree-service.test.ts` so the multi-user shared-repo apply branch
+ * (Issue #845) can be asserted without running real shell-outs.
+ *
+ * Default response: success (exitCode 0, empty stdout/stderr). Per-test
+ * scenarios can replace the responder via `responder.fn = ...`.
+ */
+function createRunAsUserMock() {
+  const calls: RunAsUserOpts[] = [];
+  const responder = {
+    fn: async (_opts: RunAsUserOpts): Promise<RunAsUserResult> => ({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+    }),
+  };
+  const runAsUserImpl = (opts: RunAsUserOpts) => {
+    calls.push(opts);
+    return responder.fn(opts);
+  };
+  return { calls, runAsUserImpl, responder };
+}
 
 // Test JobQueue instance (created fresh for each test)
 let testJobQueue: JobQueue | null = null;
@@ -16,6 +42,9 @@ describe('RepositoryManager', () => {
   const TEST_REPO_DIR = '/test/repo';
   let importCounter = 0;
   let repositoryRepository: SqliteRepositoryRepository;
+  // Capture mock for the privilege-elevation helper used by the multi-user
+  // shared-repo apply step (Issue #845). Fresh instance per test.
+  let runAsUserMock: ReturnType<typeof createRunAsUserMock>;
 
   beforeEach(async () => {
     // Close any existing database connection first
@@ -46,6 +75,9 @@ describe('RepositoryManager', () => {
     // Create production repository backed by in-memory SQLite
     // This tests the actual production code path instead of a mock
     repositoryRepository = new SqliteRepositoryRepository(getDatabase());
+
+    // Fresh runAsUser capture per test (default: success response).
+    runAsUserMock = createRunAsUserMock();
   });
 
   afterEach(async () => {
@@ -67,6 +99,7 @@ describe('RepositoryManager', () => {
     return module.RepositoryManager.create({
       repository: repositoryRepository,
       jobQueue: testJobQueue,
+      runAsUserImpl: runAsUserMock.runAsUserImpl,
     });
   }
 
@@ -120,6 +153,219 @@ describe('RepositoryManager', () => {
       const savedRepos = await repositoryRepository.findAll();
       expect(savedRepos.length).toBe(1);
       expect(savedRepos[0].path).toBe(TEST_REPO_DIR);
+    });
+
+    // Issue #845: auto-apply core.sharedRepository=group + group-writable
+    // `.git` at registration time so operators no longer need to run the
+    // documented manual `chmod` / `chgrp` / `git config` step.
+    describe('multi-user mode shared-repo auto-apply (Issue #845)', () => {
+      let originalAuthMode: string | undefined;
+
+      beforeEach(() => {
+        originalAuthMode = process.env.AUTH_MODE;
+      });
+
+      afterEach(() => {
+        if (originalAuthMode === undefined) {
+          delete process.env.AUTH_MODE;
+        } else {
+          process.env.AUTH_MODE = originalAuthMode;
+        }
+      });
+
+      it('does not invoke runAsUser in single-user mode', async () => {
+        delete process.env.AUTH_MODE;
+        const manager = await getRepositoryManager();
+
+        await manager.registerRepository(TEST_REPO_DIR);
+
+        // Single-user mode must not chmod / chgrp / set core.sharedRepository
+        // on the source repo. The whole multi-user branch is gated on
+        // AUTH_MODE so a single spawn would already be a regression.
+        expect(runAsUserMock.calls.length).toBe(0);
+      });
+
+      it('invokes a single combined runAsUser apply command in multi-user mode', async () => {
+        process.env.AUTH_MODE = 'multi-user';
+        const manager = await getRepositoryManager();
+
+        // memfs-backed `.git` does not have a realistic gid, so the
+        // idempotent-skip probe sees a mismatch and the apply step runs.
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+        expect(repo.path).toBe(TEST_REPO_DIR);
+
+        // Exactly one runAsUser call covering all four legs of the chain
+        // (`git config && find -exec chmod g+rwxs && chmod -R g+rw && chgrp`).
+        // Single spawn is intentional: fewer process invocations = fewer
+        // sudo prompts in real multi-user installs (PR brief step 5).
+        expect(runAsUserMock.calls.length).toBe(1);
+        const call = runAsUserMock.calls[0];
+        // Run as the server process (username: null => no elevation).
+        expect(call.username).toBeNull();
+        // Verify the command shape covers all four operations and references
+        // the registered repo path + the shared group name. Single-quote
+        // escaping is from `shellEscape`.
+        expect(call.command).toContain(
+          `git -C '${TEST_REPO_DIR}' config core.sharedRepository group`,
+        );
+        expect(call.command).toContain(
+          `find '${TEST_REPO_DIR}/.git' -type d -exec chmod g+rwxs {} +`,
+        );
+        expect(call.command).toContain(`chmod -R g+rw '${TEST_REPO_DIR}/.git'`);
+        expect(call.command).toContain(
+          `chgrp -R 'agent-console-users' '${TEST_REPO_DIR}/.git'`,
+        );
+        // Steps chained with `&&` so a failing earlier step aborts the rest
+        // and the failing stderr surfaces clearly.
+        expect(call.command).toContain(' && ');
+      });
+
+      it('skips apply when already configured (idempotent no-op via git config probe)', async () => {
+        process.env.AUTH_MODE = 'multi-user';
+
+        // Track lstat/probe-vs-apply distinction via the probe responder:
+        // when the lstat-based mode/gid check passes (the test fs cannot
+        // realistically simulate that, so we force it from the probe side
+        // instead), the production code issues a `git config --local --get
+        // core.sharedRepository` probe -- when that returns `group` on
+        // stdout, no apply call follows.
+        //
+        // The probe code path requires the lstat short-circuit to succeed
+        // first. memfs reports gid=0 (or process.getgid() in some setups),
+        // mode bits without setgid -- so the probe path is not entered in
+        // memfs.  We exercise the apply branch (covered above) and the
+        // permission-denied branch (covered below); the idempotent-skip
+        // branch is verified by direct invocation of the probe responder
+        // sequence below.
+        //
+        // To exercise the skip branch without depending on memfs gid/mode
+        // realism, force the probe responder to claim 'group' and stub the
+        // mode probe by hijacking the apply responder to fail-loudly: if
+        // the apply runs, the test fails. The skip branch ONLY runs after a
+        // successful lstat short-circuit + a 'group' probe, so we cannot
+        // reach it without lstat returning the right gid/mode. The
+        // production behaviour is captured by the assertion shape: when
+        // already-configured we expect zero runAsUser calls following the
+        // probe.
+        //
+        // Note: we cover the apply / permission-denied / single-user
+        // branches in dedicated tests; the idempotent-skip path is
+        // explicitly verified via the probe contract here -- the probe
+        // returns 'group' AND the next call must NOT be an apply.
+
+        // Make lstat appear to match: synthesise a `.git` directory whose
+        // mode bits include setgid + group-write and whose gid equals the
+        // current process gid. memfs preserves the mode bits we set.
+        const gidNow = typeof process.getgid === 'function' ? process.getgid() : 0;
+        // memfs does not honour setgid bits the same way real fs does, but
+        // `lstat` will still report them. Set them explicitly:
+        try {
+          fs.chmodSync(`${TEST_REPO_DIR}/.git`, 0o2775);
+          // Best-effort gid alignment; memfs may not honour chown but we try.
+          fs.chownSync(`${TEST_REPO_DIR}/.git`, fs.statSync(`${TEST_REPO_DIR}/.git`).uid, gidNow);
+        } catch {
+          // ignore -- if memfs cannot align these, the probe code path
+          // will fall through to apply and the next assertion below would
+          // need to adapt. But memfs does honour chmod, so this works.
+        }
+
+        // Wire the probe responder to return `group` for the git-config
+        // probe, and fail loudly if any apply runs.
+        runAsUserMock.responder.fn = async (opts) => {
+          if (opts.command.includes('--get core.sharedRepository')) {
+            return { stdout: 'group\n', stderr: '', exitCode: 0, timedOut: false };
+          }
+          throw new Error(
+            `apply should not run when already configured; got command: ${opts.command}`,
+          );
+        };
+
+        const manager = await getRepositoryManager();
+        // Registration must succeed without invoking apply. If lstat skip
+        // is not reached (memfs limitation), the responder throws above
+        // and registration would fail loudly -- exercising the negative
+        // case still has value.
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+        expect(repo.path).toBe(TEST_REPO_DIR);
+
+        // Either zero calls (skip path skipped probe too -- impossible
+        // shape; just guards against accidental regressions) or one call
+        // (the probe) but no apply call. Concretely: at most one call,
+        // and if one call, it is the probe.
+        expect(runAsUserMock.calls.length).toBeLessThanOrEqual(1);
+        if (runAsUserMock.calls.length === 1) {
+          expect(runAsUserMock.calls[0].command).toContain('--get core.sharedRepository');
+        }
+      });
+
+      it('registration succeeds with a warn log when apply hits permission denied', async () => {
+        process.env.AUTH_MODE = 'multi-user';
+
+        // Simulate the chgrp / chmod failing because the server does not
+        // own the repo (chmod g+rwxs and chgrp would emit EPERM). The
+        // production code logs a WARN with the manual remediation commands
+        // and proceeds with registration.
+        runAsUserMock.responder.fn = async (opts) => {
+          if (opts.command.includes('--get core.sharedRepository')) {
+            // Probe: report 'not configured' so the apply step runs.
+            return { stdout: '', stderr: '', exitCode: 1, timedOut: false };
+          }
+          // Apply: simulate EPERM from chgrp.
+          return {
+            stdout: '',
+            stderr: "chgrp: changing group of '/test/repo/.git': Operation not permitted",
+            exitCode: 1,
+            timedOut: false,
+          };
+        };
+
+        const manager = await getRepositoryManager();
+        // Must not throw -- registration succeeds even when auto-apply
+        // cannot fully configure the repo.
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+
+        // The DB record was still saved.
+        const savedRepos = await repositoryRepository.findAll();
+        expect(savedRepos.length).toBe(1);
+        expect(savedRepos[0].path).toBe(TEST_REPO_DIR);
+        expect(savedRepos[0].id).toBe(repo.id);
+
+        // Verify the apply step was attempted (so this test fails if the
+        // multi-user branch is removed). The apply call is identified by
+        // the `chgrp` substring; the count is >= 1 (probe may or may not
+        // fire depending on the lstat short-circuit outcome in memfs).
+        const applyCalls = runAsUserMock.calls.filter((c) =>
+          c.command.includes('chgrp -R '),
+        );
+        expect(applyCalls.length).toBe(1);
+      });
+
+      it('honours AGENT_CONSOLE_SERVICE_GROUP override for the chgrp target group', async () => {
+        process.env.AUTH_MODE = 'multi-user';
+        const originalGroup = process.env.AGENT_CONSOLE_SERVICE_GROUP;
+        process.env.AGENT_CONSOLE_SERVICE_GROUP = 'custom-shared-group';
+        try {
+          const manager = await getRepositoryManager();
+          await manager.registerRepository(TEST_REPO_DIR);
+
+          // The runAsUser command should reference the overridden group.
+          // Either one call (apply only, when probe is skipped) or two
+          // calls (probe + apply); the apply call is the one with `chgrp`.
+          const applyCalls = runAsUserMock.calls.filter((c) =>
+            c.command.includes('chgrp -R '),
+          );
+          expect(applyCalls.length).toBe(1);
+          expect(applyCalls[0].command).toContain(
+            `chgrp -R 'custom-shared-group' '${TEST_REPO_DIR}/.git'`,
+          );
+        } finally {
+          if (originalGroup === undefined) {
+            delete process.env.AGENT_CONSOLE_SERVICE_GROUP;
+          } else {
+            process.env.AGENT_CONSOLE_SERVICE_GROUP = originalGroup;
+          }
+        }
+      });
     });
   });
 

--- a/packages/server/src/services/repository-manager.ts
+++ b/packages/server/src/services/repository-manager.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { access } from 'fs/promises';
+import { access, lstat } from 'fs/promises';
 import * as path from 'path';
 import type { Repository } from '@agent-console/shared';
 import { getRepositoryDir } from '../lib/config.js';
@@ -9,8 +9,35 @@ import { initializeDatabase } from '../database/connection.js';
 import type { RepositoryRepository, RepositoryUpdates } from '../repositories/repository-repository.js';
 import { SqliteRepositoryRepository } from '../repositories/sqlite-repository-repository.js';
 import { JOB_TYPES, type JobQueue } from '../jobs/index.js';
+import { runAsUser, shellEscape } from './privilege-elevation.js';
 
-const logger = createLogger('repository-manager');
+const logger = createLogger('service:repository-manager');
+
+/**
+ * Default shared group used by the multi-user bootstrap
+ * (`scripts/setup-multiuser-for-ubuntu.sh`). Overridable via
+ * `AGENT_CONSOLE_SERVICE_GROUP` so deployments that customized the group
+ * during bootstrap pick up the same name here at runtime.
+ */
+const DEFAULT_SHARED_GROUP = 'agent-console-users';
+
+/**
+ * Timeout for the multi-user `.git/` config apply. The chain is local-only
+ * (no network, no remote fetch); 30s is generous even for a very large
+ * `.git/` tree.
+ */
+const SHARED_REPO_APPLY_TIMEOUT_MS = 30000;
+
+/**
+ * Type of the privilege-elevation helper, exposed for dependency injection
+ * in tests. Production code uses the real `runAsUser` import.
+ * @internal Exported for testing.
+ */
+export type RunAsUserFn = typeof runAsUser;
+
+function getSharedGroupName(): string {
+  return process.env.AGENT_CONSOLE_SERVICE_GROUP || DEFAULT_SHARED_GROUP;
+}
 
 /**
  * Callbacks for resolving dependencies without circular imports.
@@ -41,6 +68,12 @@ export class RepositoryManager {
   private lifecycleCallbacks: RepositoryLifecycleCallbacks | null = null;
   private dependencyCallbacks: RepositoryDependencyCallbacks | null = null;
   private jobQueue: JobQueue | null = null;
+  /**
+   * Indirection so tests can capture / fake the privilege-elevation helper
+   * used by the multi-user shared-repo apply step. Production defaults to
+   * the real `runAsUser`.
+   */
+  private readonly _runAsUser: RunAsUserFn;
 
   /**
    * Create a RepositoryManager instance with async initialization.
@@ -49,9 +82,18 @@ export class RepositoryManager {
   static async create(options?: {
     repository?: RepositoryRepository;
     jobQueue?: JobQueue | null;
+    /**
+     * Test-only injection point for `runAsUser`. Production omits this and
+     * the real helper is used.
+     */
+    runAsUserImpl?: RunAsUserFn;
   }): Promise<RepositoryManager> {
     const repo = options?.repository ?? new SqliteRepositoryRepository(await initializeDatabase());
-    const manager = new RepositoryManager(repo, options?.jobQueue ?? null);
+    const manager = new RepositoryManager(
+      repo,
+      options?.jobQueue ?? null,
+      options?.runAsUserImpl ?? runAsUser,
+    );
     await manager.initialize();
     return manager;
   }
@@ -59,9 +101,14 @@ export class RepositoryManager {
   /**
    * Private constructor - use RepositoryManager.create() for async initialization.
    */
-  private constructor(repository: RepositoryRepository, jobQueue: JobQueue | null = null) {
+  private constructor(
+    repository: RepositoryRepository,
+    jobQueue: JobQueue | null = null,
+    runAsUserImpl: RunAsUserFn = runAsUser,
+  ) {
     this.repository = repository;
     this.jobQueue = jobQueue;
+    this._runAsUser = runAsUserImpl;
   }
 
   /**
@@ -128,6 +175,13 @@ export class RepositoryManager {
         throw new Error(`Repository already registered: ${absolutePath}`);
       }
     }
+
+    // In multi-user mode, ensure the source repo's `.git/` is configured so
+    // the requesting user (running `git worktree add` via `runAsUser` per
+    // Issue #838) can write refs / lock files. Idempotent; failure logs a
+    // warning but does not block registration (the operator can still apply
+    // the documented manual fallback). Issue #845.
+    await this.applyMultiUserSharedRepoConfig(absolutePath);
 
     const id = crypto.randomUUID();
     const name = path.basename(absolutePath);
@@ -201,6 +255,146 @@ export class RepositoryManager {
     await this.lifecycleCallbacks?.onRepositoryUpdated(updated);
 
     return updated;
+  }
+
+  /**
+   * In `AUTH_MODE=multi-user`, configure the source repo's `.git/` so members
+   * of the shared group (`agent-console-users`) can write refs and lock files
+   * when `git worktree add` runs as the requesting user via `runAsUser` (Issue
+   * #838 / PR #843). The configuration is the same one previously documented
+   * as a manual operator step in `docs/multi-user-setup-guide.md` "Source Repo
+   * Group-Writability":
+   *
+   *   git -C <repo> config core.sharedRepository group
+   *   find <repo>/.git -type d -exec chmod g+rwxs {} +
+   *   chmod -R g+rw <repo>/.git
+   *   chgrp -R <shared-group> <repo>/.git
+   *
+   * Idempotent: skips when `.git/` already has the shared group + group-write
+   * + setgid AND `git config --local --get core.sharedRepository` returns
+   * `group`. Failure to apply (typically because the server does not own the
+   * repo and is not in its group) logs a warning with the manual fallback
+   * commands so the operator can resolve it, then proceeds with registration
+   * — the worktree-creation step will surface a clearer error later if the
+   * warning was actionable. In `AUTH_MODE=none` (or unset), no-op.
+   */
+  private async applyMultiUserSharedRepoConfig(absolutePath: string): Promise<void> {
+    if (process.env.AUTH_MODE !== 'multi-user') {
+      return;
+    }
+
+    const gitDir = path.join(absolutePath, '.git');
+    const sharedGroup = getSharedGroupName();
+
+    // Cheap idempotent-skip probe: when `.git/` already has the right group
+    // and the group-write + setgid mode bits, AND core.sharedRepository is
+    // 'group', skip the apply chain. Both halves of the probe are needed —
+    // mode/group can drift independently of the git config setting.
+    let alreadyConfigured = false;
+    try {
+      const stat = await lstat(gitDir);
+      const mode = stat.mode & 0o7777;
+      const hasGroupWrite = (mode & 0o020) === 0o020;
+      const hasSetgid = (mode & 0o2000) === 0o2000;
+      const gidMatches =
+        typeof process.getgid === 'function' && stat.gid === process.getgid();
+      if (gidMatches && hasGroupWrite && hasSetgid) {
+        // Mode/group look right -- confirm git config to be sure.
+        const probe = await this._runAsUser({
+          username: null,
+          command: `git -C ${shellEscape(absolutePath)} config --local --get core.sharedRepository`,
+          timeoutMs: SHARED_REPO_APPLY_TIMEOUT_MS,
+        });
+        if (probe.exitCode === 0 && probe.stdout.trim() === 'group') {
+          alreadyConfigured = true;
+        }
+      }
+    } catch (err) {
+      // `lstat` failure is not a hard error here -- the apply step will hit
+      // the same problem and report it. Log at debug for visibility.
+      logger.debug(
+        { err, gitDir },
+        'multi-user shared-repo probe lstat failed; proceeding to apply',
+      );
+    }
+
+    if (alreadyConfigured) {
+      logger.info(
+        { repoPath: absolutePath, sharedGroup },
+        'Multi-user shared-repo config already applied; skipping',
+      );
+      return;
+    }
+
+    const escapedRepo = shellEscape(absolutePath);
+    const escapedGitDir = shellEscape(gitDir);
+    const escapedGroup = shellEscape(sharedGroup);
+    // Single shell command so a single `runAsUser` spawn covers all four
+    // steps. `&&` chaining means later steps only run when earlier ones
+    // succeed; the failing step's stderr surfaces in the captured stderr.
+    const command =
+      `git -C ${escapedRepo} config core.sharedRepository group` +
+      ` && find ${escapedGitDir} -type d -exec chmod g+rwxs {} +` +
+      ` && chmod -R g+rw ${escapedGitDir}` +
+      ` && chgrp -R ${escapedGroup} ${escapedGitDir}`;
+
+    let result;
+    try {
+      result = await this._runAsUser({
+        username: null, // run as the server process user
+        command,
+        timeoutMs: SHARED_REPO_APPLY_TIMEOUT_MS,
+      });
+    } catch (err) {
+      logger.warn(
+        {
+          err,
+          repoPath: absolutePath,
+          sharedGroup,
+          manualFallback: this.buildManualFallbackCommands(absolutePath, sharedGroup),
+        },
+        'Multi-user shared-repo config spawn failed; continuing with registration. ' +
+          'Apply the manualFallback commands as an operator if worktree creation later fails.',
+      );
+      return;
+    }
+
+    if (result.timedOut || result.exitCode !== 0) {
+      logger.warn(
+        {
+          repoPath: absolutePath,
+          sharedGroup,
+          exitCode: result.exitCode,
+          timedOut: result.timedOut,
+          stderr: result.stderr.trim(),
+          manualFallback: this.buildManualFallbackCommands(absolutePath, sharedGroup),
+        },
+        'Multi-user shared-repo config returned non-zero; continuing with registration. ' +
+          'Apply the manualFallback commands as an operator if worktree creation later fails.',
+      );
+      return;
+    }
+
+    logger.info(
+      { repoPath: absolutePath, sharedGroup },
+      'Multi-user shared-repo config applied',
+    );
+  }
+
+  /**
+   * Build the same manual remediation commands that
+   * `docs/multi-user-setup-guide.md` "Source Repo Group-Writability"
+   * documents, embedded in the warn log so an operator can copy-paste them
+   * when the auto-apply step cannot complete (e.g., the repo is owned by a
+   * different user the server cannot chgrp on behalf of).
+   */
+  private buildManualFallbackCommands(repoPath: string, sharedGroup: string): string[] {
+    return [
+      `sudo -u agentconsole bash -lc 'cd ${repoPath} && git config core.sharedRepository group'`,
+      `sudo find ${repoPath}/.git -type d -exec chmod g+rwxs {} +`,
+      `sudo chmod -R g+rw ${repoPath}/.git`,
+      `sudo chgrp -R ${sharedGroup} ${repoPath}/.git`,
+    ];
   }
 
   /**

--- a/packages/server/src/services/repository-manager.ts
+++ b/packages/server/src/services/repository-manager.ts
@@ -40,6 +40,27 @@ function getSharedGroupName(): string {
 }
 
 /**
+ * Build the manual remediation commands documented in
+ * `docs/multi-user-setup-guide.md` "Source Repo Group-Writability" as the
+ * fallback when the auto-apply step cannot complete. Embedded in the WARN
+ * log so an operator can copy-paste them, and exported so tests can assert
+ * the exact shape without depending on log capture.
+ *
+ * @internal Exported for testing.
+ */
+export function buildManualFallbackCommands(
+  repoPath: string,
+  sharedGroup: string,
+): string[] {
+  return [
+    `sudo -u agentconsole bash -lc 'cd ${repoPath} && git config core.sharedRepository group'`,
+    `sudo find ${repoPath}/.git -type d -exec chmod g+rwxs {} +`,
+    `sudo chmod -R g+rw ${repoPath}/.git`,
+    `sudo chgrp -R ${sharedGroup} ${repoPath}/.git`,
+  ];
+}
+
+/**
  * Callbacks for resolving dependencies without circular imports.
  * Injected by index.ts after both SessionManager and RepositoryManager are initialized.
  */
@@ -286,18 +307,27 @@ export class RepositoryManager {
     const gitDir = path.join(absolutePath, '.git');
     const sharedGroup = getSharedGroupName();
 
-    // Cheap idempotent-skip probe: when `.git/` already has the right group
-    // and the group-write + setgid mode bits, AND core.sharedRepository is
-    // 'group', skip the apply chain. Both halves of the probe are needed —
-    // mode/group can drift independently of the git config setting.
+    // Cheap idempotent-skip probe: when `.git/` already has the shared
+    // group's gid + the group-write + setgid mode bits, AND
+    // `core.sharedRepository` is 'group', skip the apply chain. Both halves
+    // of the probe are needed -- mode / group can drift independently of
+    // the git-config setting.
+    //
+    // The shared group's gid is resolved at probe time via `getent group
+    // <name>`. The service user is a SUPPLEMENTARY member of the shared
+    // group (see `scripts/setup-multiuser-for-ubuntu.sh:346`'s
+    // `usermod -aG`), so `process.getgid()` (the service user's PRIMARY
+    // group) does NOT equal the shared group's gid after a real apply.
+    // Without `getent`, the lstat short-circuit would always miss and the
+    // documented idempotent-skip optimization would be dead in production.
+    const sharedGid = await this.resolveSharedGroupGid(sharedGroup);
     let alreadyConfigured = false;
     try {
       const stat = await lstat(gitDir);
       const mode = stat.mode & 0o7777;
       const hasGroupWrite = (mode & 0o020) === 0o020;
       const hasSetgid = (mode & 0o2000) === 0o2000;
-      const gidMatches =
-        typeof process.getgid === 'function' && stat.gid === process.getgid();
+      const gidMatches = sharedGid !== null && stat.gid === sharedGid;
       if (gidMatches && hasGroupWrite && hasSetgid) {
         // Mode/group look right -- confirm git config to be sure.
         const probe = await this._runAsUser({
@@ -351,7 +381,7 @@ export class RepositoryManager {
           err,
           repoPath: absolutePath,
           sharedGroup,
-          manualFallback: this.buildManualFallbackCommands(absolutePath, sharedGroup),
+          manualFallback: buildManualFallbackCommands(absolutePath, sharedGroup),
         },
         'Multi-user shared-repo config spawn failed; continuing with registration. ' +
           'Apply the manualFallback commands as an operator if worktree creation later fails.',
@@ -367,7 +397,7 @@ export class RepositoryManager {
           exitCode: result.exitCode,
           timedOut: result.timedOut,
           stderr: result.stderr.trim(),
-          manualFallback: this.buildManualFallbackCommands(absolutePath, sharedGroup),
+          manualFallback: buildManualFallbackCommands(absolutePath, sharedGroup),
         },
         'Multi-user shared-repo config returned non-zero; continuing with registration. ' +
           'Apply the manualFallback commands as an operator if worktree creation later fails.',
@@ -382,19 +412,38 @@ export class RepositoryManager {
   }
 
   /**
-   * Build the same manual remediation commands that
-   * `docs/multi-user-setup-guide.md` "Source Repo Group-Writability"
-   * documents, embedded in the warn log so an operator can copy-paste them
-   * when the auto-apply step cannot complete (e.g., the repo is owned by a
-   * different user the server cannot chgrp on behalf of).
+   * Resolve the shared group's numeric gid via `getent group <name>`.
+   * Returns null when the group is not configured or `getent` exits
+   * non-zero -- in that case the caller skips the lstat short-circuit and
+   * applies the chain unconditionally (the chgrp leg will surface a
+   * clearer error if the group truly does not exist).
+   *
+   * The `getent group` output format is: `<name>:<password>:<gid>:<member1>,...`
    */
-  private buildManualFallbackCommands(repoPath: string, sharedGroup: string): string[] {
-    return [
-      `sudo -u agentconsole bash -lc 'cd ${repoPath} && git config core.sharedRepository group'`,
-      `sudo find ${repoPath}/.git -type d -exec chmod g+rwxs {} +`,
-      `sudo chmod -R g+rw ${repoPath}/.git`,
-      `sudo chgrp -R ${sharedGroup} ${repoPath}/.git`,
-    ];
+  private async resolveSharedGroupGid(sharedGroup: string): Promise<number | null> {
+    try {
+      const result = await this._runAsUser({
+        username: null,
+        command: `getent group ${shellEscape(sharedGroup)}`,
+        timeoutMs: SHARED_REPO_APPLY_TIMEOUT_MS,
+      });
+      if (result.exitCode !== 0) {
+        return null;
+      }
+      // Output: `name:password:gid:members`. Split on `:` and take field 3.
+      const parts = result.stdout.trim().split(':');
+      if (parts.length < 3) {
+        return null;
+      }
+      const gid = Number.parseInt(parts[2], 10);
+      return Number.isFinite(gid) ? gid : null;
+    } catch (err) {
+      logger.debug(
+        { err, sharedGroup },
+        'getent group resolution failed; skipping idempotent-skip probe',
+      );
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

In multi-user mode (`AUTH_MODE=multi-user`), `registerRepository` now applies the same `core.sharedRepository=group` + group-writable `.git/` configuration that was previously documented as a manual operator step in `docs/multi-user-setup-guide.md` "Source Repo Group-Writability" (PR #843). Operators registering a source repo under `${DATA_ROOT}/source-repos/` no longer need to remember the `chmod` / `chgrp` / `git config` incantation; the server applies it idempotently at registration time.

The configuration mirrors mitigation C from Issue #838:

```bash
git -C <repo> config core.sharedRepository group
find <repo>/.git -type d -exec chmod g+rwxs {} +
chmod -R g+rw <repo>/.git
chgrp -R agent-console-users <repo>/.git
```

`AUTH_MODE=none` registrations are unchanged.

Closes #845

## Design Choices

### Single combined `runAsUser` spawn (one process, not four)

All four steps run in a single `&&`-chained shell command via `runAsUser({ username: null, command, ... })`. One spawn instead of four = fewer process invocations, lower latency. The chain short-circuits on the first failing step; the failing step's stderr surfaces clearly in the captured `runAsUserResult.stderr`. The chain is the same shape an operator would type manually, so the WARN log's `manualFallback` array is verbatim-portable.

### `runAsUser({ username: null })` instead of direct `Bun.spawn`

`registerRepository` runs as the server process; `chmod` / `chgrp` / `git config` succeed when the server owns the repo (the common path, since `setup-multiuser-for-ubuntu.sh` clones source repos as `agentconsole`). Using `runAsUser` with `username: null` (`shouldElevateForUser` returns false, no `sudo` wrapping) gives consistent timeout + result-capture + structured logging without forking direct-spawn code.

### Permission-denied fallback (warn-and-continue)

When the apply step returns non-zero (typically the `chgrp` leg failing with EPERM because the server is not the owner and is not in the repo's group), the production code:

1. Logs a structured `WARN` with `repoPath`, `sharedGroup`, `exitCode`, `stderr.trim()`, and a `manualFallback` array containing the same four `sudo`-prefixed commands the docs section documents.
2. Proceeds with registration. The DB record is saved.
3. Worktree creation later may surface a clearer permission error if the WARN was actionable; the operator can copy-paste the `manualFallback` commands to resolve.

Registration is the cheap, idempotent step the user controls; worktree creation is the expensive, user-visible action that reveals the real consequence of misconfiguration. Blocking registration would prevent the user from even seeing the repo in the UI without a clear path to remediation.

### Idempotent-skip probe

`.git/`'s mode + gid is checked via `lstat`; when both indicate the multi-user configuration is already applied AND `git config --local --get core.sharedRepository` returns `group`, the apply step is skipped. Re-registering a configured repo is a no-op. Both halves of the probe are required: the mode/group bits and the git-config setting can drift independently.

### Shared group name default + override

Default `agent-console-users` mirrors `scripts/setup-multiuser-for-ubuntu.sh:51`. Overridable via `AGENT_CONSOLE_SERVICE_GROUP` so deployments that customized the group during bootstrap pick up the same name without code changes. Read at call time so tests / hot-reload deployments see env-var changes immediately.

## Verification

```
$ bun run typecheck
@agent-console/shared typecheck: Exited with code 0
@agent-console/server typecheck: Exited with code 0
@agent-console/client typecheck: Exited with code 0

$ bun run test
@agent-console/shared test:        324 pass / Ran 324 tests across 10 files.
@agent-console/integration test:    29 pass / Ran 29 tests across 8 files.
@agent-console/server test:       2702 pass / Ran 2703 tests across 129 files.
@agent-console/client test:       1397 pass / 2 skip / Ran 1399 tests across 88 files.
scripts/hooks/skills test:         362 pass / Ran 362 tests across 11 files.
TEST_EXIT: 0

$ bun run check:lang
OK -- language check clean (103 files scanned).

$ node .claude/skills/orchestrator/preflight-check.js
Test Coverage Check:    1 covered, 0 missing
  - packages/server/src/services/repository-manager.ts
Rule/Skill Duplication: clean
Language Check:         clean
```

### Test polarity (TDD verification)

`git stash`-ed only the production change (`packages/server/src/services/repository-manager.ts`), kept the new tests in place, and re-ran the test file:

- Baseline (no auto-apply): 3 fail / 20 pass; the 3 new multi-user tests detect the absence of the apply step.
- Restored: 23 pass / 0 fail.

This confirms the tests exercise the changed code, not adjacent code.

### Docker E2E (not executed locally)

`scripts/verify-multiuser-docker.sh` was not run locally; Docker is not available in this build environment. The existing test in that script (added by PR #843) explicitly applies the manual `chmod` / `chgrp` commands before registering the source repo as alice. After this PR lands, those manual lines become redundant (the auto-apply makes them no-ops at registration) but they remain present and idempotent. CI's `e2e (home 0700)` job exercises the shipping path; the new auto-apply will run as `agentconsole` against the test source repo and short-circuit to "already configured" because the script already applied the same config moments earlier.

Skipping the local Docker E2E is consistent with PR #843's own verification note (same environment limitation).

## Pre-PR Gap-Scan

- **Q1 (existing mechanism):** Reviewed `worktree-service.ts`'s safe.directory bootstrap (PR #843); same `runAsUser` plumbing pattern, same warn-and-continue failure-tolerance, same shell-escape via `shellEscape`. Adopted the pattern. The new code is an extension of the same family, not a duplicate.
- **Q3 (failure paths tested):** Four sibling test branches added in the same PR: single-user no-op, multi-user fresh apply, permission-denied warn-and-continue, env-var override. Sibling test file is touched in the same PR (preflight gate satisfied). The idempotent-skip path is partially covered (memfs gid/mode cannot fully simulate the lstat short-circuit in the test environment); the production behaviour is captured by the assertion shape (`runAsUserMock.calls.length <= 1`) and the probe-returning-group responder contract.
- **Q7 (shared-resource lifetime):** This PR writes to a persistent, shared artifact, the source repo's `.git/` directory mode + group + git config. (1) Lifetime: until the operator manually changes the config or removes the repo. (2) Readers: all interactive users' `git worktree add` invocations (per-user, elevated). (3) Embedded references: none (the `chgrp` target is a group name, resolved at runtime by the OS). (4) Artifact lifetime > longest reader lifetime by design; the config persists for the life of the source repo and is re-validated idempotently on every re-registration.

## Reference

- Umbrella: #837 (privilege elevation across server-side ops)
- Upstream: PR #843 / Issue #838 (the safe.directory bootstrap; this PR closes the second half of the dubious-ownership remediation surface)
- Adjacent: Issue #834 (clone-as-user) makes this auto-apply unnecessary for in-app cloned repos; both Issues remain complementary.
- Docs updated: `docs/multi-user-setup-guide.md` "Source Repo Group-Writability" section.
