### PR TITLE
fix(server): elevate branch git ops to requesting user in multi-user mode (closes #870)

### DIFF
--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -116,6 +116,64 @@ import { WorktreeService } from '../services/worktree-service.js';
 import type { AppBindings } from '../app-context.js';
 import { asAppContext, TEST_AUTH_USER, ensureTestAuthUser } from './test-utils.js';
 import { SingleUserMode } from '../services/user-mode.js';
+import type { RunAsUserOpts, RunAsUserResult } from '../services/privilege-elevation.js';
+
+// =============================================================================
+// runAsUser mock for WorktreeService branch enumeration (Issue #870)
+// =============================================================================
+//
+// WorktreeService.listBranches / refreshDefaultBranch now route through
+// runAsUser so multi-user mode can pick up the user's SSH credentials. The
+// tests inject this responder via WorktreeService's `runAsUserImpl` option
+// instead of the (now-unused) lib/git branch helpers. The mock dispatches on
+// the shell command string so the response matches what the real `git ...`
+// invocation would have produced. Per-test overrides set
+// `worktreeRunAsUserOverride.fn` to short-circuit specific commands.
+let worktreeRunAsUserCalls: RunAsUserOpts[] = [];
+const worktreeRunAsUserOverride: { fn: ((opts: RunAsUserOpts) => RunAsUserResult | null) | null } = {
+  fn: null,
+};
+
+function worktreeRunAsUserDefault(opts: RunAsUserOpts): RunAsUserResult {
+  const cmd = opts.command;
+  // Local branch enumeration -> mirror the defaults in setupDefaultGitMocks.
+  if (cmd.includes("'branch' '--format=%(refname:short)'") && !cmd.includes("'-r'")) {
+    return { stdout: 'main\ndevelop\nfeature-1\n', stderr: '', exitCode: 0, timedOut: false };
+  }
+  if (cmd.includes("'branch' '-r' '--format=%(refname:short)'")) {
+    return { stdout: 'origin/main\norigin/develop\n', stderr: '', exitCode: 0, timedOut: false };
+  }
+  // Default-branch resolution probe -- prefer symbolic-ref success so the
+  // fallback rev-parse branches are never reached in the default fixture.
+  if (cmd.includes("'symbolic-ref' 'refs/remotes/origin/HEAD'")) {
+    return { stdout: 'refs/remotes/origin/main\n', stderr: '', exitCode: 0, timedOut: false };
+  }
+  if (cmd.includes("'rev-parse' '--verify' 'main'")) {
+    return { stdout: 'abc123\n', stderr: '', exitCode: 0, timedOut: false };
+  }
+  if (cmd.includes("'rev-parse' '--verify' 'master'")) {
+    return { stdout: '', stderr: '', exitCode: 128, timedOut: false };
+  }
+  // `git remote set-head origin -a` (refresh-default-branch). Success.
+  if (cmd.includes("'remote' 'set-head' 'origin' '-a'")) {
+    return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+  }
+  // Any other command (e.g., `git worktree add`) falls back to success so
+  // tests that exercise non-branch paths are not broken by this responder.
+  return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+}
+
+async function worktreeRunAsUserImpl(opts: RunAsUserOpts): Promise<RunAsUserResult> {
+  worktreeRunAsUserCalls.push(opts);
+  const override = worktreeRunAsUserOverride.fn?.(opts);
+  if (override) return override;
+  return worktreeRunAsUserDefault(opts);
+}
+
+function resetWorktreeRunAsUserMock() {
+  worktreeRunAsUserCalls = [];
+  worktreeRunAsUserOverride.fn = null;
+}
 
 // =============================================================================
 // Test Setup
@@ -245,6 +303,10 @@ describe('API Routes Integration', () => {
 
     // Setup default git command responses
     setupDefaultGitMocks();
+
+    // Reset the WorktreeService runAsUser capture/responder for branch
+    // enumeration tests (Issue #870).
+    resetWorktreeRunAsUserMock();
   });
 
   afterEach(async () => {
@@ -311,7 +373,10 @@ describe('API Routes Integration', () => {
         repositoryManager: testRepositoryManager!,
         systemCapabilities: testSystemCapabilities!,
         agentManager: testAgentManager!,
-        worktreeService: new WorktreeService({ db: getDatabase() }),
+        worktreeService: new WorktreeService({
+          db: getDatabase(),
+          runAsUserImpl: worktreeRunAsUserImpl,
+        }),
         suggestSessionMetadata: mockSuggestSessionMetadata,
         broadcastToApp: mockBroadcastToApp,
         findOpenPullRequest: mockFindOpenPullRequest,
@@ -1303,8 +1368,16 @@ describe('API Routes Integration', () => {
         const app = await createApp();
         const { repo } = await registerTestRepo(app);
 
-        // Mock refreshDefaultBranch to return 'develop' (simulating remote changed)
-        mockGit.refreshDefaultBranch.mockImplementationOnce(() => Promise.resolve('develop'));
+        // Make the symbolic-ref probe report `origin/HEAD -> develop`,
+        // simulating that the remote default changed after the `git remote
+        // set-head origin -a` call. The default responder accepts the
+        // set-head call itself with exit 0.
+        worktreeRunAsUserOverride.fn = (opts) => {
+          if (opts.command.includes("'symbolic-ref' 'refs/remotes/origin/HEAD'")) {
+            return { stdout: 'refs/remotes/origin/develop\n', stderr: '', exitCode: 0, timedOut: false };
+          }
+          return null;
+        };
 
         const res = await app.request(`/api/repositories/${repo.id}/refresh-default-branch`, {
           method: 'POST',
@@ -1328,10 +1401,20 @@ describe('API Routes Integration', () => {
         const app = await createApp();
         const { repo } = await registerTestRepo(app);
 
-        // Mock refreshDefaultBranch to reject with GitError (simulating network error)
-        mockGit.refreshDefaultBranch.mockImplementationOnce(() =>
-          Promise.reject(new GitError('git remote set-head failed: network error', 128, 'fatal: unable to access'))
-        );
+        // Make `git remote set-head origin -a` fail (simulating network /
+        // SSH-auth failure). The service surfaces this as GitError and the
+        // route maps it to ValidationError (HTTP 400).
+        worktreeRunAsUserOverride.fn = (opts) => {
+          if (opts.command.includes("'remote' 'set-head' 'origin' '-a'")) {
+            return {
+              stdout: '',
+              stderr: 'fatal: unable to access remote',
+              exitCode: 128,
+              timedOut: false,
+            };
+          }
+          return null;
+        };
 
         const res = await app.request(`/api/repositories/${repo.id}/refresh-default-branch`, {
           method: 'POST',

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -52,6 +52,18 @@ const repositoryCloneService = {
   getJob: mock((_jobId: string) => undefined as any),
 };
 
+// Mock of the worktreeService for the /branches and /refresh-default-branch
+// routes (Issue #870). Captures the `requestUsername` second arg so each test
+// can assert the route forwarded `authUser.username` correctly.
+const worktreeService = {
+  listBranches: mock((_repoPath: string, _requestUsername?: string | null) =>
+    Promise.resolve({ local: [], remote: [], defaultBranch: null }),
+  ),
+  refreshDefaultBranch: mock((_repoPath: string, _requestUsername?: string | null) =>
+    Promise.resolve('main'),
+  ),
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -73,6 +85,12 @@ function resetAllMocks(): void {
   repositoryCloneService.enqueueClone.mockReset();
   repositoryCloneService.enqueueClone.mockImplementation(() => Promise.resolve('mock-job-id'));
   repositoryCloneService.getJob.mockReset();
+  worktreeService.listBranches.mockReset();
+  worktreeService.listBranches.mockImplementation(() =>
+    Promise.resolve({ local: [], remote: [], defaultBranch: null }),
+  );
+  worktreeService.refreshDefaultBranch.mockReset();
+  worktreeService.refreshDefaultBranch.mockImplementation(() => Promise.resolve('main'));
 }
 
 // ---------------------------------------------------------------------------
@@ -92,6 +110,7 @@ describe('Repositories API', () => {
       agentManager: agentManager as any,
       generateRepositoryDescription: mockGenerateDescription as any,
       repositoryCloneService: repositoryCloneService as any,
+      worktreeService: worktreeService as any,
     });
   });
 
@@ -236,6 +255,87 @@ describe('Repositories API', () => {
       const body = (await res.json()) as { behind: number; ahead: number };
       expect(body.behind).toBe(3);
       expect(body.ahead).toBe(1);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/repositories/:id/branches (Issue #870)
+  // POST /api/repositories/:id/refresh-default-branch (Issue #870)
+  //
+  // These two routes thread `authUser.username` into `worktreeService` so
+  // multi-user mode runs git invocations as the requesting user. The test
+  // app wires SingleUserMode with TEST_AUTH_USER.username = 'testuser', so
+  // we assert that value lands on each service call.
+  // =========================================================================
+
+  describe('GET /api/repositories/:id/branches', () => {
+    it('forwards authUser.username to worktreeService.listBranches', async () => {
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      worktreeService.listBranches.mockImplementationOnce(() =>
+        Promise.resolve({ local: ['main'], remote: ['origin/main'], defaultBranch: 'main' }),
+      );
+
+      const res = await app.request('/api/repositories/repo1/branches');
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as {
+        local: string[];
+        remote: string[];
+        defaultBranch: string | null;
+      };
+      expect(body.local).toEqual(['main']);
+      expect(body.remote).toEqual(['origin/main']);
+      expect(body.defaultBranch).toBe('main');
+
+      expect(worktreeService.listBranches).toHaveBeenCalledTimes(1);
+      const [repoPath, requestUsername] = worktreeService.listBranches.mock.calls[0];
+      expect(repoPath).toBe('/repo');
+      expect(requestUsername).toBe('testuser');
+    });
+
+    it('returns 404 when the repository is not registered', async () => {
+      repositoryManager.getRepository.mockReturnValue(undefined);
+
+      const res = await app.request('/api/repositories/missing/branches');
+      expect(res.status).toBe(404);
+      expect(worktreeService.listBranches).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('POST /api/repositories/:id/refresh-default-branch', () => {
+    it('forwards authUser.username to worktreeService.refreshDefaultBranch', async () => {
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      worktreeService.refreshDefaultBranch.mockImplementationOnce(() =>
+        Promise.resolve('develop'),
+      );
+
+      const res = await app.request('/api/repositories/repo1/refresh-default-branch', {
+        method: 'POST',
+      });
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as { defaultBranch: string };
+      expect(body.defaultBranch).toBe('develop');
+
+      expect(worktreeService.refreshDefaultBranch).toHaveBeenCalledTimes(1);
+      const [repoPath, requestUsername] = worktreeService.refreshDefaultBranch.mock.calls[0];
+      expect(repoPath).toBe('/repo');
+      expect(requestUsername).toBe('testuser');
+    });
+
+    it('maps GitError to a 400 response (network failure surfaces as Validation)', async () => {
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      worktreeService.refreshDefaultBranch.mockImplementationOnce(() => {
+        throw new GitError('network unreachable', 128, 'fatal: network unreachable');
+      });
+
+      const res = await app.request('/api/repositories/repo1/refresh-default-branch', {
+        method: 'POST',
+      });
+      expect(res.status).toBe(400);
+
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain('Failed to refresh default branch');
     });
   });
 

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -55,13 +55,15 @@ const repositoryCloneService = {
 // Mock of the worktreeService for the /branches and /refresh-default-branch
 // routes (Issue #870). Captures the `requestUsername` second arg so each test
 // can assert the route forwarded `authUser.username` correctly.
+type BranchesResult = { local: string[]; remote: string[]; defaultBranch: string | null };
+
 const worktreeService = {
-  listBranches: mock((_repoPath: string, _requestUsername?: string | null) =>
-    Promise.resolve({ local: [], remote: [], defaultBranch: null }),
-  ),
-  refreshDefaultBranch: mock((_repoPath: string, _requestUsername?: string | null) =>
-    Promise.resolve('main'),
-  ),
+  listBranches: mock<
+    (repoPath: string, requestUsername?: string | null) => Promise<BranchesResult>
+  >(() => Promise.resolve({ local: [], remote: [], defaultBranch: null })),
+  refreshDefaultBranch: mock<
+    (repoPath: string, requestUsername?: string | null) => Promise<string>
+  >(() => Promise.resolve('main')),
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/routes/__tests__/sessions.test.ts
+++ b/packages/server/src/routes/__tests__/sessions.test.ts
@@ -730,20 +730,31 @@ describe('Sessions API - POST /api/sessions (shared sessions)', () => {
 // ===========================================================================
 // GET /api/sessions/:sessionId/branches (Issue #870)
 //
-// The route threads `authUser.username` into `worktreeService.listBranches`
-// so multi-user mode runs the git invocations as the requesting user (PATH,
-// gitconfig, SSH_AUTH_SOCK from the user's login shell). The default test
-// app wires SingleUserMode with TEST_AUTH_USER.username = 'testuser', so we
-// assert that value lands on the service call.
+// The route resolves the session's effective spawn user (via
+// `resolveSpawnUsername(session.createdBy, userRepository)`) and threads it
+// into `worktreeService.listBranches` so multi-user mode runs the git
+// invocations as the OS user that owns the worktree. For shared sessions
+// the spawn user is the shared account, NOT the authenticated viewer --
+// using the viewer's identity would reintroduce dubious-ownership /
+// missing-credential failures (CodeRabbit review on PR #874).
 // ===========================================================================
 describe('Sessions API - GET /api/sessions/:sessionId/branches', () => {
   let app: Hono<AppBindings>;
   const mockSessionManager = {
     getSession: mock((_id: string) => undefined as any),
   };
+  type BranchesResult = { local: string[]; remote: string[]; defaultBranch: string | null };
   const mockWorktreeService = {
-    listBranches: mock((_repoPath: string, _requestUsername?: string | null) =>
-      Promise.resolve({ local: [], remote: [], defaultBranch: null }),
+    listBranches: mock<
+      (repoPath: string, requestUsername?: string | null) => Promise<BranchesResult>
+    >(() => Promise.resolve({ local: [], remote: [], defaultBranch: null })),
+  };
+  // Minimal UserRepository stub: returns a user when findById is called with
+  // an id we registered. Lets us drive resolveSpawnUsername deterministically
+  // without spinning up a sqlite repo.
+  const mockUserRepository: any = {
+    findById: mock<(id: string) => Promise<{ id: string; username: string; homeDir: string } | null>>(
+      () => Promise.resolve(null),
     ),
   };
 
@@ -753,6 +764,8 @@ describe('Sessions API - GET /api/sessions/:sessionId/branches', () => {
     mockWorktreeService.listBranches.mockImplementation(() =>
       Promise.resolve({ local: [], remote: [], defaultBranch: null }),
     );
+    mockUserRepository.findById.mockReset();
+    mockUserRepository.findById.mockImplementation(() => Promise.resolve(null));
 
     app = new Hono<AppBindings>();
     app.use('*', async (c, next) => {
@@ -761,6 +774,7 @@ describe('Sessions API - GET /api/sessions/:sessionId/branches', () => {
         asAppContext({
           sessionManager: mockSessionManager as any,
           worktreeService: mockWorktreeService as any,
+          userRepository: mockUserRepository,
         }),
       );
       await next();
@@ -769,11 +783,17 @@ describe('Sessions API - GET /api/sessions/:sessionId/branches', () => {
     app.route('/api', api);
   });
 
-  it('forwards authUser.username to worktreeService.listBranches', async () => {
+  it('forwards the session spawn username (resolved via createdBy) to worktreeService.listBranches', async () => {
     mockSessionManager.getSession.mockReturnValueOnce({
       id: 'session1',
       locationPath: '/worktree/wt-001-aaaa',
+      createdBy: 'shared-account-id',
     });
+    mockUserRepository.findById.mockImplementationOnce((id: string) =>
+      id === 'shared-account-id'
+        ? Promise.resolve({ id, username: 'sharedacct', homeDir: '/home/sharedacct' })
+        : Promise.resolve(null),
+    );
     mockWorktreeService.listBranches.mockImplementationOnce(() =>
       Promise.resolve({ local: ['main'], remote: ['origin/main'], defaultBranch: 'main' }),
     );
@@ -793,7 +813,8 @@ describe('Sessions API - GET /api/sessions/:sessionId/branches', () => {
     expect(mockWorktreeService.listBranches).toHaveBeenCalledTimes(1);
     const [locationPath, requestUsername] = mockWorktreeService.listBranches.mock.calls[0];
     expect(locationPath).toBe('/worktree/wt-001-aaaa');
-    expect(requestUsername).toBe('testuser');
+    // Critical: the shared-account spawn user, NOT the authenticated viewer.
+    expect(requestUsername).toBe('sharedacct');
   });
 
   it('returns 404 when the session does not exist', async () => {

--- a/packages/server/src/routes/__tests__/sessions.test.ts
+++ b/packages/server/src/routes/__tests__/sessions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { Hono } from 'hono';
 import { onApiError } from '../../lib/error-handler.js';
 import { api } from '../api.js';
@@ -724,5 +724,83 @@ describe('Sessions API - POST /api/sessions (shared sessions)', () => {
     });
 
     expect(res.status).toBe(400);
+  });
+});
+
+// ===========================================================================
+// GET /api/sessions/:sessionId/branches (Issue #870)
+//
+// The route threads `authUser.username` into `worktreeService.listBranches`
+// so multi-user mode runs the git invocations as the requesting user (PATH,
+// gitconfig, SSH_AUTH_SOCK from the user's login shell). The default test
+// app wires SingleUserMode with TEST_AUTH_USER.username = 'testuser', so we
+// assert that value lands on the service call.
+// ===========================================================================
+describe('Sessions API - GET /api/sessions/:sessionId/branches', () => {
+  let app: Hono<AppBindings>;
+  const mockSessionManager = {
+    getSession: mock((_id: string) => undefined as any),
+  };
+  const mockWorktreeService = {
+    listBranches: mock((_repoPath: string, _requestUsername?: string | null) =>
+      Promise.resolve({ local: [], remote: [], defaultBranch: null }),
+    ),
+  };
+
+  beforeEach(() => {
+    mockSessionManager.getSession.mockReset();
+    mockWorktreeService.listBranches.mockReset();
+    mockWorktreeService.listBranches.mockImplementation(() =>
+      Promise.resolve({ local: [], remote: [], defaultBranch: null }),
+    );
+
+    app = new Hono<AppBindings>();
+    app.use('*', async (c, next) => {
+      c.set(
+        'appContext',
+        asAppContext({
+          sessionManager: mockSessionManager as any,
+          worktreeService: mockWorktreeService as any,
+        }),
+      );
+      await next();
+    });
+    app.onError(onApiError);
+    app.route('/api', api);
+  });
+
+  it('forwards authUser.username to worktreeService.listBranches', async () => {
+    mockSessionManager.getSession.mockReturnValueOnce({
+      id: 'session1',
+      locationPath: '/worktree/wt-001-aaaa',
+    });
+    mockWorktreeService.listBranches.mockImplementationOnce(() =>
+      Promise.resolve({ local: ['main'], remote: ['origin/main'], defaultBranch: 'main' }),
+    );
+
+    const res = await app.request('/api/sessions/session1/branches');
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      local: string[];
+      remote: string[];
+      defaultBranch: string | null;
+    };
+    expect(body.local).toEqual(['main']);
+    expect(body.remote).toEqual(['origin/main']);
+    expect(body.defaultBranch).toBe('main');
+
+    expect(mockWorktreeService.listBranches).toHaveBeenCalledTimes(1);
+    const [locationPath, requestUsername] = mockWorktreeService.listBranches.mock.calls[0];
+    expect(locationPath).toBe('/worktree/wt-001-aaaa');
+    expect(requestUsername).toBe('testuser');
+  });
+
+  it('returns 404 when the session does not exist', async () => {
+    mockSessionManager.getSession.mockReturnValueOnce(undefined);
+
+    const res = await app.request('/api/sessions/missing/branches');
+    expect(res.status).toBe(404);
+    expect(mockWorktreeService.listBranches).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/server/src/routes/repositories.ts
+++ b/packages/server/src/routes/repositories.ts
@@ -282,19 +282,26 @@ const repositories = new Hono<AppBindings>()
   .get('/:id/branches', async (c) => {
     const repoId = c.req.param('id');
     const { repositoryManager, worktreeService } = c.get('appContext');
+    const authUser = c.get('authUser');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {
       throw new NotFoundError('Repository');
     }
 
-    const branches = await worktreeService.listBranches(repo.path);
+    // Thread the authenticated username so multi-user mode runs the git
+    // invocations as the requesting user (Issue #870). The user's PATH,
+    // gitconfig, and SSH_AUTH_SOCK are picked up from their login shell
+    // via `sudo -i`; without this elevation the server's `agentconsole`
+    // identity has no SSH credentials and may hit `dubious ownership`.
+    const branches = await worktreeService.listBranches(repo.path, authUser.username);
     return c.json(branches);
   })
   // Refresh default branch from remote for a repository
   .post('/:id/refresh-default-branch', async (c) => {
     const repoId = c.req.param('id');
     const { repositoryManager, worktreeService } = c.get('appContext');
+    const authUser = c.get('authUser');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {
@@ -302,7 +309,10 @@ const repositories = new Hono<AppBindings>()
     }
 
     try {
-      const defaultBranch = await worktreeService.refreshDefaultBranch(repo.path);
+      // Thread the authenticated username so the SSH-using `git remote
+      // set-head` runs as the requesting user (Issue #870). See the
+      // GET /:id/branches handler above for the same rationale.
+      const defaultBranch = await worktreeService.refreshDefaultBranch(repo.path, authUser.username);
       return c.json({ defaultBranch });
     } catch (error) {
       // Handle git-specific errors (network issues, no remote, etc.)

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -9,6 +9,7 @@ import { createSessionValidationService } from '../services/session-validation-s
 import { InternalError, NotFoundError, ValidationError } from '../lib/errors.js';
 import { vValidator, vQueryValidator } from '../middleware/validation.js';
 import { getOrgRepoFromPath } from '../lib/git.js';
+import { resolveSpawnUsername } from '../services/resolve-spawn-username.js';
 import type { AppBindings } from '../app-context.js';
 
 const sessions = new Hono<AppBindings>()
@@ -190,17 +191,24 @@ const sessions = new Hono<AppBindings>()
   // Get branches for a session's repository
   .get('/:sessionId/branches', async (c) => {
     const sessionId = c.req.param('sessionId');
-    const { sessionManager, worktreeService } = c.get('appContext');
-    const authUser = c.get('authUser');
+    const { sessionManager, worktreeService, userRepository } = c.get('appContext');
     const session = sessionManager.getSession(sessionId);
 
     if (!session) {
       throw new NotFoundError('Session');
     }
 
-    // Thread the authenticated username so multi-user mode runs the git
-    // invocations as the requesting user (Issue #870).
-    const branches = await worktreeService.listBranches(session.locationPath, authUser.username);
+    // Multi-user mode: run the git invocations as the session's effective
+    // spawn user (the OS user that owns the worktree), not as the viewer.
+    // For shared sessions the spawn user is the shared account; using the
+    // viewer's identity would reintroduce dubious-ownership / missing-
+    // credential failures and silently fall back to empty branches.
+    // `resolveSpawnUsername` mirrors the resolution `SessionManager` uses
+    // when launching the session's PTY workers; falls back to the server
+    // username when the session has no `createdBy` or the lookup fails.
+    // (Issue #870, CodeRabbit review on #874.)
+    const spawnUsername = await resolveSpawnUsername(session.createdBy, userRepository);
+    const branches = await worktreeService.listBranches(session.locationPath, spawnUsername);
     return c.json(branches);
   })
   // Get commits created in this branch (since base commit)

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -191,13 +191,16 @@ const sessions = new Hono<AppBindings>()
   .get('/:sessionId/branches', async (c) => {
     const sessionId = c.req.param('sessionId');
     const { sessionManager, worktreeService } = c.get('appContext');
+    const authUser = c.get('authUser');
     const session = sessionManager.getSession(sessionId);
 
     if (!session) {
       throw new NotFoundError('Session');
     }
 
-    const branches = await worktreeService.listBranches(session.locationPath);
+    // Thread the authenticated username so multi-user mode runs the git
+    // invocations as the requesting user (Issue #870).
+    const branches = await worktreeService.listBranches(session.locationPath, authUser.username);
     return c.json(branches);
   })
   // Get commits created in this branch (since base commit)

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -883,52 +883,418 @@ detached
     });
   });
 
+  // ===========================================================================
+  // listBranches / getDefaultBranch / refreshDefaultBranch (Issue #870)
+  //
+  // The three branch-related methods now route all git invocations through
+  // `runAsUser` so multi-user mode can pick up the requesting user's SSH
+  // credentials, PATH, and gitconfig (eliminating "Could not check remote
+  // status" and `dubious ownership` errors against user-owned source repos).
+  // Tests inject a `runAsUserImpl` capture mock and dispatch by inspecting
+  // the captured command string.
+  // ===========================================================================
+
+  /**
+   * Build a command-aware responder for the WorktreeService runAsUser mock.
+   * Returns a builder you can compose with `with(matcher, response)`; falls
+   * back to a happy-path default for unmatched commands so individual tests
+   * only need to override the cases they care about.
+   */
+  function makeCommandResponder() {
+    const matchers: Array<{
+      match: (cmd: string) => boolean;
+      response: RunAsUserResult;
+    }> = [];
+    const responder = (cmd: string): RunAsUserResult => {
+      for (const m of matchers) {
+        if (m.match(cmd)) return m.response;
+      }
+      // Default success for unmatched commands (mostly: `git worktree add`
+      // when these listBranches tests construct a service that also serves
+      // create paths).
+      return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+    };
+    return {
+      with(match: (cmd: string) => boolean, response: RunAsUserResult) {
+        matchers.push({ match, response });
+        return this;
+      },
+      get fn() {
+        return responder;
+      },
+    };
+  }
+
   describe('listBranches', () => {
-    it('should list local and remote branches', async () => {
+    it('routes through runAsUser with username=null when no requestUsername is supplied', async () => {
+      const r = makeCommandResponder()
+        .with(
+          (c) => c.includes("'branch' '--format=%(refname:short)'") && !c.includes("'-r'"),
+          { stdout: 'main\nfeature-1\nfeature-2\n', stderr: '', exitCode: 0, timedOut: false },
+        )
+        .with(
+          (c) => c.includes("'branch' '-r' '--format=%(refname:short)'"),
+          { stdout: 'origin/main\norigin/develop\n', stderr: '', exitCode: 0, timedOut: false },
+        )
+        .with(
+          (c) => c.includes("'symbolic-ref' 'refs/remotes/origin/HEAD'"),
+          { stdout: 'refs/remotes/origin/main\n', stderr: '', exitCode: 0, timedOut: false },
+        );
+      runAsUserMock.responder.fn = async (opts) => r.fn(opts.command);
+
       const WorktreeService = await getWorktreeService();
-      const service = new WorktreeService({ worktreeRepository: mockRepo });
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
 
       const result = await service.listBranches('/repo');
 
-      expect(result.local).toContain('main');
-      expect(result.local).toContain('feature-1');
-      expect(result.remote).toContain('origin/main');
+      expect(result.local).toEqual(['main', 'feature-1', 'feature-2']);
+      expect(result.remote).toEqual(['origin/main', 'origin/develop']);
       expect(result.defaultBranch).toBe('main');
+
+      // Every call went through runAsUser with username=null (no elevation),
+      // cwd=/repo, and a shell-escaped git command.
+      expect(runAsUserMock.calls.length).toBeGreaterThan(0);
+      for (const call of runAsUserMock.calls) {
+        expect(call.username).toBeNull();
+        expect(call.cwd).toBe('/repo');
+        expect(call.command.startsWith("'git'")).toBe(true);
+      }
     });
 
-    it('should return empty arrays on error', async () => {
-      mockGit.listLocalBranches.mockImplementation(() => Promise.reject(new Error('git error')));
-      mockGit.listRemoteBranches.mockImplementation(() => Promise.reject(new Error('git error')));
-      mockGit.getDefaultBranch.mockImplementation(() => Promise.reject(new Error('git error')));
+    it('forwards a non-null requestUsername to runAsUser for every invocation (elevated path)', async () => {
+      runAsUserMock.responder.fn = async (opts) => {
+        if (opts.command.includes("'symbolic-ref'")) {
+          return {
+            stdout: 'refs/remotes/origin/main\n',
+            stderr: '',
+            exitCode: 0,
+            timedOut: false,
+          };
+        }
+        return { stdout: 'main\n', stderr: '', exitCode: 0, timedOut: false };
+      };
 
       const WorktreeService = await getWorktreeService();
-      const service = new WorktreeService({ worktreeRepository: mockRepo });
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      await service.listBranches('/repo', 'alice');
+
+      // All three calls (local, remote, symbolic-ref) carry username='alice'.
+      expect(runAsUserMock.calls.length).toBe(3);
+      for (const call of runAsUserMock.calls) {
+        expect(call.username).toBe('alice');
+        expect(call.cwd).toBe('/repo');
+      }
+      const commands = runAsUserMock.calls.map((c) => c.command);
+      expect(commands.some((c) => c.includes("'branch' '--format=%(refname:short)'"))).toBe(true);
+      expect(commands.some((c) => c.includes("'branch' '-r' '--format=%(refname:short)'"))).toBe(true);
+      expect(commands.some((c) => c.includes("'symbolic-ref' 'refs/remotes/origin/HEAD'"))).toBe(true);
+    });
+
+    it('returns the swallow contract on non-zero exits (the UI banner case)', async () => {
+      runAsUserMock.responder.fn = async () => ({
+        stdout: '',
+        stderr: 'fatal: detected dubious ownership',
+        exitCode: 128,
+        timedOut: false,
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      const result = await service.listBranches('/repo', 'alice');
+
+      expect(result).toEqual({ local: [], remote: [], defaultBranch: null });
+    });
+
+    it('treats empty stdout as no branches (boundary)', async () => {
+      runAsUserMock.responder.fn = async () => ({
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
 
       const result = await service.listBranches('/repo');
 
       expect(result.local).toEqual([]);
       expect(result.remote).toEqual([]);
-      expect(result.defaultBranch).toBeNull();
+      // All three resolve-default-branch probes return empty/exit 0 -- the
+      // symbolic-ref output is empty (so no value), and rev-parse exits 0
+      // (so 'main' resolves). The output is empty for symbolic-ref so the
+      // service falls through to rev-parse main, which succeeds.
+      expect(result.defaultBranch).toBe('main');
     });
   });
 
   describe('getDefaultBranch', () => {
-    it('should return default branch from git', async () => {
+    it('returns the branch from symbolic-ref when it succeeds', async () => {
+      runAsUserMock.responder.fn = async (opts) => {
+        if (opts.command.includes("'symbolic-ref'")) {
+          return {
+            stdout: 'refs/remotes/origin/main\n',
+            stderr: '',
+            exitCode: 0,
+            timedOut: false,
+          };
+        }
+        // Should not be reached when symbolic-ref succeeds.
+        return { stdout: '', stderr: '', exitCode: 128, timedOut: false };
+      };
+
       const WorktreeService = await getWorktreeService();
-      const service = new WorktreeService({ worktreeRepository: mockRepo });
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      const result = await service.getDefaultBranch('/repo');
+      expect(result).toBe('main');
+      // Only one call -- the symbolic-ref short-circuit.
+      expect(runAsUserMock.calls.length).toBe(1);
+    });
+
+    it('falls back to `main` when symbolic-ref fails but rev-parse main succeeds', async () => {
+      runAsUserMock.responder.fn = async (opts) => {
+        if (opts.command.includes("'symbolic-ref'")) {
+          return {
+            stdout: '',
+            stderr: "fatal: ref refs/remotes/origin/HEAD is not a symbolic ref",
+            exitCode: 128,
+            timedOut: false,
+          };
+        }
+        if (opts.command.includes("'rev-parse' '--verify' 'main'")) {
+          return { stdout: 'abc123\n', stderr: '', exitCode: 0, timedOut: false };
+        }
+        return { stdout: '', stderr: '', exitCode: 128, timedOut: false };
+      };
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
 
       const result = await service.getDefaultBranch('/repo');
       expect(result).toBe('main');
     });
 
-    it('should return null if no default branch found', async () => {
-      mockGit.getDefaultBranch.mockImplementation(() => Promise.resolve(null));
+    it('falls back to `master` when both symbolic-ref and main fail', async () => {
+      runAsUserMock.responder.fn = async (opts) => {
+        if (opts.command.includes("'symbolic-ref'")) {
+          return { stdout: '', stderr: '', exitCode: 128, timedOut: false };
+        }
+        if (opts.command.includes("'rev-parse' '--verify' 'main'")) {
+          return { stdout: '', stderr: '', exitCode: 128, timedOut: false };
+        }
+        if (opts.command.includes("'rev-parse' '--verify' 'master'")) {
+          return { stdout: 'def456\n', stderr: '', exitCode: 0, timedOut: false };
+        }
+        return { stdout: '', stderr: '', exitCode: 128, timedOut: false };
+      };
 
       const WorktreeService = await getWorktreeService();
-      const service = new WorktreeService({ worktreeRepository: mockRepo });
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      const result = await service.getDefaultBranch('/repo');
+      expect(result).toBe('master');
+    });
+
+    it('returns null when every probe fails', async () => {
+      runAsUserMock.responder.fn = async () => ({
+        stdout: '',
+        stderr: '',
+        exitCode: 128,
+        timedOut: false,
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
 
       const result = await service.getDefaultBranch('/repo');
       expect(result).toBeNull();
+      // All three probes were attempted.
+      expect(runAsUserMock.calls.length).toBe(3);
+    });
+
+    it('forwards a non-null requestUsername (elevated path)', async () => {
+      runAsUserMock.responder.fn = async () => ({
+        stdout: 'refs/remotes/origin/main\n',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      await service.getDefaultBranch('/repo', 'alice');
+
+      expect(runAsUserMock.calls.length).toBe(1);
+      expect(runAsUserMock.calls[0].username).toBe('alice');
+      expect(runAsUserMock.calls[0].cwd).toBe('/repo');
+    });
+  });
+
+  describe('refreshDefaultBranch', () => {
+    it('runs `git remote set-head origin -a` then resolves the default branch', async () => {
+      const r = makeCommandResponder()
+        .with(
+          (c) => c.includes("'remote' 'set-head' 'origin' '-a'"),
+          { stdout: '', stderr: '', exitCode: 0, timedOut: false },
+        )
+        .with(
+          (c) => c.includes("'symbolic-ref' 'refs/remotes/origin/HEAD'"),
+          { stdout: 'refs/remotes/origin/develop\n', stderr: '', exitCode: 0, timedOut: false },
+        );
+      runAsUserMock.responder.fn = async (opts) => r.fn(opts.command);
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      const result = await service.refreshDefaultBranch('/repo');
+
+      expect(result).toBe('develop');
+      // First call is the network set-head; second is the symbolic-ref probe.
+      expect(runAsUserMock.calls.length).toBe(2);
+      expect(runAsUserMock.calls[0].command).toMatch(
+        /^'git' 'remote' 'set-head' 'origin' '-a'$/,
+      );
+      expect(runAsUserMock.calls[0].cwd).toBe('/repo');
+      expect(runAsUserMock.calls[1].command).toContain("'symbolic-ref'");
+    });
+
+    it('throws GitError when the network set-head call fails', async () => {
+      runAsUserMock.responder.fn = async (opts) => {
+        if (opts.command.includes("'remote' 'set-head' 'origin' '-a'")) {
+          return {
+            stdout: '',
+            stderr: 'fatal: unable to access remote',
+            exitCode: 128,
+            timedOut: false,
+          };
+        }
+        return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+      };
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      let caught: unknown;
+      try {
+        await service.refreshDefaultBranch('/repo');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(GitError);
+      expect((caught as Error).message).toContain('git remote set-head failed');
+      expect((caught as Error).message).toContain('unable to access remote');
+    });
+
+    it('throws GitError when the post-refresh resolution returns null', async () => {
+      runAsUserMock.responder.fn = async (opts) => {
+        if (opts.command.includes("'remote' 'set-head' 'origin' '-a'")) {
+          return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+        }
+        // Every resolution probe fails -> null
+        return { stdout: '', stderr: '', exitCode: 128, timedOut: false };
+      };
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      let caught: unknown;
+      try {
+        await service.refreshDefaultBranch('/repo');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(GitError);
+      expect((caught as Error).message).toContain('Could not determine default branch after refresh');
+    });
+
+    it('forwards a non-null requestUsername to every invocation (elevated path)', async () => {
+      const r = makeCommandResponder()
+        .with(
+          (c) => c.includes("'remote' 'set-head' 'origin' '-a'"),
+          { stdout: '', stderr: '', exitCode: 0, timedOut: false },
+        )
+        .with(
+          (c) => c.includes("'symbolic-ref' 'refs/remotes/origin/HEAD'"),
+          { stdout: 'refs/remotes/origin/main\n', stderr: '', exitCode: 0, timedOut: false },
+        );
+      runAsUserMock.responder.fn = async (opts) => r.fn(opts.command);
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      const result = await service.refreshDefaultBranch('/repo', 'alice');
+
+      expect(result).toBe('main');
+      expect(runAsUserMock.calls.length).toBe(2);
+      for (const call of runAsUserMock.calls) {
+        expect(call.username).toBe('alice');
+        expect(call.cwd).toBe('/repo');
+      }
+    });
+
+    it('throws GitError when the runAsUser helper itself throws (spawn failure)', async () => {
+      runAsUserMock.responder.fn = async () => {
+        throw new Error('spawn sudo ENOENT');
+      };
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      let caught: unknown;
+      try {
+        await service.refreshDefaultBranch('/repo', 'alice');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(GitError);
+      expect((caught as Error).message).toContain('git remote set-head failed');
+      expect((caught as Error).message).toContain('spawn sudo ENOENT');
     });
   });
 

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -7,10 +7,6 @@ import {
   parseOrgRepo,
   listWorktrees as gitListWorktrees,
   removeWorktree as gitRemoveWorktree,
-  listLocalBranches,
-  listRemoteBranches,
-  getDefaultBranch as gitGetDefaultBranch,
-  refreshDefaultBranch as gitRefreshDefaultBranch,
   GitError,
 } from '../lib/git.js';
 import { createLogger } from '../lib/logger.js';
@@ -48,6 +44,23 @@ const SAFE_DIRECTORY_BOOTSTRAP_TIMEOUT_MS = 10000;
  * elevated branch). Local fs only, short content -- 10s is generous.
  */
 const TEMPLATE_MATERIALIZE_TIMEOUT_MS = 10000;
+
+/**
+ * Timeout for local-only branch enumeration / resolution commands routed
+ * through `runAsUser` (`git branch ...`, `git symbolic-ref ...`,
+ * `git rev-parse --verify ...`). Mirrors `DEFAULT_GIT_TIMEOUT_MS` in
+ * `lib/git.ts` -- these calls do not touch the network.
+ */
+const LOCAL_GIT_TIMEOUT_MS = 30000;
+
+/**
+ * Timeout for the single network git operation in this file (`git remote
+ * set-head origin -a` inside `refreshDefaultBranch`). Mirrors
+ * `NETWORK_GIT_TIMEOUT_MS` in `lib/git.ts` so the routed multi-user path
+ * has the same wall-clock budget as the direct-spawn single-user path
+ * would have.
+ */
+const NETWORK_GIT_TIMEOUT_MS = 60000;
 
 /**
  * Generate a random alphanumeric suffix
@@ -688,14 +701,38 @@ export class WorktreeService {
   }
 
   /**
-   * List branches in a repository
+   * List branches in a repository.
+   *
+   * Routes all three constituent git invocations (`git branch ...`, `git
+   * branch -r ...`, and the default-branch resolution probe) through
+   * `runAsUser` so they execute as the requesting user when the server is
+   * in `AUTH_MODE=multi-user`. Running as the requesting user means git
+   * picks up that user's PATH, `~/.gitconfig`, and -- critically for git
+   * over SSH -- their `SSH_AUTH_SOCK` (set by the user's login shell from
+   * `~/.bashrc` / `~/.profile` / 1Password CLI snippet via `sudo -i`). The
+   * server's own `SSH_AUTH_SOCK` is intentionally NOT forwarded: the
+   * server runs as a system user (`agentconsole`) which has no useful
+   * ssh-agent socket of its own. See Issue #870 for the user-facing
+   * symptom (the "Could not check remote status" banner).
+   *
+   * In `AUTH_MODE=none` or when `requestUsername` is null, `runAsUser`
+   * bypasses elevation and spawns the command directly as the server
+   * user (preserving the original single-user behaviour).
+   *
+   * Keeps the existing outer try/catch swallow contract: on overall
+   * failure the method returns `{ local: [], remote: [], defaultBranch:
+   * null }` so the UI can render a neutral "no branches" view rather
+   * than propagating an error.
    */
-  async listBranches(repoPath: string): Promise<{ local: string[]; remote: string[]; defaultBranch: string | null }> {
+  async listBranches(
+    repoPath: string,
+    requestUsername: string | null = null,
+  ): Promise<{ local: string[]; remote: string[]; defaultBranch: string | null }> {
     try {
       const [local, remote, defaultBranch] = await Promise.all([
-        listLocalBranches(repoPath),
-        listRemoteBranches(repoPath),
-        this.getDefaultBranch(repoPath),
+        this.listLocalBranchesAsUser(repoPath, requestUsername),
+        this.listRemoteBranchesAsUser(repoPath, requestUsername),
+        this.resolveDefaultBranch(repoPath, requestUsername),
       ]);
 
       return { local, remote, defaultBranch };
@@ -706,21 +743,206 @@ export class WorktreeService {
   }
 
   /**
-   * Get the default branch name from remote origin
+   * Get the default branch name from remote origin.
+   *
+   * Routes the resolution probe through `runAsUser` for the same
+   * SSH-credential / gitconfig reasons documented on `listBranches`.
    */
-  async getDefaultBranch(repoPath: string): Promise<string | null> {
-    return gitGetDefaultBranch(repoPath);
+  async getDefaultBranch(
+    repoPath: string,
+    requestUsername: string | null = null,
+  ): Promise<string | null> {
+    return this.resolveDefaultBranch(repoPath, requestUsername);
   }
 
   /**
    * Refresh the default branch reference from remote origin.
    * This updates the local refs/remotes/origin/HEAD to match the remote's default branch.
    *
+   * The network call (`git remote set-head origin -a`) is the SSH-using
+   * git invocation in this method. It is routed through `runAsUser` so
+   * that in `AUTH_MODE=multi-user` it executes as the requesting user --
+   * picking up that user's `SSH_AUTH_SOCK` from their login shell
+   * startup (`~/.bashrc` / `~/.profile` / 1Password CLI snippet), since
+   * `sudo -i` reads the target user's login env from those files. The
+   * server's own `SSH_AUTH_SOCK` is intentionally NOT forwarded: the
+   * server runs as the system user (`agentconsole`) and has no useful
+   * agent socket of its own.
+   *
    * @returns The updated default branch name
    * @throws GitError if the command fails (e.g., network error, no remote)
    */
-  async refreshDefaultBranch(repoPath: string): Promise<string> {
-    return gitRefreshDefaultBranch(repoPath);
+  async refreshDefaultBranch(
+    repoPath: string,
+    requestUsername: string | null = null,
+  ): Promise<string> {
+    const command = ['git', 'remote', 'set-head', 'origin', '-a'].map(shellEscape).join(' ');
+
+    let result: RunAsUserResult;
+    try {
+      result = await this._runAsUser({
+        username: requestUsername,
+        command,
+        cwd: repoPath,
+        timeoutMs: NETWORK_GIT_TIMEOUT_MS,
+      });
+    } catch (error) {
+      // Spawn failure (e.g., sudo missing). Surface as GitError so callers
+      // that branch on `instanceof GitError` keep working.
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new GitError(`git remote set-head failed: ${message}`, -1, message);
+    }
+
+    if (result.timedOut || result.exitCode !== 0) {
+      const stderr = result.stderr.trim();
+      const detail = stderr || `exit code ${result.exitCode}`;
+      throw new GitError(`git remote set-head failed: ${detail}`, result.exitCode, stderr);
+    }
+
+    const defaultBranch = await this.resolveDefaultBranch(repoPath, requestUsername);
+    if (!defaultBranch) {
+      throw new GitError(
+        'Could not determine default branch after refresh',
+        -1,
+        'No default branch found',
+      );
+    }
+    return defaultBranch;
+  }
+
+  /**
+   * Execute a single git command as the requesting user. Returns stdout on
+   * success, `null` when the command exits non-zero or fails to spawn.
+   * Used by the branch-enumeration helpers and the default-branch probe.
+   *
+   * The elevated user must have `SSH_AUTH_SOCK` configured in their login
+   * shell startup (`~/.bashrc` / `~/.profile` / 1Password CLI snippet)
+   * for git-over-SSH to authenticate. `sudo -i` reads the user's login
+   * env from those files; the server's own `SSH_AUTH_SOCK` is
+   * intentionally not forwarded because the server runs as a system
+   * user with no useful agent socket. See Issue #870.
+   */
+  private async runGitAsUserSafe(
+    args: string[],
+    repoPath: string,
+    requestUsername: string | null,
+    timeoutMs: number,
+  ): Promise<string | null> {
+    const command = ['git', ...args].map(shellEscape).join(' ');
+    let result: RunAsUserResult;
+    try {
+      result = await this._runAsUser({
+        username: requestUsername,
+        command,
+        cwd: repoPath,
+        timeoutMs,
+      });
+    } catch (error) {
+      logger.warn(
+        { err: error, args, repoPath, requestUsername },
+        'runGitAsUserSafe: spawn failed',
+      );
+      return null;
+    }
+    if (result.timedOut || result.exitCode !== 0) {
+      return null;
+    }
+    return result.stdout;
+  }
+
+  /**
+   * List local branches as the requesting user.
+   *
+   * Mirrors the single-user `listLocalBranches` from `lib/git.ts`: returns
+   * an empty array on any failure (output trimmed and split on newlines,
+   * empties filtered).
+   */
+  private async listLocalBranchesAsUser(
+    repoPath: string,
+    requestUsername: string | null,
+  ): Promise<string[]> {
+    const stdout = await this.runGitAsUserSafe(
+      ['branch', '--format=%(refname:short)'],
+      repoPath,
+      requestUsername,
+      LOCAL_GIT_TIMEOUT_MS,
+    );
+    if (stdout === null) return [];
+    return stdout.trim().split('\n').filter(Boolean);
+  }
+
+  /**
+   * List remote branches as the requesting user.
+   *
+   * Mirrors the single-user `listRemoteBranches` from `lib/git.ts`:
+   * returns an empty array on any failure.
+   */
+  private async listRemoteBranchesAsUser(
+    repoPath: string,
+    requestUsername: string | null,
+  ): Promise<string[]> {
+    const stdout = await this.runGitAsUserSafe(
+      ['branch', '-r', '--format=%(refname:short)'],
+      repoPath,
+      requestUsername,
+      LOCAL_GIT_TIMEOUT_MS,
+    );
+    if (stdout === null) return [];
+    return stdout.trim().split('\n').filter(Boolean);
+  }
+
+  /**
+   * Resolve the default branch as the requesting user.
+   *
+   * Mirrors the resolution order of `lib/git.ts:getDefaultBranch`:
+   *   1. `git symbolic-ref refs/remotes/origin/HEAD` -- on success, strip
+   *      the `refs/remotes/origin/` prefix and return.
+   *   2. `git rev-parse --verify main` -- on success, return `'main'`.
+   *   3. `git rev-parse --verify master` -- on success, return `'master'`.
+   *   4. Otherwise return `null`.
+   *
+   * Used by both `listBranches` (composed in parallel with the local /
+   * remote enumeration) and `refreshDefaultBranch` (called after the
+   * `git remote set-head` invocation succeeds).
+   */
+  private async resolveDefaultBranch(
+    repoPath: string,
+    requestUsername: string | null,
+  ): Promise<string | null> {
+    const symbolicRef = await this.runGitAsUserSafe(
+      ['symbolic-ref', 'refs/remotes/origin/HEAD'],
+      repoPath,
+      requestUsername,
+      LOCAL_GIT_TIMEOUT_MS,
+    );
+    if (symbolicRef !== null) {
+      const trimmed = symbolicRef.trim();
+      if (trimmed.length > 0) {
+        return trimmed.replace('refs/remotes/origin/', '');
+      }
+    }
+
+    const mainExists = await this.runGitAsUserSafe(
+      ['rev-parse', '--verify', 'main'],
+      repoPath,
+      requestUsername,
+      LOCAL_GIT_TIMEOUT_MS,
+    );
+    if (mainExists !== null) {
+      return 'main';
+    }
+
+    const masterExists = await this.runGitAsUserSafe(
+      ['rev-parse', '--verify', 'master'],
+      repoPath,
+      requestUsername,
+      LOCAL_GIT_TIMEOUT_MS,
+    );
+    if (masterExists !== null) {
+      return 'master';
+    }
+
+    return null;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes Issue #870 — "Create Worktree" dialog shows "Could not check remote status" in `AUTH_MODE=multi-user` mode.

Routes the branch enumeration / default-branch resolution / `git remote set-head` invocations in `WorktreeService` through the `runAsUser` privilege-elevation helper. Threads `authUser.username` through the `/repositories/:id/branches`, `/repositories/:id/refresh-default-branch`, and `/sessions/:sessionId/branches` routes so that in multi-user mode these git commands execute as the requesting user with that user's PATH, gitconfig, and SSH credentials.

Closes #870

## Why this works (and why it sometimes won't — SSH_AUTH_SOCK probe finding)

The issue body raises the question: does the user's SSH agent socket actually survive elevation? Validation matters because the fix depends on it.

**Conclusion: rely on the user's natural login env via the privilege helper's `-i` flag. Do NOT extend `runAsUser`'s `preserveEnv` to forward `SSH_AUTH_SOCK`.**

Rationale:

1. The current `runAsUser` defaults to `preserveEnv: ['FORCE_COLOR']`. `SSH_AUTH_SOCK` is not forwarded.
2. The server runs as `agentconsole`, a system user with `/usr/sbin/nologin`. It has no useful SSH agent socket of its own, and even if it had one the keys would belong to `agentconsole`, not to the requesting user.
3. Adding `SSH_AUTH_SOCK` to `preserveEnv` would forward `agentconsole`'s socket (or an empty value), pointing the elevated session at the wrong agent. **This is the wrong fix.**
4. The privilege helper already invokes the target user's login shell with `-i`, which sources `~/.bash_profile` → `~/.profile` → `~/.bashrc`. Users who configure their agent there — typically `export SSH_AUTH_SOCK="$HOME/.1password/agent.sock"` for 1Password CLI, or `eval $(ssh-agent)` for a plain agent — get `SSH_AUTH_SOCK` set automatically inside the elevated shell.
5. **Documented limitation:** users whose SSH agent is set up only by a graphical session (gnome-keyring's user-keyring socket at `/run/user/$UID/keyring/ssh`, or a 1Password GUI that exports the socket only into the desktop environment) will NOT have `SSH_AUTH_SOCK` set after elevation. For them, git over SSH from the worktree dialog still fails. The fix is documented in the in-code comment: they must add the agent export to their shell startup.

A reproducible probe script lives in scratchpad (`scratchpad/ssh-auth-sock-probe.ts`) for any operator who wants to validate this on a specific host — it runs three probes through `runAsUser` (default preserveEnv, `SSH_AUTH_SOCK` added to preserveEnv, and an end-to-end `git ls-remote`).

## Scope

Modified:

- `packages/server/src/services/worktree-service.ts` — `listBranches`, `getDefaultBranch`, `refreshDefaultBranch` now take an optional `requestUsername` and route all git invocations through `this._runAsUser`. New private helpers: `runGitAsUserSafe`, `listLocalBranchesAsUser`, `listRemoteBranchesAsUser`, `resolveDefaultBranch`. The previous outer try/catch swallow contract (returns `{ local: [], remote: [], defaultBranch: null }` on failure) is preserved so the UI's neutral fallback still renders. Imports of `listLocalBranches` / `listRemoteBranches` / `getDefaultBranch` / `refreshDefaultBranch` from `lib/git.ts` are removed (no longer used).
- `packages/server/src/routes/repositories.ts` — `/:id/branches` (GET) and `/:id/refresh-default-branch` (POST) now read `authUser` from the context and forward `authUser.username`.
- `packages/server/src/routes/sessions.ts` — `/:sessionId/branches` (GET) likewise.
- `packages/server/src/services/__tests__/worktree-service.test.ts` — replaces the prior `mockGit`-based branch tests with capture-and-respond tests against the existing `runAsUserImpl` DI hook. Coverage: (a) `requestUsername=null` bypass with username forwarded as `null`, (b) elevated path with username forwarded as `'alice'` for every constituent call, (c) banner swallow contract on non-zero exit (e.g. `dubious ownership`), (d) empty-stdout boundary, (e) symbolic-ref → main → master fallback chain (each layer), (f) `refreshDefaultBranch` success, network failure, post-refresh-null GitError, and spawn-failure GitError.
- `packages/server/src/__tests__/api.test.ts` — extends the integration-test `WorktreeService` construction with a command-aware `runAsUserImpl` stub so the `/repositories/:id/branches`, `/sessions/:id/branches`, and `/repositories/:id/refresh-default-branch` integration tests continue to exercise the route → service → helper composition without spawning real `git` against fake paths.

NOT modified:

- `packages/server/src/lib/git.ts` — left untouched because Issue #869 (diff-worker dubious-ownership fix) is being implemented in parallel against the same file. Elevation is wrapped at the service layer instead.
- `packages/client/src/components/worktrees/CreateWorktreeForm.tsx` — the "Could not check remote status" banner reads from `remoteStatusQuery`, which is on the `/branches/:branch/remote-status` route (Issue #869's scope, not ours). The success path here unblocks the more visible `/refresh-default-branch` action; the remote-status path is a separate follow-up.

## Test plan

- [x] `bun run typecheck` — pass.
- [x] `bun run test` — full suite green (1423 client + 349 shared + 29 integration + 2789 server + 362 hooks/skills). Exit 0.
- [x] `bun run check:lang` — pass (103 files scanned, clean).
- [x] `node .claude/skills/orchestrator/preflight-check.js` — pass; the production-file diff (`worktree-service.ts`) is matched by the sibling test diff (`worktree-service.test.ts`).
- [ ] Manual verification in a `AUTH_MODE=multi-user` environment with a user who has an SSH-configured shell startup: open the Create Worktree dialog, observe the remote default branch loads and ahead/behind counts populate (where `/branches` is sufficient — note `/branches/:branch/remote-status` is still ungated by #869).
- [ ] CodeRabbit CRITICAL/HIGH/MEDIUM findings addressed.
