### PR TITLE
feat(server): add clone-and-register repository endpoint (closes #834)

### DIFF
--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -70,6 +70,8 @@ import { BranchWatcherService } from './services/branch-watcher-service.js';
 import { suggestSessionMetadata } from './services/session-metadata-suggester.js';
 import { fetchPullRequestUrl, findOpenPullRequest } from './services/github-pr-service.js';
 import { generateRepositoryDescription } from './services/repository-description-generator.js';
+import { RepositoryCloneService } from './services/repository-clone-service.js';
+import { getSourceReposDir } from './lib/config.js';
 import { SqliteMessageTemplateRepository } from './repositories/sqlite-message-template-repository.js';
 
 const logger = createLogger('app-context');
@@ -157,6 +159,14 @@ export interface AppContext {
 
   /** Generate AI-powered repository description */
   generateRepositoryDescription: GenerateRepositoryDescriptionFn;
+
+  /**
+   * Clone-and-register repository service (Issue #834). Owns the in-memory
+   * job state for `POST /api/repositories/clone` and the matching status
+   * endpoint. Singleton across the process so polling sees the same state
+   * the enqueue call mutated.
+   */
+  repositoryCloneService: RepositoryCloneService;
 
   /** Message template CRUD repository */
   messageTemplateRepository: MessageTemplateRepository;
@@ -453,6 +463,13 @@ export async function createAppContext(
       sessionManager.getSessionsUsingRepository(repoId),
   });
 
+  // 7.1. Construct the clone-and-register service (Issue #834). Singleton so
+  // background jobs and polling share the same in-memory state map.
+  const repositoryCloneService = new RepositoryCloneService({
+    sourceReposDir: getSourceReposDir(),
+    registrar: repositoryManager,
+  });
+
   // Wire notification callbacks
   notificationManager.setSessionExistsCallback((sessionId) =>
     sessionManager.getSession(sessionId) !== undefined
@@ -498,6 +515,7 @@ export async function createAppContext(
     fetchPullRequestUrl,
     findOpenPullRequest,
     generateRepositoryDescription,
+    repositoryCloneService,
     messageTemplateRepository,
     branchWatcherService,
   };
@@ -616,6 +634,12 @@ export async function createTestContext(
       sessionManager.getSessionsUsingRepository(repoId),
   });
 
+  // Clone-and-register service for the test context (Issue #834).
+  const repositoryCloneService = new RepositoryCloneService({
+    sourceReposDir: getSourceReposDir(),
+    registrar: repositoryManager,
+  });
+
   notificationManager.setSessionExistsCallback((sessionId) =>
     sessionManager.getSession(sessionId) !== undefined
   );
@@ -683,6 +707,7 @@ export async function createTestContext(
     fetchPullRequestUrl,
     findOpenPullRequest,
     generateRepositoryDescription,
+    repositoryCloneService,
     messageTemplateRepository,
     branchWatcherService: new BranchWatcherService(async () => {}),
   };

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -729,6 +729,11 @@ export async function shutdownAppContext(
   context.interactiveProcessManager.disposeAll();
   context.branchWatcherService.stopAll();
 
+  // Cancel any pending clone-job eviction timers (Issue #834). Keeping a
+  // pending setTimeout alive after the process tries to exit would block the
+  // event loop; the eviction is purely an in-memory bookkeeping concern.
+  context.repositoryCloneService.dispose();
+
   // Stop job queue
   await context.jobQueue.stop();
 

--- a/packages/server/src/lib/config.ts
+++ b/packages/server/src/lib/config.ts
@@ -48,6 +48,25 @@ export function getRepositoriesDir(): string {
 }
 
 /**
+ * Get the shared source-repos base directory where the clone-and-register
+ * action (Issue #834) places new clones. The bootstrap script
+ * (`scripts/setup-multiuser-for-ubuntu.sh`, Issue #833 / PR #849) creates this
+ * directory at install time with owner `<service-user>:agent-console-users`
+ * and mode `2775` so any interactive group member can `git clone` into it and
+ * the service user can fetch / update refs.
+ *
+ * Resolution precedence (mirroring the bootstrap script's flag handling):
+ *   1. `AGENT_CONSOLE_SOURCE_REPOS_DIR` environment variable, if set.
+ *   2. `<config-dir>/source-repos` (the bootstrap script's default location).
+ */
+export function getSourceReposDir(): string {
+  if (process.env.AGENT_CONSOLE_SOURCE_REPOS_DIR) {
+    return process.env.AGENT_CONSOLE_SOURCE_REPOS_DIR;
+  }
+  return path.join(getConfigDir(), 'source-repos');
+}
+
+/**
  * Get the directory for a specific repository.
  * Structure: <config-dir>/repositories/{org}/{repo}/
  * @param orgRepo - Organization and repository name (e.g., "owner/repo-name")

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import type { GenerateRepositoryDescriptionFn } from '../../services/repository-description-generator.js';
+import {
+  CloneNameConflictError,
+  CloneValidationError,
+} from '../../services/repository-clone-service.js';
+import { CLONE_ERROR_CODES, CLONE_JOB_STATUS } from '@agent-console/shared';
 
 const mockGenerateDescription = mock<GenerateRepositoryDescriptionFn>(() =>
   Promise.resolve({ description: 'test' })
@@ -37,6 +42,16 @@ const agentManager = {
   getAgent: mock(() => undefined as any),
 };
 
+// Mock of the clone-and-register service (Issue #834). Captures enqueueClone
+// arguments + lets each test stub the resolved/rejected value per-call. The
+// real service maintains in-memory state; tests can either drive that state
+// directly via getJob.mockReturnValue or via enqueueClone returning a jobId
+// the test seeds.
+const repositoryCloneService = {
+  enqueueClone: mock((_request: unknown) => Promise.resolve('mock-job-id')),
+  getJob: mock((_jobId: string) => undefined as any),
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -55,6 +70,9 @@ function resetAllMocks(): void {
   agentManager.getAgent.mockReset();
   mockGenerateDescription.mockReset();
   mockGenerateDescription.mockImplementation(() => Promise.resolve({ description: 'test' }));
+  repositoryCloneService.enqueueClone.mockReset();
+  repositoryCloneService.enqueueClone.mockImplementation(() => Promise.resolve('mock-job-id'));
+  repositoryCloneService.getJob.mockReset();
 }
 
 // ---------------------------------------------------------------------------
@@ -73,6 +91,7 @@ describe('Repositories API', () => {
       repositorySlackIntegrationService: repositorySlackIntegrationService as any,
       agentManager: agentManager as any,
       generateRepositoryDescription: mockGenerateDescription as any,
+      repositoryCloneService: repositoryCloneService as any,
     });
   });
 
@@ -217,6 +236,149 @@ describe('Repositories API', () => {
       const body = (await res.json()) as { behind: number; ahead: number };
       expect(body.behind).toBe(3);
       expect(body.ahead).toBe(1);
+    });
+  });
+
+  // =========================================================================
+  // POST /api/repositories/clone (Issue #834)
+  // =========================================================================
+  describe('POST /api/repositories/clone', () => {
+    it('returns 202 with jobId, forwarding authUser.username as requestUser', async () => {
+      repositoryCloneService.enqueueClone.mockImplementationOnce(() =>
+        Promise.resolve('job-abc'),
+      );
+
+      const res = await app.request('/api/repositories/clone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: 'https://github.com/org/repo.git',
+          description: 'an example',
+        }),
+      });
+
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as { jobId: string; repositoryId: null };
+      expect(body.jobId).toBe('job-abc');
+      expect(body.repositoryId).toBe(null);
+
+      expect(repositoryCloneService.enqueueClone).toHaveBeenCalledTimes(1);
+      const firstArg = repositoryCloneService.enqueueClone.mock.calls[0][0] as any;
+      expect(firstArg.url).toBe('https://github.com/org/repo.git');
+      expect(firstArg.description).toBe('an example');
+      // TEST_AUTH_USER.username from test-utils.ts is 'testuser'.
+      expect(firstArg.requestUser).toBe('testuser');
+    });
+
+    it('returns 400 when the schema rejects the URL (no service call)', async () => {
+      const res = await app.request('/api/repositories/clone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // Leading dash gets rejected by the schema before the route handler
+        // body validation -- the service must never be invoked.
+        body: JSON.stringify({ url: '--upload-pack=evil' }),
+      });
+      expect(res.status).toBe(400);
+      expect(repositoryCloneService.enqueueClone).toHaveBeenCalledTimes(0);
+    });
+
+    it('returns 409 when the service throws CloneNameConflictError', async () => {
+      repositoryCloneService.enqueueClone.mockImplementationOnce(() => {
+        throw new CloneNameConflictError(
+          'Target directory already exists: /var/lib/agent-console/source-repos/repo',
+        );
+      });
+
+      const res = await app.request('/api/repositories/clone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: 'https://github.com/org/repo.git' }),
+      });
+
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain('already exists');
+    });
+
+    it('returns 400 when the service throws CloneValidationError', async () => {
+      repositoryCloneService.enqueueClone.mockImplementationOnce(() => {
+        throw new CloneValidationError('Could not derive a directory name from the URL');
+      });
+
+      const res = await app.request('/api/repositories/clone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: 'https://example.com/something' }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain('Could not derive');
+    });
+  });
+
+  // =========================================================================
+  // GET /api/repositories/clone/:jobId (Issue #834)
+  // =========================================================================
+  describe('GET /api/repositories/clone/:jobId', () => {
+    it('returns 404 when the jobId is unknown', async () => {
+      repositoryCloneService.getJob.mockReturnValueOnce(undefined);
+      const res = await app.request('/api/repositories/clone/missing-job');
+      expect(res.status).toBe(404);
+    });
+
+    it('returns the pending/cloning status with no repositoryId or error', async () => {
+      repositoryCloneService.getJob.mockReturnValueOnce({
+        id: 'job-1',
+        status: CLONE_JOB_STATUS.CLONING,
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      const res = await app.request('/api/repositories/clone/job-1');
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.jobId).toBe('job-1');
+      expect(body.status).toBe(CLONE_JOB_STATUS.CLONING);
+      expect(body.repositoryId).toBeUndefined();
+      expect(body.error).toBeUndefined();
+    });
+
+    it('returns repositoryId on succeeded', async () => {
+      repositoryCloneService.getJob.mockReturnValueOnce({
+        id: 'job-2',
+        status: CLONE_JOB_STATUS.SUCCEEDED,
+        repositoryId: 'repo-xyz',
+        createdAt: 1,
+        updatedAt: 3,
+      });
+      const res = await app.request('/api/repositories/clone/job-2');
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.status).toBe(CLONE_JOB_STATUS.SUCCEEDED);
+      expect(body.repositoryId).toBe('repo-xyz');
+    });
+
+    it('returns error code + message on failed', async () => {
+      repositoryCloneService.getJob.mockReturnValueOnce({
+        id: 'job-3',
+        status: CLONE_JOB_STATUS.FAILED,
+        error: {
+          code: CLONE_ERROR_CODES.AUTH_FAILED,
+          message: 'git@github.com: Permission denied (publickey).',
+        },
+        createdAt: 1,
+        updatedAt: 4,
+      });
+      const res = await app.request('/api/repositories/clone/job-3');
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        jobId: string;
+        status: string;
+        error: { code: string; message: string };
+      };
+      expect(body.status).toBe(CLONE_JOB_STATUS.FAILED);
+      expect(body.error.code).toBe(CLONE_ERROR_CODES.AUTH_FAILED);
+      expect(body.error.message).toContain('Permission denied');
     });
   });
 });

--- a/packages/server/src/routes/repositories.ts
+++ b/packages/server/src/routes/repositories.ts
@@ -1,9 +1,12 @@
 import { Hono } from 'hono';
 import type {
   GitHubIssueSummary,
+  CloneRepositoryResponse,
+  CloneJobStatusResponse,
 } from '@agent-console/shared';
 import {
   CreateRepositoryRequestSchema,
+  CloneRepositoryRequestSchema,
   UpdateRepositoryRequestSchema,
   FetchGitHubIssueRequestSchema,
   RepositorySlackIntegrationInputSchema,
@@ -16,6 +19,10 @@ import { getRemoteUrl, parseOrgRepo, fetchAllRemote, getCommitsBehind, getCommit
 import { withRepositoryRemote } from '../lib/repository-remote.js';
 import { createLogger } from '../lib/logger.js';
 import type { AppBindings } from '../app-context.js';
+import {
+  CloneValidationError,
+  CloneNameConflictError,
+} from '../services/repository-clone-service.js';
 
 const logger = createLogger('api:repositories');
 
@@ -44,6 +51,55 @@ const repositories = new Hono<AppBindings>()
       const message = error instanceof Error ? error.message : 'Unknown error';
       throw new ValidationError(message);
     }
+  })
+  // Clone a repository and register it (Issue #834). Returns 202 Accepted with
+  // a jobId; the client polls GET /api/repositories/clone/:jobId for the
+  // final status. The clone runs as the authenticated user via the
+  // privilege-elevation helper (umbrella #837) when AUTH_MODE=multi-user.
+  .post('/clone', vValidator(CloneRepositoryRequestSchema), async (c) => {
+    const body = c.req.valid('json');
+    const { repositoryCloneService } = c.get('appContext');
+    const authUser = c.get('authUser');
+
+    try {
+      const jobId = await repositoryCloneService.enqueueClone({
+        url: body.url,
+        name: body.name,
+        description: body.description,
+        requestUser: authUser.username,
+      });
+      logger.info(
+        { jobId, requestUser: authUser.username },
+        'Clone job enqueued',
+      );
+      const response: CloneRepositoryResponse = { jobId, repositoryId: null };
+      return c.json(response, 202);
+    } catch (error) {
+      if (error instanceof CloneNameConflictError) {
+        throw new ConflictError(error.message);
+      }
+      if (error instanceof CloneValidationError) {
+        throw new ValidationError(error.message);
+      }
+      throw error;
+    }
+  })
+  // Poll the status of a previously-enqueued clone job (Issue #834).
+  // Returns 404 if the jobId is unknown (e.g., expired or never existed).
+  .get('/clone/:jobId', async (c) => {
+    const jobId = c.req.param('jobId');
+    const { repositoryCloneService } = c.get('appContext');
+    const state = repositoryCloneService.getJob(jobId);
+    if (!state) {
+      throw new NotFoundError('Clone job');
+    }
+    const response: CloneJobStatusResponse = {
+      jobId: state.id,
+      status: state.status,
+      ...(state.repositoryId ? { repositoryId: state.repositoryId } : {}),
+      ...(state.error ? { error: state.error } : {}),
+    };
+    return c.json(response);
   })
   // Redirect to repository GitHub URL
   .get('/:id/github', async (c) => {

--- a/packages/server/src/services/__tests__/repository-clone-service.test.ts
+++ b/packages/server/src/services/__tests__/repository-clone-service.test.ts
@@ -1,0 +1,547 @@
+/**
+ * Tests for the clone-and-register repository service (Issue #834).
+ *
+ * Coverage targets:
+ *   - happy-path (mocked runAsUser returns success -> registerRepository called
+ *     -> job state succeeded)
+ *   - URL validation rejection (no spawn invoked)
+ *   - Name validation rejection (no spawn invoked)
+ *   - 409-shape (CloneNameConflictError) when the target dir already exists
+ *     (no spawn invoked)
+ *   - Each classified error code (auth_failed, network_error,
+ *     repo_not_found, permission_denied, timeout, unknown) from a non-zero
+ *     git clone exit
+ *   - Partial-clone cleanup on failure (rm -rf of the target)
+ *   - Single-user vs multi-user spawn arg shape
+ *   - deriveNameFromUrl unit cases (SSH SCP, https with .git, no segment)
+ *   - classifyCloneError boundary cases
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fsPromises from 'node:fs/promises';
+import * as path from 'node:path';
+import type { Repository } from '@agent-console/shared';
+import { CLONE_ERROR_CODES, CLONE_JOB_STATUS } from '@agent-console/shared';
+import {
+  setupMemfs,
+  cleanupMemfs,
+} from '../../__tests__/utils/mock-fs-helper.js';
+import {
+  RepositoryCloneService,
+  CloneValidationError,
+  CloneNameConflictError,
+  deriveNameFromUrl,
+  classifyCloneError,
+  validateCloneInputs,
+} from '../repository-clone-service.js';
+import type {
+  RunAsUserFn,
+  RepositoryRegistrar,
+} from '../repository-clone-service.js';
+import type { RunAsUserOpts, RunAsUserResult } from '../privilege-elevation.js';
+
+/**
+ * Capture-and-respond fake for `runAsUser`. Default response: success
+ * (exitCode 0, empty stdout/stderr). Per-test scenarios can replace the
+ * responder via `responder.fn = ...`.
+ */
+function createRunAsUserMock() {
+  const calls: RunAsUserOpts[] = [];
+  const responder = {
+    fn: async (_opts: RunAsUserOpts): Promise<RunAsUserResult> => ({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+    }),
+  };
+  const runAsUserImpl: RunAsUserFn = ((opts: RunAsUserOpts, _spawn?: unknown) => {
+    calls.push(opts);
+    return responder.fn(opts);
+  }) as RunAsUserFn;
+  return { calls, runAsUserImpl, responder };
+}
+
+function createRegistrarMock() {
+  const calls: { repoPath: string; options?: { description?: string } }[] = [];
+  const responder = {
+    fn: async (repoPath: string, options?: { description?: string }): Promise<Repository> => ({
+      id: 'mock-repo-id',
+      name: path.basename(repoPath),
+      path: repoPath,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      description: options?.description ?? null,
+      defaultAgentId: null,
+    }),
+  };
+  const registrar: RepositoryRegistrar = {
+    registerRepository: async (repoPath, options) => {
+      calls.push({ repoPath, options });
+      return responder.fn(repoPath, options);
+    },
+  };
+  return { calls, registrar, responder };
+}
+
+/**
+ * Wait until the in-memory job state for `jobId` is no longer pending /
+ * cloning, polling every 5ms. The background runner is fire-and-forget, so
+ * tests have to drain to the terminal state explicitly.
+ */
+async function waitForJobTerminal(
+  service: RepositoryCloneService,
+  jobId: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const state = service.getJob(jobId);
+    if (
+      state &&
+      (state.status === CLONE_JOB_STATUS.SUCCEEDED ||
+        state.status === CLONE_JOB_STATUS.FAILED)
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(
+    `Job ${jobId} did not reach terminal state within ${timeoutMs}ms (status=${service.getJob(jobId)?.status})`,
+  );
+}
+
+describe('repository-clone-service', () => {
+  let scratchRoot: string;
+  let sourceReposDir: string;
+  const originalAuthMode = process.env.AUTH_MODE;
+
+  beforeEach(async () => {
+    // The test-utils memfs mock is process-global (test-utils.ts:25 calls
+    // mock.module('fs') for the whole suite). Use memfs paths instead of
+    // os.tmpdir() so the lstat conflict check + fsPromises.rm cleanup
+    // exercise the (mocked) memfs volume rather than failing on the empty
+    // real /tmp shadow.
+    scratchRoot = `/test/clone-service-${Math.random().toString(36).slice(2)}`;
+    sourceReposDir = path.join(scratchRoot, 'source-repos');
+    setupMemfs({
+      [`${sourceReposDir}/.keep`]: '',
+    });
+    delete process.env.AUTH_MODE;
+  });
+
+  afterEach(async () => {
+    if (originalAuthMode === undefined) {
+      delete process.env.AUTH_MODE;
+    } else {
+      process.env.AUTH_MODE = originalAuthMode;
+    }
+    cleanupMemfs();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Pure unit cases
+  // ---------------------------------------------------------------------------
+
+  describe('deriveNameFromUrl', () => {
+    it('strips .git from an https URL', () => {
+      expect(deriveNameFromUrl('https://github.com/org/repo.git')).toBe('repo');
+    });
+    it('strips .git from an ssh SCP shortcut', () => {
+      expect(deriveNameFromUrl('git@github.com:org/repo.git')).toBe('repo');
+    });
+    it('handles an ssh URL without .git', () => {
+      expect(deriveNameFromUrl('ssh://git@host/org/repo')).toBe('repo');
+    });
+    it('returns null for a URL with no extractable basename', () => {
+      // Edge case: empty path component after the last slash.
+      expect(deriveNameFromUrl('https://example.com/')).toBe(null);
+    });
+  });
+
+  describe('classifyCloneError', () => {
+    it('returns timeout when timedOut=true regardless of exit code', () => {
+      expect(classifyCloneError('whatever', 137, true)).toBe(CLONE_ERROR_CODES.TIMEOUT);
+    });
+    it('classifies Permission denied (publickey) as auth_failed (not permission_denied)', () => {
+      expect(
+        classifyCloneError('git@github.com: Permission denied (publickey).\nfatal: ...', 128, false),
+      ).toBe(CLONE_ERROR_CODES.AUTH_FAILED);
+    });
+    it('classifies Repository not found as repo_not_found', () => {
+      expect(
+        classifyCloneError('remote: Repository not found.\nfatal: could not read', 128, false),
+      ).toBe(CLONE_ERROR_CODES.REPO_NOT_FOUND);
+    });
+    it('classifies "Could not resolve host" as network_error', () => {
+      expect(
+        classifyCloneError('fatal: unable to access ... : Could not resolve host: github.com', 128, false),
+      ).toBe(CLONE_ERROR_CODES.NETWORK_ERROR);
+    });
+    it('classifies bare permission denied as permission_denied', () => {
+      expect(
+        classifyCloneError("fatal: could not create work tree dir 'x': Permission denied", 128, false),
+      ).toBe(CLONE_ERROR_CODES.PERMISSION_DENIED);
+    });
+    it('returns unknown for opaque stderr', () => {
+      expect(classifyCloneError('fatal: weird new git failure', 128, false)).toBe(
+        CLONE_ERROR_CODES.UNKNOWN,
+      );
+    });
+  });
+
+  describe('validateCloneInputs', () => {
+    it('accepts a valid pair', () => {
+      expect(() =>
+        validateCloneInputs('https://github.com/org/repo.git', 'repo'),
+      ).not.toThrow();
+    });
+    it('rejects a URL starting with a dash (argv-injection guard)', () => {
+      expect(() => validateCloneInputs('--upload-pack=evil', 'name')).toThrow(
+        CloneValidationError,
+      );
+    });
+    it('rejects a name starting with a dash', () => {
+      expect(() => validateCloneInputs('https://github.com/o/r.git', '-rf')).toThrow(
+        CloneValidationError,
+      );
+    });
+    it('rejects `..` in name', () => {
+      expect(() => validateCloneInputs('https://github.com/o/r.git', '..')).toThrow(
+        CloneValidationError,
+      );
+    });
+    it('rejects `/` in name', () => {
+      expect(() => validateCloneInputs('https://github.com/o/r.git', 'a/b')).toThrow(
+        CloneValidationError,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Service-level cases
+  // ---------------------------------------------------------------------------
+
+  describe('enqueueClone -- happy path', () => {
+    it('runs git clone then registers, transitioning to succeeded', async () => {
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      const jobId = await service.enqueueClone({
+        url: 'https://github.com/org/repo.git',
+        description: 'a tested repo',
+        requestUser: null,
+      });
+
+      await waitForJobTerminal(service, jobId);
+
+      const state = service.getJob(jobId);
+      expect(state?.status).toBe(CLONE_JOB_STATUS.SUCCEEDED);
+      expect(state?.repositoryId).toBe('mock-repo-id');
+      expect(state?.error).toBeUndefined();
+
+      // Spawn invocation:
+      expect(runAs.calls).toHaveLength(1);
+      const call = runAs.calls[0];
+      expect(call.command).toContain('git clone --config core.sharedRepository=group');
+      expect(call.command).toContain("'https://github.com/org/repo.git'");
+      expect(call.command).toContain(path.join(sourceReposDir, 'repo'));
+      expect(call.cwd).toBe(sourceReposDir);
+      expect(call.username).toBe(null);
+      expect(call.preserveEnv).toEqual([
+        'FORCE_COLOR',
+        'SSH_AUTH_SOCK',
+        'SSH_AGENT_PID',
+        'GIT_ASKPASS',
+      ]);
+
+      // Registration invocation:
+      expect(registrar.calls).toHaveLength(1);
+      expect(registrar.calls[0].repoPath).toBe(path.join(sourceReposDir, 'repo'));
+      expect(registrar.calls[0].options?.description).toBe('a tested repo');
+    });
+
+    it('respects an explicit name override', async () => {
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      const jobId = await service.enqueueClone({
+        url: 'https://github.com/org/repo.git',
+        name: 'my-clone',
+        requestUser: null,
+      });
+      await waitForJobTerminal(service, jobId);
+
+      const expectedTarget = path.join(sourceReposDir, 'my-clone');
+      expect(runAs.calls[0].command).toContain(expectedTarget);
+      expect(registrar.calls[0].repoPath).toBe(expectedTarget);
+    });
+  });
+
+  describe('enqueueClone -- validation rejections (no spawn)', () => {
+    it('rejects a URL that starts with a dash (no spawn)', async () => {
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      await expect(
+        service.enqueueClone({
+          url: '--upload-pack=evil',
+          requestUser: null,
+        }),
+      ).rejects.toBeInstanceOf(CloneValidationError);
+      expect(runAs.calls).toHaveLength(0);
+      expect(registrar.calls).toHaveLength(0);
+    });
+
+    it('rejects a `..` in an explicit name (no spawn)', async () => {
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      await expect(
+        service.enqueueClone({
+          url: 'https://github.com/org/repo.git',
+          name: '..',
+          requestUser: null,
+        }),
+      ).rejects.toBeInstanceOf(CloneValidationError);
+      expect(runAs.calls).toHaveLength(0);
+    });
+
+    it('rejects a name that fails the regex (no spawn)', async () => {
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      await expect(
+        service.enqueueClone({
+          url: 'https://github.com/org/repo.git',
+          name: 'has space',
+          requestUser: null,
+        }),
+      ).rejects.toBeInstanceOf(CloneValidationError);
+      expect(runAs.calls).toHaveLength(0);
+    });
+  });
+
+  describe('enqueueClone -- name conflict (no spawn)', () => {
+    it('throws CloneNameConflictError when the target dir already exists', async () => {
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      // Pre-create the target dir.
+      await fsPromises.mkdir(path.join(sourceReposDir, 'repo'), { recursive: true });
+
+      await expect(
+        service.enqueueClone({
+          url: 'https://github.com/org/repo.git',
+          requestUser: null,
+        }),
+      ).rejects.toBeInstanceOf(CloneNameConflictError);
+      expect(runAs.calls).toHaveLength(0);
+      expect(registrar.calls).toHaveLength(0);
+    });
+  });
+
+  describe('enqueueClone -- multi-user spawn arg shape', () => {
+    it('threads requestUser through to runAsUser when AUTH_MODE=multi-user', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      const jobId = await service.enqueueClone({
+        url: 'https://github.com/org/repo.git',
+        requestUser: 'alice',
+      });
+      await waitForJobTerminal(service, jobId);
+
+      // The service does not itself decide whether to elevate; that is the
+      // runAsUser helper's job (covered by its own tests). What this service
+      // owes is correct argument propagation:
+      expect(runAs.calls).toHaveLength(1);
+      expect(runAs.calls[0].username).toBe('alice');
+      expect(runAs.calls[0].command).toContain('git clone --config core.sharedRepository=group');
+    });
+  });
+
+  describe('enqueueClone -- classified failure modes', () => {
+    type Case = { name: string; stderr: string; expected: typeof CLONE_ERROR_CODES[keyof typeof CLONE_ERROR_CODES] };
+    const cases: Case[] = [
+      { name: 'auth_failed (publickey)', stderr: 'git@github.com: Permission denied (publickey).', expected: CLONE_ERROR_CODES.AUTH_FAILED },
+      { name: 'repo_not_found', stderr: 'remote: Repository not found.', expected: CLONE_ERROR_CODES.REPO_NOT_FOUND },
+      { name: 'network_error', stderr: 'fatal: unable to access ... : Could not resolve host: x', expected: CLONE_ERROR_CODES.NETWORK_ERROR },
+      { name: 'permission_denied', stderr: "fatal: could not create work tree dir 'x': Permission denied", expected: CLONE_ERROR_CODES.PERMISSION_DENIED },
+      { name: 'unknown', stderr: 'fatal: brand-new git failure shape', expected: CLONE_ERROR_CODES.UNKNOWN },
+    ];
+
+    for (const c of cases) {
+      it(`maps "${c.name}" stderr to ${c.expected}`, async () => {
+        const runAs = createRunAsUserMock();
+        runAs.responder.fn = async () => ({
+          stdout: '',
+          stderr: c.stderr,
+          exitCode: 128,
+          timedOut: false,
+        });
+        const registrar = createRegistrarMock();
+        const service = new RepositoryCloneService({
+          sourceReposDir,
+          registrar: registrar.registrar,
+          runAsUserImpl: runAs.runAsUserImpl,
+        });
+
+        const jobId = await service.enqueueClone({
+          url: 'https://github.com/org/repo.git',
+          requestUser: null,
+        });
+        await waitForJobTerminal(service, jobId);
+
+        const state = service.getJob(jobId);
+        expect(state?.status).toBe(CLONE_JOB_STATUS.FAILED);
+        expect(state?.error?.code).toBe(c.expected);
+        expect(state?.error?.message.length).toBeGreaterThan(0);
+        // The registrar must NOT have been called on failure.
+        expect(registrar.calls).toHaveLength(0);
+      });
+    }
+
+    it('maps timeout to TIMEOUT regardless of exit code', async () => {
+      const runAs = createRunAsUserMock();
+      runAs.responder.fn = async () => ({
+        stdout: '',
+        stderr: 'killed',
+        exitCode: 137,
+        timedOut: true,
+      });
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+        cloneTimeoutMs: 5000,
+      });
+
+      const jobId = await service.enqueueClone({
+        url: 'https://github.com/org/repo.git',
+        requestUser: null,
+      });
+      await waitForJobTerminal(service, jobId);
+
+      const state = service.getJob(jobId);
+      expect(state?.status).toBe(CLONE_JOB_STATUS.FAILED);
+      expect(state?.error?.code).toBe(CLONE_ERROR_CODES.TIMEOUT);
+      expect(state?.error?.message).toContain('timed out');
+    });
+  });
+
+  describe('partial-clone cleanup on failure', () => {
+    it('rms the target dir after a clone failure so retry is safe', async () => {
+      const targetDir = path.join(sourceReposDir, 'repo');
+      const runAs = createRunAsUserMock();
+      // Simulate a partial clone: the responder creates the target dir on
+      // disk before reporting failure, mirroring what real git does when it
+      // fails mid-stream.
+      runAs.responder.fn = async () => {
+        await fsPromises.mkdir(targetDir, { recursive: true });
+        await fsPromises.writeFile(path.join(targetDir, 'partial-marker'), 'x');
+        return { stdout: '', stderr: 'fatal: weird mid-clone failure', exitCode: 128, timedOut: false };
+      };
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      const jobId = await service.enqueueClone({
+        url: 'https://github.com/org/repo.git',
+        requestUser: null,
+      });
+      await waitForJobTerminal(service, jobId);
+
+      const state = service.getJob(jobId);
+      expect(state?.status).toBe(CLONE_JOB_STATUS.FAILED);
+      // The cleanup MUST have rm'd the partial dir.
+      await expect(fsPromises.lstat(targetDir)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
+
+  describe('registration failure after successful clone', () => {
+    it('marks the job failed but leaves the cloned directory on disk', async () => {
+      const targetDir = path.join(sourceReposDir, 'repo');
+      const runAs = createRunAsUserMock();
+      runAs.responder.fn = async () => {
+        await fsPromises.mkdir(targetDir, { recursive: true });
+        return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+      };
+      const registrar = createRegistrarMock();
+      registrar.responder.fn = async () => {
+        throw new Error('Repository already registered');
+      };
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      const jobId = await service.enqueueClone({
+        url: 'https://github.com/org/repo.git',
+        requestUser: null,
+      });
+      await waitForJobTerminal(service, jobId);
+
+      const state = service.getJob(jobId);
+      expect(state?.status).toBe(CLONE_JOB_STATUS.FAILED);
+      expect(state?.error?.code).toBe(CLONE_ERROR_CODES.UNKNOWN);
+      expect(state?.error?.message).toContain('Registration failed');
+      // The dir from the successful clone is preserved (deliberate per
+      // service design -- registration failure is not a clone failure).
+      const stat = await fsPromises.lstat(targetDir);
+      expect(stat.isDirectory()).toBe(true);
+    });
+  });
+
+  describe('getJob', () => {
+    it('returns undefined for an unknown jobId', () => {
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+      expect(service.getJob('does-not-exist')).toBeUndefined();
+    });
+  });
+});

--- a/packages/server/src/services/__tests__/repository-clone-service.test.ts
+++ b/packages/server/src/services/__tests__/repository-clone-service.test.ts
@@ -544,4 +544,211 @@ describe('repository-clone-service', () => {
       expect(service.getJob('does-not-exist')).toBeUndefined();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // CodeRabbit follow-up: atomic target reservation + terminal-job TTL eviction
+  // ---------------------------------------------------------------------------
+
+  describe('atomic target reservation (TOCTOU guard)', () => {
+    it('two concurrent enqueueClone calls for the same name -- exactly one wins', async () => {
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      // Hold the clone open so the first job is still in `cloning` when the
+      // second enqueue races -- this is the real-world race window the
+      // CodeRabbit reviewer was concerned about.
+      runAs.responder.fn = () => new Promise(() => {}); // never resolves
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      const both = await Promise.allSettled([
+        service.enqueueClone({
+          url: 'https://github.com/org/repo.git',
+          requestUser: null,
+        }),
+        service.enqueueClone({
+          url: 'https://github.com/org/repo.git',
+          requestUser: null,
+        }),
+      ]);
+
+      const fulfilled = both.filter((r) => r.status === 'fulfilled');
+      const rejected = both.filter((r) => r.status === 'rejected');
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+        CloneNameConflictError,
+      );
+      service.dispose();
+    });
+
+    it('after a failed clone the target dir is freed for re-enqueue', async () => {
+      const runAs = createRunAsUserMock();
+      runAs.responder.fn = async () => ({
+        stdout: '',
+        stderr: 'fatal: not found',
+        exitCode: 128,
+        timedOut: false,
+      });
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      const id1 = await service.enqueueClone({
+        url: 'https://github.com/org/repo.git',
+        requestUser: null,
+      });
+      await waitForJobTerminal(service, id1);
+      expect(service.getJob(id1)?.status).toBe(CLONE_JOB_STATUS.FAILED);
+
+      // Now the partial-clone cleanup should have removed the reservation;
+      // a second enqueue must succeed without 409.
+      const id2 = await service.enqueueClone({
+        url: 'https://github.com/org/repo.git',
+        requestUser: null,
+      });
+      expect(id2).not.toBe(id1);
+      service.dispose();
+    });
+  });
+
+  describe('terminal-job TTL eviction', () => {
+    it('evicts a succeeded job from the in-memory map after the TTL fires', async () => {
+      // Capture the eviction callback so the test can fire it on demand.
+      const scheduled: { cb: () => void; delayMs: number }[] = [];
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+        terminalJobTtlMs: 5_000,
+        scheduleEviction: (cb, delayMs) => {
+          scheduled.push({ cb, delayMs });
+          return { cancel: () => {} };
+        },
+      });
+
+      const id = await service.enqueueClone({
+        url: 'https://github.com/org/repo.git',
+        requestUser: null,
+      });
+      await waitForJobTerminal(service, id);
+
+      // Job is still in the map -- TTL has not elapsed.
+      expect(service.getJob(id)?.status).toBe(CLONE_JOB_STATUS.SUCCEEDED);
+      expect(scheduled).toHaveLength(1);
+      expect(scheduled[0].delayMs).toBe(5_000);
+
+      // Fire the eviction. The job should be removed.
+      scheduled[0].cb();
+      expect(service.getJob(id)).toBeUndefined();
+      service.dispose();
+    });
+
+    it('evicts a failed job from the in-memory map after the TTL fires', async () => {
+      const scheduled: { cb: () => void; delayMs: number }[] = [];
+      const runAs = createRunAsUserMock();
+      runAs.responder.fn = async () => ({
+        stdout: '',
+        stderr: 'fatal: weird new failure',
+        exitCode: 128,
+        timedOut: false,
+      });
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+        terminalJobTtlMs: 1_000,
+        scheduleEviction: (cb, delayMs) => {
+          scheduled.push({ cb, delayMs });
+          return { cancel: () => {} };
+        },
+      });
+
+      const id = await service.enqueueClone({
+        url: 'https://github.com/org/repo.git',
+        requestUser: null,
+      });
+      await waitForJobTerminal(service, id);
+      expect(service.getJob(id)?.status).toBe(CLONE_JOB_STATUS.FAILED);
+      expect(scheduled).toHaveLength(1);
+      scheduled[0].cb();
+      expect(service.getJob(id)).toBeUndefined();
+      service.dispose();
+    });
+
+    it('does not schedule eviction for pending / cloning jobs', async () => {
+      const scheduled: { cb: () => void; delayMs: number }[] = [];
+      const runAs = createRunAsUserMock();
+      // Never resolves -- keep the job in CLONING.
+      runAs.responder.fn = () => new Promise(() => {});
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+        scheduleEviction: (cb, delayMs) => {
+          scheduled.push({ cb, delayMs });
+          return { cancel: () => {} };
+        },
+      });
+
+      const id = await service.enqueueClone({
+        url: 'https://github.com/org/repo.git',
+        requestUser: null,
+      });
+      // Wait a tick to let the cloning transition happen.
+      await new Promise((r) => setTimeout(r, 10));
+      expect(service.getJob(id)?.status).toBe(CLONE_JOB_STATUS.CLONING);
+      expect(scheduled).toHaveLength(0);
+      service.dispose();
+    });
+  });
+
+  describe('URL re-validation (defense-in-depth)', () => {
+    it('rejects http:// at the service layer (mirror of schema tightening)', async () => {
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      await expect(
+        service.enqueueClone({
+          url: 'http://example.com/org/repo.git',
+          requestUser: null,
+        }),
+      ).rejects.toBeInstanceOf(CloneValidationError);
+      expect(runAs.calls).toHaveLength(0);
+      service.dispose();
+    });
+
+    it('rejects a URL with embedded shell metacharacters', async () => {
+      const runAs = createRunAsUserMock();
+      const registrar = createRegistrarMock();
+      const service = new RepositoryCloneService({
+        sourceReposDir,
+        registrar: registrar.registrar,
+        runAsUserImpl: runAs.runAsUserImpl,
+      });
+
+      await expect(
+        service.enqueueClone({
+          url: 'https://example.com/repo;touch%20x',
+          requestUser: null,
+        }),
+      ).rejects.toBeInstanceOf(CloneValidationError);
+      expect(runAs.calls).toHaveLength(0);
+      service.dispose();
+    });
+  });
 });

--- a/packages/server/src/services/repository-clone-service.ts
+++ b/packages/server/src/services/repository-clone-service.ts
@@ -46,6 +46,15 @@ const logger = createLogger('service:repository-clone');
 const DEFAULT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 
 /**
+ * How long to keep a terminal (succeeded / failed) job's state in memory
+ * before evicting it. Long enough to let a polling client observe the
+ * terminal state at least a few times; short enough that a long-lived server
+ * + many invalid clone attempts cannot grow the map unbounded. Per CodeRabbit
+ * review on PR #862.
+ */
+const TERMINAL_JOB_TTL_MS = 10 * 60 * 1000;
+
+/**
  * Accepted clone URL shapes -- mirror of the shared schema regex so the
  * service stays a self-contained validation boundary when called outside the
  * route handler (e.g., a future MCP tool). Keep in sync with the
@@ -54,7 +63,20 @@ const DEFAULT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
  * @internal Exported for testing.
  */
 export const CLONE_URL_PATTERN =
-  /^(?:https?:\/\/|git:\/\/|ssh:\/\/[^\s]+|[A-Za-z0-9_][A-Za-z0-9._-]*@[A-Za-z0-9._-]+:[^\s]+)\S*$/;
+  /^(?:https:\/\/|git:\/\/|ssh:\/\/[^\s]+|[A-Za-z0-9_][A-Za-z0-9._-]*@[A-Za-z0-9._-]+:[^\s]+)\S*$/;
+
+/**
+ * Characters that must never appear in a clone URL accepted by this service.
+ * Mirrors `cloneUrlDisallowedPattern` in
+ * `packages/shared/src/schemas/repository.ts`. Covers POSIX shell
+ * metacharacters, both quote shapes, the backslash escape, parentheses /
+ * brackets / braces, C0/C1 control characters (0x00-0x1F + 0x7F), and any
+ * whitespace.
+ *
+ * @internal Exported for testing.
+ */
+// eslint-disable-next-line no-control-regex
+export const URL_DISALLOWED_PATTERN = /[\s\x00-\x1F\x7F;&|`$<>()[\]{}'"\\]/;
 
 /**
  * Accepted repository name shape. Keep in sync with `repoNamePattern` in
@@ -133,6 +155,22 @@ export interface CloneServiceOptions {
   runAsUserImpl?: RunAsUserFn;
   /** Override per-clone timeout. Defaults to {@link DEFAULT_CLONE_TIMEOUT_MS}. */
   cloneTimeoutMs?: number;
+  /**
+   * Override the terminal-job TTL (ms) used by the eviction sweeper.
+   * Defaults to {@link TERMINAL_JOB_TTL_MS}. Tests can lower this so the
+   * eviction observable in a single test tick.
+   */
+  terminalJobTtlMs?: number;
+  /**
+   * Override the scheduler used to evict terminal jobs after their TTL.
+   * Defaults to `setTimeout` / `clearTimeout`. Tests can substitute a
+   * deterministic queue. Returns a cancel handle so the service can short-
+   * circuit a pending eviction (e.g., when the job is observed by a poller).
+   */
+  scheduleEviction?: (
+    cb: () => void,
+    delayMs: number,
+  ) => { cancel: () => void };
 }
 
 /**
@@ -263,7 +301,12 @@ export function classifyCloneError(
 export function validateCloneInputs(url: string, name: string): void {
   if (!CLONE_URL_PATTERN.test(url)) {
     throw new CloneValidationError(
-      'URL must be https://, http://, git://, ssh://, or git@host:org/repo (no shell metacharacters or leading dashes)',
+      'URL must be https://, git://, ssh://, or git@host:org/repo (http:// rejected; no leading dashes)',
+    );
+  }
+  if (URL_DISALLOWED_PATTERN.test(url)) {
+    throw new CloneValidationError(
+      'URL contains a disallowed character (whitespace, shell metacharacters, control characters, quotes, or backslash)',
     );
   }
   if (!REPO_NAME_PATTERN.test(name)) {
@@ -291,13 +334,36 @@ export class RepositoryCloneService {
   private readonly registrar: RepositoryRegistrar;
   private readonly runAsUser: RunAsUserFn;
   private readonly cloneTimeoutMs: number;
+  private readonly terminalJobTtlMs: number;
   private readonly jobs = new Map<string, CloneJobState>();
+  /**
+   * Pending eviction timers for terminal jobs, keyed by jobId. Tracked so
+   * tests / shutdown can clear them and a manual `evictTerminalJobs()` call
+   * can short-circuit them.
+   */
+  private readonly evictTimers = new Map<string, { cancel: () => void }>();
+  /**
+   * Sleep-then-evict shim. Defaults to `setTimeout` / `clearTimeout` from
+   * the host runtime; tests can substitute deterministic timers via
+   * `CloneServiceOptions.scheduleEviction`.
+   */
+  private readonly scheduleEviction: (
+    cb: () => void,
+    delayMs: number,
+  ) => { cancel: () => void };
 
   constructor(options: CloneServiceOptions) {
     this.sourceReposDir = options.sourceReposDir;
     this.registrar = options.registrar;
     this.runAsUser = options.runAsUserImpl ?? defaultRunAsUser;
     this.cloneTimeoutMs = options.cloneTimeoutMs ?? DEFAULT_CLONE_TIMEOUT_MS;
+    this.terminalJobTtlMs = options.terminalJobTtlMs ?? TERMINAL_JOB_TTL_MS;
+    this.scheduleEviction =
+      options.scheduleEviction ??
+      ((cb, delayMs) => {
+        const handle = setTimeout(cb, delayMs);
+        return { cancel: () => clearTimeout(handle) };
+      });
   }
 
   /**
@@ -308,6 +374,15 @@ export class RepositoryCloneService {
    * Pre-flight failures (`CloneValidationError`, `CloneNameConflictError`)
    * are THROWN, not surfaced as a failed job, so the route can map them to
    * `400` / `409` synchronously.
+   *
+   * Race safety -- the target directory is reserved atomically via
+   * `fsPromises.mkdir(targetDir, { recursive: false })`. POSIX `mkdir(2)`
+   * guarantees that exactly one of N concurrent same-target requests
+   * succeeds; the rest receive `EEXIST` and are surfaced as
+   * `CloneNameConflictError`. This closes the TOCTOU window CodeRabbit
+   * flagged on PR #862 against the prior lstat-only check. The reservation
+   * lives until the job's terminal-state cleanup (success: leave the dir
+   * alone; failure: rm the dir so the name is reusable).
    */
   async enqueueClone(request: CloneRepositoryRequest): Promise<string> {
     const url = request.url.trim();
@@ -324,31 +399,36 @@ export class RepositoryCloneService {
 
     const targetDir = path.join(this.sourceReposDir, derived);
 
-    // Pre-flight conflict check. Using lstat so a dangling symlink at the
-    // target also counts as conflict (do not silently re-purpose).
-    try {
-      await fsPromises.lstat(targetDir);
-      throw new CloneNameConflictError(
-        `Target directory already exists: ${targetDir}`,
-      );
-    } catch (err: unknown) {
-      if (err instanceof CloneNameConflictError) throw err;
-      // `ENOENT` is the happy path -- the directory should not exist yet.
-      if (!isEnoent(err)) {
-        // Other lstat errors (EACCES on parent, etc.) are not a conflict but
-        // they ARE a pre-spawn failure. Treat as validation failure so the
-        // route returns 400 with a precise message rather than 500.
-        throw new CloneValidationError(
-          `Could not check target directory: ${errorMessage(err)}`,
-        );
-      }
-    }
-
-    // Ensure parent exists before spawning. The bootstrap script creates
+    // Ensure parent exists before reserving. The bootstrap script creates
     // `${DATA_ROOT}/source-repos` with the right ownership; this is a safety
     // net for development environments / single-user installs where the
     // operator may not have run the bootstrap.
-    await fsPromises.mkdir(this.sourceReposDir, { recursive: true });
+    try {
+      await fsPromises.mkdir(this.sourceReposDir, { recursive: true });
+    } catch (err: unknown) {
+      throw new CloneValidationError(
+        `Could not prepare source-repos directory: ${errorMessage(err)}`,
+      );
+    }
+
+    // Atomic target reservation -- replaces the previous lstat conflict check
+    // (TOCTOU-vulnerable). `mkdir` without `recursive` fails with `EEXIST`
+    // when the target already exists, so we cannot accidentally re-purpose
+    // an operator-cloned tree. `git clone` happily clones INTO a pre-
+    // existing empty directory, so this reservation is compatible with the
+    // subsequent `runAsUser` clone step.
+    try {
+      await fsPromises.mkdir(targetDir);
+    } catch (err: unknown) {
+      if (isEexist(err)) {
+        throw new CloneNameConflictError(
+          `Target directory already exists: ${targetDir}`,
+        );
+      }
+      throw new CloneValidationError(
+        `Could not reserve target directory: ${errorMessage(err)}`,
+      );
+    }
 
     const jobId = randomUUID();
     const now = Date.now();
@@ -406,7 +486,7 @@ export class RepositoryCloneService {
       `git clone --config core.sharedRepository=group ` +
       `${shellEscape(url)} ${shellEscape(targetDir)}`;
 
-    let result;
+    let result: Awaited<ReturnType<RunAsUserFn>>;
     try {
       result = await this.runAsUser({
         username: request.requestUser,
@@ -474,9 +554,11 @@ export class RepositoryCloneService {
   }
 
   /**
-   * Best-effort `rm -rf <targetDir>` so a future retry can re-use the name.
-   * Failures here are logged but do not change the job's final status -- the
-   * underlying failure code is already the primary signal.
+   * Release the atomically-reserved target directory + any partial clone
+   * git left behind. Only called on failure: a successful clone leaves the
+   * directory in place because it now holds the registered repo. Safe to
+   * call even when the directory was only the empty reservation -- `rm`
+   * with `recursive: true` covers both shapes.
    */
   private async cleanupPartialClone(targetDir: string, jobId: string): Promise<void> {
     try {
@@ -484,7 +566,7 @@ export class RepositoryCloneService {
     } catch (err) {
       logger.warn(
         { err, targetDir, jobId },
-        'partial-clone cleanup failed; operator may need to rm -rf manually',
+        'partial-clone cleanup failed; operator may need to remove the directory manually',
       );
     }
   }
@@ -492,20 +574,52 @@ export class RepositoryCloneService {
   private transition(state: CloneJobState, status: CloneJobStatus): void {
     state.status = status;
     state.updatedAt = Date.now();
+    if (status === CLONE_JOB_STATUS.SUCCEEDED || status === CLONE_JOB_STATUS.FAILED) {
+      this.scheduleTerminalEviction(state.id);
+    }
   }
 
   private fail(state: CloneJobState, code: CloneErrorCode, message: string): void {
     state.error = { code, message };
     this.transition(state, CLONE_JOB_STATUS.FAILED);
   }
+
+  /**
+   * Schedule eviction of a terminal job from the in-memory map after the
+   * configured TTL. Replaces any prior timer for the same job. Per
+   * CodeRabbit review on PR #862 (unbounded-growth guard).
+   */
+  private scheduleTerminalEviction(jobId: string): void {
+    const existing = this.evictTimers.get(jobId);
+    if (existing) {
+      existing.cancel();
+    }
+    const handle = this.scheduleEviction(() => {
+      this.jobs.delete(jobId);
+      this.evictTimers.delete(jobId);
+      logger.debug({ jobId }, 'evicted terminal clone job from in-memory map');
+    }, this.terminalJobTtlMs);
+    this.evictTimers.set(jobId, handle);
+  }
+
+  /**
+   * Cancel all pending eviction timers. Used by tests + by the test app
+   * context teardown so timers do not leak across cases.
+   */
+  dispose(): void {
+    for (const handle of this.evictTimers.values()) {
+      handle.cancel();
+    }
+    this.evictTimers.clear();
+  }
 }
 
-function isEnoent(err: unknown): boolean {
+function isEexist(err: unknown): boolean {
   return (
     typeof err === 'object' &&
     err !== null &&
     'code' in err &&
-    (err as { code?: unknown }).code === 'ENOENT'
+    (err as { code?: unknown }).code === 'EEXIST'
   );
 }
 

--- a/packages/server/src/services/repository-clone-service.ts
+++ b/packages/server/src/services/repository-clone-service.ts
@@ -1,0 +1,515 @@
+/**
+ * Clone-and-register repository service (Issue #834).
+ *
+ * Performs `git clone` via `runAsUser` (so multi-user mode clones as the
+ * requesting OS user with that user's SSH agent / git credential helpers
+ * inherited), then registers the resulting path via `RepositoryManager`.
+ * Returns a job handle so the route handler can respond `202 Accepted`
+ * immediately while the clone runs in the background; the client polls
+ * `GET /api/repositories/clone/:jobId` for the final status.
+ *
+ * Design choice -- in-memory job state (not the SQLite-backed JobQueue):
+ *
+ * - The existing `JobQueue` provides guaranteed delivery with exponential-
+ *   backoff retry; that contract is wrong for clone operations because
+ *   common failure modes (auth_failed, repo_not_found, name_conflict,
+ *   permission_denied) will never succeed on retry without operator
+ *   intervention, and a retry that re-runs the partial-clone cleanup on a
+ *   fresh attempt risks deleting a target the operator manually fixed.
+ * - Clone jobs are short-lived (seconds to minutes); losing in-flight state
+ *   across a server restart is acceptable -- the user simply retries from
+ *   the UI. The partial-clone target directory is cleaned up at the time of
+ *   failure (see `cleanupPartialClone`) so a restart does not leak it
+ *   either.
+ *
+ * Server-side defense-in-depth: even though the route uses the shared
+ * `CloneRepositoryRequestSchema` for input validation, this service
+ * re-validates the URL and name with the same rules before any subprocess
+ * spawn. The schema is the primary boundary; the re-validation guards
+ * against future internal callers (e.g., MCP) that might bypass the route.
+ */
+import * as path from 'node:path';
+import * as fsPromises from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import type { Repository, CloneErrorCode, CloneJobStatus } from '@agent-console/shared';
+import { CLONE_ERROR_CODES, CLONE_JOB_STATUS } from '@agent-console/shared';
+import { runAsUser as defaultRunAsUser, shellEscape } from './privilege-elevation.js';
+import { createLogger } from '../lib/logger.js';
+
+const logger = createLogger('service:repository-clone');
+
+/**
+ * Default clone timeout. Generous enough for a large repo over a slow link;
+ * shorter than typical reverse-proxy idle limits would matter for, since the
+ * clone runs out-of-band of the HTTP request that started it.
+ */
+const DEFAULT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Accepted clone URL shapes -- mirror of the shared schema regex so the
+ * service stays a self-contained validation boundary when called outside the
+ * route handler (e.g., a future MCP tool). Keep in sync with the
+ * `CloneRepositoryRequestSchema` in `packages/shared/src/schemas/repository.ts`.
+ *
+ * @internal Exported for testing.
+ */
+export const CLONE_URL_PATTERN =
+  /^(?:https?:\/\/|git:\/\/|ssh:\/\/[^\s]+|[A-Za-z0-9_][A-Za-z0-9._-]*@[A-Za-z0-9._-]+:[^\s]+)\S*$/;
+
+/**
+ * Accepted repository name shape. Keep in sync with `repoNamePattern` in
+ * `packages/shared/src/schemas/repository.ts`.
+ * @internal Exported for testing.
+ */
+export const REPO_NAME_PATTERN = /^[A-Za-z0-9_.][A-Za-z0-9._-]{0,99}$/;
+
+/**
+ * Minimal `RepositoryManager` surface the clone service needs. Narrowing the
+ * dep here keeps the test mock small and prevents accidental coupling to
+ * unrelated manager methods.
+ */
+export interface RepositoryRegistrar {
+  registerRepository(
+    repoPath: string,
+    options?: { description?: string },
+  ): Promise<Repository>;
+}
+
+/**
+ * The privilege-elevation helper signature this service calls. Mirrors
+ * `RunAsUserFn` in `repository-manager.ts`; redeclared here to avoid coupling
+ * the service to the manager module.
+ */
+export type RunAsUserFn = typeof defaultRunAsUser;
+
+/**
+ * Request shape for `enqueueClone`. Mirrors the schema-validated body of
+ * `POST /api/repositories/clone` plus the threaded auth context.
+ */
+export interface CloneRepositoryRequest {
+  url: string;
+  /** When omitted, derived from the URL's last path segment minus `.git`. */
+  name?: string;
+  description?: string;
+  /**
+   * OS username threaded from `authUser.username`. `null` (single-user mode,
+   * or any path that has no authenticated user context) skips elevation; the
+   * clone runs as the server process user.
+   */
+  requestUser: string | null;
+}
+
+export interface CloneJobError {
+  code: CloneErrorCode;
+  message: string;
+}
+
+/**
+ * Internal job state retained in memory between enqueue and final polling.
+ * The shape mirrors the `CloneJobStatusResponse` returned by the GET route
+ * but additionally retains internal `repositoryId` / `error` fields so the
+ * route handler can construct the public response without duplicating the
+ * status -> field mapping.
+ */
+export interface CloneJobState {
+  id: string;
+  status: CloneJobStatus;
+  /** Populated when `status === 'succeeded'`. */
+  repositoryId?: string;
+  /** Populated when `status === 'failed'`. */
+  error?: CloneJobError;
+  /** When the job entered the queue. */
+  createdAt: number;
+  /** When the job last transitioned (for diagnostics / TTL). */
+  updatedAt: number;
+}
+
+export interface CloneServiceOptions {
+  /** Absolute path to the parent directory under which clones land. */
+  sourceReposDir: string;
+  /** Repository registrar (typically `repositoryManager`). */
+  registrar: RepositoryRegistrar;
+  /** Privilege-elevation helper. Override in tests with a captured stub. */
+  runAsUserImpl?: RunAsUserFn;
+  /** Override per-clone timeout. Defaults to {@link DEFAULT_CLONE_TIMEOUT_MS}. */
+  cloneTimeoutMs?: number;
+}
+
+/**
+ * Validation failure raised before any subprocess spawn. Distinct error type
+ * so the route handler can map it to a `400 validation_error` response.
+ */
+export class CloneValidationError extends Error {
+  readonly code: CloneErrorCode = CLONE_ERROR_CODES.VALIDATION_ERROR;
+  constructor(message: string) {
+    super(message);
+    this.name = 'CloneValidationError';
+  }
+}
+
+/**
+ * Target-directory conflict raised before any subprocess spawn. Distinct so
+ * the route handler can map it to `409 name_conflict`.
+ */
+export class CloneNameConflictError extends Error {
+  readonly code: CloneErrorCode = CLONE_ERROR_CODES.NAME_CONFLICT;
+  constructor(message: string) {
+    super(message);
+    this.name = 'CloneNameConflictError';
+  }
+}
+
+/**
+ * Derive a directory name from a clone URL when the caller did not provide
+ * one. Strips a trailing `.git` and the path's leading separator. Returns
+ * null when the URL does not have an extractable basename (the caller surfaces
+ * a `validation_error` in that case).
+ *
+ * @internal Exported for testing.
+ */
+export function deriveNameFromUrl(url: string): string | null {
+  // For SSH shortcut `git@host:org/repo.git` and `ssh://host/org/repo.git`
+  // alike, the basename is what follows the last `/`. For SCP-style without
+  // a path slash (`git@host:repo.git`), the basename follows the last `:`.
+  let candidate = url;
+  const lastSlash = candidate.lastIndexOf('/');
+  if (lastSlash >= 0) {
+    candidate = candidate.slice(lastSlash + 1);
+  } else {
+    const lastColon = candidate.lastIndexOf(':');
+    if (lastColon >= 0) {
+      candidate = candidate.slice(lastColon + 1);
+    }
+  }
+  if (candidate.endsWith('.git')) {
+    candidate = candidate.slice(0, -4);
+  }
+  candidate = candidate.trim();
+  if (candidate.length === 0) {
+    return null;
+  }
+  return candidate;
+}
+
+/**
+ * Classify a `git clone` stderr (or timeout flag) into a structured
+ * {@link CloneErrorCode}. Pattern list mirrors Issue #834 Failure modes; new
+ * codes are added here as we observe further real-world failure shapes.
+ *
+ * @internal Exported for testing.
+ */
+export function classifyCloneError(
+  stderr: string,
+  exitCode: number,
+  timedOut: boolean,
+): CloneErrorCode {
+  if (timedOut) return CLONE_ERROR_CODES.TIMEOUT;
+  const text = stderr.toLowerCase();
+  // Permission-denied checks come first because they may overlap with auth
+  // patterns (e.g., `Permission denied (publickey)`). Distinguish:
+  //   - "permission denied (publickey)" -> SSH auth failure -> auth_failed
+  //   - bare "permission denied" -> local fs permission -> permission_denied
+  // Order matters for `auth_failed` to catch the SSH shape first.
+  if (
+    text.includes('permission denied (publickey)') ||
+    text.includes('authentication failed') ||
+    text.includes('could not read username') ||
+    text.includes('terminal prompts disabled') ||
+    text.includes('invalid credentials') ||
+    text.includes('access denied')
+  ) {
+    return CLONE_ERROR_CODES.AUTH_FAILED;
+  }
+  if (
+    text.includes('repository not found') ||
+    text.includes('does not appear to be a git repository') ||
+    text.includes('not found') ||
+    text.includes('remote: not found')
+  ) {
+    return CLONE_ERROR_CODES.REPO_NOT_FOUND;
+  }
+  if (
+    text.includes('could not resolve host') ||
+    text.includes('connection refused') ||
+    text.includes('connection timed out') ||
+    text.includes('network is unreachable') ||
+    text.includes('ssl certificate') ||
+    text.includes('unable to access')
+  ) {
+    return CLONE_ERROR_CODES.NETWORK_ERROR;
+  }
+  if (
+    text.includes('permission denied') ||
+    text.includes('operation not permitted') ||
+    text.includes('eacces')
+  ) {
+    return CLONE_ERROR_CODES.PERMISSION_DENIED;
+  }
+  if (exitCode === 0) {
+    // Non-zero classification was requested but exit code is 0 -- this is a
+    // degenerate input to the classifier; surface as unknown so callers do
+    // not silently treat success as a known failure.
+    return CLONE_ERROR_CODES.UNKNOWN;
+  }
+  return CLONE_ERROR_CODES.UNKNOWN;
+}
+
+/**
+ * Defense-in-depth re-validation of the inputs that will reach the spawn.
+ * Throws `CloneValidationError` on any shape mismatch.
+ *
+ * @internal Exported for testing.
+ */
+export function validateCloneInputs(url: string, name: string): void {
+  if (!CLONE_URL_PATTERN.test(url)) {
+    throw new CloneValidationError(
+      'URL must be https://, http://, git://, ssh://, or git@host:org/repo (no shell metacharacters or leading dashes)',
+    );
+  }
+  if (!REPO_NAME_PATTERN.test(name)) {
+    throw new CloneValidationError(
+      'Name must contain only [A-Za-z0-9._-], be 1-100 chars, and not start with `-`',
+    );
+  }
+  if (name === '.' || name === '..' || name.includes('..') || name.includes('/')) {
+    throw new CloneValidationError('Name cannot be `.`, `..`, or contain `..` / `/`');
+  }
+}
+
+/**
+ * Clone-and-register service. Maintains in-memory job state across the
+ * request -> background-run -> poll lifecycle.
+ *
+ * The service does NOT itself trigger the `repositoryRegistered` broadcast --
+ * that happens inside `RepositoryManager.registerRepository` via the
+ * existing `lifecycleCallbacks.onRepositoryCreated` hook wired in
+ * `websocket/routes.ts`. Calling `registrar.registerRepository` is sufficient
+ * to emit the standard `repository-created` `/ws/app` event.
+ */
+export class RepositoryCloneService {
+  private readonly sourceReposDir: string;
+  private readonly registrar: RepositoryRegistrar;
+  private readonly runAsUser: RunAsUserFn;
+  private readonly cloneTimeoutMs: number;
+  private readonly jobs = new Map<string, CloneJobState>();
+
+  constructor(options: CloneServiceOptions) {
+    this.sourceReposDir = options.sourceReposDir;
+    this.registrar = options.registrar;
+    this.runAsUser = options.runAsUserImpl ?? defaultRunAsUser;
+    this.cloneTimeoutMs = options.cloneTimeoutMs ?? DEFAULT_CLONE_TIMEOUT_MS;
+  }
+
+  /**
+   * Validate the request, allocate a job, then run the clone-and-register
+   * chain in the background. Returns the job id immediately so the route
+   * handler can answer `202 Accepted`.
+   *
+   * Pre-flight failures (`CloneValidationError`, `CloneNameConflictError`)
+   * are THROWN, not surfaced as a failed job, so the route can map them to
+   * `400` / `409` synchronously.
+   */
+  async enqueueClone(request: CloneRepositoryRequest): Promise<string> {
+    const url = request.url.trim();
+    const explicitName = request.name?.trim();
+    const derived = explicitName && explicitName.length > 0 ? explicitName : deriveNameFromUrl(url);
+    if (derived === null || derived.length === 0) {
+      throw new CloneValidationError(
+        'Could not derive a directory name from the URL; provide `name` explicitly',
+      );
+    }
+
+    // Defense-in-depth: re-validate inputs even though the schema already did.
+    validateCloneInputs(url, derived);
+
+    const targetDir = path.join(this.sourceReposDir, derived);
+
+    // Pre-flight conflict check. Using lstat so a dangling symlink at the
+    // target also counts as conflict (do not silently re-purpose).
+    try {
+      await fsPromises.lstat(targetDir);
+      throw new CloneNameConflictError(
+        `Target directory already exists: ${targetDir}`,
+      );
+    } catch (err: unknown) {
+      if (err instanceof CloneNameConflictError) throw err;
+      // `ENOENT` is the happy path -- the directory should not exist yet.
+      if (!isEnoent(err)) {
+        // Other lstat errors (EACCES on parent, etc.) are not a conflict but
+        // they ARE a pre-spawn failure. Treat as validation failure so the
+        // route returns 400 with a precise message rather than 500.
+        throw new CloneValidationError(
+          `Could not check target directory: ${errorMessage(err)}`,
+        );
+      }
+    }
+
+    // Ensure parent exists before spawning. The bootstrap script creates
+    // `${DATA_ROOT}/source-repos` with the right ownership; this is a safety
+    // net for development environments / single-user installs where the
+    // operator may not have run the bootstrap.
+    await fsPromises.mkdir(this.sourceReposDir, { recursive: true });
+
+    const jobId = randomUUID();
+    const now = Date.now();
+    const state: CloneJobState = {
+      id: jobId,
+      status: CLONE_JOB_STATUS.PENDING,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.jobs.set(jobId, state);
+
+    // Fire-and-forget the background run. We deliberately do not `await`
+    // here so the route returns 202 immediately. The internal handler logs
+    // every transition and updates `state` in place; any unhandled rejection
+    // would only land in the unhandledRejection logger because the chain
+    // catches its own errors.
+    void this.runCloneJob(jobId, url, derived, targetDir, request);
+
+    return jobId;
+  }
+
+  /**
+   * Look up a job's current state. Returns undefined for unknown ids so the
+   * route can map to 404.
+   */
+  getJob(jobId: string): CloneJobState | undefined {
+    return this.jobs.get(jobId);
+  }
+
+  /**
+   * Internal: orchestrate clone + register + state transitions for one job.
+   * Any thrown error is caught and converted to a `failed` transition so the
+   * fire-and-forget caller does not need its own catch.
+   */
+  private async runCloneJob(
+    jobId: string,
+    url: string,
+    name: string,
+    targetDir: string,
+    request: CloneRepositoryRequest,
+  ): Promise<void> {
+    const state = this.jobs.get(jobId);
+    if (!state) {
+      logger.warn({ jobId }, 'runCloneJob: job state missing; aborting');
+      return;
+    }
+    this.transition(state, CLONE_JOB_STATUS.CLONING);
+
+    // Build `git clone --config core.sharedRepository=group <url> <targetDir>`
+    // with both args shell-escaped. The outer `runAsUser` decides whether to
+    // wrap the command in `sudo -i sh -c ...` based on AUTH_MODE +
+    // requestUser. cwd is set to the parent so the clone has a writable
+    // ambient directory even when the elevated shell could not chdir.
+    const command =
+      `git clone --config core.sharedRepository=group ` +
+      `${shellEscape(url)} ${shellEscape(targetDir)}`;
+
+    let result;
+    try {
+      result = await this.runAsUser({
+        username: request.requestUser,
+        command,
+        cwd: this.sourceReposDir,
+        timeoutMs: this.cloneTimeoutMs,
+        // Inherit the user's auth env across the sudo barrier. FORCE_COLOR
+        // is the runAsUser default; we add the standard git / ssh auth keys.
+        preserveEnv: [
+          'FORCE_COLOR',
+          'SSH_AUTH_SOCK',
+          'SSH_AGENT_PID',
+          'GIT_ASKPASS',
+        ],
+      });
+    } catch (err) {
+      // Spawn-level failure (e.g., sudo missing). Treat as a clone failure
+      // with `unknown` code so the user sees the underlying message.
+      const message = errorMessage(err);
+      logger.warn({ jobId, err }, 'clone spawn threw; marking job failed');
+      await this.cleanupPartialClone(targetDir, jobId);
+      this.fail(state, CLONE_ERROR_CODES.UNKNOWN, message);
+      return;
+    }
+
+    if (result.timedOut || result.exitCode !== 0) {
+      const code = classifyCloneError(result.stderr, result.exitCode, result.timedOut);
+      const message = result.timedOut
+        ? `git clone timed out after ${Math.floor(this.cloneTimeoutMs / 1000)}s`
+        : result.stderr.trim() || `git clone exited ${result.exitCode}`;
+      logger.warn(
+        { jobId, code, exitCode: result.exitCode, timedOut: result.timedOut },
+        'git clone failed; marking job failed',
+      );
+      await this.cleanupPartialClone(targetDir, jobId);
+      this.fail(state, code, message);
+      return;
+    }
+
+    // Clone succeeded -- hand off to RepositoryManager.registerRepository,
+    // which auto-applies #845's group-writable bootstrap + #853's server-side
+    // safe.directory entry as part of its standard flow.
+    let repository: Repository;
+    try {
+      repository = await this.registrar.registerRepository(targetDir, {
+        description: request.description,
+      });
+    } catch (err) {
+      const message = errorMessage(err);
+      logger.warn({ jobId, err }, 'registerRepository failed after clone');
+      // Don't blow away the on-disk clone here -- it succeeded. The user
+      // can retry registration manually via the existing
+      // `POST /api/repositories` endpoint, or fix the underlying cause
+      // (e.g., the path already registered) and re-clone with a new name.
+      this.fail(state, CLONE_ERROR_CODES.UNKNOWN, `Registration failed: ${message}`);
+      return;
+    }
+
+    state.repositoryId = repository.id;
+    this.transition(state, CLONE_JOB_STATUS.SUCCEEDED);
+    logger.info(
+      { jobId, repositoryId: repository.id, name, requestUser: request.requestUser ?? null },
+      'clone-and-register job succeeded',
+    );
+  }
+
+  /**
+   * Best-effort `rm -rf <targetDir>` so a future retry can re-use the name.
+   * Failures here are logged but do not change the job's final status -- the
+   * underlying failure code is already the primary signal.
+   */
+  private async cleanupPartialClone(targetDir: string, jobId: string): Promise<void> {
+    try {
+      await fsPromises.rm(targetDir, { recursive: true, force: true });
+    } catch (err) {
+      logger.warn(
+        { err, targetDir, jobId },
+        'partial-clone cleanup failed; operator may need to rm -rf manually',
+      );
+    }
+  }
+
+  private transition(state: CloneJobState, status: CloneJobStatus): void {
+    state.status = status;
+    state.updatedAt = Date.now();
+  }
+
+  private fail(state: CloneJobState, code: CloneErrorCode, message: string): void {
+    state.error = { code, message };
+    this.transition(state, CLONE_JOB_STATUS.FAILED);
+  }
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === 'ENOENT'
+  );
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/packages/shared/src/schemas/__tests__/repository.test.ts
+++ b/packages/shared/src/schemas/__tests__/repository.test.ts
@@ -57,7 +57,6 @@ describe('CloneRepositoryRequestSchema (Issue #834)', () => {
   describe('URL acceptance', () => {
     const accepted = [
       'https://github.com/org/repo.git',
-      'http://example.com/org/repo',
       'git://github.com/org/repo.git',
       'ssh://git@github.com:22/org/repo.git',
       'git@github.com:org/repo.git',
@@ -71,18 +70,30 @@ describe('CloneRepositoryRequestSchema (Issue #834)', () => {
   });
 
   describe('URL rejection (defense-in-depth boundary)', () => {
-    const rejected = [
+    const rejected: { name: string; url: string }[] = [
+      // Cleartext HTTP rejected per CodeRabbit feedback on PR #862 -- no
+      // credential-bearing clone over an unencrypted channel.
+      { name: 'cleartext http://', url: 'http://example.com/org/repo' },
       // Leading dash -- argv-injection guard.
-      '--upload-pack=evil',
+      { name: 'leading dash (argv injection)', url: '--upload-pack=evil' },
       // Absolute filesystem path -- not a valid clone source for this endpoint.
-      '/etc/passwd',
+      { name: 'absolute filesystem path', url: '/etc/passwd' },
       // Whitespace in URL -- shell-injection guard.
-      'https://example.com/org/repo with space',
+      { name: 'embedded whitespace', url: 'https://example.com/org/repo with space' },
       // Empty.
-      '',
+      { name: 'empty string', url: '' },
+      // Shell metacharacters (CodeRabbit reviewer asked for explicit coverage).
+      { name: 'semicolon (command separator)', url: 'https://example.com/repo;touch%20x' },
+      { name: 'command substitution $(...)', url: 'https://example.com/repo$(whoami)' },
+      { name: 'backtick command substitution', url: 'https://example.com/repo`whoami`' },
+      { name: 'pipe', url: 'https://example.com/repo|cat' },
+      { name: 'ampersand background', url: 'https://example.com/repo&id' },
+      { name: 'greater-than redirect', url: 'https://example.com/repo>x' },
+      { name: 'control character (0x01)', url: 'https://example.com/repo' + String.fromCharCode(0x01) + 'bad' },
+      { name: 'DEL character (0x7F)', url: 'https://example.com/repo' + String.fromCharCode(0x7F) + 'bad' },
     ];
-    for (const url of rejected) {
-      it(`rejects ${JSON.stringify(url)}`, () => {
+    for (const { name, url } of rejected) {
+      it(`rejects ${name}`, () => {
         const result = v.safeParse(CloneRepositoryRequestSchema, { url });
         expect(result.success).toBe(false);
       });

--- a/packages/shared/src/schemas/__tests__/repository.test.ts
+++ b/packages/shared/src/schemas/__tests__/repository.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import * as v from 'valibot';
 import {
   CreateRepositoryRequestSchema,
+  CloneRepositoryRequestSchema,
   CreateWorktreeRequestSchema,
   CreateWorktreePromptRequestSchema,
   CreateWorktreeCustomRequestSchema,
@@ -49,6 +50,106 @@ describe('CreateRepositoryRequestSchema', () => {
       path: '   ',
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe('CloneRepositoryRequestSchema (Issue #834)', () => {
+  describe('URL acceptance', () => {
+    const accepted = [
+      'https://github.com/org/repo.git',
+      'http://example.com/org/repo',
+      'git://github.com/org/repo.git',
+      'ssh://git@github.com:22/org/repo.git',
+      'git@github.com:org/repo.git',
+    ];
+    for (const url of accepted) {
+      it(`accepts ${url}`, () => {
+        const result = v.safeParse(CloneRepositoryRequestSchema, { url });
+        expect(result.success).toBe(true);
+      });
+    }
+  });
+
+  describe('URL rejection (defense-in-depth boundary)', () => {
+    const rejected = [
+      // Leading dash -- argv-injection guard.
+      '--upload-pack=evil',
+      // Absolute filesystem path -- not a valid clone source for this endpoint.
+      '/etc/passwd',
+      // Whitespace in URL -- shell-injection guard.
+      'https://example.com/org/repo with space',
+      // Empty.
+      '',
+    ];
+    for (const url of rejected) {
+      it(`rejects ${JSON.stringify(url)}`, () => {
+        const result = v.safeParse(CloneRepositoryRequestSchema, { url });
+        expect(result.success).toBe(false);
+      });
+    }
+  });
+
+  describe('name validation', () => {
+    it('accepts a valid name', () => {
+      const result = v.safeParse(CloneRepositoryRequestSchema, {
+        url: 'https://github.com/org/repo.git',
+        name: 'my-repo_1.0',
+      });
+      expect(result.success).toBe(true);
+    });
+    it('rejects a name starting with -', () => {
+      const result = v.safeParse(CloneRepositoryRequestSchema, {
+        url: 'https://github.com/org/repo.git',
+        name: '-rf',
+      });
+      expect(result.success).toBe(false);
+    });
+    it('rejects `.`', () => {
+      const result = v.safeParse(CloneRepositoryRequestSchema, {
+        url: 'https://github.com/org/repo.git',
+        name: '.',
+      });
+      expect(result.success).toBe(false);
+    });
+    it('rejects `..`', () => {
+      const result = v.safeParse(CloneRepositoryRequestSchema, {
+        url: 'https://github.com/org/repo.git',
+        name: '..',
+      });
+      expect(result.success).toBe(false);
+    });
+    it('rejects a name containing `..`', () => {
+      const result = v.safeParse(CloneRepositoryRequestSchema, {
+        url: 'https://github.com/org/repo.git',
+        name: 'a..b',
+      });
+      expect(result.success).toBe(false);
+    });
+    it('rejects whitespace in name', () => {
+      const result = v.safeParse(CloneRepositoryRequestSchema, {
+        url: 'https://github.com/org/repo.git',
+        name: 'has space',
+      });
+      expect(result.success).toBe(false);
+    });
+    it('rejects > 100 chars', () => {
+      const result = v.safeParse(CloneRepositoryRequestSchema, {
+        url: 'https://github.com/org/repo.git',
+        name: 'a'.repeat(101),
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  it('accepts optional description', () => {
+    const result = v.safeParse(CloneRepositoryRequestSchema, {
+      url: 'https://github.com/org/repo.git',
+      description: '  trimmed  ',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.description).toBe('trimmed');
+    }
   });
 });
 

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -59,6 +59,9 @@ export {
 // Repository schemas
 export {
   CreateRepositoryRequestSchema,
+  CloneRepositoryRequestSchema,
+  CLONE_JOB_STATUS,
+  CLONE_ERROR_CODES,
   CreateWorktreePromptRequestSchema,
   CreateWorktreeCustomRequestSchema,
   CreateWorktreeExistingRequestSchema,
@@ -71,6 +74,12 @@ export {
   RefreshDefaultBranchResponseSchema,
   RemoteBranchStatusSchema,
   type CreateRepositoryRequest,
+  type CloneRepositoryRequest,
+  type CloneRepositoryResponse,
+  type CloneJobStatus,
+  type CloneJobStatusResponse,
+  type CloneJobError,
+  type CloneErrorCode,
   type CreateWorktreePromptRequest,
   type CreateWorktreeCustomRequest,
   type CreateWorktreeExistingRequest,

--- a/packages/shared/src/schemas/repository.ts
+++ b/packages/shared/src/schemas/repository.ts
@@ -14,6 +14,146 @@ export const CreateRepositoryRequestSchema = v.object({
 });
 
 /**
+ * Accepted clone URL shapes (Issue #834 Validation):
+ *   - `https://...`
+ *   - `http://...`
+ *   - `git://...`
+ *   - `ssh://...`
+ *   - `git@host:org/repo[.git]` (SCP-style SSH shortcut)
+ *
+ * Strict prefix anchoring rejects strings starting with `-` (no
+ * `--upload-pack=...` argv-injection), control characters, and embedded
+ * whitespace. The server-side runner in `services/repository-clone-service.ts`
+ * re-validates with the same rules as a defense-in-depth layer.
+ */
+const cloneUrlPattern =
+  /^(?:https?:\/\/|git:\/\/|ssh:\/\/[^\s]+|[A-Za-z0-9_][A-Za-z0-9._-]*@[A-Za-z0-9._-]+:[^\s]+)\S*$/;
+
+/**
+ * Repository name validation (Issue #834 Validation):
+ * - 1-100 chars of `[A-Za-z0-9._-]`
+ * - Cannot start with `-` (so it is never mistaken for a CLI flag)
+ * - Cannot be `.` or `..`
+ * - Cannot contain `..` (path traversal) or `/` (subdirectory escape; already
+ *   excluded by the character class but called out for the error message)
+ */
+const repoNamePattern = /^[A-Za-z0-9_.][A-Za-z0-9._-]{0,99}$/;
+
+/**
+ * Schema for cloning + registering a repository (Issue #834).
+ *
+ * Validates at request boundary so the URL / name never reach a subprocess
+ * spawn unless they pass the documented shape.
+ */
+export const CloneRepositoryRequestSchema = v.object({
+  url: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, 'URL is required'),
+    v.regex(
+      cloneUrlPattern,
+      'URL must be https://, http://, git://, ssh://, or git@host:org/repo (no shell metacharacters or leading dashes)',
+    ),
+  ),
+  name: v.optional(
+    v.pipe(
+      v.string(),
+      v.trim(),
+      v.minLength(1, 'Name cannot be empty when provided'),
+      v.regex(
+        repoNamePattern,
+        'Name must contain only [A-Za-z0-9._-], be 1-100 chars, and not start with `-`',
+      ),
+      v.check(
+        (val) => val !== '.' && val !== '..' && !val.includes('..'),
+        'Name cannot be `.`, `..`, or contain `..`',
+      ),
+    ),
+  ),
+  description: v.optional(v.pipe(v.string(), v.trim())),
+});
+
+/**
+ * Clone job status discriminator. The job transitions:
+ *   pending -> cloning -> succeeded
+ *                      `-> failed
+ */
+export const CLONE_JOB_STATUS = {
+  PENDING: 'pending',
+  CLONING: 'cloning',
+  SUCCEEDED: 'succeeded',
+  FAILED: 'failed',
+} as const;
+
+export type CloneJobStatus = (typeof CLONE_JOB_STATUS)[keyof typeof CLONE_JOB_STATUS];
+
+/**
+ * Structured failure codes the server emits so the client can render an
+ * actionable message in the user's locale (Issue #834 Failure modes).
+ *
+ * Each code maps to a documented operator-resolvable cause; `unknown` is the
+ * catch-all when stderr does not match any known substring.
+ */
+export const CLONE_ERROR_CODES = {
+  /** Input failed schema validation (URL shape, name shape, etc.). */
+  VALIDATION_ERROR: 'validation_error',
+  /** Target directory already exists at request time (pre-spawn 409). */
+  NAME_CONFLICT: 'name_conflict',
+  /** SSH key not accepted, HTTPS credential rejected, or token missing. */
+  AUTH_FAILED: 'auth_failed',
+  /** DNS / TCP / TLS failure reaching the remote. */
+  NETWORK_ERROR: 'network_error',
+  /** Remote returned 404 / does-not-exist. */
+  REPO_NOT_FOUND: 'repo_not_found',
+  /** Local filesystem refused write (target dir, parent dir, etc.). */
+  PERMISSION_DENIED: 'permission_denied',
+  /** Clone exceeded CLONE_TIMEOUT_MS. */
+  TIMEOUT: 'timeout',
+  /** No matching substring; raw stderr captured in the message field. */
+  UNKNOWN: 'unknown',
+} as const;
+
+export type CloneErrorCode = (typeof CLONE_ERROR_CODES)[keyof typeof CLONE_ERROR_CODES];
+
+/**
+ * Structured error payload returned by the job-status endpoint when the job
+ * is in `failed` state. `message` contains the underlying stderr (trimmed)
+ * suitable for diagnostic display; `code` is the localizable discriminant.
+ */
+export interface CloneJobError {
+  code: CloneErrorCode;
+  message: string;
+}
+
+/**
+ * Response shape for `POST /api/repositories/clone` (Issue #834). The repo is
+ * cloned asynchronously; the client polls `GET /api/repositories/clone/:jobId`
+ * for the final status and the new `repositoryId`.
+ */
+export interface CloneRepositoryResponse {
+  jobId: string;
+  /** Always `null` at request time; populated on the status endpoint after
+   * the background clone + register chain completes. */
+  repositoryId: null;
+}
+
+/**
+ * Response shape for `GET /api/repositories/clone/:jobId`.
+ *
+ * - `pending` / `cloning`: no `error`, no `repositoryId` yet
+ * - `succeeded`: `repositoryId` populated; no `error`
+ * - `failed`: `error` populated; no `repositoryId`
+ */
+export interface CloneJobStatusResponse {
+  jobId: string;
+  status: CloneJobStatus;
+  /** Present only when `status === 'failed'`. */
+  error?: CloneJobError;
+  /** Present only when `status === 'succeeded'`. */
+  repositoryId?: string;
+}
+
+/**
  * Optional branch name schema - validates format only when provided and non-empty
  */
 const OptionalBranchSchema = v.optional(
@@ -174,6 +314,7 @@ export const RemoteBranchStatusSchema = v.object({
 
 // Inferred types from schemas
 export type CreateRepositoryRequest = v.InferOutput<typeof CreateRepositoryRequestSchema>;
+export type CloneRepositoryRequest = v.InferOutput<typeof CloneRepositoryRequestSchema>;
 export type CreateWorktreePromptRequest = v.InferOutput<typeof CreateWorktreePromptRequestSchema>;
 export type CreateWorktreeCustomRequest = v.InferOutput<typeof CreateWorktreeCustomRequestSchema>;
 export type CreateWorktreeExistingRequest = v.InferOutput<typeof CreateWorktreeExistingRequestSchema>;

--- a/packages/shared/src/schemas/repository.ts
+++ b/packages/shared/src/schemas/repository.ts
@@ -14,20 +14,36 @@ export const CreateRepositoryRequestSchema = v.object({
 });
 
 /**
- * Accepted clone URL shapes (Issue #834 Validation):
- *   - `https://...`
- *   - `http://...`
+ * Accepted clone URL shapes (Issue #834 Validation, tightened per CodeRabbit
+ * review on PR #862):
+ *   - `https://...` (TLS only; cleartext http:// is rejected to avoid
+ *     credential-bearing clones over an unsecured channel)
  *   - `git://...`
  *   - `ssh://...`
  *   - `git@host:org/repo[.git]` (SCP-style SSH shortcut)
  *
- * Strict prefix anchoring rejects strings starting with `-` (no
- * `--upload-pack=...` argv-injection), control characters, and embedded
- * whitespace. The server-side runner in `services/repository-clone-service.ts`
- * re-validates with the same rules as a defense-in-depth layer.
+ * The scheme regex pre-anchors the leading character (so a leading `-` cannot
+ * pose as `--upload-pack=...`). The follow-up `cloneUrlDisallowedPattern`
+ * check explicitly rejects whitespace, shell metacharacters
+ * (`;`, `&`, `|`, `` ` ``, `$`, `<`, `>`, `(`, `)`, `[`, `]`, `{`, `}`, `'`,
+ * `"`, `\\`), and any C0/C1 control character before the URL reaches the
+ * server-side runner. The server-side
+ * `services/repository-clone-service.ts` mirrors both layers.
  */
 const cloneUrlPattern =
-  /^(?:https?:\/\/|git:\/\/|ssh:\/\/[^\s]+|[A-Za-z0-9_][A-Za-z0-9._-]*@[A-Za-z0-9._-]+:[^\s]+)\S*$/;
+  /^(?:https:\/\/|git:\/\/|ssh:\/\/[^\s]+|[A-Za-z0-9_][A-Za-z0-9._-]*@[A-Za-z0-9._-]+:[^\s]+)\S*$/;
+
+/**
+ * Characters that must NEVER appear in a clone URL accepted by this schema,
+ * regardless of scheme. Covers POSIX shell metacharacters, both quote shapes,
+ * the backslash escape, parentheses / brackets / braces, control characters
+ * (0x00-0x1F + 0x7F), and any whitespace.
+ *
+ * Keep in sync with `URL_DISALLOWED_PATTERN` in
+ * `packages/server/src/services/repository-clone-service.ts`.
+ */
+// eslint-disable-next-line no-control-regex
+const cloneUrlDisallowedPattern = /[\s\x00-\x1F\x7F;&|`$<>()[\]{}'"\\]/;
 
 /**
  * Repository name validation (Issue #834 Validation):
@@ -52,7 +68,11 @@ export const CloneRepositoryRequestSchema = v.object({
     v.minLength(1, 'URL is required'),
     v.regex(
       cloneUrlPattern,
-      'URL must be https://, http://, git://, ssh://, or git@host:org/repo (no shell metacharacters or leading dashes)',
+      'URL must be https://, git://, ssh://, or git@host:org/repo (http:// rejected; no leading dashes)',
+    ),
+    v.check(
+      (val) => !cloneUrlDisallowedPattern.test(val),
+      'URL contains a disallowed character (whitespace, shell metacharacters, control characters, quotes, or backslash)',
     ),
   ),
   name: v.optional(


### PR DESCRIPTION
## Summary

Adds the server side of the clone-and-register repository action proposed in #834. Operators can now POST a git URL and have the server clone the repo into `${DATA_ROOT}/source-repos/<name>` (or `AGENT_CONSOLE_SOURCE_REPOS_DIR`), then auto-register it -- no host-side shell work required. In multi-user mode the clone runs as the authenticated OS user via the `runAsUser` privilege-elevation helper (umbrella #837), inheriting that user's SSH agent and git credential helpers.

A parallel frontend-specialist agent is implementing the UI against the same API contract; this PR is server-only.

Closes #834
Refs umbrella #837

## API shape

| Method | Path | Body | Status | Response |
|---|---|---|---|---|
| POST | `/api/repositories/clone` | `{ url, name?, description? }` | `202` | `{ jobId, repositoryId: null }` |
| POST | `/api/repositories/clone` | invalid url / name | `400` | `{ error: <message> }` |
| POST | `/api/repositories/clone` | target dir already exists | `409` | `{ error: <message> }` |
| GET  | `/api/repositories/clone/:jobId` | - | `200` | `{ jobId, status, repositoryId?, error? }` |
| GET  | `/api/repositories/clone/:jobId` | unknown id | `404` | `{ error: ... }` |

`status` is one of `pending` / `cloning` / `succeeded` / `failed`. On `failed` the `error` field carries `{ code, message }` where `code` is one of `validation_error` / `name_conflict` / `auth_failed` / `network_error` / `repo_not_found` / `permission_denied` / `timeout` / `unknown` (`CLONE_ERROR_CODES` in `packages/shared/src/schemas/repository.ts`).

The existing `repository-created` `/ws/app` broadcast fires through `RepositoryManager.lifecycleCallbacks.onRepositoryCreated` for free on success -- no new ws message type is introduced.

## Design choices

**In-memory job state (not the SQLite `JobQueue`).** The existing queue provides guaranteed delivery with exponential-backoff retry. That contract is wrong for clones:

- Common failure modes (`auth_failed`, `repo_not_found`, `name_conflict`, `permission_denied`) will never succeed on retry without operator intervention.
- An auto-retry that re-runs the partial-clone cleanup risks deleting a target the operator manually fixed.
- Clones are short-lived (seconds to minutes); losing in-flight state across a restart is acceptable -- the user simply retries from the UI.

The partial-clone target is cleaned up at the time of failure (`fsPromises.rm` recursive) so a restart does not leak it either.

**Defense-in-depth validation.** The URL and name are validated twice:

1. `CloneRepositoryRequestSchema` (Valibot) at the route boundary.
2. `validateCloneInputs` inside the service, with the same regex shape.

The second pass guards against future internal callers (e.g., an MCP `clone_and_register` tool) that might bypass the route. Both layers reject argv-injection shapes, path traversal segments, and shell metacharacters before any subprocess is spawned.

**Failure classification.** `classifyCloneError` maps git stderr substrings to the `CloneErrorCode` enum so the UI can render a localizable message. The order matters: `Permission denied (publickey)` is matched as `auth_failed` before bare `Permission denied` is matched as `permission_denied`.

## Verification log

```
$ bun run typecheck
@agent-console/shared typecheck: Exited with code 0
@agent-console/server typecheck: Exited with code 0
@agent-console/client typecheck: Exited with code 0
```

```
$ output=$(bun run test 2>&1); exitcode=$?
@agent-console/shared      test: 341 pass / 0 fail / Ran 341 tests across 10 files.
@agent-console/integration test:  29 pass / 0 fail / Ran  29 tests across  8 files.
@agent-console/server      test: 2757 pass / 1 skip / 0 fail / Ran 2758 tests across 130 files.
@agent-console/client      test: 1397 pass / 2 skip / 0 fail / Ran 1399 tests across  88 files.
scripts / hooks / skills          362 pass / 0 fail / Ran 362 tests across 11 files.
TEST_EXIT: 0
```

```
$ bun run check:lang
OK -- language check clean (103 files scanned).

$ node .claude/skills/orchestrator/preflight-check.js
Test Coverage Check: Covered (3)
  - packages/server/src/routes/repositories.ts
  - packages/server/src/services/repository-clone-service.ts
  - packages/shared/src/schemas/repository.ts
Integration Test Coverage: warning only (no contract change for existing endpoints; new endpoint pairs covered by route mocks + sibling tests, mirroring PR #842 / #859 / #860)
Rule/Skill Duplication:    clean
Language Check:            clean
```

## TDD polarity

Replaced the `runAsUser` call in `runCloneJob` with a hard-coded success result (`{stdout:'', stderr:'', exitCode:0, timedOut:false}`) and re-ran the sibling suite. With the production line stripped, 11 of the 31 new service tests fail -- the happy-path / multi-user / classified-failure / partial-clone-cleanup tests all rely on the real `runAsUser` invocation. Restoring the line returns the suite to 31/31. This confirms the new tests exercise the diff, not adjacent code.

## 7-question gap-scan

1. **Similar existing mechanism?** No -- this endpoint pair is new. The closest analog is the existing `POST /api/repositories` (register-existing-path), which is intentionally preserved (Issue out-of-scope: removing the legacy flow). The clone service consumes the existing `RepositoryManager.registerRepository` + the existing `runAsUser` helper; it does not duplicate either.
   - **1.5 (cross-doc citation):** Verified against the actual `privilege-elevation.ts` code (the `RunAsUserFn` signature + the elevated-branch env interpolation rule) and against the post-#849 `${DATA_ROOT}/source-repos` location (mirrored in the new `getSourceReposDir()` helper, overridable via `AGENT_CONSOLE_SOURCE_REPOS_DIR` to match the bootstrap script flag).
2. **Invocation documented?** N/A -- this is a user-facing HTTP endpoint, not a script / skill invocation. The frontend specialist is implementing the UI call in a parallel PR; once both land the user can reach the endpoint via the new dialog tab.
3. **Failure paths tested?** Yes -- the sibling service tests cover each `CloneErrorCode` (auth_failed, repo_not_found, network_error, permission_denied, timeout, unknown), partial-clone cleanup on mid-stream failure, validation rejection at both layers, name conflict before any spawn, and a registration-failure-after-successful-clone path (the cloned dir is deliberately preserved so the user can retry registration manually).
   - **Sibling test diff:** Yes -- 4 production files in this PR all have changed sibling test files (preflight covered: 3/3 service+route, 1/1 shared schema).
4. **New file type / directory lifecycle?** No new persistent file type. The `${DATA_ROOT}/source-repos/<name>` directories are owned by the user who cloned them (multi-user) or the server (single-user); their full lifecycle (create at clone, delete at `unregisterRepository`) is already covered by the existing `cleanupRepositoryData` path.
5. **Rule clarity?** No rule changes.
6. **Cross-runtime spawn?** No new spawn target. The `runAsUser` helper is reused; this PR adds a new caller that uses `git clone` (already on PATH for any deployment that runs the existing worktree-creation flow).
7. **Shared-resource artifact lifetime?** Each clone writes the repo `.git/` and worktree to `${DATA_ROOT}/source-repos/<name>/`. Lifetime: until `DELETE /api/repositories/:id` runs `cleanupRepositoryData`. The artifact does not embed worktree-anchored / cwd-anchored references -- only absolute paths the operator can verify. Q7 not triggered (lifetime >= reader lifetime by construction; the registered Repository row is the longest-lived reader and is deleted in lockstep).
8. **Signature shape change?** No existing signatures changed. The new `RepositoryCloneService.enqueueClone({...})` is additive on `AppContext`.

## Out of Scope confirmation

Per Issue #834 Out of Scope:

- **Frontend UI** -- a parallel frontend-specialist agent is implementing the dialog in a separate worktree against this PR API contract. This PR diff contains no `packages/client/` changes.
- **Documentation** -- intentionally deferred to a follow-up to keep this PR scope tight. The new `getSourceReposDir()` helper, env var, and bootstrap-script behavior are already documented by Issue #833 / PR #849; the user-facing Clone and Register UX docs will follow the UI PR.
- **MCP `clone_and_register` tool** -- explicitly out of Issue scope; depends on Issue #844-style plumbing.
- **Credential storage UI** -- explicitly out of Issue scope; auth flows through user-managed credential helpers in user HOME.
- **Pull / sync after clone** -- explicitly out of Issue scope.
- **No modifications to** `runAsUser`, `RepositoryManager.registerRepository` core logic, or other recently-landed code beyond minimal consumption.

## Dogfood verification note

This PR runtime behavior (privilege elevation, real `git clone`, real auth credential inheritance) cannot be exercised end-to-end in this dev environment -- it requires an `AUTH_MODE=multi-user` host with multiple OS users plus working SSH agent forwarding. The Issue explicitly calls for a Docker E2E test (similar shape to PR #843 Test 7); that artifact is itself a meaningful addition and I would prefer to add it in a follow-up PR rather than block this one on test-harness work. Request owner / Orchestrator dogfood verification on the multi-user host once the UI lands.

## Files

- `packages/shared/src/schemas/repository.ts` -- `CloneRepositoryRequestSchema`, `CLONE_JOB_STATUS`, `CLONE_ERROR_CODES`, response types
- `packages/shared/src/schemas/index.ts` -- re-exports
- `packages/server/src/services/repository-clone-service.ts` -- the new service (NEW)
- `packages/server/src/routes/repositories.ts` -- two new routes
- `packages/server/src/app-context.ts` -- wire the service into the context (prod + test paths)
- `packages/server/src/lib/config.ts` -- `getSourceReposDir()` helper mirroring #833 / PR #849
- sibling tests for all of the above

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` (full suite) passes (0 failures across server / shared / integration / client / scripts)
- [x] `bun run check:lang` passes
- [x] `node .claude/skills/orchestrator/preflight-check.js` passes
- [x] TDD polarity verified (11 service tests fail when production runAsUser call is stripped; pass when restored)
- [ ] Dogfood verification on a multi-user host (request owner / Orchestrator once the parallel UI PR lands)