### PR TITLE
fix(mcp): elevate suggestSessionMetadata to parent OS user in delegate_to_worktree

### DIFF
--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -33,12 +33,17 @@ import { SingleUserMode } from '../../services/user-mode.js';
 import { createMcpApp } from '../mcp-server.js';
 import { createWorktreeWithSession } from '../../services/worktree-creation-service.js';
 import { deleteWorktree, _getDeletionsInProgress } from '../../services/worktree-deletion-service.js';
+import type { SuggestSessionMetadataFn } from '../../services/session-metadata-suggester.js';
 
 // Mock session-metadata-suggester to avoid spawning real agent processes.
-const mockSuggestSessionMetadata = mock(async () => ({
-  branch: 'feat/auto-generated-branch',
-  title: 'Auto-Generated Title',
-}));
+// Declaring the parameter type makes `mock.calls` typed correctly so the
+// Issue #876 tests can read `mock.calls[0][0].requestUser` without casting.
+const mockSuggestSessionMetadata = mock(
+  async (_request: Parameters<SuggestSessionMetadataFn>[0]) => ({
+    branch: 'feat/auto-generated-branch',
+    title: 'Auto-Generated Title',
+  }),
+);
 
 // github-pr-service mocks (injected via McpDependencies)
 const mockFindOpenPullRequest = mock(async () => null as { number: number; title: string } | null);
@@ -2154,20 +2159,10 @@ describe('MCP Server Tools', () => {
     //   3. Orphan parent createdBy -> requestUser is null; suggestion failure
     //      falls back to `task-<timestamp>`.
     describe('Issue #876: suggestSessionMetadata receives resolved OS username', () => {
-      /**
-       * Read the first captured argument to `mockSuggestSessionMetadata`.
-       *
-       * The bun:test `mock(async () => ...)` factory at the top of this file
-       * declares no parameters, so `mock.calls` is inferred as `[][]` even
-       * though the production code passes a single options object. Cast
-       * through `unknown` to recover the real argument shape — same pattern
-       * used by `findSpawnCallByCommand` (~line 1318) and the test that
-       * reads `ptyFactory.spawn.mock.calls` (~line 1830).
-       */
+      // Read the captured `requestUser` argument from the first
+      // suggestion call (typed via the top-of-file mock parameter).
       function readSuggestRequestUser(): string | null {
-        const calls = mockSuggestSessionMetadata.mock.calls as unknown as Array<
-          [{ requestUser: string | null }]
-        >;
+        const calls = mockSuggestSessionMetadata.mock.calls;
         expect(calls.length).toBeGreaterThan(0);
         return calls[0][0].requestUser;
       }
@@ -2236,35 +2231,36 @@ describe('MCP Server Tools', () => {
           locationPath: TEST_REPO_PATH,
         }, { createdBy: 'orphan-uuid-not-in-users-table' });
 
-        // Force the suggestion to fail so the production path falls back to
-        // `task-<timestamp>`. The mock factory at the top of this file is
-        // typed as returning `{branch, title}` (no `error`), but the
-        // production response type allows `{error}` — return the
-        // success-shape fields as `undefined` to satisfy the strict
-        // generic without invasive casts. The production code checks
-        // `suggestion.error || !suggestion.branch` and falls back when
-        // `branch` is missing.
+        // Empty `branch` triggers the production fallback path
+        // (`suggestion.error || !suggestion.branch`).
         mockSuggestSessionMetadata.mockImplementationOnce(async () => ({
-          branch: undefined as unknown as string,
-          title: undefined as unknown as string,
+          branch: '',
+          title: '',
         }));
 
-        // We do not assert on the response branch shape because the
-        // listWorktrees mock would also need to know the fallback timestamp;
-        // the narrowly-scoped assertion is on the captured `requestUser`
-        // argument plus the suggestion call actually happening.
-        await setupDelegateEnvironment('task-fallback');
+        // Freeze `Date.now` so the `task-<timestamp>` fallback name is
+        // deterministic and the listWorktrees mock can match it.
+        const originalDateNow = Date.now;
+        Date.now = () => 876000;
+        await setupDelegateEnvironment('task-876000');
 
-        await callTool(app, mcpSessionId, 'delegate_to_worktree', {
-          repositoryId: 'test-repo',
-          prompt: 'Delegation from an orphan parent',
-          // branch intentionally omitted -> exercises the suggestion path
-          parentSessionId: parentSession.id,
-          parentWorkerId: 'parent-worker-id',
-        }, nextId++);
+        try {
+          const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+            repositoryId: 'test-repo',
+            prompt: 'Delegation from an orphan parent',
+            // branch intentionally omitted -> exercises the suggestion path
+            parentSessionId: parentSession.id,
+            parentWorkerId: 'parent-worker-id',
+          }, nextId++);
 
-        // The suggestion call must have received null, not a forged username.
-        expect(readSuggestRequestUser()).toBeNull();
+          expect(response.result?.isError).toBeUndefined();
+          const data = parseToolResult(response) as { branch: string };
+          expect(data.branch).toBe('task-876000');
+          // The suggestion call must have received null, not a forged username.
+          expect(readSuggestRequestUser()).toBeNull();
+        } finally {
+          Date.now = originalDateNow;
+        }
       });
     });
 

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -2137,6 +2137,137 @@ describe('MCP Server Tools', () => {
       });
     });
 
+    // -------------------------------------------------------------------------
+    // Issue #876: suggestSessionMetadata receives resolved OS username
+    // -------------------------------------------------------------------------
+    //
+    // Sibling of Issue #844: the same parent-createdBy -> OS-username
+    // resolution must also be threaded into `suggestSessionMetadata` so the
+    // headless `claude -p ...` invocation it performs runs as the requesting
+    // user in multi-user mode (otherwise it runs as the server process user,
+    // which has no per-user Claude auth, and silently falls back to
+    // `task-<timestamp>` branch names). The tests below assert the argument
+    // shape `suggestSessionMetadata` is called with, covering:
+    //   1. Resolved username -> passed through; LLM-suggested branch is used.
+    //   2. No parentSessionId -> requestUser is null; LLM suggestion still
+    //      succeeds via the default mock and the suggested branch is used.
+    //   3. Orphan parent createdBy -> requestUser is null; suggestion failure
+    //      falls back to `task-<timestamp>`.
+    describe('Issue #876: suggestSessionMetadata receives resolved OS username', () => {
+      /**
+       * Read the first captured argument to `mockSuggestSessionMetadata`.
+       *
+       * The bun:test `mock(async () => ...)` factory at the top of this file
+       * declares no parameters, so `mock.calls` is inferred as `[][]` even
+       * though the production code passes a single options object. Cast
+       * through `unknown` to recover the real argument shape — same pattern
+       * used by `findSpawnCallByCommand` (~line 1318) and the test that
+       * reads `ptyFactory.spawn.mock.calls` (~line 1830).
+       */
+      function readSuggestRequestUser(): string | null {
+        const calls = mockSuggestSessionMetadata.mock.calls as unknown as Array<
+          [{ requestUser: string | null }]
+        >;
+        expect(calls.length).toBeGreaterThan(0);
+        return calls[0][0].requestUser;
+      }
+
+      it('passes resolved OS username to suggestSessionMetadata when parent createdBy resolves to a registered user', async () => {
+        // Seed userRepository with an OS user; upsertByOsUid assigns a UUID
+        // that we thread through as the parent session's createdBy. Use a
+        // distinct uid/username from the #844 block to avoid any cross-test
+        // collisions on the in-memory database.
+        const aliceOsUid = 9101;
+        const alice = await userRepository.upsertByOsUid(aliceOsUid, 'alice876', '/home/alice876');
+
+        const parentSession = await sessionManager.createSession({
+          type: 'quick',
+          locationPath: TEST_REPO_PATH,
+        }, { createdBy: alice.id });
+
+        mockSuggestSessionMetadata.mockImplementationOnce(async () => ({
+          branch: 'fix/diff-worker-elevation',
+          title: 'Diff worker elevation',
+        }));
+
+        await setupDelegateEnvironment('fix/diff-worker-elevation');
+
+        const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+          repositoryId: 'test-repo',
+          prompt: 'Fix diff worker elevation',
+          // branch intentionally omitted -> exercises the suggestion path
+          parentSessionId: parentSession.id,
+          parentWorkerId: 'parent-worker-id',
+        }, nextId++);
+
+        expect(response.result?.isError).toBeUndefined();
+
+        // The suggestion call must have received the resolved username, not null.
+        expect(readSuggestRequestUser()).toBe('alice876');
+
+        const data = parseToolResult(response) as { branch: string };
+        expect(data.branch).toBe('fix/diff-worker-elevation');
+      });
+
+      it('passes null requestUser to suggestSessionMetadata when delegate_to_worktree is called without parentSessionId', async () => {
+        // Default mockSuggestSessionMetadata returns 'feat/auto-generated-branch';
+        // no need to override.
+        await setupDelegateEnvironment('feat/auto-generated-branch');
+
+        const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+          repositoryId: 'test-repo',
+          prompt: 'Direct delegation with no parent context',
+          // branch and parentSessionId both intentionally omitted
+        }, nextId++);
+
+        expect(response.result?.isError).toBeUndefined();
+
+        expect(readSuggestRequestUser()).toBeNull();
+
+        const data = parseToolResult(response) as { branch: string };
+        expect(data.branch).toBe('feat/auto-generated-branch');
+      });
+
+      it('passes null requestUser to suggestSessionMetadata when parent createdBy UUID does not resolve to a user', async () => {
+        // Parent has a createdBy that does not correspond to any
+        // userRepository entry (orphan UUID, mirrors the #844 orphan case).
+        const parentSession = await sessionManager.createSession({
+          type: 'quick',
+          locationPath: TEST_REPO_PATH,
+        }, { createdBy: 'orphan-uuid-not-in-users-table' });
+
+        // Force the suggestion to fail so the production path falls back to
+        // `task-<timestamp>`. The mock factory at the top of this file is
+        // typed as returning `{branch, title}` (no `error`), but the
+        // production response type allows `{error}` — return the
+        // success-shape fields as `undefined` to satisfy the strict
+        // generic without invasive casts. The production code checks
+        // `suggestion.error || !suggestion.branch` and falls back when
+        // `branch` is missing.
+        mockSuggestSessionMetadata.mockImplementationOnce(async () => ({
+          branch: undefined as unknown as string,
+          title: undefined as unknown as string,
+        }));
+
+        // We do not assert on the response branch shape because the
+        // listWorktrees mock would also need to know the fallback timestamp;
+        // the narrowly-scoped assertion is on the captured `requestUser`
+        // argument plus the suggestion call actually happening.
+        await setupDelegateEnvironment('task-fallback');
+
+        await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+          repositoryId: 'test-repo',
+          prompt: 'Delegation from an orphan parent',
+          // branch intentionally omitted -> exercises the suggestion path
+          parentSessionId: parentSession.id,
+          parentWorkerId: 'parent-worker-id',
+        }, nextId++);
+
+        // The suggestion call must have received null, not a forged username.
+        expect(readSuggestRequestUser()).toBeNull();
+      });
+    });
+
     it('should accept optional templateVars parameter and create session successfully', async () => {
       await setupDelegateEnvironment('feat/template-vars');
 

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -615,6 +615,31 @@ export function createMcpApp(deps: McpDependencies): Hono {
           return errorResult(`Agent not found: ${selectedAgentId}`);
         }
 
+        // Inherit createdBy from parent session (if delegated)
+        const parentCreatedBy = parentSessionId
+          ? sessionManager.getSession(parentSessionId)?.createdBy
+          : undefined;
+
+        // Resolve parent's createdBy (a users.id UUID) to its OS username
+        // so the suggestion call and `git worktree add` both run as the
+        // requesting user in multi-user mode (Issues #844, #876, extending
+        // Issue #838 / PR #843 from REST to MCP). When `parentCreatedBy`
+        // is unset, or the UUID does not resolve (legacy / orphan
+        // sessions), `requestUsername` is null and `runAsUser` bypasses
+        // elevation — current behaviour preserved.
+        let requestUsername: string | null = null;
+        if (parentCreatedBy) {
+          const parentUser = await userRepository.findById(parentCreatedBy);
+          if (parentUser) {
+            requestUsername = parentUser.username;
+          } else {
+            logger.warn(
+              { parentCreatedBy, repositoryId },
+              'delegate_to_worktree: parent createdBy does not resolve to a user; running git worktree add without elevation',
+            );
+          }
+        }
+
         // Determine branch name
         let effectiveBranch: string;
         let effectiveTitle = title;
@@ -623,17 +648,17 @@ export function createMcpApp(deps: McpDependencies): Hono {
           // Explicit branch name provided
           effectiveBranch = branch;
         } else {
-          // Auto-generate branch name from prompt.
-          // MCP-side privilege elevation for the suggestion call is tracked
-          // separately (Issue #856 Out-of-Scope note). For now pass `null`
-          // so `runAsUser` bypasses elevation; this preserves prior MCP
-          // behaviour. A future issue (modelled on #844) can resolve the
-          // parent session's createdBy -> OS username and thread it here.
+          // Auto-generate branch name from prompt. The suggestion's headless
+          // `claude -p ...` invocation runs via `runAsUser` with the same
+          // resolved parent OS username threaded into `git worktree add`
+          // below, so in multi-user mode it picks up the user's per-user
+          // Claude auth instead of running as the server process user.
+          // Issue #876 (mirrors Issue #856 / PR #859 for the REST path).
           const suggestion = await suggestSessionMetadata({
             prompt: prompt.trim(),
             repositoryPath: repo.path,
             agent,
-            requestUser: null,
+            requestUser: requestUsername,
           });
           if (suggestion.error || !suggestion.branch) {
             effectiveBranch = `task-${Date.now()}`;
@@ -652,30 +677,6 @@ export function createMcpApp(deps: McpDependencies): Hono {
           baseBranch ??
           (await worktreeService.getDefaultBranch(repo.path)) ??
           'main';
-
-        // Inherit createdBy from parent session (if delegated)
-        const parentCreatedBy = parentSessionId
-          ? sessionManager.getSession(parentSessionId)?.createdBy
-          : undefined;
-
-        // Resolve parent's createdBy (a users.id UUID) to its OS username so
-        // `git worktree add` runs as the requesting user in multi-user mode
-        // (Issue #844, extending Issue #838 / PR #843 from REST to MCP).
-        // When `parentCreatedBy` is unset, or the UUID does not resolve
-        // (legacy / orphan sessions), `requestUsername` is null and
-        // `runAsUser` bypasses elevation — current behaviour preserved.
-        let requestUsername: string | null = null;
-        if (parentCreatedBy) {
-          const parentUser = await userRepository.findById(parentCreatedBy);
-          if (parentUser) {
-            requestUsername = parentUser.username;
-          } else {
-            logger.warn(
-              { parentCreatedBy, repositoryId },
-              'delegate_to_worktree: parent createdBy does not resolve to a user; running git worktree add without elevation',
-            );
-          }
-        }
 
         const result = await createWorktreeWithSession({
           repoPath: repo.path,


### PR DESCRIPTION
## Summary

- `delegate_to_worktree`'s `suggestSessionMetadata` call was passing `requestUser: null`, so in `AUTH_MODE=multi-user` the headless `claude -p ...` invocation ran as the server process user with no per-user Claude auth, silently failing and falling back to `task-<timestamp>` branch names.
- Hoist the existing `parentSessionId -> createdBy -> userRepository -> OS username` resolution above the branch-name block so the suggestion call and the subsequent `git worktree add` share a single resolved `requestUsername`.
- Mirrors the REST-side fix from PR #859 / Issue #856 and re-uses the existing MCP-side `git worktree add` elevation contract from PR #843 / Issue #844 (unchanged: same value, same call site).

## Behavior

- Multi-user mode, parent OS user resolves: `delegate_to_worktree` without an explicit `branch` now produces an LLM-suggested branch name (e.g. `fix/diff-worker-elevation`) instead of `task-<timestamp>`.
- No parent session, or parent `createdBy` is unset / orphan UUID: `requestUsername` stays `null`, `runAsUser` bypasses elevation, and the existing `task-<timestamp>` fallback still fires if the suggestion itself fails.
- Single-user mode: unchanged (`runAsUser` bypasses elevation regardless of the username value).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — full suite green (1423 client + 349 shared + 29 integration + 2782 server + 362 root, 0 fail)
- [x] `bun run check:lang` — clean
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean
- [x] New tests in `packages/server/src/mcp/__tests__/mcp-server.test.ts` cover three cases:
  - parent `createdBy` resolves to OS user → `suggestSessionMetadata` receives that username; LLM-suggested branch is used end-to-end
  - no `parentSessionId` → `requestUser: null` pass-through; default LLM branch is used
  - parent `createdBy` is an orphan UUID + forced suggestion failure → `requestUser: null` pass-through; fallback path engages

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)