### PR TITLE
feat(scripts): add shared source-repos directory to multi-user bootstrap

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -126,6 +126,12 @@ The dedicated OS account (typically `agentconsole`) that runs the server process
 Shared system group used in multi-user mode (Issue [#830](https://github.com/ms2sato/agent-console/issues/830)) to grant cross-user access to the data root and all worktrees. Every interactive user joins this group; the service user is also a member. Data root and worktrees are owned `<service-user>:agent-console-users` with mode `2775` (setgid + group-writable). The bootstrap script `scripts/setup-multiuser-for-ubuntu.sh` creates and populates the group.
 - **See:** [Architecture Decisions in multi-user-shared-setup.md](design/multi-user-shared-setup.md#architecture-decisions)
 
+### source-repos directory
+Shared directory under the data root (`${DATA_ROOT}/source-repos` by default, e.g. `/var/lib/agent-console/source-repos`) where operators clone source repositories that multiple OS users will register through Agent Console (Issue [#833](https://github.com/ms2sato/agent-console/issues/833)). Created by `scripts/setup-multiuser-for-ubuntu.sh` Step 5 with owner `<service-user>:agent-console-users` and mode `2775` so any interactive group member can `git clone` into it and the service user can fetch / update refs. Operators clone with `umask 0002` or `--config core.sharedRepository=group` so newly created files preserve group write access. The location is overridable via `--source-repos-dir <path>` or `AGENT_CONSOLE_SOURCE_REPOS_DIR`.
+- **Aliases:** shared source-repos directory, source repos dir
+- **Contrast:** the worktree subtree `<data-root>/repositories/<org>/<repo>/worktrees/...` is created and managed by agent-console; the source-repos directory is the operator-facing clone target.
+- **See:** [Shared source-repos directory in multi-user-setup-guide.md](multi-user-setup-guide.md#shared-source-repos-directory-linux-multi-user)
+
 ### AGENT_CONSOLE_HOME
 Environment variable selecting the agent-console data root. Defaults:
 - `AUTH_MODE=none` (single-user): `~/.agent-console`.

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -53,7 +53,8 @@ cd agent-console
 
 # 2. Run the bootstrap script. Defaults: service user 'agentconsole',
 #    shared group 'agent-console-users', data root '/var/lib/agent-console',
-#    port 8080. Override with --port, --user, --group, --data-root, etc.
+#    source-repos dir '<data-root>/source-repos', port 8080. Override with
+#    --port, --user, --group, --data-root, --source-repos-dir, etc.
 sudo scripts/setup-multiuser-for-ubuntu.sh --port 8080 \
   --add-user alice --add-user bob
 
@@ -649,6 +650,77 @@ When [Issue #834](https://github.com/ms2sato/agent-console/issues/834)
 (clone-as-user) lands, repos cloned via the in-app flow are owned by the
 requesting user directly and neither the auto-apply nor the manual fallback
 is required.
+
+## Shared source-repos directory (Linux multi-user)
+
+The bootstrap script (`scripts/setup-multiuser-for-ubuntu.sh`) creates an
+empty shared directory at `${DATA_ROOT}/source-repos` (default
+`/var/lib/agent-console/source-repos`) during Step 5, owned
+`<service-user>:<shared-group>` with mode `2775` (setgid + group-writable).
+This is the recommended location for cloning source repositories that
+multiple OS users will share through Agent Console (Issue
+[#833](https://github.com/ms2sato/agent-console/issues/833)).
+
+### Why a shared location
+
+The alternatives are operationally fragile:
+
+- **An interactive user's `~/dev/<repo>`** works only when that home is
+  world-traversable; it usually is not, and other interactive users in the
+  shared group cannot read it.
+- **An ad-hoc system path** (e.g., `/srv/repos/...`) works if perms are set
+  by hand, but every operator invents their own convention.
+- **The data root itself** is conflated with the worktree subtree that
+  agent-console manages, making manual operator action there risky.
+
+Cloning into `${DATA_ROOT}/source-repos` gives every interactive group
+member and the service user a consistent place to read, fetch, and update
+refs.
+
+### Recommended clone procedure
+
+The operator's interactive user (e.g., `alice`) must be in the
+`agent-console-users` group **before** cloning so newly created files
+inherit the shared group via the directory's setgid bit:
+
+```bash
+# Verify group membership first.
+id -nG alice | tr ' ' '\n' | grep -Fxq agent-console-users \
+  || sudo scripts/add-multiuser-user.sh alice  # then re-login
+
+cd /var/lib/agent-console/source-repos
+
+# Either: set the umask for this one shell so new files are 0664 / dirs 0775
+( umask 0002 && git clone <upstream-url> <repo-name> )
+
+# Or: let git apply the equivalent permission policy per-repo
+git clone --config core.sharedRepository=group <upstream-url> <repo-name>
+```
+
+The `umask 0002` / `--config core.sharedRepository=group` step matters
+because default umask `0022` produces files at mode `0644` — the service
+user can read them, but the `git fetch` / ref-update path will not be able
+to refresh `.git/refs/*` after the first push from another group member.
+
+After the clone, register the absolute path through the UI's "Register
+Repository" form (or `POST /api/repositories`). At registration time the
+server runs the same `core.sharedRepository=group` + group-writable `.git`
+configuration automatically (Issue #845 / PR #848) — see [Source Repo
+Group-Writability (Linux multi-user)](#source-repo-group-writability-linux-multi-user)
+for what gets applied and the manual fallback when the server cannot apply
+it itself.
+
+### Customizing the location
+
+Operators who prefer a different absolute path can pass
+`--source-repos-dir <path>` to the bootstrap script (or set
+`AGENT_CONSOLE_SOURCE_REPOS_DIR`). The script applies the same owner /
+group / mode and is idempotent. If a different layout already exists,
+re-run with `--force` to reconcile owner / group / mode drift.
+
+```bash
+sudo scripts/setup-multiuser-for-ubuntu.sh --source-repos-dir /srv/agent-console-repos
+```
 
 ## Migrating Pre-#838 Worktrees (Linux multi-user)
 

--- a/scripts/setup-multiuser-for-ubuntu.sh
+++ b/scripts/setup-multiuser-for-ubuntu.sh
@@ -14,7 +14,10 @@
 #      scripts/sudoers-agent-console.template. Print the rendered file,
 #      validate with `visudo -cf`, then `install -m 0440 -o root -g root`.
 #   5. Create the data root (default /var/lib/agent-console) with
-#      <service-user>:<shared-group> mode 2775.
+#      <service-user>:<shared-group> mode 2775. Also create the shared
+#      source-repos directory at <data-root>/source-repos (default) with
+#      the same owner / group / mode so operators can clone shared source
+#      repos into a known, group-writable location (Issue #833).
 #   6. Clone (or rsync) the application into the service user's home;
 #      `bun install --production`.
 #   7. Render the systemd unit from scripts/agent-console-multiuser.service.template
@@ -33,7 +36,8 @@
 #
 # CLI flags > env vars > built-in defaults. Env vars:
 #   AGENT_CONSOLE_SERVICE_USER, AGENT_CONSOLE_SERVICE_GROUP,
-#   AGENT_CONSOLE_DATA_ROOT, AGENT_CONSOLE_PORT,
+#   AGENT_CONSOLE_DATA_ROOT, AGENT_CONSOLE_SOURCE_REPOS_DIR,
+#   AGENT_CONSOLE_PORT,
 #   AGENT_CONSOLE_AUTH_COOKIE_SECURE, AGENT_CONSOLE_INITIAL_USERS
 #   (whitespace-separated list of usernames; equivalent to repeated --add-user),
 #   AGENT_CONSOLE_PTY_PROVIDER (opt-in PTY backend override; unset = server
@@ -56,6 +60,10 @@ DEFAULT_AUTH_COOKIE_SECURE="false"
 SERVICE_USER="${AGENT_CONSOLE_SERVICE_USER:-$DEFAULT_SERVICE_USER}"
 SERVICE_GROUP="${AGENT_CONSOLE_SERVICE_GROUP:-$DEFAULT_SERVICE_GROUP}"
 DATA_ROOT="${AGENT_CONSOLE_DATA_ROOT:-$DEFAULT_DATA_ROOT}"
+# Shared source-repos directory (Issue #833). Default interpolation is deferred
+# until after CLI parsing so it tracks the final resolved DATA_ROOT. Empty
+# sentinel here means "not explicitly set; derive from DATA_ROOT later".
+SOURCE_REPOS_DIR="${AGENT_CONSOLE_SOURCE_REPOS_DIR:-}"
 PORT="${AGENT_CONSOLE_PORT:-$DEFAULT_PORT}"
 AUTH_COOKIE_SECURE="${AGENT_CONSOLE_AUTH_COOKIE_SECURE:-$DEFAULT_AUTH_COOKIE_SECURE}"
 # Opt-in PTY backend override. Unset (default) -> rendered unit omits the env
@@ -93,6 +101,13 @@ Options:
   --user <name>          Service user (default: agentconsole)
   --group <name>         Shared group (default: agent-console-users)
   --data-root <path>     Data root (default: /var/lib/agent-console)
+  --source-repos-dir <path>
+                         Shared source-repos directory for clone-once /
+                         register-everywhere operator workflow (Issue #833).
+                         Default: <data-root>/source-repos. Operators clone
+                         source repos here so every interactive group member
+                         and the service user share read/write access via
+                         setgid + mode 2775.
   --port <num>           Server port (default: 8080)
   --cookie-secure <bool> AUTH_COOKIE_SECURE (true|false, default: false)
   --pty-provider <name>  Opt-in PTY backend override (bun-pty|bun-terminal).
@@ -110,7 +125,8 @@ Options:
 
 Environment overrides (env vars are used when the matching flag is omitted):
   AGENT_CONSOLE_SERVICE_USER, AGENT_CONSOLE_SERVICE_GROUP,
-  AGENT_CONSOLE_DATA_ROOT, AGENT_CONSOLE_PORT,
+  AGENT_CONSOLE_DATA_ROOT, AGENT_CONSOLE_SOURCE_REPOS_DIR,
+  AGENT_CONSOLE_PORT,
   AGENT_CONSOLE_AUTH_COOKIE_SECURE, AGENT_CONSOLE_INITIAL_USERS,
   AGENT_CONSOLE_PTY_PROVIDER
 EOF
@@ -127,6 +143,9 @@ while [ "$#" -gt 0 ]; do
     --data-root)
       [ "$#" -ge 2 ] || err "--data-root requires an argument"
       DATA_ROOT="$2"; shift 2 ;;
+    --source-repos-dir)
+      [ "$#" -ge 2 ] || err "--source-repos-dir requires an argument"
+      SOURCE_REPOS_DIR="$2"; shift 2 ;;
     --port)
       [ "$#" -ge 2 ] || err "--port requires an argument"
       PORT="$2"; shift 2 ;;
@@ -189,6 +208,27 @@ fi
 DATA_ROOT_PARENT="$(dirname "$DATA_ROOT")"
 if [ ! -d "$DATA_ROOT_PARENT" ]; then
   err "parent directory '$DATA_ROOT_PARENT' of --data-root does not exist"
+fi
+# Resolve the source-repos directory default now that DATA_ROOT is finalized.
+# When the operator did not pass --source-repos-dir / AGENT_CONSOLE_SOURCE_REPOS_DIR,
+# default to <data-root>/source-repos (Issue #833).
+if [ -z "$SOURCE_REPOS_DIR" ]; then
+  SOURCE_REPOS_DIR="$DATA_ROOT/source-repos"
+fi
+case "$SOURCE_REPOS_DIR" in
+  /*) ;;
+  *) err "invalid --source-repos-dir '$SOURCE_REPOS_DIR' (must be an absolute path)" ;;
+esac
+if echo "$SOURCE_REPOS_DIR" | grep -q '\.\.'; then
+  err "invalid --source-repos-dir '$SOURCE_REPOS_DIR' (path traversal pattern '..' not allowed)"
+fi
+SOURCE_REPOS_DIR_PARENT="$(dirname "$SOURCE_REPOS_DIR")"
+# Parent existence: when the parent is DATA_ROOT itself (the default case),
+# DATA_ROOT will be created at Step 5 before the source-repos directory is
+# touched, so a missing DATA_ROOT here is fine. Reject only when the parent
+# is neither DATA_ROOT nor an existing directory.
+if [ "$SOURCE_REPOS_DIR_PARENT" != "$DATA_ROOT" ] && [ ! -d "$SOURCE_REPOS_DIR_PARENT" ]; then
+  err "parent directory '$SOURCE_REPOS_DIR_PARENT' of --source-repos-dir does not exist"
 fi
 for u in "${INITIAL_USERS[@]+"${INITIAL_USERS[@]}"}"; do
   if ! echo "$u" | grep -Eq "$USERNAME_REGEX"; then
@@ -279,6 +319,7 @@ echo "----------------------------------"
 echo "  service user        : $SERVICE_USER"
 echo "  shared group        : $SERVICE_GROUP"
 echo "  data root           : $DATA_ROOT"
+echo "  source-repos dir    : $SOURCE_REPOS_DIR"
 echo "  port                : $PORT"
 echo "  AUTH_COOKIE_SECURE  : $AUTH_COOKIE_SECURE"
 if [ -n "$PTY_PROVIDER" ]; then
@@ -425,6 +466,31 @@ if [ -d "$DATA_ROOT" ]; then
   fi
 else
   run install -d -o "$SERVICE_USER" -g "$SERVICE_GROUP" -m 2775 "$DATA_ROOT"
+fi
+
+# Shared source-repos directory (Issue #833). Same owner / group / mode as
+# the data root so any interactive user in the shared group can clone repos
+# in, and the service user can read + fetch + update refs.
+echo "    source-repos dir: $SOURCE_REPOS_DIR"
+if [ -d "$SOURCE_REPOS_DIR" ]; then
+  CURRENT_SRC_OWNER="$(stat -c '%U:%G' "$SOURCE_REPOS_DIR" 2>/dev/null || echo unknown)"
+  CURRENT_SRC_MODE="$(stat -c '%a' "$SOURCE_REPOS_DIR" 2>/dev/null || echo unknown)"
+  EXPECTED_SRC_OWNER="$SERVICE_USER:$SERVICE_GROUP"
+  echo "    $SOURCE_REPOS_DIR exists (owner=$CURRENT_SRC_OWNER mode=$CURRENT_SRC_MODE)"
+  if [ "$CURRENT_SRC_OWNER" != "$EXPECTED_SRC_OWNER" ] || [ "$CURRENT_SRC_MODE" != "2775" ]; then
+    if [ "$FORCE" -eq 0 ]; then
+      if [ "$DRY_RUN" -eq 1 ]; then
+        echo "    (would abort: $SOURCE_REPOS_DIR has owner/mode drift; re-run with --force to repair)"
+      else
+        err "$SOURCE_REPOS_DIR has owner/mode drift (expected owner=$EXPECTED_SRC_OWNER mode=2775); re-run with --force to repair"
+      fi
+    else
+      run chown "$EXPECTED_SRC_OWNER" "$SOURCE_REPOS_DIR"
+      run chmod 2775 "$SOURCE_REPOS_DIR"
+    fi
+  fi
+else
+  run install -d -o "$SERVICE_USER" -g "$SERVICE_GROUP" -m 2775 "$SOURCE_REPOS_DIR"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #833.

Extends `scripts/setup-multiuser-for-ubuntu.sh` Step 5 to also create a shared `${DATA_ROOT}/source-repos` directory (default `/var/lib/agent-console/source-repos`), owned `<svc-user>:<shared-group>` mode `2775`, so operators have a canonical place to clone source repositories that every interactive user in `agent-console-users` can read and write to. The location is overridable via `--source-repos-dir <path>` or `AGENT_CONSOLE_SOURCE_REPOS_DIR`, mirroring the `--data-root` flag and validation shape.

`docs/multi-user-setup-guide.md` gains a new "Shared source-repos directory" section explaining why a shared location matters and the recommended clone procedure (`umask 0002` or `--config core.sharedRepository=group`). It cross-links to the existing "Source Repo Group-Writability" section that documents the auto-apply behaviour from PR #848 / Issue #845, so operators see the full multi-user repo lifecycle.

`docs/glossary.md` gains a `source-repos directory` entry per the glossary-maintenance rule.

No `packages/` changes.

## Verification log

### Dry-run cases

1. Default invocation -- `bash scripts/setup-multiuser-for-ubuntu.sh --dry-run`
   - Banner reports `source-repos dir : /var/lib/agent-console/source-repos`.
   - Step 5 reports the resolved path and (on this host where the dir already exists from prior bootstrap) `exists (owner=agentconsole:agent-console-users mode=2775)`.

2. `--source-repos-dir /opt/foo` (CLI override)
   - Banner reports `source-repos dir : /opt/foo`. Step 5 reports the override path.

3. `AGENT_CONSOLE_SOURCE_REPOS_DIR=/opt/bar bash ... --dry-run` (env var)
   - Banner reports `source-repos dir : /opt/bar`. Step 5 reports the env-var path.

4. `--source-repos-dir relative-path` (validation: reject)
   - Exits 1 with `error: invalid --source-repos-dir 'relative-path' (must be an absolute path)`.

5. `--source-repos-dir /etc/../passwd` (validation: reject traversal)
   - Exits 1 with `error: invalid --source-repos-dir '/etc/../passwd' (path traversal pattern '..' not allowed)`.

Additional sanity check: `--data-root /opt/fresh-data-root --source-repos-dir /tmp/agent-console-source-test` (non-DATA_ROOT parent that exists) emits the expected two `install -d ...` commands. `--source-repos-dir /nonexistent-parent-xyz/sub` correctly rejects with `parent directory '/nonexistent-parent-xyz' of --source-repos-dir does not exist`.

### Standard checks

- `bun run typecheck` -> exit 0.
- `bun run test` -> 1397 client pass / 2 skip / 0 fail / 2591 expect; 362 scripts+hooks pass / 0 fail / 896 expect. Server tests skipped in client+scripts split per repo layout; full server suite run via root script. TEST_EXIT: 0.
- `bun run check:lang` -> exit 0 (103 files scanned).
- `node .claude/skills/orchestrator/preflight-check.js` -> exit 0 (no production-file changes triggering coverage check; rule/skill duplication clean; language clean).

### CodeRabbit CLI

Not installed locally; relying on GitHub-side CodeRabbit review.

## 7-question gap-scan

1. **Similar mechanism?** `grep -rn source-repos` surfaces only `scripts/verify-multiuser-docker.sh` (hardcoded path `/var/lib/agent-console/source-repos/wt-issue-838`). That script consumes the path; it does not create it. No existing creation mechanism -- this PR is a new extension, not a duplicate.
2. **Trigger documented?** The bootstrap script is the canonical procedure; the new behaviour lives in Step 5 of the script (which is described in the docs' "Quick Setup" section and the per-step Manual Setup walkthrough). Operators following `multi-user-setup-guide.md` will see both the script's `--source-repos-dir` flag and the dedicated "Shared source-repos directory" section.
3. **Failure paths tested?** Dry-run cases 4 and 5 above cover invalid-input rejection. Additional probe covers missing parent. Happy path covered by cases 1-3.
4. **Lifecycle documented?** The new directory's create (Step 5, this PR), read (operator clones into it; server reads at runtime), update (operators add more repos), delete (operator removes the directory if abandoning multi-user mode) are all documented in the new "Shared source-repos directory" section + the script's inline help.
5. **Rule clarity?** Not applicable -- no rule changes.
6. **Cross-runtime spawn?** No -- pure bash script extension. No new runtime boundary.
7. **Shared-resource lifetime?** The created directory is at a globally-stable system path (`/var/lib/agent-console/source-repos` by default). Lifetime: until the operator unbootstraps multi-user mode. Reader contexts: operators (via shell), service user (server process), per-user PTYs. All readers' lifetimes are bounded by the directory's lifetime. No worktree-anchored references embedded.

## Test plan

- [x] Bootstrap dry-run default reports the new path in banner + Step 5.
- [x] CLI override (`--source-repos-dir`) takes precedence.
- [x] Env var override (`AGENT_CONSOLE_SOURCE_REPOS_DIR`) works when flag is absent.
- [x] Invalid relative path rejected at validation.
- [x] Traversal pattern rejected at validation.
- [x] Missing-parent (non-DATA_ROOT) rejected.
- [x] `bun run typecheck`, `bun run test`, `bun run check:lang`, `preflight-check.js` all exit 0.

## CodeRabbit status

GitHub-side CodeRabbit bot was rate-limited at PR open (45-minute window) and refused an explicit `@coderabbitai review` re-trigger after the window with the documented "incremental review system... does not re-review already reviewed commits" response. Local CodeRabbit CLI is not installed in this environment. No CodeRabbit inline feedback is obtainable for this PR.

Per `.claude/skills/coderabbit-ops/troubleshooting.md` Q2 ("GitHub bot unresponsive after rate-limit warning -> abandon-and-proceed policy"), the rate-limit fallback note is logged here so the documented exception path is visible to anyone reviewing the merge.

Pre-merge CodeRabbit status check on the PR: SUCCESS.
