### PR TITLE
feat(server): bootstrap server-side safe.directory at registerRepository

### DIFF
--- a/packages/server/src/services/__tests__/repository-manager.test.ts
+++ b/packages/server/src/services/__tests__/repository-manager.test.ts
@@ -284,7 +284,10 @@ describe('RepositoryManager', () => {
         // Replace the responder so `getent group` returns FAKE_SHARED_GID
         // (matching the synthesised dir gid) AND the `git config --get
         // core.sharedRepository` probe returns 'group'. The apply call
-        // MUST NOT run -- enforce by throwing if it's invoked.
+        // MUST NOT run -- enforce by throwing if it's invoked. The
+        // server-side safe.directory bootstrap (Issue #853) is a separate,
+        // unrelated runAsUser call and MUST be permitted (it always runs
+        // in multi-user mode regardless of the shared-repo apply state).
         runAsUserMock.responder.fn = async (opts) => {
           if (opts.command.startsWith('getent group ')) {
             return {
@@ -302,6 +305,10 @@ describe('RepositoryManager', () => {
               timedOut: false,
             };
           }
+          if (opts.command.includes('safe.directory')) {
+            // Server-side safe.directory bootstrap (Issue #853); permitted.
+            return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+          }
           throw new Error(
             `apply should not run when already configured; got command: ${opts.command}`,
           );
@@ -311,13 +318,15 @@ describe('RepositoryManager', () => {
         const repo = await manager.registerRepository(TEST_REPO_DIR);
         expect(repo.path).toBe(TEST_REPO_DIR);
 
-        // Exactly two runAsUser calls -- the `getent` resolve + the
-        // `git config --get core.sharedRepository` probe -- AND no apply
-        // call. The probe-first contract ensures we tightly assert the
-        // idempotent-skip path was actually taken (not bypassed early).
-        expect(runAsUserMock.calls.length).toBe(2);
+        // Three runAsUser calls -- the `getent` resolve + the
+        // `git config --get core.sharedRepository` probe + the server-side
+        // safe.directory bootstrap (Issue #853) -- AND no apply call. The
+        // probe-first contract ensures we tightly assert the idempotent-skip
+        // path was actually taken (not bypassed early).
+        expect(runAsUserMock.calls.length).toBe(3);
         expect(runAsUserMock.calls[0].command).toContain('getent group ');
         expect(runAsUserMock.calls[1].command).toContain('--get core.sharedRepository');
+        expect(runAsUserMock.calls[2].command).toContain('safe.directory');
         const applyCalls = runAsUserMock.calls.filter((c) =>
           c.command.includes('chgrp -R '),
         );
@@ -419,6 +428,144 @@ describe('RepositoryManager', () => {
             process.env.AGENT_CONSOLE_SERVICE_GROUP = originalGroup;
           }
         }
+      });
+    });
+
+    // Issue #853: bootstrap safe.directory into the SERVER's gitconfig at
+    // registration so subsequent server-initiated git operations (listWorktrees,
+    // getRemoteUrl, fetch, ...) against an operator-cloned source repo do not
+    // hit `fatal: detected dubious ownership`. Mirror of #838 / PR #843 for the
+    // per-user side but with `username: null`.
+    describe('multi-user mode server-side safe.directory bootstrap (Issue #853)', () => {
+      let originalAuthMode: string | undefined;
+
+      const FAKE_SHARED_GID = 9876;
+
+      // Same default responder as the #845 block: `getent` returns the
+      // synthetic shared gid, everything else returns success. The new
+      // safe.directory bootstrap call will land in the catch-all branch
+      // (success).
+      function defaultResponder(opts: RunAsUserOpts): Promise<RunAsUserResult> {
+        if (opts.command.startsWith('getent group ')) {
+          return Promise.resolve({
+            stdout: `agent-console-users:x:${FAKE_SHARED_GID}:agentconsole\n`,
+            stderr: '',
+            exitCode: 0,
+            timedOut: false,
+          });
+        }
+        return Promise.resolve({
+          stdout: '',
+          stderr: '',
+          exitCode: 0,
+          timedOut: false,
+        });
+      }
+
+      beforeEach(() => {
+        originalAuthMode = process.env.AUTH_MODE;
+        runAsUserMock.responder.fn = defaultResponder;
+      });
+
+      afterEach(() => {
+        if (originalAuthMode === undefined) {
+          delete process.env.AUTH_MODE;
+        } else {
+          process.env.AUTH_MODE = originalAuthMode;
+        }
+      });
+
+      it('invokes a single server-side safe.directory bootstrap call in multi-user mode', async () => {
+        process.env.AUTH_MODE = 'multi-user';
+        const manager = await getRepositoryManager();
+
+        await manager.registerRepository(TEST_REPO_DIR);
+
+        // Exactly one bootstrap call -- identified by the `safe.directory`
+        // substring -- should have been issued. The command shape is the
+        // idempotent grep-guarded `git config --global --add` pattern that
+        // mirrors `bootstrapSafeDirectoryForUser` in worktree-service.ts.
+        const bootstrapCalls = runAsUserMock.calls.filter((c) =>
+          c.command.includes('safe.directory'),
+        );
+        expect(bootstrapCalls.length).toBe(1);
+        const bootstrap = bootstrapCalls[0];
+        // Run as the SERVER process (username: null) -- writing the server's
+        // own gitconfig, not a user's. This is the distinguishing
+        // characteristic versus #838's per-user bootstrap.
+        expect(bootstrap.username).toBeNull();
+        // Idempotent guard: the grep -Fxq check against the existing
+        // entries, with a conditional `git config --global --add` only when
+        // the value is missing. The repo path is shell-escaped via single
+        // quotes by `shellEscape`.
+        expect(bootstrap.command).toContain(
+          `git config --global --get-all safe.directory`,
+        );
+        expect(bootstrap.command).toContain(`grep -Fxq '${TEST_REPO_DIR}'`);
+        expect(bootstrap.command).toContain(
+          `git config --global --add safe.directory '${TEST_REPO_DIR}'`,
+        );
+      });
+
+      it('does not invoke the safe.directory bootstrap in single-user mode', async () => {
+        delete process.env.AUTH_MODE;
+        const manager = await getRepositoryManager();
+
+        await manager.registerRepository(TEST_REPO_DIR);
+
+        // Single-user mode: neither the #845 apply chain nor the #853
+        // bootstrap should fire. The entire multi-user branch is gated on
+        // AUTH_MODE.
+        expect(runAsUserMock.calls.length).toBe(0);
+      });
+
+      it('registration succeeds with a warn log when the bootstrap returns non-zero', async () => {
+        process.env.AUTH_MODE = 'multi-user';
+
+        // Replace the responder so the safe.directory bootstrap returns
+        // non-zero (e.g. the server's gitconfig is read-only, or the inner
+        // grep pipeline produced an unexpected exit code). Other commands
+        // (getent / chgrp apply) keep default success behaviour so the test
+        // isolates the bootstrap failure.
+        runAsUserMock.responder.fn = async (opts) => {
+          if (opts.command.startsWith('getent group ')) {
+            return {
+              stdout: `agent-console-users:x:${FAKE_SHARED_GID}:agentconsole\n`,
+              stderr: '',
+              exitCode: 0,
+              timedOut: false,
+            };
+          }
+          if (opts.command.includes('safe.directory')) {
+            return {
+              stdout: '',
+              stderr: 'error: could not lock config file /home/agentconsole/.gitconfig: Permission denied',
+              exitCode: 255,
+              timedOut: false,
+            };
+          }
+          // chgrp apply etc.: success
+          return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+        };
+
+        const manager = await getRepositoryManager();
+        // Must not throw -- bootstrap failure is non-fatal so registration
+        // proceeds. The contract mirrors the #845 apply chain's
+        // failure-tolerance: warn + continue rather than abort.
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+
+        // The DB record was still saved.
+        const savedRepos = await repositoryRepository.findAll();
+        expect(savedRepos.length).toBe(1);
+        expect(savedRepos[0].path).toBe(TEST_REPO_DIR);
+        expect(savedRepos[0].id).toBe(repo.id);
+
+        // Verify the bootstrap was actually attempted (so this test fails
+        // if the bootstrap call site is removed from registerRepository).
+        const bootstrapCalls = runAsUserMock.calls.filter((c) =>
+          c.command.includes('safe.directory'),
+        );
+        expect(bootstrapCalls.length).toBe(1);
       });
     });
   });

--- a/packages/server/src/services/repository-manager.ts
+++ b/packages/server/src/services/repository-manager.ts
@@ -29,6 +29,15 @@ const DEFAULT_SHARED_GROUP = 'agent-console-users';
 const SHARED_REPO_APPLY_TIMEOUT_MS = 30000;
 
 /**
+ * Timeout for the server-side `safe.directory` bootstrap (Issue #853). Short --
+ * the command is a pure local gitconfig write with no network or fs traversal.
+ * Mirrors `SAFE_DIRECTORY_BOOTSTRAP_TIMEOUT_MS` in `worktree-service.ts`, which
+ * implements the per-user side of the same idempotent bootstrap pattern
+ * (Issue #838 / PR #843).
+ */
+const SAFE_DIRECTORY_BOOTSTRAP_TIMEOUT_MS = 10000;
+
+/**
  * Type of the privilege-elevation helper, exposed for dependency injection
  * in tests. Production code uses the real `runAsUser` import.
  * @internal Exported for testing.
@@ -203,6 +212,15 @@ export class RepositoryManager {
     // warning but does not block registration (the operator can still apply
     // the documented manual fallback). Issue #845.
     await this.applyMultiUserSharedRepoConfig(absolutePath);
+
+    // In multi-user mode, also bootstrap `safe.directory` into the SERVER's
+    // own gitconfig so subsequent server-initiated git operations
+    // (`listWorktrees`, `getRemoteUrl`, `fetch`, ...) against a source repo
+    // cloned by a different OS user do not hit `dubious ownership`. Mirror of
+    // `bootstrapSafeDirectoryForUser` in worktree-service.ts but with
+    // `username: null` (run as the server itself, writing the server's
+    // gitconfig). Issue #853.
+    await this.bootstrapSafeDirectoryForServer(absolutePath);
 
     const id = crypto.randomUUID();
     const name = path.basename(absolutePath);
@@ -409,6 +427,69 @@ export class RepositoryManager {
       { repoPath: absolutePath, sharedGroup },
       'Multi-user shared-repo config applied',
     );
+  }
+
+  /**
+   * Append `<repoPath>` to the SERVER user's `safe.directory` list when not
+   * already present. Required because, in multi-user mode, an operator may
+   * have cloned the source repo as their own OS user. git's CVE-2022-24765
+   * owner check then refuses any server-initiated git operation against
+   * that repo with `fatal: detected dubious ownership`. The previous
+   * `applyMultiUserSharedRepoConfig` step targets filesystem mode + group
+   * ownership but does NOT change file OWNER uid, so safe.directory is the
+   * minimum-trust-expansion mitigation. Mirror of
+   * `bootstrapSafeDirectoryForUser` in worktree-service.ts (Issue #838 /
+   * PR #843), but with `username: null` so the bootstrap writes the SERVER's
+   * gitconfig rather than a user's. Issue #853.
+   *
+   * Idempotent -- checks `git config --get-all safe.directory` first and only
+   * adds the entry when this exact `repoPath` is missing. Failure is logged
+   * but not thrown, so a misconfigured gitconfig does not block registration;
+   * subsequent server-initiated git operations will surface a clearer
+   * `dubious ownership` error if the bootstrap was actually needed. In
+   * `AUTH_MODE=none` (or unset), no-op.
+   */
+  private async bootstrapSafeDirectoryForServer(repoPath: string): Promise<void> {
+    if (process.env.AUTH_MODE !== 'multi-user') {
+      return;
+    }
+
+    const escapedPath = shellEscape(repoPath);
+    // `--get-all` returns one line per entry, exit 0 even if none match the
+    // value. We post-filter rather than relying on `--get` (which would only
+    // return the first match and could mis-report when the server has
+    // multiple entries).
+    const command = `if ! git config --global --get-all safe.directory 2>/dev/null | grep -Fxq ${escapedPath}; then git config --global --add safe.directory ${escapedPath}; fi`;
+
+    let result;
+    try {
+      result = await this._runAsUser({
+        username: null, // run as the server process user (e.g. agentconsole)
+        command,
+        timeoutMs: SAFE_DIRECTORY_BOOTSTRAP_TIMEOUT_MS,
+      });
+    } catch (err) {
+      logger.warn(
+        { err, repoPath },
+        'server-side safe.directory bootstrap spawn failed; continuing with registration',
+      );
+      return;
+    }
+
+    if (result.timedOut || result.exitCode !== 0) {
+      logger.warn(
+        {
+          repoPath,
+          exitCode: result.exitCode,
+          timedOut: result.timedOut,
+          stderr: result.stderr.trim(),
+        },
+        'server-side safe.directory bootstrap returned non-zero; continuing with registration',
+      );
+      return;
+    }
+
+    logger.info({ repoPath }, 'server-side safe.directory bootstrap completed');
   }
 
   /**


### PR DESCRIPTION
## Summary

Mirror PR #843's `bootstrapSafeDirectoryForUser` pattern for the **server** side. At `registerRepository`, after the existing #845 `applyMultiUserSharedRepoConfig` step, also bootstrap the absolute source-repo path into the SERVER's own gitconfig (e.g. `/home/agentconsole/.gitconfig`) via the same idempotent grep-guarded `git config --global --add safe.directory <path>` invocation -- but with `username: null` so the call runs as the server itself rather than as a requesting user.

Closes #853

## Why

In multi-user mode, an operator may have cloned a source repo as their own OS user (the documented operator flow). After PR #848 / Issue #845 auto-applied `core.sharedRepository=group` + group-writable `.git`, the `chgrp` leg still cannot change file OWNER uid (EPERM unless the server owns the file), so file ownership stays with the cloning user. git's CVE-2022-24765 owner check then refuses any server-initiated git operation against that repo with `fatal: detected dubious ownership in repository at <repoPath>`.

The dogfood observation from Issue #853 captures the cascade -- `git remote get-url origin` (orgRepo detection), `git worktree list` (post-create verification), `git fetch` (branch remote status) all fail, surfaced to the user as the misleading "Worktree was created but could not be found in the list" error.

PR #848 / #845 targets filesystem mode + group ownership; it does NOT change file OWNER uid and therefore does NOT satisfy git's owner check. PR #843 / #838 added `bootstrapSafeDirectoryForUser` for the per-user side at `worktree-service.ts:createWorktree`. This PR is the mirror for the server side at `repository-manager.ts:registerRepository`.

## Implementation

- `repository-manager.ts`: new `SAFE_DIRECTORY_BOOTSTRAP_TIMEOUT_MS = 10000` constant (mirrors `worktree-service.ts`); new `bootstrapSafeDirectoryForServer(repoPath)` private method invoked from `registerRepository` right after `applyMultiUserSharedRepoConfig`. The method early-returns in non-`multi-user` mode. The command shape is the same grep-guarded `git config --global --add safe.directory <path>` idiom used by the user-side bootstrap, only with `username: null` so `runAsUser` skips elevation and writes the SERVER's gitconfig. Failure (timeout or non-zero exit) logs a `warn` and continues; registration is never aborted by a bootstrap failure (the subsequent server-initiated git op will surface a clearer `dubious ownership` error if the bootstrap was actually needed).
- Sibling test file: new `describe('multi-user mode server-side safe.directory bootstrap (Issue #853)')` block with three tests -- (1) multi-user mode invokes a single bootstrap call with the expected grep-guarded command shape and `username: null`, (2) single-user mode is a no-op (`runAsUser.calls.length === 0`), (3) non-zero exit from the bootstrap is logged-and-continued and the DB record is still persisted. The pre-existing #845 idempotent-skip test was updated to acknowledge the new bootstrap call (count 2 -> 3, additional `safe.directory` permitted-branch in the test responder).

## TDD polarity

`git stash` of just the production diff (`packages/server/src/services/repository-manager.ts`) while keeping the new tests in the worktree:

```
RepositoryManager > registerRepository > multi-user mode shared-repo auto-apply (Issue #845) > skips apply when already configured (idempotent no-op via git config probe) [6.00ms]
RepositoryManager > registerRepository > multi-user mode server-side safe.directory bootstrap (Issue #853) > invokes a single server-side safe.directory bootstrap call in multi-user mode [6.00ms]
RepositoryManager > registerRepository > multi-user mode server-side safe.directory bootstrap (Issue #853) > registration succeeds with a warn log when the bootstrap returns non-zero [9.00ms]
Ran 26 tests across 1 file. [361.00ms]  -- 3 fail, 23 pass
```

Three tests fail without the production call (the modified #845 idempotent-skip test + the two new #853 tests that need the bootstrap to fire). The single-user-mode test correctly stays green (it asserts zero calls and the bootstrap is gated on `AUTH_MODE`). Restoring the production file: all 26 tests pass.

## Pre-PR 7-question Gap-Scan

1. **Similar existing mechanism?** Yes -- `worktree-service.ts:bootstrapSafeDirectoryForUser` (PR #843 / #838). This PR is the explicit mirror for the server side. Identical command shape, identical failure-tolerance, identical idempotency guard, identical log shape -- only `username` differs (`null` vs `requestUsername`).
2. **Invocation documented in canonical procedure?** N/A -- this is an automatic step inside `registerRepository`, not an operator-invoked command. Followed the existing #845 `applyMultiUserSharedRepoConfig` pattern that added a step in the same place without a separate procedure doc.
3. **Failure paths tested?** Yes -- non-zero exit (test 3) and single-user no-op (test 2). The `runAsUserMock` already covers spawn-throw at the helper layer.
4. **New file type / directory lifecycle?** No new files / no new artifact types.
5. **Rule clarity?** No rule changes.
6. **Cross-runtime spawn?** No new spawn target. The `runAsUser` helper itself is reused; this PR adds one new caller.
7. **Shared-resource lifetime?** The bootstrap writes one `safe.directory` entry to the server's gitconfig per registered source repo. Lifetime: server-lifetime + (until operator removes it). Out-of-scope from the original Issue: removing entries on `unregisterRepository`. Idempotent re-registration is a no-op via the `grep -Fxq` guard. No embedded paths that could go stale (only the absolute repo path the user just registered, which is the same anchor `registerRepository` already validates).

## Verification log

```
$ bun run typecheck
@agent-console/shared typecheck: Exited with code 0
@agent-console/server typecheck: Exited with code 0
@agent-console/client typecheck: Exited with code 0

$ output=$(bun run test 2>&1); exitcode=$?; echo "$output" | tail -100; echo "TEST_EXIT: $exitcode"
@agent-console/shared test:  324 pass / 0 fail / Ran 324 tests across 10 files.
@agent-console/integration test:  29 pass / 0 fail / Ran 29 tests across 8 files.
@agent-console/server test:  2708 pass / 1 skip / 0 fail / Ran 2709 tests across 129 files.
@agent-console/client test:  1397 pass / 2 skip / 0 fail / Ran 1399 tests across 88 files.
scripts:  362 pass / 0 fail / Ran 362 tests across 11 files.
TEST_EXIT: 0

$ bun run check:lang
OK -- language check clean (103 files scanned).

$ node .claude/skills/orchestrator/preflight-check.js
Test Coverage Check: No production files matching coverage patterns were changed.
Rule/Skill Duplication Check: clean
Language Check: clean
```

## Diff scope

```
 .../services/__tests__/repository-manager.test.ts  | 159 ++++++++++++++++++++-
 packages/server/src/services/repository-manager.ts |  81 +++++++++++
 2 files changed, 234 insertions(+), 6 deletions(-)
```

Two files only: production + its sibling test under `packages/server/src/services/`. No files outside `services/`. No documentation files.

## Related

- Umbrella: #837
- Mirror reference (per-user side): #838 / PR #843
- Sibling step in the same registration flow (group-writable + sharedRepository=group): #845 / PR #848
- Companion follow-up surfaced by the same dogfood log: the misleading "could not be found in the list" error-propagation Issue noted in #853's Related section