### PR TITLE
fix(server): include env-filter's color env in privilege-elevated PTY workers (#863)

### DIFF
--- a/packages/server/src/services/__tests__/user-mode.test.ts
+++ b/packages/server/src/services/__tests__/user-mode.test.ts
@@ -390,6 +390,36 @@ describe('MultiUserMode', () => {
       expect(args[2]).toBe('--preserve-env=FORCE_COLOR');
       expect(args[3]).toBe('-i');
     });
+
+    // Issue #863 — env-filter's curated child env (TERM=xterm-256color,
+    // COLORTERM=truecolor, FORCE_COLOR=3, ...) must be exported in the
+    // inner shell so chalk-based CLIs (claude) render in color. The
+    // previous design relied on sudo's env_keep defaults, which on
+    // Ubuntu sudo strip TERM and leave it as 'unknown' — observed on
+    // the dogfood host as all-white claude output.
+    it('exports TERM=xterm-256color, COLORTERM=truecolor, and FORCE_COLOR=3 in the inner shell command (Issue #863)', async () => {
+      const { provider, lastCall } = createCapturingPtyProvider();
+      const userRepository = new SqliteUserRepository(db);
+      const mode = await MultiUserMode.create(provider, userRepository);
+
+      const request: TerminalPtySpawnRequest = {
+        type: 'terminal',
+        username: 'definitely-not-the-server-user',
+        cwd: '/workspace',
+        additionalEnvVars: {},
+        cols: 80,
+        rows: 24,
+      };
+
+      mode.spawnPty(request);
+
+      const [, args] = lastCall();
+      // sudo arg shape: -u <user> --preserve-env=FORCE_COLOR -i sh -c <innerCommand>
+      const innerCommand = args[6] as string;
+      expect(innerCommand).toContain("TERM='xterm-256color'");
+      expect(innerCommand).toContain("COLORTERM='truecolor'");
+      expect(innerCommand).toContain("FORCE_COLOR='3'");
+    });
   });
 
   describe('validateLinux uses Bun.spawn with array args', () => {

--- a/packages/server/src/services/user-mode.ts
+++ b/packages/server/src/services/user-mode.ts
@@ -490,13 +490,18 @@ export class MultiUserMode implements UserMode {
 
     return this.ptyProvider.spawn(
       'sudo',
-      // --preserve-env=FORCE_COLOR survives `sudo -i`'s environment reset, which
-      // otherwise strips FORCE_COLOR (it is not in the sudoers env_keep defaults
-      // on most distros). Without this flag the target user's PTY sees only
-      // TERM/COLORTERM, and Node-based agents like Claude Code render their
-      // banner in plain white because chalk falls back to 256-color support.
-      // TERM and COLORTERM are kept by sudo's default env_keep, so they do not
-      // need explicit preservation here.
+      // `sudo -i` strips most of the env it inherits from the parent. We do
+      // NOT rely on `--preserve-env=...` here for color env: the bun server
+      // process does not carry FORCE_COLOR / TERM / COLORTERM in its own env,
+      // so there is nothing for sudo to preserve. Instead, those values are
+      // inserted into the inner shell's export list (see `buildEnvExportString`,
+      // which merges env-filter's curated child env), so they reach the
+      // spawned process regardless of sudo's env_keep policy. The
+      // `--preserve-env=FORCE_COLOR` flag is retained for harmless safety
+      // (in case a future deploy injects FORCE_COLOR at the systemd unit
+      // level). Issue #863 corrected the previous incorrect assumption that
+      // sudo's env_keep defaults retain TERM/COLORTERM (they do not on
+      // Ubuntu sudo); claude rendered in plain white as a result.
       ['-u', request.username, '--preserve-env=FORCE_COLOR', '-i', 'sh', '-c', innerCommand],
       {
         name: 'xterm-256color',
@@ -510,10 +515,17 @@ export class MultiUserMode implements UserMode {
   }
 
   /**
-   * Build export string from additionalEnvVars (repository + template env vars).
+   * Build export string from env-filter's curated system env (TERM,
+   * COLORTERM, FORCE_COLOR, AGENT_CONSOLE_* unset prefix, etc.) merged
+   * with additionalEnvVars (repository + template env vars). Without
+   * env-filter, `sudo -i` would strip TERM and the inner shell would
+   * land on TERM=unknown — chalk-based CLIs (claude, etc.) then
+   * suppress color output. additionalEnvVars wins on key collision,
+   * preserving per-spawn overrides. Issue #863.
    */
   private buildEnvExportString(request: PtySpawnRequest): string {
-    return this.buildExportString(request.additionalEnvVars);
+    const combined = { ...getCleanChildProcessEnv(), ...request.additionalEnvVars };
+    return this.buildExportString(combined);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes Issue #863. Multi-user mode's privilege-elevated PTY workers were missing TERM, COLORTERM, and FORCE_COLOR env vars because MultiUserMode.spawnSudoPty exported only request.additionalEnvVars (repository/template env) and never consumed env-filter's curated child env. The inner shell landed on TERM=unknown; chalk-based CLIs (claude, etc.) treated this as "no color" and emitted plain text — every line of a Claude Code agent session rendered in white.

Fix: merge getCleanChildProcessEnv() into the export string built by buildEnvExportString. additionalEnvVars still wins on key collision (per-spawn overrides preserved). The misleading comment near the elevation argv (claiming TERM/COLORTERM are kept by env_keep defaults) is corrected.

## Change Shape

- packages/server/src/services/user-mode.ts — 2 spots:
  - buildEnvExportString: merge getCleanChildProcessEnv() first, then additionalEnvVars.
  - Comment near elevation argv: replace the env_keep claim with an explanation of why we now export the color env inline.
- packages/server/src/services/__tests__/user-mode.test.ts — 1 new test under the existing describe block, asserting innerCommand contains the three color env exports.

## TDD polarity check

Stashed the production change in buildEnvExportString. The new Issue #863 test failed with:

  Expected to contain: TERM='xterm-256color'
  Received: cd '/workspace' && exec $SHELL -l

Restored production -> test passes. The test exercises the production line directly.

## Verification log

bun run typecheck: exit 0.

bun run test: exit 0
- shared: 324 pass / 0 fail
- integration: 29 pass / 0 fail
- server: 2725 pass / 1 skip / 0 fail
- client: 1397 pass / 2 skip / 0 fail
- scripts/hooks/skills: 362 pass / 0 fail

bun run check:lang: OK — 103 files clean.

node .claude/skills/orchestrator/preflight-check.js: Test coverage clean, Rule/Skill duplication clean, Language check clean.

## Out of scope

- Removing the --preserve-env=FORCE_COLOR flag on the elevation invocation. The flag is now redundant but harmless; a later cleanup PR can drop it.
- Cross-validation of every chalk-based CLI. Once TERM=xterm-256color + FORCE_COLOR=3 + COLORTERM=truecolor reach the inner shell, any chalk- or TERM-respecting tool behaves correctly.

## Pre-PR gap-scan (7 questions, condensed)

1. Similar mechanism — env-filter.ts:getCleanChildProcessEnv() is canonical; wired into the second path that needed it. No duplication.
2. Invocation documented — N/A (no new procedure).
3. Failure paths — happy path covered; additionalEnvVars-wins behavior is Object.assign default.
4. New file type / dir / lifecycle — none.
5. Rule clarity — N/A.
6. Cross-runtime spawn — none (elevation argv unchanged).
7. Shared-artifact lifetime — none.

Closes #863
