### PR TITLE
fix(server): embed {{prompt}} via shellEscape instead of env-var indirection

### DIFF
--- a/packages/server/src/__tests__/utils/extract-prompt-from-command.ts
+++ b/packages/server/src/__tests__/utils/extract-prompt-from-command.ts
@@ -1,0 +1,29 @@
+/**
+ * Helper for tests asserting the prompt content reached the spawn boundary.
+ *
+ * After Issue #851, `expandTemplate` embeds the `{{prompt}}` placeholder
+ * directly into the spawned command string via `shellEscape` (single-quoted
+ * literal with `'\''` for embedded single quotes), instead of indirecting
+ * through `env.__AGENT_PROMPT__`. Tests that previously read the prompt
+ * from the spawn options' `env` field must now extract it from the command
+ * string.
+ *
+ * `extractPromptFromSpawnCommand` finds the LAST single-quoted run in the
+ * command — agent headless templates always place `{{prompt}}` last
+ * (e.g. `claude -p --format text {{prompt}}`), and `shellEscape` always
+ * wraps its argument in `'...'` and never produces a bare `'` outside the
+ * wrap. The helper then reverses the `'\''` escape that `shellEscape`
+ * inserts for embedded single quotes.
+ */
+export function extractPromptFromSpawnCommand(command: string): string {
+  // Match the LAST single-quoted run, allowing the `'\''` escape sequence
+  // inside (which `shellEscape` produces for embedded single quotes).
+  // The regex content `(?:[^']|'\\'')*` accepts non-quote chars or the
+  // literal 4-char sequence `'\''`.
+  const match = command.match(/'((?:[^']|'\\'')*)'\s*$/);
+  if (!match) {
+    throw new Error(`could not extract prompt from command: ${command}`);
+  }
+  // Unescape the `'\''` sequence back to a literal single quote.
+  return match[1].replace(/'\\''/g, "'");
+}

--- a/packages/server/src/lib/__tests__/template.test.ts
+++ b/packages/server/src/lib/__tests__/template.test.ts
@@ -1,21 +1,20 @@
 import { describe, it, expect } from 'bun:test';
 import {
   expandTemplate,
-  getPromptEnvVar,
   TemplateExpansionError,
 } from '../template.js';
 
 describe('expandTemplate', () => {
   describe('basic expansion', () => {
-    it('should expand {{prompt}} placeholder with environment variable reference', () => {
+    it('should expand {{prompt}} placeholder with shell-escaped inline prompt', () => {
       const result = expandTemplate({
         template: 'test-cli {{prompt}}',
         prompt: 'Hello World',
         cwd: '/repo',
       });
 
-      expect(result.command).toBe('test-cli "$__AGENT_PROMPT__"');
-      expect(result.env.__AGENT_PROMPT__).toBe('Hello World');
+      expect(result.command).toBe("test-cli 'Hello World'");
+      expect(result.env).toEqual({});
     });
 
     it('should expand {{cwd}} placeholder with shell-escaped path', () => {
@@ -25,9 +24,9 @@ describe('expandTemplate', () => {
         cwd: '/path/to/repo',
       });
 
-      // cwd is shell-escaped (single-quoted) for safety
-      expect(result.command).toBe("cd '/path/to/repo' && run \"$__AGENT_PROMPT__\"");
-      expect(result.env.__AGENT_PROMPT__).toBe('test');
+      // cwd and prompt are both shell-escaped (single-quoted) for safety
+      expect(result.command).toBe("cd '/path/to/repo' && run 'test'");
+      expect(result.env).toEqual({});
     });
 
     it('should expand both {{prompt}} and {{cwd}} placeholders', () => {
@@ -37,9 +36,8 @@ describe('expandTemplate', () => {
         cwd: '/workspace',
       });
 
-      // cwd is shell-escaped (single-quoted) for safety
-      expect(result.command).toBe("cd '/workspace' && test-cli \"$__AGENT_PROMPT__\"");
-      expect(result.env.__AGENT_PROMPT__).toBe('my task');
+      expect(result.command).toBe("cd '/workspace' && test-cli 'my task'");
+      expect(result.env).toEqual({});
     });
 
     it('should handle multiple {{prompt}} placeholders', () => {
@@ -49,8 +47,8 @@ describe('expandTemplate', () => {
         cwd: '/repo',
       });
 
-      expect(result.command).toBe('cmd "$__AGENT_PROMPT__" --extra "$__AGENT_PROMPT__"');
-      expect(result.env.__AGENT_PROMPT__).toBe('test');
+      expect(result.command).toBe("cmd 'test' --extra 'test'");
+      expect(result.env).toEqual({});
     });
 
     it('should handle multiple {{cwd}} placeholders', () => {
@@ -61,8 +59,8 @@ describe('expandTemplate', () => {
       });
 
       // Each cwd is shell-escaped (single-quoted) for safety
-      expect(result.command).toBe("cd '/repo' && ls '/repo' && run \"$__AGENT_PROMPT__\"");
-      expect(result.env.__AGENT_PROMPT__).toBe('test');
+      expect(result.command).toBe("cd '/repo' && ls '/repo' && run 'test'");
+      expect(result.env).toEqual({});
     });
   });
 
@@ -112,14 +110,14 @@ describe('expandTemplate', () => {
   });
 
   describe('no prompt provided', () => {
-    it('should expand {{prompt}} with empty string when no prompt provided', () => {
+    it('should expand {{prompt}} with empty shell-escaped string when no prompt provided', () => {
       const result = expandTemplate({
         template: 'test-cli {{prompt}}',
         cwd: '/repo',
       });
 
-      expect(result.command).toBe('test-cli "$__AGENT_PROMPT__"');
-      expect(result.env.__AGENT_PROMPT__).toBe('');
+      expect(result.command).toBe("test-cli ''");
+      expect(result.env).toEqual({});
     });
 
     it('should allow starting agents interactively without initial prompt', () => {
@@ -129,8 +127,8 @@ describe('expandTemplate', () => {
         cwd: '/repo',
       });
 
-      expect(result.command).toBe('test-cli "$__AGENT_PROMPT__"');
-      expect(result.env.__AGENT_PROMPT__).toBe('');
+      expect(result.command).toBe("test-cli ''");
+      expect(result.env).toEqual({});
     });
   });
 
@@ -142,9 +140,9 @@ describe('expandTemplate', () => {
         cwd: '/repo',
       });
 
-      // The prompt is passed via environment variable, so special characters are safe
-      expect(result.command).toBe('test-cli "$__AGENT_PROMPT__"');
-      expect(result.env.__AGENT_PROMPT__).toBe('test; rm -rf /');
+      // Single-quoted: every metacharacter is a literal, no command substitution.
+      expect(result.command).toBe("test-cli 'test; rm -rf /'");
+      expect(result.env).toEqual({});
     });
 
     it('should safely handle prompts with quotes', () => {
@@ -154,8 +152,10 @@ describe('expandTemplate', () => {
         cwd: '/repo',
       });
 
-      expect(result.command).toBe('test-cli "$__AGENT_PROMPT__"');
-      expect(result.env.__AGENT_PROMPT__).toBe('Say "hello" and \'goodbye\'');
+      // Double quotes pass through inside single-quoted literal;
+      // embedded single quote is escaped via '\''.
+      expect(result.command).toBe("test-cli 'Say \"hello\" and '\\''goodbye'\\'''");
+      expect(result.env).toEqual({});
     });
 
     it('should safely handle prompts with newlines', () => {
@@ -165,8 +165,9 @@ describe('expandTemplate', () => {
         cwd: '/repo',
       });
 
-      expect(result.command).toBe('test-cli "$__AGENT_PROMPT__"');
-      expect(result.env.__AGENT_PROMPT__).toBe('Line 1\nLine 2\nLine 3');
+      // Newlines are preserved literally inside single-quoted shell literals.
+      expect(result.command).toBe("test-cli 'Line 1\nLine 2\nLine 3'");
+      expect(result.env).toEqual({});
     });
 
     it('should safely handle prompts with dollar signs', () => {
@@ -176,8 +177,9 @@ describe('expandTemplate', () => {
         cwd: '/repo',
       });
 
-      expect(result.command).toBe('test-cli "$__AGENT_PROMPT__"');
-      expect(result.env.__AGENT_PROMPT__).toBe('$HOME and $(whoami)');
+      // Single quotes suppress all expansion (no $VAR, no $(...) substitution).
+      expect(result.command).toBe("test-cli '$HOME and $(whoami)'");
+      expect(result.env).toEqual({});
     });
   });
 
@@ -190,8 +192,8 @@ describe('expandTemplate', () => {
       });
 
       // Paths with spaces are safely handled by single-quoting
-      expect(result.command).toBe("cd '/path/with spaces/repo' && run \"$__AGENT_PROMPT__\"");
-      expect(result.env.__AGENT_PROMPT__).toBe('test');
+      expect(result.command).toBe("cd '/path/with spaces/repo' && run 'test'");
+      expect(result.env).toEqual({});
     });
 
     it('should handle paths with special characters', () => {
@@ -202,15 +204,9 @@ describe('expandTemplate', () => {
       });
 
       // Single quotes in paths are escaped using the '\'' technique
-      expect(result.command).toBe("cd '/path/with'\\''quote/repo' && run \"$__AGENT_PROMPT__\"");
-      expect(result.env.__AGENT_PROMPT__).toBe('test');
+      expect(result.command).toBe("cd '/path/with'\\''quote/repo' && run 'test'");
+      expect(result.env).toEqual({});
     });
-  });
-});
-
-describe('getPromptEnvVar', () => {
-  it('should return the environment variable name used for prompts', () => {
-    expect(getPromptEnvVar()).toBe('__AGENT_PROMPT__');
   });
 });
 
@@ -223,8 +219,8 @@ describe('custom template variables', () => {
         cwd: '/repo',
       });
 
-      expect(result.command).toBe("cli --model 'claude-opus-4-6' \"$__AGENT_PROMPT__\"");
-      expect(result.env.__AGENT_PROMPT__).toBe('do stuff');
+      expect(result.command).toBe("cli --model 'claude-opus-4-6' 'do stuff'");
+      expect(result.env).toEqual({});
     });
 
     it('should expand {{model}} (no default) to empty string when no templateVars provided', () => {
@@ -234,7 +230,7 @@ describe('custom template variables', () => {
         cwd: '/repo',
       });
 
-      expect(result.command).toBe('cli --model  "$__AGENT_PROMPT__"');
+      expect(result.command).toBe("cli --model  'do stuff'");
     });
   });
 
@@ -247,7 +243,7 @@ describe('custom template variables', () => {
         templateVars: { model: 'gpt-4' },
       });
 
-      expect(result.command).toBe("cli --model 'gpt-4' \"$__AGENT_PROMPT__\"");
+      expect(result.command).toBe("cli --model 'gpt-4' 'do stuff'");
     });
 
     it('should override no-default variable when templateVars provides a value', () => {
@@ -258,7 +254,7 @@ describe('custom template variables', () => {
         templateVars: { model: 'gpt-4' },
       });
 
-      expect(result.command).toBe("cli --model 'gpt-4' \"$__AGENT_PROMPT__\"");
+      expect(result.command).toBe("cli --model 'gpt-4' 'do stuff'");
     });
   });
 
@@ -272,7 +268,7 @@ describe('custom template variables', () => {
       });
 
       // model overridden, temperature uses default
-      expect(result.command).toBe("cli --model 'gpt-4' --temp '0.7' \"$__AGENT_PROMPT__\"");
+      expect(result.command).toBe("cli --model 'gpt-4' --temp '0.7' 'test'");
     });
   });
 
@@ -285,8 +281,8 @@ describe('custom template variables', () => {
         templateVars: { model: 'sonnet' },
       });
 
-      expect(result.command).toBe("cd '/workspace' && cli --model 'sonnet' \"$__AGENT_PROMPT__\"");
-      expect(result.env.__AGENT_PROMPT__).toBe('my task');
+      expect(result.command).toBe("cd '/workspace' && cli --model 'sonnet' 'my task'");
+      expect(result.env).toEqual({});
     });
 
     it('should NOT allow templateVars to override {{prompt}} expansion', () => {
@@ -297,9 +293,9 @@ describe('custom template variables', () => {
         templateVars: { prompt: 'hacked' },
       });
 
-      // {{prompt}} should still expand to env var reference, not the templateVars value
-      expect(result.command).toBe('cli "$__AGENT_PROMPT__"');
-      expect(result.env.__AGENT_PROMPT__).toBe('real prompt');
+      // {{prompt}} should still expand to the real prompt, not the templateVars value
+      expect(result.command).toBe("cli 'real prompt'");
+      expect(result.env).toEqual({});
     });
 
     it('should NOT allow templateVars to override {{cwd}} expansion', () => {
@@ -310,7 +306,7 @@ describe('custom template variables', () => {
         templateVars: { cwd: '/hacked/path' },
       });
 
-      expect(result.command).toBe("cd '/real/path' && cli \"$__AGENT_PROMPT__\"");
+      expect(result.command).toBe("cd '/real/path' && cli 'test'");
     });
   });
 
@@ -345,8 +341,8 @@ describe('custom template variables', () => {
         templateVars: { model: 'haiku' },
       });
 
-      expect(result.command).toBe("cli --model 'haiku' -p \"$__AGENT_PROMPT__\"");
-      expect(result.env.__AGENT_PROMPT__).toBe('headless task');
+      expect(result.command).toBe("cli --model 'haiku' -p 'headless task'");
+      expect(result.env).toEqual({});
     });
   });
 
@@ -359,7 +355,7 @@ describe('custom template variables', () => {
         templateVars: { model: 'my model name' },
       });
 
-      expect(result.command).toBe("cli --model 'my model name' \"$__AGENT_PROMPT__\"");
+      expect(result.command).toBe("cli --model 'my model name' 'test'");
     });
 
     it('should shell-escape values with single quotes', () => {
@@ -370,7 +366,7 @@ describe('custom template variables', () => {
         templateVars: { model: "it's-a-model" },
       });
 
-      expect(result.command).toBe("cli --model 'it'\\''s-a-model' \"$__AGENT_PROMPT__\"");
+      expect(result.command).toBe("cli --model 'it'\\''s-a-model' 'test'");
     });
 
     it('should shell-escape values with double quotes and semicolons', () => {
@@ -381,7 +377,7 @@ describe('custom template variables', () => {
         templateVars: { note: 'say "hello"; rm -rf /' },
       });
 
-      expect(result.command).toBe("cli --note 'say \"hello\"; rm -rf /' \"$__AGENT_PROMPT__\"");
+      expect(result.command).toBe("cli --note 'say \"hello\"; rm -rf /' 'test'");
     });
 
     it('should shell-escape default values with special characters', () => {
@@ -391,7 +387,7 @@ describe('custom template variables', () => {
         cwd: '/repo',
       });
 
-      expect(result.command).toBe("cli --flag 'value with spaces' \"$__AGENT_PROMPT__\"");
+      expect(result.command).toBe("cli --flag 'value with spaces' 'test'");
     });
   });
 });

--- a/packages/server/src/lib/template.ts
+++ b/packages/server/src/lib/template.ts
@@ -2,8 +2,6 @@
  * Template expansion utilities for agent commands
  */
 
-const PROMPT_ENV_VAR = '__AGENT_PROMPT__';
-
 /**
  * Escape a string for safe use in shell commands (single-quoted context).
  * This handles paths with special characters safely.
@@ -40,8 +38,8 @@ export class TemplateExpansionError extends Error {
  * Expand a command template by replacing placeholders
  *
  * Placeholders:
- * - {{prompt}} - Replaced with environment variable reference (safe from injection)
- * - {{cwd}} - Replaced with the working directory path (direct substitution)
+ * - {{prompt}} - Replaced with the shell-escaped prompt string (direct substitution)
+ * - {{cwd}} - Replaced with the shell-escaped working directory path (direct substitution)
  *
  * @param options - Template expansion options
  * @returns The expanded command and environment variables
@@ -64,12 +62,20 @@ export function expandTemplate(options: ExpandTemplateOptions): ExpandTemplateRe
     command = command.replace(/\{\{cwd\}\}/g, shellEscape(cwd));
   }
 
-  // Expand {{prompt}} - via environment variable (user input, must be protected)
-  // When no prompt is provided, the placeholder is replaced with an empty string
-  // This allows starting agents interactively without a pre-filled prompt
+  // Expand {{prompt}} - shell-escaped and embedded directly into the command,
+  // matching how {{cwd}} and custom {{varName}} placeholders are handled.
+  // The historical env-var indirection (via "$__AGENT_PROMPT__") is incompatible
+  // with the `sudo -u <user> -i` privilege-elevation path used by runAsUser:
+  // sudo wraps the inner command in double quotes when forwarding it to the
+  // login shell, which then expands `"$VAR"` against its own (empty)
+  // environment before the inner shell sees the command. Direct shell-escaped
+  // embedding is injection-safe (single-quote enclosed, embedded single quotes
+  // escaped) and works uniformly under elevation. When no prompt is provided,
+  // the placeholder is replaced with an empty shell-escaped string, which
+  // allows starting agents interactively without a pre-filled prompt.
+  // See Issue #851.
   if (command.includes('{{prompt}}')) {
-    command = command.replace(/\{\{prompt\}\}/g, `"$${PROMPT_ENV_VAR}"`);
-    env[PROMPT_ENV_VAR] = prompt ?? '';
+    command = command.replace(/\{\{prompt\}\}/g, shellEscape(prompt ?? ''));
   }
 
   // Expand custom template variables (after reserved variables are already expanded)
@@ -93,11 +99,4 @@ export function expandTemplate(options: ExpandTemplateOptions): ExpandTemplateRe
   }
 
   return { command, env };
-}
-
-/**
- * Get the environment variable name used for prompt injection
- */
-export function getPromptEnvVar(): string {
-  return PROMPT_ENV_VAR;
 }

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -23,6 +23,7 @@ import { SqliteWorktreeRepository } from '../../repositories/sqlite-worktree-rep
 import { SqliteUserRepository } from '../../repositories/sqlite-user-repository.js';
 import { WorktreeService } from '../../services/worktree-service.js';
 import type { PtySpawnOptions } from '../../lib/pty-provider.js';
+import { extractPromptFromSpawnCommand } from '../../__tests__/utils/extract-prompt-from-command.js';
 import { TimerManager } from '../../services/timer-manager.js';
 import { ConditionalWakeupManager } from '../../services/conditional-wakeup-manager.js';
 import { InteractiveProcessManager } from '../../services/interactive-process-manager.js';
@@ -1806,8 +1807,10 @@ describe('MCP Server Tools', () => {
     // -----------------------------------------------------------------------
 
     /**
-     * Extract the __AGENT_PROMPT__ env var from the PTY spawn call
-     * that matches the given session ID.
+     * Extract the embedded prompt from the PTY spawn call that matches the
+     * given session ID. After Issue #851, the prompt is embedded directly
+     * into the spawn command via shellEscape (single-quoted literal),
+     * instead of being indirected through env.__AGENT_PROMPT__.
      */
     function getAgentPromptForSession(sessionId: string): string {
       const calls = ptyFactory.spawn.mock.calls as unknown as Array<[string, string[], PtySpawnOptions]>;
@@ -1815,9 +1818,12 @@ describe('MCP Server Tools', () => {
         call[2]?.env?.AGENT_CONSOLE_SESSION_ID === sessionId,
       );
       expect(matchingCall).toBeDefined();
-      const agentPrompt = matchingCall![2].env!.__AGENT_PROMPT__;
-      expect(agentPrompt).toBeDefined();
-      return agentPrompt!;
+      // PTY spawn shape: ('sh', ['-c', '<unsetPrefix><command>'], options).
+      // The shell-escaped prompt is the trailing single-quoted segment of
+      // the second arg.
+      const shellCommand = matchingCall![1][1];
+      expect(shellCommand).toBeDefined();
+      return extractPromptFromSpawnCommand(shellCommand);
     }
 
     it('should append callback instructions to prompt when parent IDs are provided', async () => {

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -1813,6 +1813,13 @@ describe('MCP Server Tools', () => {
      * instead of being indirected through env.__AGENT_PROMPT__.
      */
     function getAgentPromptForSession(sessionId: string): string {
+      // `bun:test`'s `mock(() => ...)` (see __tests__/utils/mock-pty.ts)
+      // infers `mock.calls` as `[][]` because the factory has no declared
+      // parameters; a direct tuple cast fails with TS2352 ("Source has 0
+      // element(s) but target requires 3 — convert the expression to 'unknown'
+      // first"). The `as unknown as ...` step is therefore required, and
+      // matches the pre-existing shape used by `findSpawnCallByCommand` and
+      // the activity-detector probe in this file.
       const calls = ptyFactory.spawn.mock.calls as unknown as Array<[string, string[], PtySpawnOptions]>;
       const matchingCall = calls.find((call) =>
         call[2]?.env?.AGENT_CONSOLE_SESSION_ID === sessionId,

--- a/packages/server/src/services/__tests__/repository-description-generator.test.ts
+++ b/packages/server/src/services/__tests__/repository-description-generator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterAll, afterEach } from 'bun:test';
 import * as os from 'node:os';
 import type { AgentDefinition } from '@agent-console/shared';
+import { extractPromptFromSpawnCommand } from '../../__tests__/utils/extract-prompt-from-command.js';
 
 // Mock Bun.spawn for agent command execution
 let mockSpawnResult = {
@@ -228,9 +229,10 @@ describe('repository-description-generator', () => {
         requestUser: null,
       });
 
-      // Verify the prompt uses the README.md content
-      const options = spawnCalls[0].options as { env?: Record<string, string> };
-      const prompt = options.env!.__AGENT_PROMPT__;
+      // Verify the prompt uses the README.md content. After Issue #851, the
+      // prompt is embedded directly in the spawn command via shellEscape
+      // (no longer indirected through env.__AGENT_PROMPT__).
+      const prompt = extractPromptFromSpawnCommand(spawnCalls[0].args[2]);
       expect(prompt).toContain('# Markdown README');
       expect(prompt).not.toContain('Plain README');
     });
@@ -248,8 +250,7 @@ describe('repository-description-generator', () => {
         requestUser: null,
       });
 
-      const options = spawnCalls[0].options as { env?: Record<string, string> };
-      const prompt = options.env!.__AGENT_PROMPT__;
+      const prompt = extractPromptFromSpawnCommand(spawnCalls[0].args[2]);
       expect(prompt).toContain('...(truncated)');
       // The truncated content should be ~8000 chars, not 10000
       expect(prompt.length).toBeLessThan(10000);
@@ -268,8 +269,7 @@ describe('repository-description-generator', () => {
         requestUser: null,
       });
 
-      const options = spawnCalls[0].options as { env?: Record<string, string> };
-      const prompt = options.env!.__AGENT_PROMPT__;
+      const prompt = extractPromptFromSpawnCommand(spawnCalls[0].args[2]);
       expect(prompt).not.toContain('...(truncated)');
       expect(prompt).toContain(shortContent);
     });
@@ -321,7 +321,7 @@ describe('repository-description-generator', () => {
       expect(result.description).toBe('A project description.');
     });
 
-    it('should pass prompt via environment variable', async () => {
+    it('should pass prompt embedded in the spawn command (Issue #851)', async () => {
       mockFileContents.set('/repo/README.md', '# My Project');
       setMockSpawnResult('A project.');
 
@@ -333,12 +333,14 @@ describe('repository-description-generator', () => {
         requestUser: null,
       });
 
-      // Verify env contains the prompt
+      // Verify the prompt is embedded in the spawn command (no longer via env).
       expect(spawnCalls.length).toBe(1);
+      const prompt = extractPromptFromSpawnCommand(spawnCalls[0].args[2]);
+      expect(prompt).toContain('repository description generator');
+      expect(prompt).toContain('# My Project');
+      // env must NOT carry the prompt anymore.
       const options = spawnCalls[0].options as { env?: Record<string, string> };
-      expect(options.env).toBeDefined();
-      expect(options.env!.__AGENT_PROMPT__).toContain('repository description generator');
-      expect(options.env!.__AGENT_PROMPT__).toContain('# My Project');
+      expect(options.env?.__AGENT_PROMPT__).toBeUndefined();
     });
 
     it('should include language instruction in prompt', async () => {
@@ -353,8 +355,7 @@ describe('repository-description-generator', () => {
         requestUser: null,
       });
 
-      const options = spawnCalls[0].options as { env?: Record<string, string> };
-      const prompt = options.env!.__AGENT_PROMPT__;
+      const prompt = extractPromptFromSpawnCommand(spawnCalls[0].args[2]);
       expect(prompt).toContain('same language as the README');
     });
 
@@ -370,8 +371,7 @@ describe('repository-description-generator', () => {
         requestUser: null,
       });
 
-      const options = spawnCalls[0].options as { env?: Record<string, string> };
-      const prompt = options.env!.__AGENT_PROMPT__;
+      const prompt = extractPromptFromSpawnCommand(spawnCalls[0].args[2]);
       expect(prompt).toContain('ONLY the description text');
     });
 
@@ -524,14 +524,25 @@ describe('repository-description-generator', () => {
       expect(args[6]).toBe('-c');
       // `sudo -i` resets env + chdirs to target HOME, so cwd / env MUST be
       // interpolated into the inner command. The inner shell should contain
-      // the cd to the repo path, the agent command, and the env exports
-      // (`export K1=v1 K2=v2; <command>`) carrying both __AGENT_PROMPT__ and
-      // TERM=dumb.
+      // the cd to the repo path, the env exports (`export K=v; <command>`
+      // carrying TERM=dumb), and the agent command. After Issue #851, the
+      // prompt is embedded directly into the agent command via shellEscape
+      // (single-quoted literal), not exported as __AGENT_PROMPT__. The
+      // env-var indirection is incompatible with `sudo -u <user> -i`'s
+      // double-quote wrapping of the inner command, which would expand
+      // "$__AGENT_PROMPT__" against the empty login-shell environment
+      // before the inner shell sees it.
       const inner = args[7];
       expect(inner).toContain("cd '/repo'");
       expect(inner).toMatch(/export\b[^;]*\bTERM='dumb'/);
-      expect(inner).toContain("__AGENT_PROMPT__=");
+      expect(inner).not.toContain('__AGENT_PROMPT__');
       expect(inner).toContain('test-cli -p --format text');
+      // The prompt is now embedded as the last single-quoted segment of
+      // the inner command (after the headless template's trailing
+      // {{prompt}} placeholder).
+      const prompt = extractPromptFromSpawnCommand(inner);
+      expect(prompt).toContain('repository description generator');
+      expect(prompt).toContain('# Project');
     });
 
     it('AUTH_MODE=multi-user with requestUser == server user: bypasses elevation', async () => {

--- a/packages/server/src/services/__tests__/session-metadata-suggester.test.ts
+++ b/packages/server/src/services/__tests__/session-metadata-suggester.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
 import type { AgentDefinition } from '@agent-console/shared';
 import { mockGit } from '../../__tests__/utils/mock-git-helper.js';
+import { extractPromptFromSpawnCommand } from '../../__tests__/utils/extract-prompt-from-command.js';
 
 // Mock Bun.spawn for agent command execution
 let mockSpawnResult = {
@@ -329,7 +330,7 @@ describe('session-metadata-suggester', () => {
       expect(result.title).toBe('Some title');
     });
 
-    it('should pass prompt via environment variable', async () => {
+    it('should pass prompt embedded in the spawn command (Issue #851)', async () => {
       setMockSpawnResult('{"branch": "feat/new-feature", "title": "New feature"}');
 
       const { suggestSessionMetadata } = await getModule();
@@ -340,11 +341,13 @@ describe('session-metadata-suggester', () => {
         agent: mockAgent,
       });
 
-      // Verify env contains the prompt
+      // Verify the prompt is embedded in the spawn command (no longer via env).
       expect(spawnCalls.length).toBe(1);
+      const prompt = extractPromptFromSpawnCommand(spawnCalls[0].args[2]);
+      expect(prompt).toContain('Add new feature');
+      // env must NOT carry the prompt anymore.
       const options = spawnCalls[0].options as { env?: Record<string, string> };
-      expect(options.env).toBeDefined();
-      expect(options.env!.__AGENT_PROMPT__).toContain('Add new feature');
+      expect(options.env?.__AGENT_PROMPT__).toBeUndefined();
     });
 
     it('should include existing branches in prompt to avoid duplicates', async () => {
@@ -361,10 +364,9 @@ describe('session-metadata-suggester', () => {
         agent: mockAgent,
       });
 
-      // Verify the env prompt includes instruction to avoid existing branches
+      // Verify the embedded prompt includes instruction to avoid existing branches
       expect(spawnCalls.length).toBe(1);
-      const options = spawnCalls[0].options as { env?: Record<string, string> };
-      const prompt = options.env!.__AGENT_PROMPT__;
+      const prompt = extractPromptFromSpawnCommand(spawnCalls[0].args[2]);
       expect(prompt).toContain('Do NOT use any of these existing branch names');
       expect(prompt).toContain('main');
       expect(prompt).toContain('feat/existing-feature');
@@ -383,10 +385,9 @@ describe('session-metadata-suggester', () => {
         existingBranches: ['feat/conflicting-name', 'fix/another-branch'],
       });
 
-      // Verify the env prompt includes instruction to avoid provided branches
+      // Verify the embedded prompt includes instruction to avoid provided branches
       expect(spawnCalls.length).toBe(1);
-      const options = spawnCalls[0].options as { env?: Record<string, string> };
-      const prompt = options.env!.__AGENT_PROMPT__;
+      const prompt = extractPromptFromSpawnCommand(spawnCalls[0].args[2]);
       expect(prompt).toContain('Do NOT use any of these existing branch names');
       expect(prompt).toContain('feat/conflicting-name');
       expect(prompt).toContain('fix/another-branch');
@@ -404,10 +405,9 @@ describe('session-metadata-suggester', () => {
         agent: mockAgent,
       });
 
-      // Verify the env prompt does NOT include duplicate avoidance instruction
+      // Verify the embedded prompt does NOT include duplicate avoidance instruction
       expect(spawnCalls.length).toBe(1);
-      const options = spawnCalls[0].options as { env?: Record<string, string> };
-      const prompt = options.env!.__AGENT_PROMPT__;
+      const prompt = extractPromptFromSpawnCommand(spawnCalls[0].args[2]);
       expect(prompt).not.toContain('Do NOT use any of these existing branch names');
     });
   });


### PR DESCRIPTION
## Summary

`expandTemplate` previously replaced `{{prompt}}` with `"$__AGENT_PROMPT__"` and stashed the prompt content in `env.__AGENT_PROMPT__`. This pattern is incompatible with the `sudo -u <user> -i` privilege-elevation path used by `runAsUser` (Issue #839 / PR #840) and exercised by the description generator (Issue #835 / PR #842): sudo wraps the inner command in double quotes when forwarding it to the login shell, which then expands `"$VAR"` against its own (empty) environment before the inner shell sees the command. User-visible symptom in multi-user mode after PR #842 was "Input must be provided either through stdin or as a prompt argument when using --print".

This change replaces the env-var indirection with `shellEscape(prompt ?? '')` direct embedding, matching how `{{cwd}}` and custom `{{varName}}` placeholders are already handled. `PROMPT_ENV_VAR` and `getPromptEnvVar` are removed (no callers remained).

Pre-verified on the dogfood host (Ubuntu 24.04 multi-user mode) in a separate worktree before this PR was opened. See Issue #851 "Verification" section for the manual repro + fix verification trace.

Closes #851

## Files changed

- `packages/server/src/lib/template.ts` -- production fix: `{{prompt}}` now expands via `shellEscape` direct embedding. `PROMPT_ENV_VAR` constant and `getPromptEnvVar` exported function removed.
- `packages/server/src/lib/__tests__/template.test.ts` -- every `result.command` assertion updated to expect the shell-escaped inline prompt; every `result.env.__AGENT_PROMPT__` assertion removed; `getPromptEnvVar` describe block removed; edge-case coverage (empty / shell-meta / quotes / newlines / dollar signs / paths) preserved.
- `packages/server/src/__tests__/utils/extract-prompt-from-command.ts` -- new shared test helper that extracts the prompt from a spawn command string (parses the trailing single-quoted segment, reverses the `'\''` escape).
- `packages/server/src/services/__tests__/repository-description-generator.test.ts` -- three spawn-call assertions (README content, prompt instruction, output format) and the elevated-branch inner-command assertion updated to extract the prompt from `args[2]` / inner via the helper; explicit assertion that `env.__AGENT_PROMPT__` is `undefined` in the non-elevated branch and not exported in the elevated inner command.
- `packages/server/src/services/__tests__/session-metadata-suggester.test.ts` -- same pattern; existingBranches / no-branches cases use the helper.
- `packages/server/src/mcp/__tests__/mcp-server.test.ts` -- `getAgentPromptForSession` helper updated to extract the prompt from the PTY spawn args[1][1] instead of options.env.

## Verification log

```
$ bun run typecheck
@agent-console/shared typecheck: Exited with code 0
@agent-console/server typecheck: Exited with code 0
@agent-console/client typecheck: vite v6.4.1 building for production...
@agent-console/client typecheck: transforming...
@agent-console/client typecheck: ✓ 689 modules transformed.
@agent-console/client typecheck: ✓ built in 2.42s
@agent-console/client typecheck: Exited with code 0
```

```
$ output=$(bun run test 2>&1); exitcode=$?; echo "$output" | tail -100; echo "TEST_EXIT: $exitcode"
[... full last 100 lines of test output, last block reproduced below ...]
@agent-console/client test:  1397 pass
@agent-console/client test:  2 skip
@agent-console/client test:  0 fail
@agent-console/client test:  2591 expect() calls
@agent-console/client test: Ran 1399 tests across 88 files. [15.28s]
@agent-console/client test: Exited with code 0
$ bun test scripts/ ./.claude/hooks/__tests__/ ./.claude/skills/*/__tests__/
bun test v1.3.10 (30e609e0)
 362 pass
 0 fail
 896 expect() calls
Ran 362 tests across 11 files. [2.42s]
TEST_EXIT: 0
```

```
$ bun run check:lang
OK -- language check clean (103 files scanned).
```

```
$ node .claude/skills/orchestrator/preflight-check.js
## Test Coverage Check
No production files matching coverage patterns were changed.
## Rule/Skill Duplication Check
No rule paragraphs found verbatim in any skill file.
## Language Check (public artifacts)
All public artifacts use Latin / Greek / Cyrillic scripts only.
```

(Note: preflight reports "No production files matching coverage patterns were changed" because the touched production file `packages/server/src/lib/template.ts` falls under `lib/` rather than the routes/services/components paths listed in `COVERAGE_PATTERNS`. The sibling test `packages/server/src/lib/__tests__/template.test.ts` is still updated in this PR.)

## TDD polarity check

Stashed `packages/server/src/lib/template.ts` (the production fix only, leaving the updated test file in place), then re-ran `bun test src/lib/__tests__/template.test.ts`:

```
 9 pass
 26 fail
 38 expect() calls
Ran 35 tests across 1 file. [13.00ms]
```

Sample failure shape:

```
Expected: "test-cli 'Hello World'"
Received: "test-cli "$__AGENT_PROMPT__""
```

Restored the fix; all 35 template tests pass again. The new assertions genuinely verify the new shellEscape-embed behaviour and would fail on a future regression to the env-var pattern.

## 7-question pre-PR gap-scan

1. **Existing mechanism?** Yes -- `shellEscape` is already used for `{{cwd}}` (line 64) and custom `{{varName}}` (line 82). This PR aligns `{{prompt}}` with the existing pattern. No duplication.
2. **Trigger / invocation documented?** N/A -- internal refactor; `expandTemplate`'s public contract (return shape `{ command, env }`) is unchanged from callers' perspectives. The `env` field is now empty for prompt callers but remains available for future placeholders that may need env indirection.
3. **Failure paths tested?** Yes -- empty prompt, undefined prompt, shell metacharacters, quotes (single + double), newlines, dollar signs, paths with spaces / quotes, multiple `{{prompt}}` occurrences. All preserved from the existing edge-case set. Sibling tests (`template.test.ts`, the three consumer test files) all updated in this PR.
4. **New file type / lifecycle?** No -- the only new file is a test utility (`extract-prompt-from-command.ts`) under the existing `packages/server/src/__tests__/utils/` directory.
5. **Rule clarity?** N/A -- no rule changes.
6. **Cross-runtime spawn?** No -- no new spawn boundary; `runAsUser` continues to dispatch to `Bun.spawn` as before.
7. **Shared / persistent artifact write?** No -- no installer / daemon / hook / package metadata changes.
8. **Signature shape change?** No -- `expandTemplate`'s signature and return shape are unchanged. The `getPromptEnvVar` exported helper is removed; only one consumer (the test file) referenced it, and that consumer is updated in the same PR.

## Out of scope (per Issue #851)

- Refactoring `runAsUser` to forward `opts.env` via `sudo --preserve-env` (deferred unless a real second caller surfaces).
- PTY worker (`user-mode.ts`) refactor -- its inner script does not reference env vars via `"$VAR"` in the command itself; the env-export pattern works correctly for inheritance and remains unchanged.
- Backward compatibility for the env-var pattern -- no external consumer relies on `env.__AGENT_PROMPT__` being populated.
