### PR TITLE
fix(mcp): elevate run_process to requesting OS user via spawnAsUser

### DIFF
--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -3208,6 +3208,112 @@ describe('MCP Server Tools', () => {
           expect(response.result?.isError).toBe(true);
         }
       });
+
+      // -----------------------------------------------------------------------
+      // Issue #879: authentication / elevation
+      // -----------------------------------------------------------------------
+      //
+      // run_process must resolve the session's `createdBy` (a users.id UUID)
+      // to its OS `username` via `userRepository.findById` and pass that
+      // through to `interactiveProcessManager.runProcess` as `requestUser`.
+      // Mirrors the resolution pattern already covered for
+      // `delegate_to_worktree` (Issue #844 / #876 blocks above), this time
+      // capturing the argument via a `jest.spyOn` of the manager's
+      // `runProcess` method.
+      describe('authentication / elevation', () => {
+        async function createSessionWithWorkerForUser(
+          createdBy: string | undefined,
+        ): Promise<{ sessionId: string; workerId: string }> {
+          const session = await sessionManager.createSession(
+            {
+              type: 'quick',
+              locationPath: '/test/path',
+              agentId: 'claude-code',
+            },
+            createdBy === undefined ? undefined : { createdBy },
+          );
+          return { sessionId: session.id, workerId: session.workers[0].id };
+        }
+
+        it('plumbs resolved OS username when session createdBy resolves to a registered user', async () => {
+          const alice = await userRepository.upsertByOsUid(9101, 'alice', '/home/alice');
+          const { sessionId, workerId } = await createSessionWithWorkerForUser(alice.id);
+
+          const runProcessSpy = jest.spyOn(
+            interactiveProcessManager,
+            'runProcess',
+          );
+
+          const response = await callTool(app, mcpSessionId, 'run_process', {
+            command: 'echo hi',
+            sessionId,
+            workerId,
+          }, nextId++);
+
+          expect(response.result?.isError).toBeUndefined();
+          expect(runProcessSpy).toHaveBeenCalledTimes(1);
+          const params = runProcessSpy.mock.calls[0][0] as {
+            requestUser?: string | null;
+          };
+          expect(params.requestUser).toBe('alice');
+
+          runProcessSpy.mockRestore();
+        });
+
+        it('passes null requestUser when session has no createdBy (legacy)', async () => {
+          const { sessionId, workerId } =
+            await createSessionWithWorkerForUser(undefined);
+
+          const runProcessSpy = jest.spyOn(
+            interactiveProcessManager,
+            'runProcess',
+          );
+
+          const response = await callTool(app, mcpSessionId, 'run_process', {
+            command: 'echo hi',
+            sessionId,
+            workerId,
+          }, nextId++);
+
+          expect(response.result?.isError).toBeUndefined();
+          expect(runProcessSpy).toHaveBeenCalledTimes(1);
+          const params = runProcessSpy.mock.calls[0][0] as {
+            requestUser?: string | null;
+          };
+          expect(params.requestUser).toBeNull();
+
+          runProcessSpy.mockRestore();
+        });
+
+        it('passes null requestUser when session createdBy UUID does not resolve to a user', async () => {
+          // Orphan / pre-multi-user createdBy that does not match any
+          // userRepository entry. The MCP path must log a warning and fall
+          // back to null rather than aborting the spawn.
+          const { sessionId, workerId } = await createSessionWithWorkerForUser(
+            'orphan-uuid-not-in-users-table',
+          );
+
+          const runProcessSpy = jest.spyOn(
+            interactiveProcessManager,
+            'runProcess',
+          );
+
+          const response = await callTool(app, mcpSessionId, 'run_process', {
+            command: 'echo hi',
+            sessionId,
+            workerId,
+          }, nextId++);
+
+          expect(response.result?.isError).toBeUndefined();
+          expect(runProcessSpy).toHaveBeenCalledTimes(1);
+          const params = runProcessSpy.mock.calls[0][0] as {
+            requestUser?: string | null;
+          };
+          expect(params.requestUser).toBeNull();
+
+          runProcessSpy.mockRestore();
+        });
+      });
     });
 
     describe('list_processes', () => {

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -1151,12 +1151,33 @@ export function createMcpApp(deps: McpDependencies): Hono {
           );
         }
 
+        // Resolve the session's createdBy (a users.id UUID) to its OS
+        // `username` so the spawned process runs as the requesting user in
+        // multi-user mode (Issue #879). Mirrors the resolution pattern in
+        // `delegate_to_worktree` (above). When `createdBy` is unset or the
+        // UUID does not resolve (legacy / orphan sessions), `requestUsername`
+        // is null and the underlying `spawnAsUser` bypasses elevation --
+        // single-user behaviour preserved.
+        let requestUsername: string | null = null;
+        if (session.createdBy) {
+          const sessionUser = await userRepository.findById(session.createdBy);
+          if (sessionUser) {
+            requestUsername = sessionUser.username;
+          } else {
+            logger.warn(
+              { createdBy: session.createdBy, sessionId },
+              'run_process: session createdBy does not resolve to a user; running command without elevation',
+            );
+          }
+        }
+
         const process = await interactiveProcessManager.runProcess({
           sessionId,
           workerId,
           command,
           cwd,
           outputMode,
+          requestUser: requestUsername,
         });
 
         return textResult({

--- a/packages/server/src/services/__tests__/interactive-process-manager.test.ts
+++ b/packages/server/src/services/__tests__/interactive-process-manager.test.ts
@@ -3,6 +3,11 @@ import {
   InteractiveProcessManager,
   MAX_PROCESSES_PER_SESSION,
 } from '../interactive-process-manager.js';
+import type {
+  SpawnAsUserFn,
+  SpawnAsUserOpts,
+  SpawnAsUserResult,
+} from '../privilege-elevation.js';
 
 describe('InteractiveProcessManager', () => {
   let manager: InteractiveProcessManager;
@@ -217,6 +222,230 @@ describe('InteractiveProcessManager', () => {
       expect(exitInfo.exitCode).toBe(0);
     });
 
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #879: spawn elevation through `spawnAsUser` for run_process
+  // -------------------------------------------------------------------------
+  //
+  // `runProcess` must route the underlying spawn through the injected
+  // `spawnAsUserFn` and pass `requestUser` through. This tests the contract
+  // at the helper boundary (the elevation argv shape itself is covered by
+  // privilege-elevation.test.ts).
+  describe('runProcess (Issue #879: requestUser plumbing via spawnAsUser)', () => {
+    interface CapturedSpawn {
+      opts: SpawnAsUserOpts;
+    }
+
+    /**
+     * Build a fake `spawnAsUserFn` that records the spawn opts and returns
+     * a controllable FakeSubprocess. The FakeSubprocess exposes
+     * `.simulateExit(code)` so tests can drive the lifecycle.
+     */
+    function makeFakeSpawnAsUser(captured: CapturedSpawn[]): {
+      fn: SpawnAsUserFn;
+      lastStdinWrites: Array<string | Uint8Array>;
+      flushCalls: { count: number };
+      killSignals: number[];
+      simulateExit: (code: number) => void;
+    } {
+      const lastStdinWrites: Array<string | Uint8Array> = [];
+      const flushCalls = { count: 0 };
+      const killSignals: number[] = [];
+      let resolveExited: ((code: number) => void) | null = null;
+      const exited = new Promise<number>((resolve) => {
+        resolveExited = resolve;
+      });
+
+      const stdin = {
+        write: (chunk: string | Uint8Array) => {
+          lastStdinWrites.push(chunk);
+          return 0;
+        },
+        end: () => {},
+        flush: () => {
+          flushCalls.count++;
+          return Promise.resolve(0);
+        },
+      };
+
+      const subprocess = {
+        exited,
+        stdin,
+        stdout: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        stderr: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        kill: (signal?: number) => {
+          killSignals.push(signal ?? 15);
+        },
+      };
+
+      const fn: SpawnAsUserFn = (opts) => {
+        captured.push({ opts });
+        // Cast bridges FakeSubprocess subset -> SpawnAsUserResult shape at
+        // the test boundary. The production code only consumes the fields
+        // included on the fake (subprocess, stdin, elevated).
+        return {
+          subprocess,
+          stdin,
+          elevated:
+            opts.username !== null &&
+            opts.username !== undefined &&
+            opts.username !== '',
+        } as unknown as SpawnAsUserResult;
+      };
+
+      return {
+        fn,
+        lastStdinWrites,
+        flushCalls,
+        killSignals,
+        simulateExit: (code: number) => resolveExited?.(code),
+      };
+    }
+
+    it('passes requestUser=undefined as null username to spawnAsUserFn (no elevation)', async () => {
+      const captured: CapturedSpawn[] = [];
+      const fake = makeFakeSpawnAsUser(captured);
+      const elevatedManager = new InteractiveProcessManager(
+        onOutput,
+        onExit,
+        { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+        onResponse,
+        fake.fn,
+      );
+
+      await elevatedManager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'echo hi',
+      });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].opts.username).toBeNull();
+      expect(captured[0].opts.command).toBe('echo hi');
+
+      fake.simulateExit(0);
+      elevatedManager.disposeAll();
+    });
+
+    it('passes requestUser=null as null username to spawnAsUserFn (no elevation)', async () => {
+      const captured: CapturedSpawn[] = [];
+      const fake = makeFakeSpawnAsUser(captured);
+      const elevatedManager = new InteractiveProcessManager(
+        onOutput,
+        onExit,
+        { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+        onResponse,
+        fake.fn,
+      );
+
+      await elevatedManager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'echo hi',
+        requestUser: null,
+      });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].opts.username).toBeNull();
+
+      fake.simulateExit(0);
+      elevatedManager.disposeAll();
+    });
+
+    it('forwards requestUser="alice" to spawnAsUserFn as username and propagates the returned subprocess', async () => {
+      const captured: CapturedSpawn[] = [];
+      const fake = makeFakeSpawnAsUser(captured);
+      const elevatedManager = new InteractiveProcessManager(
+        onOutput,
+        onExit,
+        { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+        onResponse,
+        fake.fn,
+      );
+
+      const info = await elevatedManager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'whoami',
+        cwd: '/work/here',
+        requestUser: 'alice',
+      });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].opts.username).toBe('alice');
+      expect(captured[0].opts.command).toBe('whoami');
+      expect(captured[0].opts.cwd).toBe('/work/here');
+      // The returned info must be a valid InteractiveProcessInfo and the
+      // process should be tracked.
+      expect(info.status).toBe('running');
+      expect(elevatedManager.getProcess(info.id)).toBeDefined();
+
+      fake.simulateExit(0);
+      elevatedManager.disposeAll();
+    });
+
+    it('writeResponse writes to the elevated subprocess stdin with content + null byte', async () => {
+      const captured: CapturedSpawn[] = [];
+      const fake = makeFakeSpawnAsUser(captured);
+      const elevatedManager = new InteractiveProcessManager(
+        onOutput,
+        onExit,
+        { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+        onResponse,
+        fake.fn,
+      );
+
+      const info = await elevatedManager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'cat',
+        requestUser: 'alice',
+      });
+
+      const written = await elevatedManager.writeResponse(info.id, 'hello');
+      expect(written).toBe(true);
+      expect(fake.lastStdinWrites).toContain('hello\0');
+      expect(fake.flushCalls.count).toBeGreaterThan(0);
+
+      fake.simulateExit(0);
+      elevatedManager.disposeAll();
+    });
+
+    it('killProcess sends SIGTERM (15) to the elevated subprocess', async () => {
+      const captured: CapturedSpawn[] = [];
+      const fake = makeFakeSpawnAsUser(captured);
+      const elevatedManager = new InteractiveProcessManager(
+        onOutput,
+        onExit,
+        { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+        onResponse,
+        fake.fn,
+      );
+
+      const info = await elevatedManager.runProcess({
+        sessionId: 'session-1',
+        workerId: 'worker-1',
+        command: 'sleep 60',
+        requestUser: 'alice',
+      });
+
+      const killed = elevatedManager.killProcess(info.id);
+      expect(killed).toBe(true);
+      expect(fake.killSignals).toContain(15);
+
+      // Resolve to avoid hanging promises in afterEach
+      fake.simulateExit(143);
+      elevatedManager.disposeAll();
+    });
   });
 
   describe('killProcess', () => {

--- a/packages/server/src/services/__tests__/interactive-process-manager.test.ts
+++ b/packages/server/src/services/__tests__/interactive-process-manager.test.ts
@@ -238,6 +238,33 @@ describe('InteractiveProcessManager', () => {
     }
 
     /**
+     * Subset of Bun's `FileSink` shape that `interactive-process-manager`
+     * actually consumes (`write` + `flush`; `end` is included so the fake
+     * matches the shape `spawnAsUser` exposes on `subprocess.stdin`).
+     * Declaring it explicitly lets the fake be typed without casting through
+     * `unknown` (which the repo's TypeScript guideline prohibits).
+     */
+    interface FakeFileSink {
+      write: (chunk: string | Uint8Array) => number;
+      end: () => void;
+      flush: () => Promise<number>;
+    }
+
+    /**
+     * Subset of Bun's `Subprocess<'pipe','pipe','pipe'>` shape that
+     * `interactive-process-manager` actually consumes (`exited`, `stdout`,
+     * `stderr`, `stdin`, `kill`). Mirrors the `FakeProc` pattern used in
+     * `privilege-elevation.test.ts` for the runAsUser fakes.
+     */
+    interface FakeSubprocess {
+      exited: Promise<number>;
+      stdin: FakeFileSink;
+      stdout: ReadableStream<Uint8Array>;
+      stderr: ReadableStream<Uint8Array>;
+      kill: (signal?: number) => void;
+    }
+
+    /**
      * Build a fake `spawnAsUserFn` that records the spawn opts and returns
      * a controllable FakeSubprocess. The FakeSubprocess exposes
      * `.simulateExit(code)` so tests can drive the lifecycle.
@@ -257,7 +284,7 @@ describe('InteractiveProcessManager', () => {
         resolveExited = resolve;
       });
 
-      const stdin = {
+      const stdin: FakeFileSink = {
         write: (chunk: string | Uint8Array) => {
           lastStdinWrites.push(chunk);
           return 0;
@@ -269,7 +296,7 @@ describe('InteractiveProcessManager', () => {
         },
       };
 
-      const subprocess = {
+      const subprocess: FakeSubprocess = {
         exited,
         stdin,
         stdout: new ReadableStream<Uint8Array>({
@@ -289,17 +316,21 @@ describe('InteractiveProcessManager', () => {
 
       const fn: SpawnAsUserFn = (opts) => {
         captured.push({ opts });
-        // Cast bridges FakeSubprocess subset -> SpawnAsUserResult shape at
-        // the test boundary. The production code only consumes the fields
-        // included on the fake (subprocess, stdin, elevated).
-        return {
+        // Single direct cast at the fake boundary; the fake's typed members
+        // (FakeSubprocess / FakeFileSink) cover the subset production code
+        // consumes. No `unknown` intermediate.
+        const result: Pick<SpawnAsUserResult, 'elevated'> & {
+          subprocess: FakeSubprocess;
+          stdin: FakeFileSink;
+        } = {
           subprocess,
           stdin,
           elevated:
             opts.username !== null &&
             opts.username !== undefined &&
             opts.username !== '',
-        } as unknown as SpawnAsUserResult;
+        };
+        return result as SpawnAsUserResult;
       };
 
       return {

--- a/packages/server/src/services/__tests__/privilege-elevation.test.ts
+++ b/packages/server/src/services/__tests__/privilege-elevation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as os from 'node:os';
 import {
   runAsUser,
+  spawnAsUser,
   buildSpawnArgs,
   buildInnerCommand,
   shellEscape,
@@ -653,6 +654,226 @@ describe('privilege-elevation', () => {
 
       const opts = captured[0].options as { stdin?: unknown };
       expect(opts.stdin).toBeUndefined();
+    });
+  });
+
+  describe('spawnAsUser (integration with spawn)', () => {
+    /**
+     * Build a fake spawn for spawnAsUser. Unlike the runAsUser fake above,
+     * `spawnAsUser` does NOT await `proc.exited` (lifecycle belongs to the
+     * caller), so we keep it simple: a recorded argv/options pair and a
+     * FakeFileSink stub for `stdin` so consumers can call `.write()`/
+     * `.flush()`/`.end()` without touching a real subprocess.
+     */
+    function makeFakeSpawnForSpawnAsUser(captured: CapturedSpawn[]): SpawnFn {
+      const fakeFn = (
+        args: string[],
+        options: Parameters<typeof Bun.spawn>[1],
+      ) => {
+        captured.push({ args, options });
+        const stdinStub = {
+          write: () => 0,
+          end: () => {},
+          flush: () => Promise.resolve(0),
+        };
+        // The fake never resolves `exited` (no caller awaits it) and never
+        // emits stream bytes -- only the spawn-time argv / options shape and
+        // the FileSink-shaped stdin are exercised by these tests.
+        const fake = {
+          exited: new Promise<number>(() => {}),
+          stdout: new ReadableStream<Uint8Array>(),
+          stderr: new ReadableStream<Uint8Array>(),
+          stdin: stdinStub,
+          kill: () => {},
+        };
+        return fake;
+      };
+      // Single direct cast at the fake boundary, no `unknown` intermediate.
+      return fakeFn as unknown as SpawnFn;
+    }
+
+    it('AUTH_MODE=none: invokes sh -c directly even when username is set', () => {
+      process.env.AUTH_MODE = 'none';
+      const captured: CapturedSpawn[] = [];
+      const fakeSpawn = makeFakeSpawnForSpawnAsUser(captured);
+
+      const result = spawnAsUser(
+        { username: 'alice', command: 'echo hello' },
+        fakeSpawn,
+      );
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].args).toEqual(['sh', '-c', 'echo hello']);
+      expect(result.elevated).toBe(false);
+      expect(result.subprocess).toBeDefined();
+      expect(result.stdin).toBeDefined();
+    });
+
+    it('AUTH_MODE=multi-user with a non-server username: elevates and preserves FORCE_COLOR by default', () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const targetUser = `${serverUsername}-someone-else`;
+      const captured: CapturedSpawn[] = [];
+      const fakeSpawn = makeFakeSpawnForSpawnAsUser(captured);
+
+      const result = spawnAsUser(
+        { username: targetUser, command: 'whoami' },
+        fakeSpawn,
+      );
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].args).toEqual([
+        'sudo',
+        '-u',
+        targetUser,
+        '--preserve-env=FORCE_COLOR',
+        '-i',
+        'sh',
+        '-c',
+        'whoami',
+      ]);
+      expect(result.elevated).toBe(true);
+    });
+
+    it('AUTH_MODE=multi-user with username === serverUsername: bypasses elevation (direct spawn)', () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const captured: CapturedSpawn[] = [];
+      const fakeSpawn = makeFakeSpawnForSpawnAsUser(captured);
+
+      const result = spawnAsUser(
+        { username: serverUsername, command: 'id -un' },
+        fakeSpawn,
+      );
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].args).toEqual(['sh', '-c', 'id -un']);
+      expect(result.elevated).toBe(false);
+    });
+
+    it('AUTH_MODE=multi-user with null username: bypasses elevation', () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const captured: CapturedSpawn[] = [];
+      const fakeSpawn = makeFakeSpawnForSpawnAsUser(captured);
+
+      const result = spawnAsUser(
+        { username: null, command: 'echo legacy' },
+        fakeSpawn,
+      );
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].args).toEqual(['sh', '-c', 'echo legacy']);
+      expect(result.elevated).toBe(false);
+    });
+
+    it('always sets stdin/stdout/stderr to "pipe" regardless of elevation', () => {
+      const captured: CapturedSpawn[] = [];
+      const fakeSpawn = makeFakeSpawnForSpawnAsUser(captured);
+
+      // Non-elevated branch
+      process.env.AUTH_MODE = 'none';
+      spawnAsUser({ username: null, command: 'echo nonelev' }, fakeSpawn);
+
+      // Elevated branch
+      process.env.AUTH_MODE = 'multi-user';
+      spawnAsUser(
+        { username: `${serverUsername}-other`, command: 'echo elev' },
+        fakeSpawn,
+      );
+
+      expect(captured).toHaveLength(2);
+      for (const cap of captured) {
+        const opts = cap.options as {
+          stdin?: unknown;
+          stdout?: unknown;
+          stderr?: unknown;
+        };
+        expect(opts.stdin).toBe('pipe');
+        expect(opts.stdout).toBe('pipe');
+        expect(opts.stderr).toBe('pipe');
+      }
+    });
+
+    it('non-elevated: forwards cwd via spawn options AND merges opts.env over process.env', () => {
+      // Mirror of the runAsUser non-elevated env-merge regression test.
+      process.env.AUTH_MODE = 'none';
+      const sentinelKey = '__SPAWN_AS_USER_TEST_SENTINEL__';
+      const sentinelValue = 'parent-env-survives';
+      process.env[sentinelKey] = sentinelValue;
+      try {
+        const captured: CapturedSpawn[] = [];
+        const fakeSpawn = makeFakeSpawnForSpawnAsUser(captured);
+
+        spawnAsUser(
+          {
+            username: null,
+            command: 'pwd',
+            cwd: '/some/dir',
+            env: { FOO: 'bar' },
+          },
+          fakeSpawn,
+        );
+
+        const opts = captured[0].options as {
+          cwd?: string;
+          env?: Record<string, string>;
+        };
+        expect(opts.cwd).toBe('/some/dir');
+        expect(opts.env?.FOO).toBe('bar');
+        expect(opts.env?.[sentinelKey]).toBe(sentinelValue);
+        if (process.env.PATH !== undefined) {
+          expect(opts.env?.PATH).toBe(process.env.PATH);
+        }
+        expect(captured[0].args).toEqual(['sh', '-c', 'pwd']);
+      } finally {
+        delete process.env[sentinelKey];
+      }
+    });
+
+    it('elevated: interpolates cwd/env into the inner command AND pins spawn cwd to /', () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const targetUser = `${serverUsername}-someone-else`;
+      const captured: CapturedSpawn[] = [];
+      const fakeSpawn = makeFakeSpawnForSpawnAsUser(captured);
+
+      spawnAsUser(
+        {
+          username: targetUser,
+          command: 'git clone https://x',
+          cwd: '/work/here',
+          env: { GIT_TERMINAL_PROMPT: '0' },
+        },
+        fakeSpawn,
+      );
+
+      const innerCommand = captured[0].args[captured[0].args.length - 1];
+      expect(innerCommand).toBe(
+        "cd '/work/here' && export GIT_TERMINAL_PROMPT='0'; git clone https://x",
+      );
+
+      const opts = captured[0].options as {
+        cwd?: string;
+        env?: Record<string, string>;
+      };
+      expect(opts.cwd).toBe('/');
+      expect(opts.env).toBeUndefined();
+    });
+
+    it('returns subprocess, stdin, and elevated boolean in the result', () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const captured: CapturedSpawn[] = [];
+      const fakeSpawn = makeFakeSpawnForSpawnAsUser(captured);
+
+      const result = spawnAsUser(
+        { username: `${serverUsername}-someone-else`, command: 'echo hi' },
+        fakeSpawn,
+      );
+
+      expect(result.subprocess).toBeDefined();
+      expect(result.stdin).toBeDefined();
+      // stdin must point at the same FileSink the subprocess exposes -- the
+      // `stdin` field is an alias so callers can store it once without
+      // re-reading subprocess.stdin later.
+      expect(result.stdin).toBe(result.subprocess.stdin);
+      expect(result.elevated).toBe(true);
     });
   });
 });

--- a/packages/server/src/services/__tests__/privilege-elevation.test.ts
+++ b/packages/server/src/services/__tests__/privilege-elevation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as os from 'node:os';
+import type { FileSink } from 'bun';
 import {
   runAsUser,
   spawnAsUser,
@@ -659,6 +660,39 @@ describe('privilege-elevation', () => {
 
   describe('spawnAsUser (integration with spawn)', () => {
     /**
+     * Subset of Bun's `FileSink` shape that `spawnAsUser`'s callers consume
+     * via `subprocess.stdin` (write / end / flush). Pick from Bun's actual
+     * `FileSink` type so the stub literal stays type-compatible with the
+     * field's declared shape on `Subprocess.stdin`. Mirrors the typed-fake
+     * pattern used by `FakeProc` above for the runAsUser fakes.
+     */
+    type FakeFileSink = Pick<FileSink, 'write' | 'end' | 'flush'>;
+
+    /**
+     * Subset of Bun's `Subprocess<'pipe','pipe','pipe'>` shape exposed by
+     * `spawnAsUser`'s result. Differs from `FakeProc` in that it carries a
+     * `stdin` `FileSink` (spawnAsUser callers manage stdin over time) and
+     * `exited: Promise<number>` rather than `Promise<number | null>` because
+     * the spawnAsUser tests never resolve `exited` and never expose the
+     * signal-killed-as-null path. `stdin` is typed to Bun's actual `FileSink`
+     * so the outer fake -> `SpawnFn` cast structurally overlaps with
+     * `Subprocess<Writable,Readable,Readable>.stdin` (one direct cast at the
+     * stub boundary substitutes for the previous `as unknown as`).
+     */
+    interface FakeSpawnAsUserProc {
+      exited: Promise<number>;
+      stdout: ReadableStream<Uint8Array>;
+      stderr: ReadableStream<Uint8Array>;
+      stdin: FileSink;
+      kill: () => void;
+    }
+
+    type FakeSpawnFn = (
+      args: string[],
+      options: Parameters<typeof Bun.spawn>[1],
+    ) => FakeSpawnAsUserProc;
+
+    /**
      * Build a fake spawn for spawnAsUser. Unlike the runAsUser fake above,
      * `spawnAsUser` does NOT await `proc.exited` (lifecycle belongs to the
      * caller), so we keep it simple: a recorded argv/options pair and a
@@ -666,30 +700,31 @@ describe('privilege-elevation', () => {
      * `.flush()`/`.end()` without touching a real subprocess.
      */
     function makeFakeSpawnForSpawnAsUser(captured: CapturedSpawn[]): SpawnFn {
-      const fakeFn = (
-        args: string[],
-        options: Parameters<typeof Bun.spawn>[1],
-      ) => {
+      const fakeFn: FakeSpawnFn = (args, options) => {
         captured.push({ args, options });
-        const stdinStub = {
+        const stdinStub: FakeFileSink = {
           write: () => 0,
-          end: () => {},
+          end: () => 0,
           flush: () => Promise.resolve(0),
         };
         // The fake never resolves `exited` (no caller awaits it) and never
         // emits stream bytes -- only the spawn-time argv / options shape and
-        // the FileSink-shaped stdin are exercised by these tests.
-        const fake = {
+        // the FileSink-shaped stdin are exercised by these tests. The stub
+        // only models the three FileSink methods callers touch; a single
+        // direct cast at THIS boundary widens it to `FileSink` so the outer
+        // `fakeFn as SpawnFn` cast structurally overlaps without `unknown`.
+        const fake: FakeSpawnAsUserProc = {
           exited: new Promise<number>(() => {}),
           stdout: new ReadableStream<Uint8Array>(),
           stderr: new ReadableStream<Uint8Array>(),
-          stdin: stdinStub,
+          stdin: stdinStub as FileSink,
           kill: () => {},
         };
         return fake;
       };
-      // Single direct cast at the fake boundary, no `unknown` intermediate.
-      return fakeFn as unknown as SpawnFn;
+      // Single direct cast at the fake boundary; the fake's typed return
+      // shape (FakeSpawnAsUserProc) matches the subset spawnAsUser consumes.
+      return fakeFn as SpawnFn;
     }
 
     it('AUTH_MODE=none: invokes sh -c directly even when username is set', () => {

--- a/packages/server/src/services/interactive-process-manager.ts
+++ b/packages/server/src/services/interactive-process-manager.ts
@@ -1,6 +1,7 @@
 import type { InteractiveProcessInfo, InteractiveProcessOutputMode } from '@agent-console/shared';
 import type { Subprocess, FileSink } from 'bun';
 import { createLogger } from '../lib/logger.js';
+import { spawnAsUser, type SpawnAsUserFn } from './privilege-elevation.js';
 
 const logger = createLogger('interactive-process-manager');
 
@@ -57,17 +58,26 @@ export class InteractiveProcessManager {
   private onExit: ProcessExitCallback;
   private ptyMessageInjector?: PtyMessageInjector;
   private onResponse?: ProcessResponseCallback;
+  /**
+   * Long-lived elevated-spawn helper. Routes the underlying `Bun.spawn`
+   * through `sudo -u <user> -i sh -c ...` when the requesting user differs
+   * from the server process user under `AUTH_MODE=multi-user`. Injected for
+   * testability; defaults to the production import.
+   */
+  private spawnAsUserFn: SpawnAsUserFn;
 
   constructor(
     onOutput: ProcessOutputCallback,
     onExit: ProcessExitCallback,
     ptyMessageInjector?: PtyMessageInjector,
     onResponse?: ProcessResponseCallback,
+    spawnAsUserFn: SpawnAsUserFn = spawnAsUser,
   ) {
     this.onOutput = onOutput;
     this.onExit = onExit;
     this.ptyMessageInjector = ptyMessageInjector;
     this.onResponse = onResponse;
+    this.spawnAsUserFn = spawnAsUserFn;
   }
 
   async runProcess(params: {
@@ -76,8 +86,17 @@ export class InteractiveProcessManager {
     command: string;
     cwd?: string;
     outputMode?: InteractiveProcessOutputMode;
+    /**
+     * OS username to run the command as. Treated identically when
+     * `null` / `undefined` -- no elevation. When set under
+     * `AUTH_MODE=multi-user` and differing from the server process user,
+     * the underlying spawn is elevated via `sudo`. Plumbed in by the
+     * `run_process` MCP tool, which resolves it from the calling
+     * session's `createdBy` (Issue #879).
+     */
+    requestUser?: string | null;
   }): Promise<InteractiveProcessInfo> {
-    const { sessionId, workerId, command, cwd } = params;
+    const { sessionId, workerId, command, cwd, requestUser } = params;
     const outputMode: InteractiveProcessOutputMode = params.outputMode ?? 'pty';
 
     const sessionProcessCount = this.listProcesses(sessionId).filter(
@@ -100,10 +119,14 @@ export class InteractiveProcessManager {
       outputMode,
     };
 
-    const subprocess = Bun.spawn(['sh', '-c', command], {
-      stdin: 'pipe',
-      stdout: 'pipe',
-      stderr: 'pipe',
+    // Route the spawn through `spawnAsUser` so multi-user mode elevates the
+    // child to the requesting user. When `requestUser` is null/undefined or
+    // `AUTH_MODE !== 'multi-user'`, the helper bypasses elevation and spawns
+    // `sh -c command` directly -- byte-identical to the prior raw
+    // `Bun.spawn(['sh', '-c', command], { ... })` invocation.
+    const { subprocess, stdin } = this.spawnAsUserFn({
+      username: requestUser ?? null,
+      command,
       cwd,
     });
 
@@ -120,7 +143,7 @@ export class InteractiveProcessManager {
     const stored: StoredProcess = {
       info,
       subprocess,
-      stdin: subprocess.stdin,
+      stdin,
       streamsDone,
     };
     this.processes.set(id, stored);

--- a/packages/server/src/services/privilege-elevation.ts
+++ b/packages/server/src/services/privilege-elevation.ts
@@ -458,7 +458,7 @@ export function spawnAsUser(
   >;
 
   logger.info(
-    { username: opts.username ?? null, elevated, command: opts.command },
+    { username: opts.username ?? null, elevated },
     'spawnAsUser spawned',
   );
 

--- a/packages/server/src/services/privilege-elevation.ts
+++ b/packages/server/src/services/privilege-elevation.ts
@@ -30,6 +30,7 @@
  * statements inside the inner command.
  */
 import * as os from 'node:os';
+import type { Subprocess, FileSink } from 'bun';
 import { createLogger } from '../lib/logger.js';
 
 const logger = createLogger('service:privilege-elevation');
@@ -327,4 +328,143 @@ export async function runAsUser(
   );
 
   return { stdout, stderr, exitCode, timedOut };
+}
+
+/**
+ * Options for `spawnAsUser`. Mirrors the elevation-relevant subset of
+ * `RunAsUserOpts`, minus one-shot-only concerns (`timeoutMs`, `stdin` bytes).
+ */
+export interface SpawnAsUserOpts {
+  /**
+   * Target OS user. Same semantics as `RunAsUserOpts.username`: null /
+   * undefined / equal-to-server-user / `AUTH_MODE !== 'multi-user'` all
+   * bypass elevation.
+   */
+  username: string | null | undefined;
+  /** Shell command (passed verbatim to `sh -c`). */
+  command: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  /**
+   * Env-var names to preserve across the elevated shell via
+   * `--preserve-env=NAME1,NAME2,...`. Defaults to `['FORCE_COLOR']`. An empty
+   * array suppresses the flag entirely. Ignored when elevation is bypassed.
+   */
+  preserveEnv?: string[];
+}
+
+/**
+ * Long-lived spawn result. Unlike `runAsUser`, the caller manages the
+ * lifecycle of the returned subprocess (write to stdin over time, kill, etc).
+ */
+export interface SpawnAsUserResult {
+  /**
+   * The live Bun subprocess. Discriminated to the `'pipe','pipe','pipe'`
+   * variant so callers retain typed access to `stdin` / `stdout` / `stderr`
+   * as the corresponding streams.
+   */
+  subprocess: Subprocess<'pipe', 'pipe', 'pipe'>;
+  /**
+   * Alias for `subprocess.stdin` so callers that previously stored
+   * `subprocess.stdin` separately (e.g. `StoredProcess.stdin` in
+   * `interactive-process-manager.ts`) can keep the existing field shape.
+   */
+  stdin: FileSink;
+  /** Whether the spawn was elevated via `sudo`. Useful for logging. */
+  elevated: boolean;
+}
+
+/**
+ * Indirection so tests can inject a fake spawnAsUser implementation. Mirrors
+ * the {@link SpawnFn} pattern used by `runAsUser`.
+ * @internal Exported for testing.
+ */
+export type SpawnAsUserFn = (opts: SpawnAsUserOpts) => SpawnAsUserResult;
+
+/**
+ * Long-lived counterpart to {@link runAsUser}. Spawns `command` as
+ * `opts.username` (elevating via `sudo` when necessary) and returns the live
+ * `Subprocess` plus its `stdin` `FileSink` so callers can write over time
+ * and kill on demand.
+ *
+ * Use this when the caller needs to:
+ * - feed bytes to the child's stdin across multiple turns
+ * - send SIGTERM / SIGKILL at a later point
+ * - read stdout / stderr as streams rather than waiting for a final blob
+ *
+ * Use {@link runAsUser} when the caller wants a one-shot exec with optional
+ * stdin bytes and a fixed timeout.
+ *
+ * Outer pipe-through-sudo behaviour is identical to the elevated stdin path
+ * already in production at `worktree-service.ts:597-602`
+ * (`makeUserOwnedTemplateSink.writeFile`), which feeds bytes through
+ * `sudo -u <user> --preserve-env=FORCE_COLOR -i sh -c 'cat > <dst>'` via
+ * `runAsUser`'s `opts.stdin`. The argv shape and the elevated/non-elevated
+ * cwd / env decisions are produced by the same {@link buildSpawnArgs} pure
+ * function, so unit tests on `buildSpawnArgs` cover both helpers.
+ *
+ * Lifecycle is fully the caller's responsibility -- no timeout, no auto-kill.
+ */
+export function spawnAsUser(
+  opts: SpawnAsUserOpts,
+  spawn: SpawnFn = Bun.spawn,
+): SpawnAsUserResult {
+  const preserveEnv = opts.preserveEnv ?? [...DEFAULT_PRESERVE_ENV];
+  const serverUsername = os.userInfo().username;
+  const authMode = process.env.AUTH_MODE;
+
+  const { args, elevated } = buildSpawnArgs(
+    opts.username,
+    opts.command,
+    preserveEnv,
+    serverUsername,
+    authMode,
+    opts.cwd,
+    opts.env,
+  );
+
+  // Spawn options mirror `runAsUser`'s elevated / non-elevated branches:
+  // - Elevated: cwd / env are embedded into the inner shell command, the
+  //   outer spawn pins to SUDO_NEUTRAL_CWD and does not forward `opts.env`
+  //   (it would be reset by `sudo -i` anyway).
+  // - Non-elevated: cwd / env flow through spawn options as usual; `opts.env`
+  //   is layered over `process.env` because `Bun.spawn`'s `env` option
+  //   REPLACES (not merges) the child environment.
+  const spawnOptions: Parameters<typeof Bun.spawn>[1] = {
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  };
+  if (elevated) {
+    spawnOptions.cwd = SUDO_NEUTRAL_CWD;
+  } else {
+    if (opts.cwd !== undefined) {
+      spawnOptions.cwd = opts.cwd;
+    }
+    if (opts.env !== undefined) {
+      spawnOptions.env = { ...process.env, ...opts.env };
+    }
+  }
+
+  // `Bun.spawn`'s discriminated return type narrows on the stdio options we
+  // pass. We always request `'pipe'` for all three streams above, so the
+  // returned subprocess is of the fully-piped variant. The `as` is a single
+  // direct cast at the boundary (no `unknown` intermediate); it does not
+  // change any runtime behaviour.
+  const subprocess = spawn(args, spawnOptions) as Subprocess<
+    'pipe',
+    'pipe',
+    'pipe'
+  >;
+
+  logger.info(
+    { username: opts.username ?? null, elevated, command: opts.command },
+    'spawnAsUser spawned',
+  );
+
+  return {
+    subprocess,
+    stdin: subprocess.stdin,
+    elevated,
+  };
 }


### PR DESCRIPTION
## Summary

- Adds new long-lived `spawnAsUser` helper alongside `runAsUser` so callers that need a live `Subprocess` + `FileSink` (write to stdin over time, kill later) can also benefit from the existing privilege-elevation contract.
- Routes the MCP `run_process` tool's interactive-process spawn through `spawnAsUser`, so in `AUTH_MODE=multi-user` it now runs as the requesting OS user instead of the `agentconsole` service user. Single-user / orphan / unresolvable-createdBy paths bypass elevation — existing behaviour preserved.
- Threads the resolution `session.createdBy → userRepository.findById → osUsername` in `mcp-server.ts run_process` tool, mirroring the block added to `delegate_to_worktree` in PR #877 (`0c93729`).

Closes #879

## Why a new helper, not a `runAsUser` swap

`run_process` is long-lived: `InteractiveProcessManager` stores the live `Subprocess<'pipe','pipe','pipe'>` + `FileSink` for ongoing `writeResponse` (writes `content + '\0'` to stdin) and `killProcess` (SIGTERM 15). `runAsUser` is one-shot — it awaits exit and returns text. A direct substitution would block at spawn time and break the interactive-process model.

`spawnAsUser` reuses the elevation primitives byte-identically:

| Primitive | Reused via |
|---|---|
| Argv shape | `buildSpawnArgs(...)` (same pure function) |
| Inner command (cwd + env interpolation) | `buildInnerCommand(...)` |
| Neutral outer cwd when elevated | `SUDO_NEUTRAL_CWD` (= `/`) |
| Default preserveEnv | `DEFAULT_PRESERVE_ENV` (= `['FORCE_COLOR']`) |
| Env merge in non-elevated branch | `{ ...process.env, ...opts.env }` |

The only differences are lifecycle (returns live subprocess instead of awaiting exit) and the absence of `timeoutMs` / `stdin: string | Uint8Array` (both are one-shot concerns).

## Stdin pipe-through-sudo probe finding

The mandatory fresh `sudo -u <user> -i sh -c 'cat'` probe (per Issue #879's recommended approach) could not be executed in this branch's sandbox (the harness denies sudo invocations). However, the design is supported by direct prior art in production code:

- `packages/server/src/services/worktree-service.ts:589-607` (`makeUserOwnedTemplateSink.writeFile`) already pipes stdin through `runAsUser` via `sudo -u <user> --preserve-env=FORCE_COLOR -i sh -c 'cat > <dst>'`, shipped since Issue #838 / PR #843 and verified working on the dogfood host (template-file materialization for user-owned worktrees creates target-user-owned files via stdin bytes).
- `spawnAsUser` uses the IDENTICAL outer argv contract (via the same `buildSpawnArgs` pure function) and the same `stdin: 'pipe'` spawn option. The only difference is that `spawnAsUser` returns the live `FileSink` instead of pre-loading bytes via `opts.stdin`.
- Conclusion: viability is inherited by construction. Post-deploy verification on the dogfood host (after merge) is recommended; the existing `scripts/smoke/check-multiuser-pty-env.ts` pattern (importing the production helper, asserting against real OS state) is the right shape — a follow-up smoke variant for `spawnAsUser` could be added if a divergence is ever suspected.

## Resolution pattern (parity with PR #877)

In `mcp-server.ts run_process` (around line 1153):

```ts
let requestUsername: string | null = null;
if (session.createdBy) {
  const sessionUser = await userRepository.findById(session.createdBy);
  if (sessionUser) {
    requestUsername = sessionUser.username;
  } else {
    logger.warn(
      { createdBy: session.createdBy, sessionId },
      'run_process: session createdBy does not resolve to a user; running command without elevation',
    );
  }
}
```

Identical structure to `delegate_to_worktree` at lines 618-641. Orphan / legacy paths (no `createdBy`, or UUID does not resolve) flow `null` through to `spawnAsUser`, which bypasses elevation.

## Files changed

Production (3):
- `packages/server/src/services/privilege-elevation.ts` — `SpawnAsUserOpts`, `SpawnAsUserResult`, `SpawnAsUserFn`, `spawnAsUser`. Reuses shared primitives; no logic duplication.
- `packages/server/src/services/interactive-process-manager.ts` — replaces raw `Bun.spawn(['sh', '-c', command], ...)` at line 103 with `this.spawnAsUserFn({ username: requestUser ?? null, command, cwd })`. New optional 5th constructor parameter `spawnAsUserFn?: SpawnAsUserFn` and new `requestUser?: string | null` runProcess param. API drop-in.
- `packages/server/src/mcp/mcp-server.ts` — `run_process` tool resolves `session.createdBy → userRepository.findById → osUsername` and forwards as `requestUser`.

Tests (3 — sibling):
- `packages/server/src/services/__tests__/privilege-elevation.test.ts` — new `describe('spawnAsUser (integration with spawn)', ...)` block covering AUTH_MODE=none direct-spawn, multi-user elevation argv shape, server-user / null-username bypasses, always-`stdin: 'pipe'` stdio assertion, non-elevated cwd + env merge, elevated cwd / env interpolation, returned subprocess / stdin / elevated shape.
- `packages/server/src/services/__tests__/interactive-process-manager.test.ts` — new requestUser-plumbing block via injected fake `spawnAsUserFn`: requestUser undefined → null, requestUser null → null, requestUser='alice' propagated, writeResponse writes content + '\0' and flushes, killProcess sends SIGTERM 15.
- `packages/server/src/mcp/__tests__/mcp-server.test.ts` — new `'authentication / elevation'` sub-describe inside `run_process` covering resolved-username path (createdBy → alice), legacy null createdBy → null, orphan UUID → null. Spies on `interactiveProcessManager.runProcess` to capture the `requestUser` argument.

## Verification

All four gates exit 0:

```
bun run typecheck                    # OK
bun run test                          # 1425 client + 349 shared + 29 integration + 2798 server + 362 hooks = all pass
bun run check:lang                    # OK — 104 files scanned
node .claude/skills/orchestrator/preflight-check.js  # OK
```

Test result paste (last lines of `bun run test`):

```
@agent-console/client     1425 pass / 2 skip / 0 fail (29.13s)
@agent-console/shared      349 pass / 0 fail (50ms)
@agent-console/integration  29 pass / 0 fail (1.83s)
@agent-console/server     2798 pass / 1 skip / 0 fail (56.02s)
scripts + .claude/hooks    362 pass / 0 fail (2.65s)
TEST_EXIT: 0
```

## Test plan

- [ ] CI green (typecheck + test + preflight + language-lint + coverage-check)
- [ ] CodeRabbit 3-layer clean (Pre-merge checks / `reviewDecision` / inline comments) — address any CRITICAL / HIGH / MEDIUM findings
- [ ] Post-merge dogfood smoke on the multi-user host: orchestrator runs `run_process` (e.g., `node .claude/skills/orchestrator/acceptance-check.js <PR>`); confirm `$USER`, `$HOME`, `~/.ssh`, `gh auth status`, `claude` CLI auth all reflect the calling user, not `agentconsole`.

## Out of scope

- MCP caller-authentication binding (verifying caller owns claimed sessionId) — Issue #878.
- Other tools that may want long-lived elevated subprocesses in the future — they should consume `spawnAsUser`.

## CodeRabbit review disposition (Refs #878)

The GitHub-side CodeRabbit bot has been queued in a simultaneous-rate-limit state (the workaround documented in `.claude/skills/coderabbit-ops/SKILL.md`). The local CLI was run from the orchestrator side and returned two findings:

1. **Minor** — `privilege-elevation.ts` `spawnAsUser` info log was emitting `opts.command`, which can leak credential-bearing URLs / args. **Addressed in this PR** by matching sibling `runAsUser`'s log shape (`{ username, elevated }` only — sibling does not log `command` at any level either).
2. **Critical** — `mcp-server.ts` `run_process` resolves `requestUsername` from `session.createdBy` without verifying that the authenticated MCP caller owns that session, so a caller could elevate using another session's OS user. **Deferred to Issue #878 — same disposition as PR #877's identical Critical for `delegate_to_worktree`.** The fix requires an MCP auth-boundary layer that applies uniformly across `delegate_to_worktree`, `run_process`, and any future MCP tool taking session IDs — that is Issue #878's scope, not this PR's. This PR ships the long-lived elevation primitive; #878 will gate it.

Per the project's **3-layer clean** verdict and the documented simultaneous-rate-limit fallback (see `.claude/skills/coderabbit-ops/SKILL.md`), this PR is eligible for owner-approved merge once Pre-merge checks pass, the Minor is resolved, and the deferred Critical is acknowledged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)