### PR TITLE
feat(server): run session-metadata-suggester as requesting user via runAsUser

### DIFF
--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -623,11 +623,17 @@ export function createMcpApp(deps: McpDependencies): Hono {
           // Explicit branch name provided
           effectiveBranch = branch;
         } else {
-          // Auto-generate branch name from prompt
+          // Auto-generate branch name from prompt.
+          // MCP-side privilege elevation for the suggestion call is tracked
+          // separately (Issue #856 Out-of-Scope note). For now pass `null`
+          // so `runAsUser` bypasses elevation; this preserves prior MCP
+          // behaviour. A future issue (modelled on #844) can resolve the
+          // parent session's createdBy -> OS username and thread it here.
           const suggestion = await suggestSessionMetadata({
             prompt: prompt.trim(),
             repositoryPath: repo.path,
             agent,
+            requestUser: null,
           });
           if (suggestion.error || !suggestion.branch) {
             effectiveBranch = `task-${Date.now()}`;

--- a/packages/server/src/routes/__tests__/worktrees.test.ts
+++ b/packages/server/src/routes/__tests__/worktrees.test.ts
@@ -223,6 +223,80 @@ describe('Worktrees API', () => {
       // 'testuser' as the 5th positional arg.
       expect(args[4]).toBe('testuser');
     });
+
+    it("forwards authUser.username as requestUser to suggestSessionMetadata (Issue #856)", async () => {
+      // For `mode: 'prompt'`, the route invokes `suggestSessionMetadata` to
+      // auto-generate a branch name + title. After Issue #856 the route must
+      // thread `authUser.username` down so the headless agent command runs
+      // as the requesting user in multi-user mode (via runAsUser inside the
+      // suggester). The default SingleUserMode used by asAppContext is
+      // constructed with TEST_AUTH_USER (username='testuser'), so we assert
+      // the route forwards 'testuser' as `requestUser`.
+      const mockAgentManager = {
+        getAgent: mock(() => ({ id: 'claude-code-builtin', name: 'Claude Code' })),
+      } as unknown as Parameters<typeof asAppContext>[0]['agentManager'];
+
+      // Capture the args the suggester receives. Resolve to an error so the
+      // downstream worktree creation falls back to `task-<timestamp>` and we
+      // do not need to mock the success-broadcast path further.
+      let resolveSuggestionCall!: (args: unknown[]) => void;
+      const suggestionCaptured = new Promise<unknown[]>((resolve) => {
+        resolveSuggestionCall = resolve;
+      });
+      const suggestionMock = mock((...args: unknown[]) => {
+        resolveSuggestionCall(args);
+        return Promise.resolve({ branch: undefined, title: undefined, error: 'short-circuit for test' });
+      });
+
+      // Short-circuit the worktree creation so we do not exercise the full
+      // pipeline; we only care that the suggester was called with the right
+      // requestUser.
+      const { mockFn: createCapture } = createCapturingWorktreeMock();
+      (mockWorktreeService as unknown as { createWorktree: typeof createCapture }).createWorktree = createCapture;
+
+      app = new Hono<AppBindings>();
+      app.use('*', async (c, next) => {
+        c.set('appContext', asAppContext({
+          repositoryManager: mockRepositoryManager,
+          worktreeService: mockWorktreeService,
+          agentManager: mockAgentManager,
+          sessionManager: { createSession: mock() } as unknown as SessionManager,
+          broadcastToApp: () => {},
+          suggestSessionMetadata: suggestionMock as unknown as Parameters<typeof asAppContext>[0]['suggestSessionMetadata'],
+        }));
+        await next();
+      });
+      app.onError(onApiError);
+      app.route('/api', api);
+
+      const res = await app.request(
+        `/api/repositories/${TEST_REPO.id}/worktrees`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            taskId: 'task-issue-856',
+            mode: 'prompt',
+            initialPrompt: 'Add a dark mode toggle',
+            baseBranch: 'main',
+            useRemote: false,
+            autoStartSession: false,
+            agentId: 'claude-code-builtin',
+          }),
+        },
+      );
+
+      expect(res.status).toBe(202);
+
+      // The suggester is invoked from the fire-and-forget IIFE; await the
+      // captured-args promise so we observe the call deterministically.
+      const args = await suggestionCaptured;
+      const req = args[0] as { prompt: string; repositoryPath: string; requestUser: string | null };
+      expect(req.prompt).toBe('Add a dark mode toggle');
+      expect(req.repositoryPath).toBe(REPO_PATH);
+      // Primary assertion: requestUser must equal the authenticated OS user.
+      expect(req.requestUser).toBe('testuser');
+    });
   });
 
   // =========================================================================

--- a/packages/server/src/routes/worktrees.ts
+++ b/packages/server/src/routes/worktrees.ts
@@ -80,11 +80,17 @@ const worktrees = new Hono<AppBindings>()
 
         switch (mode) {
           case 'prompt': {
-            // Generate branch name from prompt using the selected agent
+            // Generate branch name from prompt using the selected agent.
+            // Thread the authenticated OS username down so the headless agent
+            // command runs as the requesting user in multi-user mode (Issue
+            // #856 -- mirrors Issue #835 / PR #842 for description gen). In
+            // single-user mode `runAsUser` reads this value but `AUTH_MODE`
+            // gates the elevation to a no-op.
             const suggestion = await suggestSessionMetadata({
               prompt: body.initialPrompt!.trim(),
               repositoryPath: repo.path,
               agent,
+              requestUser: authUser.username,
             });
             if (suggestion.error || !suggestion.branch) {
               // Fallback: use timestamp-based branch name, empty title

--- a/packages/server/src/services/__tests__/session-metadata-suggester.test.ts
+++ b/packages/server/src/services/__tests__/session-metadata-suggester.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
+import { describe, it, expect, beforeEach, afterAll, afterEach } from 'bun:test';
+import * as os from 'node:os';
 import type { AgentDefinition } from '@agent-console/shared';
 import { mockGit } from '../../__tests__/utils/mock-git-helper.js';
 import { extractPromptFromSpawnCommand } from '../../__tests__/utils/extract-prompt-from-command.js';
@@ -52,10 +53,17 @@ const mockAgentWithoutHeadless: AgentDefinition = {
 
 let importCounter = 0;
 
+const originalAuthMode = process.env.AUTH_MODE;
+
 describe('session-metadata-suggester', () => {
   beforeEach(() => {
     mockGit.listAllBranches.mockReset();
     mockGit.listAllBranches.mockImplementation(() => Promise.resolve(['main', 'feat/existing']));
+
+    // Default to single-user mode for the existing test set; the
+    // multi-user tests below set AUTH_MODE explicitly and rely on
+    // afterEach to restore the original value.
+    delete process.env.AUTH_MODE;
 
     spawnCalls = [];
     // Reset mock spawn result
@@ -80,6 +88,14 @@ describe('session-metadata-suggester', () => {
       spawnCalls.push({ args, options: options || {} });
       return mockSpawnResult;
     }) as typeof Bun.spawn;
+  });
+
+  afterEach(() => {
+    if (originalAuthMode === undefined) {
+      delete process.env.AUTH_MODE;
+    } else {
+      process.env.AUTH_MODE = originalAuthMode;
+    }
   });
 
   // Restore original Bun.spawn after all tests
@@ -148,6 +164,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'Add a dark mode toggle',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.branch).toBe('feat/add-dark-mode');
@@ -169,6 +186,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'Some task',
         repositoryPath: '/repo',
         agent: mockAgentWithoutHeadless,
+        requestUser: null,
       });
 
       expect(result.branch).toBeUndefined();
@@ -184,6 +202,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'Add dark mode',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       // Should be sanitized to lowercase with hyphens
@@ -200,6 +219,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'Some task',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.branch).toBeUndefined();
@@ -215,6 +235,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'Some task',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.branch).toBeUndefined();
@@ -230,6 +251,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'Some task',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.branch).toBeUndefined();
@@ -245,6 +267,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'Some task',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.branch).toBeUndefined();
@@ -261,6 +284,7 @@ describe('session-metadata-suggester', () => {
         repositoryPath: '/repo',
         agent: mockAgent,
         existingBranches: ['feat/login', 'feat/signup'],
+        requestUser: null,
       });
 
       // Should not call listAllBranches
@@ -278,6 +302,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'Some feature',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.branch).toBe('feat/feature');
@@ -294,6 +319,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'New feature',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.branch).toBe('feat/new-feature');
@@ -309,6 +335,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'ダークモードを追加する',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.branch).toBe('feat/dark-mode');
@@ -324,6 +351,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'Some feature',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       expect(result.branch).toBe('feat/feature');
@@ -339,6 +367,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'Add new feature',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       // Verify the prompt is embedded in the spawn command (no longer via env).
@@ -362,6 +391,7 @@ describe('session-metadata-suggester', () => {
         prompt: 'Add new feature',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       // Verify the embedded prompt includes instruction to avoid existing branches
@@ -383,6 +413,7 @@ describe('session-metadata-suggester', () => {
         repositoryPath: '/repo',
         agent: mockAgent,
         existingBranches: ['feat/conflicting-name', 'fix/another-branch'],
+        requestUser: null,
       });
 
       // Verify the embedded prompt includes instruction to avoid provided branches
@@ -403,12 +434,128 @@ describe('session-metadata-suggester', () => {
         prompt: 'Add first feature',
         repositoryPath: '/repo',
         agent: mockAgent,
+        requestUser: null,
       });
 
       // Verify the embedded prompt does NOT include duplicate avoidance instruction
       expect(spawnCalls.length).toBe(1);
       const prompt = extractPromptFromSpawnCommand(spawnCalls[0].args[2]);
       expect(prompt).not.toContain('Do NOT use any of these existing branch names');
+    });
+
+    // -- Privilege-elevation branch (Issue #856) --
+    //
+    // The runAsUser helper inspects AUTH_MODE + requestUser to decide whether
+    // to elevate via sudo. These assertions exercise the resulting spawn argv
+    // shape so a regression in routing back to the elevated branch fails the
+    // test rather than only manifesting at runtime in multi-user deployments.
+    // Mirrors the Issue #835 / PR #842 pattern in
+    // repository-description-generator.test.ts.
+
+    it('AUTH_MODE=none: bypasses elevation even when requestUser is set', async () => {
+      process.env.AUTH_MODE = 'none';
+      setMockSpawnResult('{"branch": "feat/feature", "title": "Feature"}');
+
+      const { suggestSessionMetadata } = await getModule();
+
+      const result = await suggestSessionMetadata({
+        prompt: 'Add feature',
+        repositoryPath: '/repo',
+        agent: mockAgent,
+        requestUser: 'alice',
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args[0]).toBe('sh');
+      expect(spawnCalls[0].args[1]).toBe('-c');
+      expect(spawnCalls[0].args[2]).toContain('test-cli -p --format text');
+    });
+
+    it('AUTH_MODE=multi-user with non-server requestUser: elevates via sudo as that user', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const targetUser = `${os.userInfo().username}-someone-else`;
+      setMockSpawnResult('{"branch": "feat/feature", "title": "Feature"}');
+
+      const { suggestSessionMetadata } = await getModule();
+
+      const result = await suggestSessionMetadata({
+        prompt: 'Add feature',
+        repositoryPath: '/repo',
+        agent: mockAgent,
+        requestUser: targetUser,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(spawnCalls.length).toBe(1);
+      // Elevated argv: ['sudo', '-u', <user>, '--preserve-env=FORCE_COLOR', '-i', 'sh', '-c', <inner>]
+      const args = spawnCalls[0].args;
+      expect(args[0]).toBe('sudo');
+      expect(args[1]).toBe('-u');
+      expect(args[2]).toBe(targetUser);
+      expect(args[3]).toBe('--preserve-env=FORCE_COLOR');
+      expect(args[4]).toBe('-i');
+      expect(args[5]).toBe('sh');
+      expect(args[6]).toBe('-c');
+      // `sudo -i` resets env + chdirs to target HOME, so cwd / env MUST be
+      // interpolated into the inner command. The inner shell should contain
+      // the cd to the repo path, the env exports (`export K=v; <command>`
+      // carrying TERM=dumb), and the agent command. After Issue #851, the
+      // prompt is embedded directly into the agent command via shellEscape
+      // (single-quoted literal), not exported as __AGENT_PROMPT__.
+      const inner = args[7];
+      expect(inner).toContain("cd '/repo'");
+      expect(inner).toMatch(/export\b[^;]*\bTERM='dumb'/);
+      expect(inner).not.toContain('__AGENT_PROMPT__');
+      expect(inner).toContain('test-cli -p --format text');
+      // The prompt is now embedded as the last single-quoted segment of the
+      // inner command (after the headless template's trailing {{prompt}}
+      // placeholder). Verify the suggestion prompt content reached the spawn.
+      const prompt = extractPromptFromSpawnCommand(inner);
+      expect(prompt).toContain('session metadata generator');
+      expect(prompt).toContain('Add feature');
+    });
+
+    it('AUTH_MODE=multi-user with requestUser == server user: bypasses elevation', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      setMockSpawnResult('{"branch": "feat/feature", "title": "Feature"}');
+
+      const { suggestSessionMetadata } = await getModule();
+
+      const result = await suggestSessionMetadata({
+        prompt: 'Add feature',
+        repositoryPath: '/repo',
+        agent: mockAgent,
+        requestUser: os.userInfo().username,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(spawnCalls.length).toBe(1);
+      // Direct spawn, no sudo prefix.
+      expect(spawnCalls[0].args[0]).toBe('sh');
+      expect(spawnCalls[0].args[1]).toBe('-c');
+      expect(spawnCalls[0].args[2]).toContain('test-cli -p --format text');
+    });
+
+    it('AUTH_MODE=multi-user with non-server requestUser: surfaces stderr when sudo exits non-zero', async () => {
+      // Real-world failure shape: `claude` not on the elevated user's PATH.
+      // The helper returns a non-zero exitCode and captured stderr; the
+      // suggester surfaces it via the error path.
+      process.env.AUTH_MODE = 'multi-user';
+      setMockSpawnResult('', 127, 'sh: 1: claude: not found');
+
+      const { suggestSessionMetadata } = await getModule();
+
+      const result = await suggestSessionMetadata({
+        prompt: 'Add feature',
+        repositoryPath: '/repo',
+        agent: mockAgent,
+        requestUser: `${os.userInfo().username}-someone-else`,
+      });
+
+      expect(result.branch).toBeUndefined();
+      expect(result.error).toContain('Agent command failed');
+      expect(result.error).toContain('claude: not found');
     });
   });
 });

--- a/packages/server/src/services/session-metadata-suggester.ts
+++ b/packages/server/src/services/session-metadata-suggester.ts
@@ -7,12 +7,25 @@
 import type { AgentDefinition } from '@agent-console/shared';
 import { listAllBranches } from '../lib/git.js';
 import { expandTemplate, TemplateExpansionError } from '../lib/template.js';
+import { runAsUser } from './privilege-elevation.js';
+
+const TIMEOUT_MS = 30000;
 
 interface SessionMetadataSuggestionRequest {
   prompt: string;
   repositoryPath: string;
   agent: AgentDefinition;
   existingBranches?: string[];
+  /**
+   * The OS username that requested the suggestion. In multi-user mode this is
+   * threaded down so the agent's headless command (e.g. `claude -p ...`) runs
+   * with the requesting user's PATH and per-user auth credentials via the
+   * `runAsUser` privilege-elevation helper. In single-user mode `runAsUser`
+   * bypasses elevation regardless of this value; pass the authenticated
+   * username (auth middleware always provides one). Mirrors the Issue #835 /
+   * PR #842 pattern in `repository-description-generator.ts`. Issue #856.
+   */
+  requestUser: string | null;
 }
 
 interface SessionMetadataSuggestionResponse {
@@ -98,7 +111,7 @@ Output ONLY the JSON, nothing else:`;
 export async function suggestSessionMetadata(
   request: SessionMetadataSuggestionRequest
 ): Promise<SessionMetadataSuggestionResponse> {
-  const { prompt, repositoryPath, agent, existingBranches } = request;
+  const { prompt, repositoryPath, agent, existingBranches, requestUser } = request;
 
   // Check if agent supports headless mode
   if (!agent.capabilities.supportsHeadlessMode) {
@@ -120,39 +133,41 @@ export async function suggestSessionMetadata(
       cwd: repositoryPath,
     });
 
-    // Spawn via shell with the expanded command
-    // The prompt is safely passed via environment variable to prevent injection
-    const proc = Bun.spawn(['sh', '-c', command], {
+    // Route through the privilege-elevation helper so multi-user mode runs the
+    // agent's headless command (e.g. `claude -p ...`) as the requesting user --
+    // i.e. with that user's PATH and per-user auth credentials. After Issue
+    // #851 / PR #852 the prompt is embedded directly into `command` via
+    // shellEscape; `templateEnv` carries only template-level env (typically
+    // none for headlessTemplate), plus we add TERM=dumb to suppress
+    // interactive settings.
+    // In single-user mode (or when requestUser equals the server user) the
+    // helper bypasses sudo and spawns directly, preserving prior behavior.
+    // Issue #856 (mirrors Issue #835 / PR #842 for repository-description-generator).
+    const { stdout, stderr, exitCode, timedOut } = await runAsUser({
+      username: requestUser,
+      command,
       cwd: repositoryPath,
-      stdout: 'pipe',
-      stderr: 'pipe',
       env: {
-        ...process.env,
         ...templateEnv,
         // Ensure we don't inherit any interactive settings
         TERM: 'dumb',
       },
+      timeoutMs: TIMEOUT_MS,
     });
 
-    // Set up timeout
-    const timeoutId = setTimeout(() => {
-      proc.kill();
-    }, 30000);
-
-    const exitCode = await proc.exited;
-    clearTimeout(timeoutId);
-
     if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
+      if (timedOut) {
+        return {
+          error: `Session metadata suggestion timed out after ${TIMEOUT_MS / 1000} seconds`,
+        };
+      }
       return {
         error: `Agent command failed: ${stderr.trim() || `exit code ${exitCode}`}`,
       };
     }
 
-    const result = await new Response(proc.stdout).text();
-
     // Clean up the result - try to parse as JSON
-    const trimmedResult = result.trim();
+    const trimmedResult = stdout.trim();
 
     // Try to extract JSON from the response (in case there's extra text)
     const jsonMatch = trimmedResult.match(/\{[\s\S]*\}/);


### PR DESCRIPTION
## Summary

Routes session-metadata-suggester (used when creating a worktree with `mode: 'prompt'`) through the `runAsUser` privilege-elevation helper landed in PR #840, so multi-user mode (`AUTH_MODE=multi-user`) runs the agent's headless command (e.g. `claude -p ...`) as the requesting user — with that user's PATH and per-user Claude auth credentials. Mirrors the Issue #835 / PR #842 fix that did the same for repository-description-generator.

Before this change, the suggestion spawn ran as the server-process user (`agentconsole`), which lacks `claude` on PATH and per-user Claude auth. The suggestion silently failed and the route fell back to `task-<timestamp>` for the branch name + empty title (observed end-to-end on the dogfood host 2026-06-24, per Issue #856).

In single-user mode (`AUTH_MODE=none`) or when the requesting user equals the server-process user, `runAsUser` bypasses elevation and spawns directly via `sh -c <command>`, preserving prior behavior with no regression risk.

Closes #856
Refs umbrella #837

## Rate-limit fallback (CodeRabbit)

Both local CodeRabbit CLI (not installed in this environment) and the GitHub-side CodeRabbit bot were rate-limited at this PR's review window. The GitHub bot posted a rate-limit warning at PR open ("Review limit reached"; "More reviews will be available in 24 minutes"). An `@coderabbitai review` re-trigger 8 minutes later also returned the rate-limited template ("More reviews will be available in 15 minutes"); no review submission appeared within the documented ~10-15 min abandon-and-proceed window. No CodeRabbit feedback obtainable from either source. Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority) per the disposition in [`coderabbit-ops/troubleshooting.md`](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/coderabbit-ops/troubleshooting.md).

## Changes

- `packages/server/src/services/session-metadata-suggester.ts`
  - Adds `requestUser: string | null` to `SessionMetadataSuggestionRequest`.
  - Replaces the direct `Bun.spawn(['sh', '-c', command], ...)` block with a single `runAsUser({...})` call. Timeout handling, env merging, and cwd are now delegated to the helper. `templateEnv` and `TERM=dumb` flow through `opts.env`, which the helper merges in the non-elevated branch and interpolates as `export K=v` statements inside the inner shell in the elevated branch. After Issue #851 / PR #852 the prompt itself is embedded directly into `command` via `shellEscape`; the comment in the new block reflects that.
- `packages/server/src/routes/worktrees.ts`
  - In the `mode: 'prompt'` branch, threads `c.get('authUser').username` (always present after the route's auth middleware) as `requestUser` to `suggestSessionMetadata`.
- `packages/server/src/mcp/mcp-server.ts`
  - Adds `requestUser: null` to the existing `suggestSessionMetadata` call in `delegate_to_worktree`. This is a compile-fix downstream of the interface change; per Issue #856 "Out of Scope", MCP-side privilege elevation for metadata suggestion is tracked separately (modelled on Issue #844). Passing `null` keeps MCP behaviour identical to before (no elevation), so there is no behavioural change on the MCP path in this PR.
- Sibling tests
  - `packages/server/src/services/__tests__/session-metadata-suggester.test.ts`: adds `requestUser: null` to the existing 16 calls, adds `AUTH_MODE` setup/teardown (afterEach restores the original value), and adds 4 privilege-elevation branch tests covering: `AUTH_MODE=none` bypass even when `requestUser` is set, `AUTH_MODE=multi-user` with a non-server `requestUser` (asserts the full elevated argv shape and that the inner command embeds cwd / TERM export / prompt without `__AGENT_PROMPT__`), `AUTH_MODE=multi-user` with `requestUser == server user` (same-user bypass), and a non-zero-exit stderr surface path (the `claude: not found` failure shape).
  - `packages/server/src/routes/__tests__/worktrees.test.ts`: adds a route test asserting the `mode: 'prompt'` handler forwards `authUser.username` (`'testuser'` from the default `TEST_AUTH_USER`) as `requestUser` to the suggester, using the same DI-mocked capture pattern PR #843 introduced for the `requestUsername` plumbing test.

## Verification

```
$ bun run typecheck
@agent-console/shared typecheck: Exited with code 0
@agent-console/server typecheck: Exited with code 0
@agent-console/client typecheck: Exited with code 0
```

```
$ bun run test
@agent-console/shared      test: Ran  324 tests across  10 files (0 fail)
@agent-console/integration test: Ran   29 tests across   8 files (0 fail)
@agent-console/server      test: Ran 2711 tests across 129 files (0 fail)
@agent-console/client      test: Ran 1399 tests across  88 files (1397 pass / 2 skip / 0 fail)
scripts / hooks / skills        Ran  362 tests across  11 files (0 fail)
TEST_EXIT: 0
```

```
$ bun run check:lang
OK -- language check clean (103 files scanned).

$ node .claude/skills/orchestrator/preflight-check.js
Test Coverage Check: Covered (2): routes/worktrees.ts, services/session-metadata-suggester.ts
Integration Test Coverage: warning only (no contract change -- see note below)
Rule/Skill Duplication:    clean
Language Check:            clean
PREFLIGHT_EXIT: 0
```

## TDD polarity check

Verified by stashing only the production change in `session-metadata-suggester.ts` (`git stash push -- packages/server/src/services/session-metadata-suggester.ts`) while keeping the new tests, then re-running the sibling suite: the new `AUTH_MODE=multi-user with non-server requestUser: elevates via sudo as that user` test fails (`Expected: "sudo" / Received: "sh"` — direct `Bun.spawn` does not produce the sudo prefix). Restoring the production change (`git stash pop`) returns the suite to 22 pass / 0 fail.

## 7-question gap-scan

- **Q1 (existing mechanism):** `runAsUser` is the existing mechanism (PR #840, umbrella #837). This PR is the latest consumer migration, mirroring Issue #835 / PR #842 for description gen exactly. The previous implementation used a direct `Bun.spawn(['sh', '-c', ...])` block that does not satisfy multi-user requirements (the bug in #856).
- **Q1.5 (cross-doc citation):** Verified against the actual `privilege-elevation.ts` code (the `buildSpawnArgs` argv shape and the cwd / env interpolation rule) and against the post-#852 prompt-delivery contract in `expandTemplate` (prompt embedded as a single-quoted literal in the command, not via env var). Test assertions check both `'sh' '-c' <command>` for the non-elevated branch and `'sudo' '-u' <user> '--preserve-env=FORCE_COLOR' '-i' 'sh' '-c' <inner>` for the elevated branch.
- **Q3 (failure paths tested):** Yes. Sibling suggester tests cover the happy path (both branches), the same-user bypass, and the realistic failure shape (`claude: not found` -> non-zero exit -> stderr surfaced through the error response). The route-level test verifies the username threading.
- **Q3 (sibling test diff):** Yes -- both production files in this PR have changed sibling test files in the same diff (preflight verified: 2 covered, 0 missing).
- **Q6 (cross-runtime spawn):** N / A. No new cross-runtime spawn introduced; `runAsUser` is the existing helper.
- **Q7 (shared-resource lifetime):** N / A. No new persistent artifacts.
- **Q8 (signature shape change):** `suggestSessionMetadata`'s `SessionMetadataSuggestionRequest` gains one new required field (`requestUser: string | null`). Call sites: 2 production (`routes/worktrees.ts`, `mcp/mcp-server.ts`) + 17 test sites in the sibling test file (16 existing + 4 new = 20, but 4 new are added with `requestUser` from the start; the 16 existing got `requestUser: null` mechanically). Bulk update was applied via a regex script targeting only `suggestSessionMetadata({ ... })` closing blocks (validated on one file before applying).

## Integration test note

Preflight surfaces a `route changed without integration test diff` warning. This is intentional: the change does not alter the `POST /api/repositories/:id/worktrees` client-server contract (request body, response shape, status codes are unchanged); it only changes how the server executes the underlying suggester command. Existing integration coverage of this endpoint continues to apply.

## Out of scope / parallel work

- Parallel work on umbrella #837 mentioned in the brief: Issues #853 (repository-manager.ts) and #854 (worktree-creation-service.ts) are owned by separate agents on different files; this PR's diff does not touch those files.
- Issue #851 / PR #852 (already merged) landed the `{{prompt}}` direct-embed fix in `lib/template.ts`. This PR consumes that change transparently; the new privilege-elevation tests assert the inner command does NOT contain `__AGENT_PROMPT__` (per post-#852 contract).
- MCP-side privilege elevation for the metadata-suggestion call is documented as Out-of-Scope in Issue #856 and is tracked for a future Issue modelled on #844. This PR passes `requestUser: null` from the MCP call site so MCP behaviour is unchanged from before.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` (full suite) passes (0 failures across server / client / shared / integration / scripts)
- [x] `bun run check:lang` passes
- [x] `node .claude/skills/orchestrator/preflight-check.js` passes
- [x] TDD polarity verified (new sudo-shape test fails when production change is stashed; passes when restored)
- [ ] Dogfood verification on a multi-user host -- request owner / Orchestrator (this environment cannot exercise the elevation path end-to-end; reproduction of the original `task-<timestamp>` symptom would require an `AUTH_MODE=multi-user` host with `agentconsole` lacking `claude` on PATH)
