### PR TITLE
fix(server): pre-probe source repo accessibility before worktree create

### DIFF
--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -307,6 +307,13 @@ describe('MCP Server Tools', () => {
         const wtPath = tokens.find((t) => t.includes('/worktrees/wt-'));
         if (wtPath) {
           mcpRunAsUserCapture.capturedWorktreePath = wtPath;
+          // Mirror what real `git worktree add` does on disk so the
+          // post-create sanity-net `fsPromises.stat` (Issue #854) finds
+          // the directory. The stub still bypasses real git, but the
+          // creation-service contract assumes the directory exists after
+          // a successful exitCode 0.
+          const fs = await import('fs');
+          fs.mkdirSync(wtPath, { recursive: true });
         }
         if (mcpRunAsUserCapture.responseOverride) {
           return mcpRunAsUserCapture.responseOverride;

--- a/packages/server/src/routes/__tests__/worktrees.test.ts
+++ b/packages/server/src/routes/__tests__/worktrees.test.ts
@@ -35,6 +35,10 @@ const WORKTREE_PATH = `${REPO_PATH}/worktrees/wt-1`;
 function createMockWorktreeService() {
   return {
     listWorktrees: mock(() => Promise.resolve([])),
+    // Pre-create accessibility probe (Issue #854). Default to success so
+    // tests that don't care about the probe see the legacy behaviour;
+    // probe-failure tests override per-call.
+    verifyRepoAccessible: mock(() => Promise.resolve()),
     isWorktreeOf: mock(() => Promise.resolve(true)),
     getDefaultBranch: mock(() => Promise.resolve('main')),
     listLocalBranches: mock(() => Promise.resolve([])),

--- a/packages/server/src/services/__tests__/worktree-creation-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-creation-service.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import * as fs from 'fs';
 import type { HookCommandResult, Worktree } from '@agent-console/shared';
 import type { SessionManager } from '../session-manager.js';
 import { buildWorktreeSession } from '../../__tests__/utils/build-test-data.js';
-import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
+import { GitError, mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
 // --- Mock worktreeService (now passed as parameter, no mock.module needed) ---
 
-const mockListWorktrees = mock<(repoPath: string, repoId: string) => Promise<Worktree[]>>(() =>
-  Promise.resolve([]),
+const mockVerifyRepoAccessible = mock<(repoPath: string) => Promise<void>>(() =>
+  Promise.resolve(),
 );
 const mockCreateWorktree = mock<
   (
@@ -15,7 +16,7 @@ const mockCreateWorktree = mock<
     repoId: string,
     baseBranch?: string,
     requestUsername?: string | null,
-  ) => Promise<{ worktreePath: string; error?: string }>
+  ) => Promise<{ worktreePath: string; error?: string; index?: number }>
 >(() => Promise.resolve({ worktreePath: '/repos/my-repo/worktrees/wt-new' }));
 const mockRemoveWorktree = mock<
   (repoPath: string, path: string, force: boolean) => Promise<{ success: boolean; error?: string }>
@@ -25,7 +26,7 @@ const mockExecuteHookCommand = mock<
 >(() => Promise.resolve({ success: true }));
 
 const mockWorktreeService = {
-  listWorktrees: mockListWorktrees,
+  verifyRepoAccessible: mockVerifyRepoAccessible,
   createWorktree: mockCreateWorktree,
   removeWorktree: mockRemoveWorktree,
   executeHookCommand: mockExecuteHookCommand,
@@ -48,7 +49,10 @@ const { createWorktreeWithSession } = await import('../worktree-creation-service
 
 const CREATED_PATH = '/repos/my-repo/worktrees/wt-new';
 
-const WORKTREE: Worktree = {
+// The orchestration no longer derives the worktree from `listWorktrees`; it
+// builds it directly from the create call's result + the request params.
+// The expected shape mirrors that construction.
+const EXPECTED_WORKTREE: Worktree = {
   path: CREATED_PATH,
   branch: 'feature-new',
   isMain: false,
@@ -85,22 +89,44 @@ const DEFAULT_PARAMS = {
 };
 
 describe('createWorktreeWithSession', () => {
+  // `fs.promises.stat` is called by the production code as a sanity safety
+  // net after `createWorktree` reports success. The default spy resolves so
+  // the happy-path tests succeed without a real filesystem; the sanity-net
+  // test overrides it to reject. `mockRestore` runs after each test so the
+  // spy never leaks into sibling test files.
+  let statSpy: ReturnType<typeof spyOn> | undefined;
+
   beforeEach(() => {
     resetGitMocks();
-    mockListWorktrees.mockReset();
+    mockVerifyRepoAccessible.mockReset();
     mockCreateWorktree.mockReset();
     mockRemoveWorktree.mockReset();
     mockExecuteHookCommand.mockReset();
 
     // Default implementations
+    mockVerifyRepoAccessible.mockImplementation(() => Promise.resolve());
     mockCreateWorktree.mockImplementation(() =>
       Promise.resolve({ worktreePath: CREATED_PATH, index: 2 }),
     );
-    mockListWorktrees.mockImplementation(() => Promise.resolve([WORKTREE]));
     mockRemoveWorktree.mockImplementation(() => Promise.resolve({ success: true }));
     mockExecuteHookCommand.mockImplementation(() =>
       Promise.resolve({ success: true, output: 'setup done' }),
     );
+
+    // Default fs.promises.stat spy: resolve so the sanity check passes.
+    // The production call site uses the single-arg form `fsPromises.stat(path)`
+    // which always returns Promise<Stats>; the rejected-promise pattern below
+    // (used by the sanity-net failure test) mirrors the same cast already
+    // present in worktree-service.test.ts.
+    statSpy = spyOn(fs.promises, 'stat').mockImplementation(
+      ((_p: fs.PathLike) =>
+        Promise.resolve({ isDirectory: () => true } as fs.Stats)) as typeof fs.promises.stat,
+    );
+  });
+
+  afterEach(() => {
+    statSpy?.mockRestore();
+    statSpy = undefined;
   });
 
   it('happy path: fetch, create worktree, setup command, create session', async () => {
@@ -112,7 +138,7 @@ describe('createWorktreeWithSession', () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.worktree).toEqual(WORKTREE);
+    expect(result.worktree).toEqual(EXPECTED_WORKTREE);
     expect(result.session).toEqual(MOCK_SESSION);
     expect(result.setupCommandResult).toEqual({ success: true, output: 'setup done' });
 
@@ -180,18 +206,75 @@ describe('createWorktreeWithSession', () => {
     expect(sm.createSession).not.toHaveBeenCalled();
   });
 
-  it('rolls back worktree and returns failure when worktree not found after creation', async () => {
-    // listWorktrees returns empty — the created worktree is not found
-    mockListWorktrees.mockImplementation(() => Promise.resolve([]));
+  // --- Issue #854: pre-probe + sanity-net (replaces the old post-create
+  // listWorktrees-find-rollback branch which was removed in favour of a
+  // pre-create accessibility probe). ---
+
+  it('returns "Cannot access repository" when pre-probe throws GitError (Issue #854)', async () => {
+    mockVerifyRepoAccessible.mockImplementation(() =>
+      Promise.reject(
+        new GitError(
+          'git worktree failed: fatal: detected dubious ownership in repository at /repo',
+          128,
+          "fatal: detected dubious ownership in repository at '/repo'",
+        ),
+      ),
+    );
 
     const sm = createMockSessionManager();
     const result = await createWorktreeWithSession(DEFAULT_PARAMS, sm, mockWorktreeService);
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe('Worktree was created but could not be found in the list');
+    expect(result.error).toBe(
+      "Cannot access repository: fatal: detected dubious ownership in repository at '/repo'",
+    );
+    // Pre-probe failure aborts BEFORE any filesystem side effect.
+    expect(mockCreateWorktree).not.toHaveBeenCalled();
+    expect(mockRemoveWorktree).not.toHaveBeenCalled();
+    expect(sm.createSession).not.toHaveBeenCalled();
+  });
 
-    // Rollback should have been called
+  it('falls back to git exit code when probe GitError stderr is empty (Issue #854)', async () => {
+    mockVerifyRepoAccessible.mockImplementation(() =>
+      Promise.reject(new GitError('git worktree failed', 128, '   ')),
+    );
+
+    const sm = createMockSessionManager();
+    const result = await createWorktreeWithSession(DEFAULT_PARAMS, sm, mockWorktreeService);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Cannot access repository: git exit code 128');
+    expect(mockCreateWorktree).not.toHaveBeenCalled();
+  });
+
+  it('surfaces plain Error message when pre-probe throws non-GitError (Issue #854)', async () => {
+    mockVerifyRepoAccessible.mockImplementation(() => Promise.reject(new Error('unexpected boom')));
+
+    const sm = createMockSessionManager();
+    const result = await createWorktreeWithSession(DEFAULT_PARAMS, sm, mockWorktreeService);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Cannot access repository: unexpected boom');
+    expect(mockCreateWorktree).not.toHaveBeenCalled();
+  });
+
+  it('rolls back and returns "directory is missing" when sanity-net stat fails (Issue #854)', async () => {
+    // createWorktree reports success but the path does not actually exist
+    // on disk -- the sanity-net stat catches it and triggers rollback.
+    statSpy?.mockRestore();
+    statSpy = spyOn(fs.promises, 'stat').mockImplementation((() =>
+      Promise.reject(Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' }))
+    ) as typeof fs.promises.stat);
+
+    const sm = createMockSessionManager();
+    const result = await createWorktreeWithSession(DEFAULT_PARAMS, sm, mockWorktreeService);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      `Worktree create reported success but directory is missing: ${CREATED_PATH}`,
+    );
     expect(mockRemoveWorktree).toHaveBeenCalledWith('/repos/my-repo', CREATED_PATH, true);
+    expect(sm.createSession).not.toHaveBeenCalled();
   });
 
   it('rolls back worktree and returns failure when session creation fails', async () => {
@@ -216,7 +299,7 @@ describe('createWorktreeWithSession', () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.worktree).toEqual(WORKTREE);
+    expect(result.worktree).toEqual(EXPECTED_WORKTREE);
     expect(result.session).toBeUndefined();
     expect(sm.createSession).not.toHaveBeenCalled();
   });

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -242,6 +242,45 @@ detached
     });
   });
 
+  describe('verifyRepoAccessible', () => {
+    // Unlike `listWorktrees` (which swallows GitError and returns `[]` for
+    // UI listing callers), `verifyRepoAccessible` must propagate the
+    // underlying GitError so the pre-create probe in
+    // `createWorktreeWithSession` can surface stderr to the operator
+    // (Issue #854).
+    it('propagates GitError instead of swallowing it', async () => {
+      const cause = new GitError(
+        'git worktree failed: fatal: detected dubious ownership in repository',
+        128,
+        "fatal: detected dubious ownership in repository at '/repo'",
+      );
+      mockGit.listWorktrees.mockImplementation(() => Promise.reject(cause));
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      let caught: unknown;
+      try {
+        await service.verifyRepoAccessible('/repo');
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBe(cause);
+      expect(caught).toBeInstanceOf(GitError);
+    });
+
+    it('resolves with no value when git accepts the repo', async () => {
+      // The top-level beforeEach already wires `mockGit.listWorktrees` to a
+      // resolving implementation; the probe should resolve to undefined.
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      const result = await service.verifyRepoAccessible('/repo/main');
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('createWorktree', () => {
     // `runAsUser` is now the single execution point for `git worktree add`,
     // so the tests inject a capture mock via `runAsUserImpl` rather than

--- a/packages/server/src/services/worktree-creation-service.ts
+++ b/packages/server/src/services/worktree-creation-service.ts
@@ -1,3 +1,4 @@
+import { promises as fsPromises } from 'fs';
 import type { Worktree, HookCommandResult } from '@agent-console/shared';
 import type { Session } from '@agent-console/shared';
 import type { SessionManager } from './session-manager.js';
@@ -7,9 +8,9 @@ import type { WorktreeService } from './worktree-service.js';
 /** Narrow subset of WorktreeService methods needed by the creation service. */
 type CreateWorktreeServiceDeps = Pick<
   WorktreeService,
-  'createWorktree' | 'listWorktrees' | 'removeWorktree' | 'executeHookCommand'
+  'verifyRepoAccessible' | 'createWorktree' | 'removeWorktree' | 'executeHookCommand'
 >;
-import { fetchRemote } from '../lib/git.js';
+import { fetchRemote, GitError } from '../lib/git.js';
 import { createLogger } from '../lib/logger.js';
 
 const logger = createLogger('worktree-creation-service');
@@ -83,7 +84,27 @@ export async function createWorktreeWithSession(
     requestUsername,
   } = params;
 
-  // 1. Handle remote fetch if requested
+  // 1. Pre-probe: verify the source repo is git-accessible BEFORE any
+  // filesystem side effects. Surfaces failures like `dubious ownership`,
+  // missing remote, or corrupt `.git/` with the underlying git stderr so
+  // operators see the real cause instead of a misleading post-create
+  // "could not be found in the list" message (Issue #854).
+  try {
+    await worktreeService.verifyRepoAccessible(repoPath);
+  } catch (probeErr) {
+    const detail = probeErr instanceof GitError
+      ? (probeErr.stderr.trim() || `git exit code ${probeErr.exitCode}`)
+      : probeErr instanceof Error
+        ? probeErr.message
+        : String(probeErr);
+    logger.warn(
+      { repoId, repoPath, err: probeErr },
+      'Source repo accessibility probe failed; aborting worktree create',
+    );
+    return { success: false, error: `Cannot access repository: ${detail}` };
+  }
+
+  // 2. Handle remote fetch if requested
   let effectiveBaseBranch = baseBranch;
   let fetchFailed = false;
   let fetchError: string | undefined;
@@ -103,7 +124,7 @@ export async function createWorktreeWithSession(
     }
   }
 
-  // 2. Create worktree
+  // 3. Create worktree
   const wtResult = await worktreeService.createWorktree(
     repoPath,
     branch,
@@ -118,17 +139,38 @@ export async function createWorktreeWithSession(
 
   const createdWorktreePath = wtResult.worktreePath;
 
+  // 4. Sanity safety net: confirm the directory actually exists. `git worktree
+  // add` is reliable -- exit 0 means the worktree is registered -- so this
+  // check is expected to fire approximately never. Kept defensively so a
+  // genuinely unexpected failure (e.g., filesystem race, out-of-band deletion)
+  // does not silently propagate into session creation.
   try {
-    // 3. Find created worktree info
-    const worktrees = await worktreeService.listWorktrees(repoPath, repoId);
-    const worktree = worktrees.find(wt => wt.path === createdWorktreePath);
+    await fsPromises.stat(createdWorktreePath);
+  } catch (statErr) {
+    logger.warn(
+      { worktreePath: createdWorktreePath, err: statErr },
+      'createWorktree reported success but stat failed; rolling back',
+    );
+    await rollbackWorktree(worktreeService, repoPath, createdWorktreePath);
+    return {
+      success: false,
+      error: `Worktree create reported success but directory is missing: ${createdWorktreePath}`,
+    };
+  }
 
-    if (!worktree) {
-      await rollbackWorktree(worktreeService, repoPath, createdWorktreePath);
-      return { success: false, error: 'Worktree was created but could not be found in the list' };
-    }
+  // The freshly-created worktree's authoritative description. `branch` here
+  // is the requested branch name (the same string `createWorktree` was called
+  // with); `path` is what `git worktree add` actually produced.
+  const worktree: Worktree = {
+    path: createdWorktreePath,
+    branch,
+    isMain: false,
+    repositoryId: repoId,
+    index: wtResult.index,
+  };
 
-    // 4. Execute setup command if configured
+  try {
+    // 5. Execute setup command if configured
     let setupCommandResult: HookCommandResult | undefined;
     if (setupCommand && wtResult.index !== undefined) {
       setupCommandResult = await worktreeService.executeHookCommand(
@@ -142,7 +184,7 @@ export async function createWorktreeWithSession(
       );
     }
 
-    // 5. Create session (unless explicitly skipped)
+    // 6. Create session (unless explicitly skipped)
     let session: Session | undefined;
     if (autoStartSession) {
       session = await sessionManager.createSession({

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -223,6 +223,27 @@ export class WorktreeService {
   }
 
   /**
+   * Probe the source repo's git accessibility. Runs `git worktree list`
+   * against the source repo and **throws** on git failure (does not swallow).
+   *
+   * This is the verification that `listWorktrees` was conceptually doing,
+   * preserved as a separate method so the swallow contract of `listWorktrees`
+   * (used by UI / API listings that expect `[]` on transient errors) stays
+   * intact for its other callers.
+   *
+   * Used as a pre-create probe by `createWorktreeWithSession` so failures
+   * such as `dubious ownership`, corrupt `.git/`, or missing remote surface
+   * as actionable errors before any filesystem side effect is performed
+   * (Issue #854).
+   *
+   * @throws GitError when the underlying `git worktree list` fails.
+   */
+  async verifyRepoAccessible(repoPath: string): Promise<void> {
+    // We discard the return value; only the throw-or-not signal is needed.
+    await gitListWorktrees(repoPath);
+  }
+
+  /**
    * List all worktrees for a repository.
    * Includes git-tracked worktrees registered in DB and orphaned DB records
    * (worktrees that exist in DB but are no longer tracked by git).


### PR DESCRIPTION
## Summary

Closes #854.

When the server cannot access a source repo (e.g. `fatal: detected dubious ownership` after the operator cloned as their own user), `git worktree add` runs anyway, and the post-create `WorktreeService.listWorktrees` swallows the underlying git error (returns `[]`) -- so the UI shows the misleading `"Worktree was created but could not be found in the list"` while the real cause sits in `journalctl`.

This PR inverts the verification order: probe the source repo's git accessibility **before** any filesystem side effect, surface the underlying stderr (`"Cannot access repository: <stderr>"`), and remove the misleading post-create list-verify entirely. `git worktree add`'s own exit code already authoritatively reports success; the list-then-rollback dance was a defensive belt-and-suspenders that hid the real failure mode.

Replaces the original "catch listWorktrees error after create" design (PR #857, now closed) -- that approach was dead code because `listWorktrees` swallows internally for the UI listing use case.

### Change shape

- **`WorktreeService.verifyRepoAccessible(repoPath)`** -- new method that calls `gitListWorktrees(repoPath)` and propagates `GitError`. Placed adjacent to `listWorktrees` for proximity. `listWorktrees`'s swallow contract (used by UI / API listings that expect `[]` on transient errors) is intentionally unchanged.
- **`createWorktreeWithSession`** -- runs `verifyRepoAccessible` first; on failure returns `{ success: false, error: "Cannot access repository: ..." }` with no rollback (no side effect to roll back). After `createWorktree` reports success, a defensive `fsPromises.stat` sanity net catches the practically-never case of git exit 0 with no directory and triggers rollback with a distinct `"directory is missing"` error. The previous `listWorktrees + find` + rollback-if-missing block is removed.
- **Sibling tests**:
  - `worktree-service.test.ts` -- two new cases for `verifyRepoAccessible` (throws / resolves).
  - `worktree-creation-service.test.ts` -- four new cases (pre-probe GitError with stderr, pre-probe GitError with empty stderr -> exit code fallback, pre-probe non-GitError, sanity-net stat-rejects -> rollback). All previously existing tests preserved, except the obsolete "rolls back when worktree not found after creation" (the listWorktrees-find-rollback branch it covered no longer exists).
- **Adjacent test plumbing**:
  - `routes/worktrees.test.ts` mock factory exposes `verifyRepoAccessible`.
  - `mcp/__tests__/mcp-server.test.ts`'s `runAsUserImpl` stub mirrors `git worktree add`'s on-disk side effect (`fs.mkdirSync`) so the new sanity-net stat finds the directory in the MCP integration tests.

### Note on companion Issue

Issue #853 addresses the dogfood incident's root cause (server-side `safe.directory` bootstrap). This PR ships the UX improvement independently -- the new `"Cannot access repository: <stderr>"` message stays meaningful for any other probe-failure mode (corrupt `.git/`, missing remote, permission errors, etc.) regardless of whether #853 has landed.

## Verification log

```
$ bun run typecheck
@agent-console/shared typecheck: Exited with code 0
@agent-console/server typecheck: Exited with code 0
@agent-console/client typecheck: Exited with code 0

$ output=$(bun run test 2>&1); exitcode=$?; echo "TEST_EXIT: $exitcode"
@agent-console/server test:  2710 pass
@agent-console/server test:  0 fail
@agent-console/server test: Ran 2711 tests across 129 files. [55.40s]
@agent-console/client test:  1397 pass
@agent-console/client test:  0 fail
@agent-console/client test: Ran 1399 tests across 88 files. [14.09s]
@agent-console/* scripts test:  362 pass / 0 fail / Ran 362 tests across 11 files. [2.44s]
TEST_EXIT: 0

$ bun run check:lang
OK -- language check clean (103 files scanned).

$ node .claude/skills/orchestrator/preflight-check.js
## Test Coverage Check
### Covered (2)
- packages/server/src/services/worktree-creation-service.ts
- packages/server/src/services/worktree-service.ts
**All production files have corresponding tests.**
## Rule/Skill Duplication Check -- No rule paragraphs found verbatim in any skill file.
## Language Check (public artifacts) -- All public artifacts use Latin / Greek / Cyrillic scripts only.
```

## TDD polarity

Verified before commit:

1. With the new tests present but production change `git stash`-ed: **14 tests fail** -- 12 in `worktree-creation-service.test.ts` (probe failure tests fail because the production code never calls `verifyRepoAccessible`; sanity-net test fails because the post-create flow no longer uses `fsPromises.stat`; happy-path tests fail because they previously relied on `listWorktrees` returning the worktree from the dropped `WORKTREE` constant) and 2 in `worktree-service.test.ts` (`verifyRepoAccessible` method does not exist). Polarity is meaningful -- the new tests target the new code path, not adjacent code.
2. Restored production: **all 79 file-scoped tests pass**, and the full suite passes (4469 tests / 0 fail).

## 7-question gap-scan

1. **Similar mechanism exists?** Yes -- `WorktreeService.listWorktrees` covers the read use case for UI listings (swallow-and-return-`[]` contract). `verifyRepoAccessible` is intentionally a **sibling** with a different contract (propagate `GitError`), not a replacement -- the swallow contract for other callers is preserved.
2. **Invocation documented in canonical procedure?** N/A -- no new script, skill, or canonical procedure.
3. **Failure paths tested?** Yes -- probe with `GitError` stderr, probe with empty stderr -> exit-code fallback, probe with non-GitError, sanity-net stat rejects. The probe-success path is covered by the happy-path tests; the sanity-net-success path is implicit in every other test that exercises the orchestration end-to-end.
4. **New file type / directory?** No.
5. **New rule text?** No.
6. **Cross-runtime spawn?** No.
7. **Shared-resource artifact write?** No.
8. **Signature shape change?** Yes-ish -- `CreateWorktreeServiceDeps` Pick changes (`listWorktrees` -> `verifyRepoAccessible`). The two production call sites (`packages/server/src/index.ts:144`, `packages/server/src/mcp/mcp-server.ts:693`) pass the full `WorktreeService` instance, which now has `verifyRepoAccessible`; no call-site code change needed. Test mocks updated where the mock factory creates a synthetic `worktreeService` (`routes/__tests__/worktrees.test.ts`, `mcp/__tests__/mcp-server.test.ts`, `services/__tests__/worktree-creation-service.test.ts`). Total affected call sites: 2 production (no code change) + 3 test files (each adds one mock method).

## Out of scope

- Root cause of dubious-ownership: see #853 (server-side `safe.directory` bootstrap).
- Retry on transient probe failures: single-shot probe per Issue spec.
- Frontend rendering changes: the route returns `error` as a string and existing UI dialogs render it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)