### PR TITLE
refactor(server): thread requestUser through lib/git.ts to elevate git ops in multi-user mode (closes #869 #870)

### DIFF
--- a/packages/server/src/__tests__/utils/mock-git-helper.ts
+++ b/packages/server/src/__tests__/utils/mock-git-helper.ts
@@ -22,19 +22,24 @@ import { mock, type Mock } from 'bun:test';
 import { GitError } from '../../lib/git.js';
 export { GitError };
 
-// Type definitions for mock functions
-type AsyncStringFn = (cwd: string) => Promise<string>;
-type AsyncStringNullFn = (cwd: string) => Promise<string | null>;
-type AsyncStringArrayFn = (cwd: string) => Promise<string[]>;
+// Type definitions for mock functions.
+//
+// Issue #869 / #870: Many lib/git.ts helpers now accept an optional trailing
+// `requestUser` argument so callers can route the invocation through
+// `runAsUser` for multi-user mode. The mock signatures mirror that shape so
+// `toHaveBeenCalledWith(..., 'someuser')` assertions in tests type-check.
+type AsyncStringFn = (cwd: string, requestUser?: string | null) => Promise<string>;
+type AsyncStringNullFn = (cwd: string, requestUser?: string | null) => Promise<string | null>;
+type AsyncStringArrayFn = (cwd: string, requestUser?: string | null) => Promise<string[]>;
 type AsyncVoidFn = (...args: unknown[]) => Promise<void>;
 
 // Exported mock functions - configure these in beforeEach
 export const mockGit = {
   // Low-level
   git: mock(() => Promise.resolve('')) as Mock<AsyncStringFn>,
-  gitRaw: mock(() => Promise.resolve('')) as Mock<AsyncStringFn>,
-  gitSafe: mock(() => Promise.resolve(null)) as Mock<(args: string[], cwd: string) => Promise<string | null>>,
-  gitRefExists: mock(() => Promise.resolve(false)) as Mock<(ref: string, cwd: string) => Promise<boolean>>,
+  gitRaw: mock(() => Promise.resolve('')) as Mock<(args: string[], cwd: string, timeoutMs?: number, requestUser?: string | null) => Promise<string>>,
+  gitSafe: mock(() => Promise.resolve(null)) as Mock<(args: string[], cwd: string, requestUser?: string | null) => Promise<string | null>>,
+  gitRefExists: mock(() => Promise.resolve(false)) as Mock<(ref: string, cwd: string, requestUser?: string | null) => Promise<boolean>>,
 
   // Branch operations
   getCurrentBranch: mock(() => Promise.resolve('main')) as Mock<AsyncStringFn>,
@@ -74,10 +79,10 @@ export const mockGit = {
   pullFastForward: mock(() => Promise.resolve(0)) as Mock<(cwd: string) => Promise<number>>,
 
   // Diff operations
-  getMergeBase: mock(() => Promise.resolve('abc1234')) as Mock<(ref1: string, ref2: string, cwd: string) => Promise<string>>,
-  getMergeBaseSafe: mock(() => Promise.resolve('abc1234')) as Mock<(ref1: string, ref2: string, cwd: string) => Promise<string | null>>,
-  getDiff: mock(() => Promise.resolve('')) as Mock<(baseRef: string, targetRef: string | undefined, cwd: string) => Promise<string>>,
-  getDiffNumstat: mock(() => Promise.resolve('')) as Mock<(baseRef: string, targetRef: string | undefined, cwd: string) => Promise<string>>,
+  getMergeBase: mock(() => Promise.resolve('abc1234')) as Mock<(ref1: string, ref2: string, cwd: string, requestUser?: string | null) => Promise<string>>,
+  getMergeBaseSafe: mock(() => Promise.resolve('abc1234')) as Mock<(ref1: string, ref2: string, cwd: string, requestUser?: string | null) => Promise<string | null>>,
+  getDiff: mock(() => Promise.resolve('')) as Mock<(baseRef: string, targetRef: string | undefined, cwd: string, requestUser?: string | null) => Promise<string>>,
+  getDiffNumstat: mock(() => Promise.resolve('')) as Mock<(baseRef: string, targetRef: string | undefined, cwd: string, requestUser?: string | null) => Promise<string>>,
   getStagedFiles: mock(() => Promise.resolve('')) as Mock<AsyncStringFn>,
   getUnstagedFiles: mock(() => Promise.resolve('')) as Mock<AsyncStringFn>,
   getUntrackedFiles: mock(() => Promise.resolve([])) as Mock<AsyncStringArrayFn>,

--- a/packages/server/src/lib/__tests__/git.test.ts
+++ b/packages/server/src/lib/__tests__/git.test.ts
@@ -856,4 +856,168 @@ index abc1234..def5678 100644
       }
     });
   });
+
+  // =========================================================================
+  // Privilege-elevation seam (Issue #869 / #870)
+  //
+  // When a `requestUser` is passed, lib/git.ts must route the invocation
+  // through `runAsUser` instead of spawning git directly. The
+  // `__setRunAsUserForTesting` hook lets us swap in a capture mock to
+  // assert the contract without spawning any sudo/sh processes.
+  // =========================================================================
+  describe('requestUser routing (Issue #869 / #870)', () => {
+    it('uses Bun.spawn directly when requestUser is null/undefined (default path)', async () => {
+      setMockSpawnResult('main\n');
+      const { git } = await getGitModule();
+
+      const result = await git(['rev-parse', 'HEAD'], '/repo');
+
+      expect(result).toBe('main');
+      // Direct spawn path: Bun.spawn was invoked with the full git argv.
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args).toEqual(['git', 'rev-parse', 'HEAD']);
+      expect(spawnCalls[0].options.cwd).toBe('/repo');
+    });
+
+    it('routes through runAsUser when requestUser is non-empty (elevated path)', async () => {
+      const runAsUserCalls: Array<Record<string, unknown>> = [];
+      const fakeRunAsUser = async (opts: Record<string, unknown>) => {
+        runAsUserCalls.push(opts);
+        return { stdout: 'mainbranch\n', stderr: '', exitCode: 0, timedOut: false };
+      };
+
+      const mod = await getGitModule();
+      mod.__setRunAsUserForTesting(fakeRunAsUser);
+      try {
+        const result = await mod.git(['rev-parse', 'HEAD'], '/repo', undefined, 'alice');
+
+        expect(result).toBe('mainbranch');
+        // Direct-spawn path was NOT used: Bun.spawn was never called.
+        expect(spawnCalls.length).toBe(0);
+        // runAsUser was invoked once with username, cwd, and a shell-escaped
+        // git command string.
+        expect(runAsUserCalls.length).toBe(1);
+        expect(runAsUserCalls[0].username).toBe('alice');
+        expect(runAsUserCalls[0].cwd).toBe('/repo');
+        expect(runAsUserCalls[0].command).toBe("'git' 'rev-parse' 'HEAD'");
+      } finally {
+        mod.__setRunAsUserForTesting(null);
+      }
+    });
+
+    it('translates a non-zero exitCode from runAsUser into a GitError', async () => {
+      const fakeRunAsUser = async () => ({
+        stdout: '',
+        stderr: 'fatal: bad revision\n',
+        exitCode: 128,
+        timedOut: false,
+      });
+
+      const mod = await getGitModule();
+      mod.__setRunAsUserForTesting(fakeRunAsUser);
+      try {
+        let caught: unknown;
+        try {
+          await mod.git(['rev-parse', 'no-such-ref'], '/repo', undefined, 'alice');
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(mod.GitError);
+        expect((caught as Error).message).toContain('bad revision');
+      } finally {
+        mod.__setRunAsUserForTesting(null);
+      }
+    });
+
+    it('translates timedOut from runAsUser into a GitError', async () => {
+      const fakeRunAsUser = async () => ({
+        stdout: '',
+        stderr: '',
+        exitCode: 137,
+        timedOut: true,
+      });
+
+      const mod = await getGitModule();
+      mod.__setRunAsUserForTesting(fakeRunAsUser);
+      try {
+        let caught: unknown;
+        try {
+          await mod.git(['fetch'], '/repo', 5000, 'alice');
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(mod.GitError);
+        expect((caught as Error).message).toContain('timed out');
+      } finally {
+        mod.__setRunAsUserForTesting(null);
+      }
+    });
+
+    it('wraps a spawn failure thrown by runAsUser into a GitError (e.g., sudo missing)', async () => {
+      const fakeRunAsUser = async () => {
+        throw new Error('spawn sudo ENOENT');
+      };
+
+      const mod = await getGitModule();
+      mod.__setRunAsUserForTesting(fakeRunAsUser);
+      try {
+        let caught: unknown;
+        try {
+          await mod.git(['rev-parse', 'HEAD'], '/repo', undefined, 'alice');
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(mod.GitError);
+        expect((caught as Error).message).toContain('spawn sudo ENOENT');
+      } finally {
+        mod.__setRunAsUserForTesting(null);
+      }
+    });
+  });
+
+  // =========================================================================
+  // getStatusPorcelain whitespace preservation (Issue #870 latent fix)
+  //
+  // The porcelain output's two-column status prefix (`XY filename`) is
+  // separated from the filename by a single space, and the first line in
+  // particular carries meaningful leading whitespace when X is ' ' (e.g.,
+  // ` M file.ts` = unstaged-modified). Trimming the whole stdout would
+  // silently strip that whitespace and break parseStatusPorcelain's
+  // `^(.)(.) (.+)$` regex. Verify the output is returned UNTRIMMED.
+  // =========================================================================
+  describe('getStatusPorcelain whitespace preservation (Issue #870)', () => {
+    it('preserves leading whitespace on the first line so XY status survives', async () => {
+      // ` M file.ts` -> unstaged modified. The leading space is the index
+      // status column and must NOT be stripped by `.trim()`.
+      setMockSpawnResult(' M file.ts\n M other.ts\n');
+      const { getStatusPorcelain } = await getGitModule();
+
+      const result = await getStatusPorcelain('/repo');
+
+      // The leading space MUST be intact. If gitExec stripped it via
+      // .trim()/.trimStart(), the first line would become `M file.ts` and
+      // the XY parser would see only one status column.
+      expect(result.startsWith(' M file.ts')).toBe(true);
+      expect(result).toContain(' M file.ts\n M other.ts');
+    });
+
+    it('preserves leading whitespace under the elevated runAsUser path too', async () => {
+      const fakeRunAsUser = async () => ({
+        stdout: ' M file.ts\n?? new.ts\n',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      const mod = await getGitModule();
+      mod.__setRunAsUserForTesting(fakeRunAsUser);
+      try {
+        const result = await mod.getStatusPorcelain('/repo', 'alice');
+        // Same invariant on the elevated path.
+        expect(result.startsWith(' M file.ts')).toBe(true);
+      } finally {
+        mod.__setRunAsUserForTesting(null);
+      }
+    });
+  });
 });

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -5,7 +5,21 @@
  * - No shell injection vulnerabilities (args passed as array, not string)
  * - Consistent async API
  * - Non-blocking I/O
+ *
+ * Issue #869 / #870: Many exported helpers accept an optional `requestUser`
+ * trailing argument. When non-null, the invocation is routed via
+ * `runAsUser` (see `../services/privilege-elevation.js`) so that, in
+ * multi-user mode, git executes as the requesting OS user — picking up
+ * that user's PATH, gitconfig, and SSH_AUTH_SOCK from their login shell
+ * via `sudo -i`. When `requestUser` is null/undefined (the default), the
+ * historical `Bun.spawn(['git', ...args])` direct-spawn path runs verbatim.
  */
+import {
+  runAsUser as defaultRunAsUser,
+  shellEscape,
+  type RunAsUserOpts,
+  type RunAsUserResult,
+} from '../services/privilege-elevation.js';
 
 /** Default timeout for local git operations (30 seconds) */
 const DEFAULT_GIT_TIMEOUT_MS = 30000;
@@ -25,6 +39,25 @@ export class GitError extends Error {
     super(message);
     this.name = 'GitError';
   }
+}
+
+// ============================================================
+// Privilege-elevation test seam (Issue #869 / #870)
+// ============================================================
+
+type RunAsUserFn = (opts: RunAsUserOpts) => Promise<RunAsUserResult>;
+
+let _runAsUser: RunAsUserFn = defaultRunAsUser;
+
+/**
+ * Inject a fake `runAsUser` implementation for tests. Pass `null` to
+ * restore the real implementation. Tests should call this in
+ * `beforeEach`/`afterEach` to avoid cross-test leakage.
+ *
+ * @internal Test-only seam; production callers must not use this.
+ */
+export function __setRunAsUserForTesting(fn: RunAsUserFn | null): void {
+  _runAsUser = fn ?? defaultRunAsUser;
 }
 
 /**
@@ -50,12 +83,36 @@ function createTimeoutPromise(timeoutMs: number, command: string): { promise: Pr
 }
 
 /**
+ * Apply the chosen trim mode to raw stdout.
+ *
+ * - `'full'`     - trims both ends; use for single-token outputs like
+ *                  rev-parse / merge-base / symbolic-ref.
+ * - `'start'`    - trims only leading whitespace; use for diff output where
+ *                  trailing newlines are significant.
+ * - `'preserve'` - no trimming; use for `git status --porcelain` and similar
+ *                  formats whose every line has meaningful leading whitespace
+ *                  (the staged/unstaged status columns). Trimming the output
+ *                  would silently strip the indexStatus from the first line
+ *                  and break porcelain parsing.
+ */
+function applyTrim(stdout: string, mode: 'full' | 'start' | 'preserve'): string {
+  switch (mode) {
+    case 'full':     return stdout.trim();
+    case 'start':    return stdout.trimStart();
+    case 'preserve': return stdout;
+  }
+}
+
+/**
  * Internal implementation of git command execution.
  *
  * @param args - Git command arguments (without 'git' prefix)
  * @param cwd - Working directory for the command
  * @param timeoutMs - Timeout in milliseconds
- * @param trimOutput - How to trim the output: 'full' trims both ends, 'start' only trims leading whitespace
+ * @param trimOutput - How to trim stdout (see `applyTrim`).
+ * @param requestUser - When non-null, route the invocation through
+ *   `runAsUser` so it executes as that OS user under multi-user mode.
+ *   When null/undefined (the default), use the direct `Bun.spawn` path.
  * @returns The stdout output
  * @throws GitError if the command fails or times out
  */
@@ -63,8 +120,47 @@ async function gitExec(
   args: string[],
   cwd: string,
   timeoutMs: number,
-  trimOutput: 'full' | 'start'
+  trimOutput: 'full' | 'start' | 'preserve',
+  requestUser?: string | null
 ): Promise<string> {
+  if (requestUser != null && requestUser.length > 0) {
+    // Elevated path: route via runAsUser. cwd is interpolated inside the
+    // sudo'd inner command; the helper handles single-user bypass when the
+    // requestUser matches the server process user (or AUTH_MODE != multi-user).
+    const command = ['git', ...args].map(shellEscape).join(' ');
+    let result: RunAsUserResult;
+    try {
+      result = await _runAsUser({
+        username: requestUser,
+        command,
+        cwd,
+        timeoutMs,
+      });
+    } catch (error) {
+      // Spawn failure (e.g., sudo missing). Surface as GitError so callers
+      // that branch on `instanceof GitError` keep working.
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new GitError(`git ${args[0] ?? '<unknown>'} failed: ${message}`, -1, message);
+    }
+    if (result.timedOut) {
+      throw new GitError(
+        `git ${args[0] ?? '<unknown>'} timed out after ${timeoutMs}ms`,
+        result.exitCode,
+        'Timeout'
+      );
+    }
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr;
+      throw new GitError(
+        `git ${args[0] ?? '<unknown>'} failed: ${stderr.trim() || `exit code ${result.exitCode}`}`,
+        result.exitCode,
+        stderr
+      );
+    }
+    return applyTrim(result.stdout, trimOutput);
+  }
+
+  // Direct-spawn path (unchanged from pre-Issue-#869 behaviour).
   const proc = Bun.spawn(['git', ...args], {
     cwd,
     stdout: 'pipe',
@@ -87,7 +183,7 @@ async function gitExec(
     }
 
     const stdout = await new Response(proc.stdout).text();
-    return trimOutput === 'full' ? stdout.trim() : stdout.trimStart();
+    return applyTrim(stdout, trimOutput);
   } catch (error) {
     // If timeout occurred, kill the process
     if (error instanceof GitError && error.stderr === 'Timeout') {
@@ -109,6 +205,9 @@ async function gitExec(
  * @param args - Git command arguments (without 'git' prefix)
  * @param cwd - Working directory for the command
  * @param timeoutMs - Timeout in milliseconds (default: 30000ms)
+ * @param requestUser - When non-null, run as this OS user via `runAsUser`
+ *   (multi-user mode picks up that user's PATH/gitconfig/SSH_AUTH_SOCK).
+ *   When null/undefined (the default), spawn directly as the server user.
  * @returns The stdout output trimmed
  * @throws GitError if the command fails or times out
  *
@@ -116,8 +215,13 @@ async function gitExec(
  * const branch = await git(['branch', '--show-current'], repoPath);
  * const remoteUrl = await git(['remote', 'get-url', 'origin'], repoPath);
  */
-export async function git(args: string[], cwd: string, timeoutMs: number = DEFAULT_GIT_TIMEOUT_MS): Promise<string> {
-  return gitExec(args, cwd, timeoutMs, 'full');
+export async function git(
+  args: string[],
+  cwd: string,
+  timeoutMs: number = DEFAULT_GIT_TIMEOUT_MS,
+  requestUser?: string | null,
+): Promise<string> {
+  return gitExec(args, cwd, timeoutMs, 'full', requestUser);
 }
 
 /**
@@ -127,6 +231,7 @@ export async function git(args: string[], cwd: string, timeoutMs: number = DEFAU
  * @param args - Git command arguments (without 'git' prefix)
  * @param cwd - Working directory for the command
  * @param timeoutMs - Timeout in milliseconds (default: 30000ms)
+ * @param requestUser - See {@link git}.
  * @returns The stdout output with only leading whitespace trimmed
  * @throws GitError if the command fails or times out
  *
@@ -134,17 +239,28 @@ export async function git(args: string[], cwd: string, timeoutMs: number = DEFAU
  * // Use for diff commands where trailing newlines matter for parsing
  * const diff = await gitRaw(['diff', baseRef], repoPath);
  */
-export async function gitRaw(args: string[], cwd: string, timeoutMs: number = DEFAULT_GIT_TIMEOUT_MS): Promise<string> {
-  return gitExec(args, cwd, timeoutMs, 'start');
+export async function gitRaw(
+  args: string[],
+  cwd: string,
+  timeoutMs: number = DEFAULT_GIT_TIMEOUT_MS,
+  requestUser?: string | null,
+): Promise<string> {
+  return gitExec(args, cwd, timeoutMs, 'start', requestUser);
 }
 
 /**
  * Execute a git command, returning null on failure instead of throwing.
  * Useful for commands where failure is expected (e.g., checking if a branch exists).
+ *
+ * @param requestUser - See {@link git}.
  */
-export async function gitSafe(args: string[], cwd: string): Promise<string | null> {
+export async function gitSafe(
+  args: string[],
+  cwd: string,
+  requestUser?: string | null,
+): Promise<string | null> {
   try {
-    return await git(args, cwd);
+    return await git(args, cwd, DEFAULT_GIT_TIMEOUT_MS, requestUser);
   } catch {
     return null;
   }
@@ -152,9 +268,15 @@ export async function gitSafe(args: string[], cwd: string): Promise<string | nul
 
 /**
  * Check if a git ref exists.
+ *
+ * @param requestUser - See {@link git}.
  */
-export async function gitRefExists(ref: string, cwd: string): Promise<boolean> {
-  const result = await gitSafe(['rev-parse', '--verify', ref], cwd);
+export async function gitRefExists(
+  ref: string,
+  cwd: string,
+  requestUser?: string | null,
+): Promise<boolean> {
+  const result = await gitSafe(['rev-parse', '--verify', ref], cwd, requestUser);
   return result !== null;
 }
 
@@ -183,10 +305,17 @@ export async function getRemoteUrl(cwd: string): Promise<string | null> {
 
 /**
  * List local branches.
+ *
+ * @param requestUser - See {@link git}. Issue #870: enables multi-user mode
+ *   to run as the worktree-owning user (picks up that user's gitconfig,
+ *   avoiding `dubious ownership` on user-owned repos).
  */
-export async function listLocalBranches(cwd: string): Promise<string[]> {
+export async function listLocalBranches(
+  cwd: string,
+  requestUser?: string | null,
+): Promise<string[]> {
   try {
-    const output = await git(['branch', '--format=%(refname:short)'], cwd);
+    const output = await git(['branch', '--format=%(refname:short)'], cwd, DEFAULT_GIT_TIMEOUT_MS, requestUser);
     return output.split('\n').filter(Boolean);
   } catch {
     return [];
@@ -195,10 +324,15 @@ export async function listLocalBranches(cwd: string): Promise<string[]> {
 
 /**
  * List remote branches.
+ *
+ * @param requestUser - See {@link listLocalBranches}.
  */
-export async function listRemoteBranches(cwd: string): Promise<string[]> {
+export async function listRemoteBranches(
+  cwd: string,
+  requestUser?: string | null,
+): Promise<string[]> {
   try {
-    const output = await git(['branch', '-r', '--format=%(refname:short)'], cwd);
+    const output = await git(['branch', '-r', '--format=%(refname:short)'], cwd, DEFAULT_GIT_TIMEOUT_MS, requestUser);
     return output.split('\n').filter(Boolean);
   } catch {
     return [];
@@ -223,19 +357,24 @@ export async function listAllBranches(cwd: string): Promise<string[]> {
 
 /**
  * Get the default branch name from remote origin.
+ *
+ * @param requestUser - See {@link listLocalBranches}.
  */
-export async function getDefaultBranch(cwd: string): Promise<string | null> {
+export async function getDefaultBranch(
+  cwd: string,
+  requestUser?: string | null,
+): Promise<string | null> {
   // Try symbolic-ref first
-  const symbolicRef = await gitSafe(['symbolic-ref', 'refs/remotes/origin/HEAD'], cwd);
+  const symbolicRef = await gitSafe(['symbolic-ref', 'refs/remotes/origin/HEAD'], cwd, requestUser);
   if (symbolicRef) {
     return symbolicRef.replace('refs/remotes/origin/', '');
   }
 
   // Fallback: check if main or master exists
-  if (await gitRefExists('main', cwd)) {
+  if (await gitRefExists('main', cwd, requestUser)) {
     return 'main';
   }
-  if (await gitRefExists('master', cwd)) {
+  if (await gitRefExists('master', cwd, requestUser)) {
     return 'master';
   }
 
@@ -246,15 +385,25 @@ export async function getDefaultBranch(cwd: string): Promise<string | null> {
  * Refresh the default branch reference from remote origin.
  * This updates the local refs/remotes/origin/HEAD to match the remote's default branch.
  *
+ * The network call `git remote set-head origin -a` is the SSH-using git
+ * invocation here. When `requestUser` is non-null, it runs via `runAsUser`
+ * so it executes as that user — picking up their SSH_AUTH_SOCK from the
+ * login shell (sudo -i) so git-over-SSH authenticates against
+ * private remotes. (Issue #870.)
+ *
+ * @param requestUser - See {@link listLocalBranches}.
  * @returns The updated default branch name
  * @throws GitError if the command fails (e.g., network error, no remote)
  */
-export async function refreshDefaultBranch(cwd: string): Promise<string> {
+export async function refreshDefaultBranch(
+  cwd: string,
+  requestUser?: string | null,
+): Promise<string> {
   // Update the remote HEAD reference
-  await git(['remote', 'set-head', 'origin', '-a'], cwd, NETWORK_GIT_TIMEOUT_MS);
+  await git(['remote', 'set-head', 'origin', '-a'], cwd, NETWORK_GIT_TIMEOUT_MS, requestUser);
 
   // Now get the updated default branch
-  const defaultBranch = await getDefaultBranch(cwd);
+  const defaultBranch = await getDefaultBranch(cwd, requestUser);
   if (!defaultBranch) {
     throw new GitError('Could not determine default branch after refresh', -1, 'No default branch found');
   }
@@ -370,23 +519,39 @@ export async function removeWorktree(
  * Get the merge-base commit of two refs (their common ancestor).
  * Useful for finding where a branch diverged from the base branch.
  *
+ * @param requestUser - See {@link git}.
+ *
  * @example
  * const mergeBase = await getMergeBase('main', 'HEAD', repoPath);
  */
-export async function getMergeBase(ref1: string, ref2: string, cwd: string): Promise<string> {
-  return git(['merge-base', ref1, ref2], cwd);
+export async function getMergeBase(
+  ref1: string,
+  ref2: string,
+  cwd: string,
+  requestUser?: string | null,
+): Promise<string> {
+  return git(['merge-base', ref1, ref2], cwd, DEFAULT_GIT_TIMEOUT_MS, requestUser);
 }
 
 /**
  * Get the merge-base commit of two refs, returning null on failure.
+ *
+ * @param requestUser - See {@link git}.
  */
-export async function getMergeBaseSafe(ref1: string, ref2: string, cwd: string): Promise<string | null> {
-  return gitSafe(['merge-base', ref1, ref2], cwd);
+export async function getMergeBaseSafe(
+  ref1: string,
+  ref2: string,
+  cwd: string,
+  requestUser?: string | null,
+): Promise<string | null> {
+  return gitSafe(['merge-base', ref1, ref2], cwd, requestUser);
 }
 
 /**
  * Get unified diff between a base ref and working directory (including staged and unstaged).
  * If targetRef is provided, compares base to that ref instead of working directory.
+ *
+ * @param requestUser - See {@link git}.
  *
  * @example
  * // Diff from merge-base to working directory
@@ -395,12 +560,17 @@ export async function getMergeBaseSafe(ref1: string, ref2: string, cwd: string):
  * // Diff between two commits
  * const diff = await getDiff(commit1, commit2, repoPath);
  */
-export async function getDiff(baseRef: string, targetRef: string | undefined, cwd: string): Promise<string> {
+export async function getDiff(
+  baseRef: string,
+  targetRef: string | undefined,
+  cwd: string,
+  requestUser?: string | null,
+): Promise<string> {
   if (targetRef) {
-    return gitRaw(['diff', baseRef, targetRef], cwd);
+    return gitRaw(['diff', baseRef, targetRef], cwd, DEFAULT_GIT_TIMEOUT_MS, requestUser);
   } else {
     // Diff from baseRef to working directory (staged + unstaged)
-    return gitRaw(['diff', baseRef], cwd);
+    return gitRaw(['diff', baseRef], cwd, DEFAULT_GIT_TIMEOUT_MS, requestUser);
   }
 }
 
@@ -409,16 +579,23 @@ export async function getDiff(baseRef: string, targetRef: string | undefined, cw
  * Returns lines of: additions<TAB>deletions<TAB>filename
  * For binary files, returns "-<TAB>-<TAB>filename"
  *
+ * @param requestUser - See {@link git}.
+ *
  * @example
  * const stats = await getDiffNumstat(mergeBase, undefined, repoPath);
  * // "12\t5\tsrc/index.ts"
  * // "0\t3\tREADME.md"
  */
-export async function getDiffNumstat(baseRef: string, targetRef: string | undefined, cwd: string): Promise<string> {
+export async function getDiffNumstat(
+  baseRef: string,
+  targetRef: string | undefined,
+  cwd: string,
+  requestUser?: string | null,
+): Promise<string> {
   if (targetRef) {
-    return gitRaw(['diff', '--numstat', baseRef, targetRef], cwd);
+    return gitRaw(['diff', '--numstat', baseRef, targetRef], cwd, DEFAULT_GIT_TIMEOUT_MS, requestUser);
   } else {
-    return gitRaw(['diff', '--numstat', baseRef], cwd);
+    return gitRaw(['diff', '--numstat', baseRef], cwd, DEFAULT_GIT_TIMEOUT_MS, requestUser);
   }
 }
 
@@ -442,10 +619,15 @@ export async function getUnstagedFiles(cwd: string): Promise<string> {
 
 /**
  * Get list of untracked files.
+ *
+ * @param requestUser - See {@link git}.
  */
-export async function getUntrackedFiles(cwd: string): Promise<string[]> {
+export async function getUntrackedFiles(
+  cwd: string,
+  requestUser?: string | null,
+): Promise<string[]> {
   try {
-    const output = await git(['ls-files', '--others', '--exclude-standard'], cwd);
+    const output = await git(['ls-files', '--others', '--exclude-standard'], cwd, DEFAULT_GIT_TIMEOUT_MS, requestUser);
     return output.split('\n').filter(Boolean);
   } catch {
     return [];
@@ -476,9 +658,21 @@ export interface DiffSummary {
 /**
  * Parse git status output to understand staged/unstaged state.
  * Uses porcelain format for reliable parsing.
+ *
+ * IMPORTANT: porcelain output is returned UNTRIMMED. Every line carries the
+ * staged / unstaged status in its leading two columns (e.g. ` M file.ts`),
+ * and trimming the whole stdout silently strips the indexStatus from the
+ * first line so `XY filename` regex parsing fails on it. Hence we route
+ * through `gitExec` with `trimOutput: 'preserve'` rather than the standard
+ * `git()` wrapper.
+ *
+ * @param requestUser - See {@link git}.
  */
-export async function getStatusPorcelain(cwd: string): Promise<string> {
-  return git(['status', '--porcelain', '-uall'], cwd);
+export async function getStatusPorcelain(
+  cwd: string,
+  requestUser?: string | null,
+): Promise<string> {
+  return gitExec(['status', '--porcelain', '-uall'], cwd, DEFAULT_GIT_TIMEOUT_MS, 'preserve', requestUser);
 }
 
 // ============================================================

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -52,6 +52,20 @@ const repositoryCloneService = {
   getJob: mock((_jobId: string) => undefined as any),
 };
 
+// Mock of the worktreeService for the /branches and /refresh-default-branch
+// routes (Issue #870). Captures the `requestUsername` second arg so each test
+// can assert the route forwarded `authUser.username` correctly.
+type BranchesResult = { local: string[]; remote: string[]; defaultBranch: string | null };
+
+const worktreeService = {
+  listBranches: mock<
+    (repoPath: string, requestUsername?: string | null) => Promise<BranchesResult>
+  >(() => Promise.resolve({ local: [], remote: [], defaultBranch: null })),
+  refreshDefaultBranch: mock<
+    (repoPath: string, requestUsername?: string | null) => Promise<string>
+  >(() => Promise.resolve('main')),
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -73,6 +87,12 @@ function resetAllMocks(): void {
   repositoryCloneService.enqueueClone.mockReset();
   repositoryCloneService.enqueueClone.mockImplementation(() => Promise.resolve('mock-job-id'));
   repositoryCloneService.getJob.mockReset();
+  worktreeService.listBranches.mockReset();
+  worktreeService.listBranches.mockImplementation(() =>
+    Promise.resolve({ local: [], remote: [], defaultBranch: null }),
+  );
+  worktreeService.refreshDefaultBranch.mockReset();
+  worktreeService.refreshDefaultBranch.mockImplementation(() => Promise.resolve('main'));
 }
 
 // ---------------------------------------------------------------------------
@@ -92,6 +112,7 @@ describe('Repositories API', () => {
       agentManager: agentManager as any,
       generateRepositoryDescription: mockGenerateDescription as any,
       repositoryCloneService: repositoryCloneService as any,
+      worktreeService: worktreeService as any,
     });
   });
 
@@ -236,6 +257,87 @@ describe('Repositories API', () => {
       const body = (await res.json()) as { behind: number; ahead: number };
       expect(body.behind).toBe(3);
       expect(body.ahead).toBe(1);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/repositories/:id/branches (Issue #870)
+  // POST /api/repositories/:id/refresh-default-branch (Issue #870)
+  //
+  // These two routes thread `authUser.username` into `worktreeService` so
+  // multi-user mode runs git invocations as the requesting user. The test
+  // app wires SingleUserMode with TEST_AUTH_USER.username = 'testuser', so
+  // we assert that value lands on each service call.
+  // =========================================================================
+
+  describe('GET /api/repositories/:id/branches', () => {
+    it('forwards authUser.username to worktreeService.listBranches', async () => {
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      worktreeService.listBranches.mockImplementationOnce(() =>
+        Promise.resolve({ local: ['main'], remote: ['origin/main'], defaultBranch: 'main' }),
+      );
+
+      const res = await app.request('/api/repositories/repo1/branches');
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as {
+        local: string[];
+        remote: string[];
+        defaultBranch: string | null;
+      };
+      expect(body.local).toEqual(['main']);
+      expect(body.remote).toEqual(['origin/main']);
+      expect(body.defaultBranch).toBe('main');
+
+      expect(worktreeService.listBranches).toHaveBeenCalledTimes(1);
+      const [repoPath, requestUsername] = worktreeService.listBranches.mock.calls[0];
+      expect(repoPath).toBe('/repo');
+      expect(requestUsername).toBe('testuser');
+    });
+
+    it('returns 404 when the repository is not registered', async () => {
+      repositoryManager.getRepository.mockReturnValue(undefined);
+
+      const res = await app.request('/api/repositories/missing/branches');
+      expect(res.status).toBe(404);
+      expect(worktreeService.listBranches).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('POST /api/repositories/:id/refresh-default-branch', () => {
+    it('forwards authUser.username to worktreeService.refreshDefaultBranch', async () => {
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      worktreeService.refreshDefaultBranch.mockImplementationOnce(() =>
+        Promise.resolve('develop'),
+      );
+
+      const res = await app.request('/api/repositories/repo1/refresh-default-branch', {
+        method: 'POST',
+      });
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as { defaultBranch: string };
+      expect(body.defaultBranch).toBe('develop');
+
+      expect(worktreeService.refreshDefaultBranch).toHaveBeenCalledTimes(1);
+      const [repoPath, requestUsername] = worktreeService.refreshDefaultBranch.mock.calls[0];
+      expect(repoPath).toBe('/repo');
+      expect(requestUsername).toBe('testuser');
+    });
+
+    it('maps GitError to a 400 response (network failure surfaces as Validation)', async () => {
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      worktreeService.refreshDefaultBranch.mockImplementationOnce(() => {
+        throw new GitError('network unreachable', 128, 'fatal: network unreachable');
+      });
+
+      const res = await app.request('/api/repositories/repo1/refresh-default-branch', {
+        method: 'POST',
+      });
+      expect(res.status).toBe(400);
+
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain('Failed to refresh default branch');
     });
   });
 

--- a/packages/server/src/routes/__tests__/sessions.test.ts
+++ b/packages/server/src/routes/__tests__/sessions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { Hono } from 'hono';
 import { onApiError } from '../../lib/error-handler.js';
 import { api } from '../api.js';
@@ -724,5 +724,104 @@ describe('Sessions API - POST /api/sessions (shared sessions)', () => {
     });
 
     expect(res.status).toBe(400);
+  });
+});
+
+// ===========================================================================
+// GET /api/sessions/:sessionId/branches (Issue #870)
+//
+// The route resolves the session's effective spawn user (via
+// `resolveSpawnUsername(session.createdBy, userRepository)`) and threads it
+// into `worktreeService.listBranches` so multi-user mode runs the git
+// invocations as the OS user that owns the worktree. For shared sessions
+// the spawn user is the shared account, NOT the authenticated viewer --
+// using the viewer's identity would reintroduce dubious-ownership /
+// missing-credential failures (CodeRabbit review on PR #874).
+// ===========================================================================
+describe('Sessions API - GET /api/sessions/:sessionId/branches', () => {
+  let app: Hono<AppBindings>;
+  const mockSessionManager = {
+    getSession: mock((_id: string) => undefined as any),
+  };
+  type BranchesResult = { local: string[]; remote: string[]; defaultBranch: string | null };
+  const mockWorktreeService = {
+    listBranches: mock<
+      (repoPath: string, requestUsername?: string | null) => Promise<BranchesResult>
+    >(() => Promise.resolve({ local: [], remote: [], defaultBranch: null })),
+  };
+  // Minimal UserRepository stub: returns a user when findById is called with
+  // an id we registered. Lets us drive resolveSpawnUsername deterministically
+  // without spinning up a sqlite repo.
+  const mockUserRepository: any = {
+    findById: mock<(id: string) => Promise<{ id: string; username: string; homeDir: string } | null>>(
+      () => Promise.resolve(null),
+    ),
+  };
+
+  beforeEach(() => {
+    mockSessionManager.getSession.mockReset();
+    mockWorktreeService.listBranches.mockReset();
+    mockWorktreeService.listBranches.mockImplementation(() =>
+      Promise.resolve({ local: [], remote: [], defaultBranch: null }),
+    );
+    mockUserRepository.findById.mockReset();
+    mockUserRepository.findById.mockImplementation(() => Promise.resolve(null));
+
+    app = new Hono<AppBindings>();
+    app.use('*', async (c, next) => {
+      c.set(
+        'appContext',
+        asAppContext({
+          sessionManager: mockSessionManager as any,
+          worktreeService: mockWorktreeService as any,
+          userRepository: mockUserRepository,
+        }),
+      );
+      await next();
+    });
+    app.onError(onApiError);
+    app.route('/api', api);
+  });
+
+  it('forwards the session spawn username (resolved via createdBy) to worktreeService.listBranches', async () => {
+    mockSessionManager.getSession.mockReturnValueOnce({
+      id: 'session1',
+      locationPath: '/worktree/wt-001-aaaa',
+      createdBy: 'shared-account-id',
+    });
+    mockUserRepository.findById.mockImplementationOnce((id: string) =>
+      id === 'shared-account-id'
+        ? Promise.resolve({ id, username: 'sharedacct', homeDir: '/home/sharedacct' })
+        : Promise.resolve(null),
+    );
+    mockWorktreeService.listBranches.mockImplementationOnce(() =>
+      Promise.resolve({ local: ['main'], remote: ['origin/main'], defaultBranch: 'main' }),
+    );
+
+    const res = await app.request('/api/sessions/session1/branches');
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      local: string[];
+      remote: string[];
+      defaultBranch: string | null;
+    };
+    expect(body.local).toEqual(['main']);
+    expect(body.remote).toEqual(['origin/main']);
+    expect(body.defaultBranch).toBe('main');
+
+    expect(mockWorktreeService.listBranches).toHaveBeenCalledTimes(1);
+    const [locationPath, requestUsername] = mockWorktreeService.listBranches.mock.calls[0];
+    expect(locationPath).toBe('/worktree/wt-001-aaaa');
+    // Critical: the shared-account spawn user, NOT the authenticated viewer.
+    expect(requestUsername).toBe('sharedacct');
+  });
+
+  it('returns 404 when the session does not exist', async () => {
+    mockSessionManager.getSession.mockReturnValueOnce(undefined);
+
+    const res = await app.request('/api/sessions/missing/branches');
+    expect(res.status).toBe(404);
+    expect(mockWorktreeService.listBranches).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/server/src/routes/__tests__/workers.test.ts
+++ b/packages/server/src/routes/__tests__/workers.test.ts
@@ -777,6 +777,67 @@ describe('Workers API', () => {
       expect(body.error).toContain('Could not resolve diff base');
       expect(body.error).toContain('merge-base:origin/main');
     });
+
+    it('threads the session spawn username into the git-diff service (Issue #869 + CodeRabbit lesson)', async () => {
+      // The route must forward the SESSION'S spawn user (resolved via
+      // resolveSpawnUsername(session.createdBy, userRepository)), NOT the
+      // authenticated viewer. For shared sessions the spawn user is the
+      // shared account, so using the viewer's identity would reintroduce
+      // dubious-ownership / missing-credential errors on user-owned worktrees.
+      //
+      // Override the route's appContext with a userRepository stub that
+      // resolves a known createdBy to a specific OS username. The mockGit.*
+      // calls then receive that username as their trailing argument.
+      const mockUserRepository: any = {
+        findById: (id: string) =>
+          id === 'shared-account-id'
+            ? Promise.resolve({ id, username: 'sharedacct', homeDir: '/home/sharedacct' })
+            : Promise.resolve(null),
+      };
+      const elevatedApp = new Hono<AppBindings>();
+      elevatedApp.use('*', async (c, next) => {
+        c.set('appContext', asAppContext({ sessionManager, userRepository: mockUserRepository }));
+        await next();
+      });
+      elevatedApp.onError(onApiError);
+      elevatedApp.route('/api', api);
+
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+      // Patch the internal session's createdBy directly to simulate a shared
+      // session. The public Session returned by getSession is a fresh object
+      // each call, so we must mutate the internal map entry.
+      const internalSessions = (sessionManager as unknown as { sessions: Map<string, { createdBy?: string }> }).sessions;
+      const internalSession = internalSessions.get(session.id)!;
+      internalSession.createdBy = 'shared-account-id';
+
+      const worker = await sessionManager.createWorker(session.id, {
+        type: 'git-diff',
+        baseCommit: 'merge-base:origin/main',
+      });
+      expect(worker).not.toBeNull();
+
+      mockGit.getMergeBaseSafe.mockImplementation(() => Promise.resolve('resolvedbase999'));
+      mockGit.getDiff.mockImplementation(() => Promise.resolve(''));
+      mockGit.getDiffNumstat.mockImplementation(() => Promise.resolve(''));
+      mockGit.getMergeBaseSafe.mockClear();
+
+      const res = await elevatedApp.request(
+        `/api/sessions/${session.id}/workers/${worker!.id}/diff`,
+      );
+
+      expect(res.status).toBe(200);
+      // mockGit.getMergeBaseSafe is called as
+      // (ref1, ref2, cwd, requestUser). Assert the SHARED-account username
+      // landed there, NOT the authenticated viewer.
+      const calls = mockGit.getMergeBaseSafe.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      const lastCall = calls[calls.length - 1] as unknown as [string, string, string, string | null];
+      expect(lastCall[3]).toBe('sharedacct');
+    });
   });
 
   // ===========================================================================

--- a/packages/server/src/routes/repositories.ts
+++ b/packages/server/src/routes/repositories.ts
@@ -282,19 +282,27 @@ const repositories = new Hono<AppBindings>()
   .get('/:id/branches', async (c) => {
     const repoId = c.req.param('id');
     const { repositoryManager, worktreeService } = c.get('appContext');
+    const authUser = c.get('authUser');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {
       throw new NotFoundError('Repository');
     }
 
-    const branches = await worktreeService.listBranches(repo.path);
+    // Issue #870: thread the authenticated username so multi-user mode runs
+    // the git invocations as the requesting user. The user's PATH,
+    // ~/.gitconfig, and SSH_AUTH_SOCK are picked up from their login shell
+    // via `sudo -i`; without this elevation the server's `agentconsole`
+    // identity has no SSH credentials and hits `dubious ownership` against
+    // user-owned source repos.
+    const branches = await worktreeService.listBranches(repo.path, authUser.username);
     return c.json(branches);
   })
   // Refresh default branch from remote for a repository
   .post('/:id/refresh-default-branch', async (c) => {
     const repoId = c.req.param('id');
     const { repositoryManager, worktreeService } = c.get('appContext');
+    const authUser = c.get('authUser');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {
@@ -302,7 +310,10 @@ const repositories = new Hono<AppBindings>()
     }
 
     try {
-      const defaultBranch = await worktreeService.refreshDefaultBranch(repo.path);
+      // Issue #870: same rationale as GET /:id/branches above — the network
+      // `git remote set-head` runs as the requesting user so SSH-using git
+      // can authenticate.
+      const defaultBranch = await worktreeService.refreshDefaultBranch(repo.path, authUser.username);
       return c.json({ defaultBranch });
     } catch (error) {
       // Handle git-specific errors (network issues, no remote, etc.)

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -9,6 +9,7 @@ import { createSessionValidationService } from '../services/session-validation-s
 import { InternalError, NotFoundError, ValidationError } from '../lib/errors.js';
 import { vValidator, vQueryValidator } from '../middleware/validation.js';
 import { getOrgRepoFromPath } from '../lib/git.js';
+import { resolveSpawnUsername } from '../services/resolve-spawn-username.js';
 import type { AppBindings } from '../app-context.js';
 
 const sessions = new Hono<AppBindings>()
@@ -190,14 +191,24 @@ const sessions = new Hono<AppBindings>()
   // Get branches for a session's repository
   .get('/:sessionId/branches', async (c) => {
     const sessionId = c.req.param('sessionId');
-    const { sessionManager, worktreeService } = c.get('appContext');
+    const { sessionManager, worktreeService, userRepository } = c.get('appContext');
     const session = sessionManager.getSession(sessionId);
 
     if (!session) {
       throw new NotFoundError('Session');
     }
 
-    const branches = await worktreeService.listBranches(session.locationPath);
+    // Issue #870 / CodeRabbit review on PR #874: multi-user mode must run
+    // the git invocations as the session's effective spawn user (the OS user
+    // that owns the worktree), not as the authenticated viewer. For shared
+    // sessions the spawn user is the shared account; using the viewer's
+    // identity would reintroduce dubious-ownership / missing-credential
+    // failures and silently fall back to empty branches. `resolveSpawnUsername`
+    // mirrors the resolution `SessionManager` uses when launching the
+    // session's PTY workers and falls back to the server username when the
+    // session has no `createdBy` or the lookup fails.
+    const spawnUsername = await resolveSpawnUsername(session.createdBy, userRepository);
+    const branches = await worktreeService.listBranches(session.locationPath, spawnUsername);
     return c.json(branches);
   })
   // Get commits created in this branch (since base commit)

--- a/packages/server/src/routes/workers.ts
+++ b/packages/server/src/routes/workers.ts
@@ -15,6 +15,7 @@ import type { AppBindings } from '../app-context.js';
 import { NotFoundError, ValidationError } from '../lib/errors.js';
 import { vValidator } from '../middleware/validation.js';
 import { createLogger } from '../lib/logger.js';
+import { resolveSpawnUsername } from '../services/resolve-spawn-username.js';
 
 const logger = createLogger('api:workers');
 
@@ -334,7 +335,7 @@ const workers = new Hono<AppBindings>()
     const sessionId = c.req.param('sessionId');
     const workerId = c.req.param('workerId');
 
-    const { sessionManager } = c.get('appContext');
+    const { sessionManager, userRepository } = c.get('appContext');
     const session = sessionManager.getSession(sessionId);
     if (!session) {
       throw new NotFoundError('Session');
@@ -349,12 +350,19 @@ const workers = new Hono<AppBindings>()
       throw new ValidationError('Worker is not a git-diff worker');
     }
 
+    // Issue #869 / CodeRabbit lesson from PR #874: multi-user mode must run
+    // git as the session's effective spawn user (the OS user that owns the
+    // worktree), NOT the authenticated viewer. For shared sessions the spawn
+    // user is the shared account — using the viewer's identity would
+    // reintroduce dubious-ownership errors on user-owned worktrees.
+    const spawnUsername = await resolveSpawnUsername(session.createdBy, userRepository);
+
     const { resolveBaseSpec, getDiffData } = await import('../services/git-diff-service.js');
-    const resolved = await resolveBaseSpec(worker.baseCommit, session.locationPath);
+    const resolved = await resolveBaseSpec(worker.baseCommit, session.locationPath, spawnUsername);
     if (!resolved) {
       throw new ValidationError(`Could not resolve diff base: ${worker.baseCommit}`);
     }
-    const diffData = await getDiffData(session.locationPath, resolved);
+    const diffData = await getDiffData(session.locationPath, resolved, spawnUsername);
 
     return c.json(diffData);
   })
@@ -368,7 +376,7 @@ const workers = new Hono<AppBindings>()
       throw new ValidationError('path query parameter is required');
     }
 
-    const { sessionManager } = c.get('appContext');
+    const { sessionManager, userRepository } = c.get('appContext');
     const session = sessionManager.getSession(sessionId);
     if (!session) {
       throw new NotFoundError('Session');
@@ -383,12 +391,17 @@ const workers = new Hono<AppBindings>()
       throw new ValidationError('Worker is not a git-diff worker');
     }
 
+    // Issue #869 / CodeRabbit lesson from PR #874: see GET /diff above for
+    // the shared-session correctness reason. Resolve the spawn user from
+    // session.createdBy, not the viewer.
+    const spawnUsername = await resolveSpawnUsername(session.createdBy, userRepository);
+
     const { resolveBaseSpec, getFileDiff } = await import('../services/git-diff-service.js');
-    const resolved = await resolveBaseSpec(worker.baseCommit, session.locationPath);
+    const resolved = await resolveBaseSpec(worker.baseCommit, session.locationPath, spawnUsername);
     if (!resolved) {
       throw new ValidationError(`Could not resolve diff base: ${worker.baseCommit}`);
     }
-    const rawDiff = await getFileDiff(session.locationPath, resolved, filePath);
+    const rawDiff = await getFileDiff(session.locationPath, resolved, filePath, spawnUsername);
 
     return c.json({ rawDiff });
   });

--- a/packages/server/src/services/__tests__/git-diff-base-reresolve.test.ts
+++ b/packages/server/src/services/__tests__/git-diff-base-reresolve.test.ts
@@ -146,9 +146,9 @@ describe('Issue #800: git-diff base spec re-resolution (real repo)', () => {
 
     // Diff #1: resolves merge-base(main, HEAD) — should contain the feature
     // change but NOT the upstream-only file.
-    const resolved1 = await resolveBaseSpec(spec, repo);
+    const resolved1 = await resolveBaseSpec(spec, repo, null);
     expect(resolved1).not.toBeNull();
-    const diff1 = await getDiffData(repo, resolved1!);
+    const diff1 = await getDiffData(repo, resolved1!, null);
     const paths1 = diff1.summary.files.map((f) => f.path);
     expect(paths1).toContain('feature.txt');
     expect(paths1).not.toContain('upstream.txt');
@@ -158,11 +158,11 @@ describe('Issue #800: git-diff base spec re-resolution (real repo)', () => {
 
     // Diff #2: SAME spec, re-resolved → merge-base moves forward to include the
     // upstream commit, so upstream.txt must NOT appear in the diff.
-    const resolved2 = await resolveBaseSpec(spec, repo);
+    const resolved2 = await resolveBaseSpec(spec, repo, null);
     expect(resolved2).not.toBeNull();
     // The merge-base must have advanced (re-resolution actually happened).
     expect(resolved2).not.toBe(resolved1);
-    const diff2 = await getDiffData(repo, resolved2!);
+    const diff2 = await getDiffData(repo, resolved2!, null);
     const paths2 = diff2.summary.files.map((f) => f.path);
     expect(paths2).toContain('feature.txt');
     // CORE REGRESSION ASSERTION: with the old frozen-hash behavior diff2 WOULD
@@ -174,9 +174,9 @@ describe('Issue #800: git-diff base spec re-resolution (real repo)', () => {
     // A branch identical to main: merge-base is HEAD, diff must be empty.
     await git(['checkout', '-b', 'no-changes'], repo);
     const spec = `${MERGE_BASE_REF_PREFIX}main`;
-    const resolved = await resolveBaseSpec(spec, repo);
+    const resolved = await resolveBaseSpec(spec, repo, null);
     expect(resolved).not.toBeNull();
-    const diff = await getDiffData(repo, resolved!);
+    const diff = await getDiffData(repo, resolved!, null);
     expect(diff.summary.files).toHaveLength(0);
   });
 });

--- a/packages/server/src/services/__tests__/git-diff-service.test.ts
+++ b/packages/server/src/services/__tests__/git-diff-service.test.ts
@@ -25,17 +25,17 @@ describe('GitDiffService', () => {
         Promise.resolve(ref === 'origin/main')
       );
 
-      const result = await computeDefaultBaseSpec('/repo/path');
+      const result = await computeDefaultBaseSpec('/repo/path', null);
 
       expect(result).toBe('merge-base:origin/main');
-      expect(mockGit.gitRefExists).toHaveBeenCalledWith('origin/main', '/repo/path');
+      expect(mockGit.gitRefExists).toHaveBeenCalledWith('origin/main', '/repo/path', null);
     });
 
     it('returns merge-base:<default> when default branch exists but origin/<default> does not', async () => {
       mockGit.getDefaultBranch.mockResolvedValue('main');
       mockGit.gitRefExists.mockResolvedValue(false);
 
-      const result = await computeDefaultBaseSpec('/repo/path');
+      const result = await computeDefaultBaseSpec('/repo/path', null);
 
       expect(result).toBe('merge-base:main');
     });
@@ -44,12 +44,13 @@ describe('GitDiffService', () => {
       mockGit.getDefaultBranch.mockResolvedValue(null);
       mockGit.gitSafe.mockResolvedValue('first-commit-hash');
 
-      const result = await computeDefaultBaseSpec('/repo/path');
+      const result = await computeDefaultBaseSpec('/repo/path', null);
 
       expect(result).toBe('first-commit-hash');
       expect(mockGit.gitSafe).toHaveBeenCalledWith(
         ['rev-list', '--max-parents=0', 'HEAD'],
-        '/repo/path'
+        '/repo/path',
+        null
       );
     });
 
@@ -57,7 +58,7 @@ describe('GitDiffService', () => {
       mockGit.getDefaultBranch.mockResolvedValue(null);
       mockGit.gitSafe.mockResolvedValue('root1hash\nroot2hash');
 
-      const result = await computeDefaultBaseSpec('/repo/path');
+      const result = await computeDefaultBaseSpec('/repo/path', null);
 
       expect(result).toBe('root1hash');
     });
@@ -66,7 +67,7 @@ describe('GitDiffService', () => {
       mockGit.getDefaultBranch.mockResolvedValue(null);
       mockGit.gitSafe.mockResolvedValue(null);
 
-      const result = await computeDefaultBaseSpec('/repo/path');
+      const result = await computeDefaultBaseSpec('/repo/path', null);
 
       expect(result).toBe('HEAD');
     });
@@ -82,10 +83,10 @@ describe('GitDiffService', () => {
         Promise.resolve(ref1 === 'origin/main' ? 'origin-merge-base' : null)
       );
 
-      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path');
+      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path', null);
 
       expect(result).toBe('origin-merge-base');
-      expect(mockGit.getMergeBaseSafe).toHaveBeenCalledWith('origin/main', 'HEAD', '/repo/path');
+      expect(mockGit.getMergeBaseSafe).toHaveBeenCalledWith('origin/main', 'HEAD', '/repo/path', null);
     });
 
     it('falls back to local merge-base when origin/<default> is missing', async () => {
@@ -93,17 +94,17 @@ describe('GitDiffService', () => {
       mockGit.gitRefExists.mockResolvedValue(false);
       mockGit.getMergeBaseSafe.mockResolvedValue('local-merge-base');
 
-      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path');
+      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path', null);
 
       expect(result).toBe('local-merge-base');
-      expect(mockGit.getMergeBaseSafe).toHaveBeenCalledWith('main', 'HEAD', '/repo/path');
+      expect(mockGit.getMergeBaseSafe).toHaveBeenCalledWith('main', 'HEAD', '/repo/path', null);
     });
 
     it('falls back to first commit when no default branch (sentinel never hard-fails)', async () => {
       mockGit.getDefaultBranch.mockResolvedValue(null);
       mockGit.gitSafe.mockResolvedValue('first-commit-hash');
 
-      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path');
+      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path', null);
 
       expect(result).toBe('first-commit-hash');
     });
@@ -112,7 +113,7 @@ describe('GitDiffService', () => {
       mockGit.getDefaultBranch.mockResolvedValue(null);
       mockGit.gitSafe.mockResolvedValue('root1hash\nroot2hash');
 
-      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path');
+      const result = await resolveBaseSpec(DEFAULT_FORK_POINT_SPEC, '/repo/path', null);
 
       expect(result).toBe('root1hash');
     });
@@ -120,16 +121,16 @@ describe('GitDiffService', () => {
     it('resolves merge-base:<ref> via getMergeBaseSafe', async () => {
       mockGit.getMergeBaseSafe.mockResolvedValue('mb-hash');
 
-      const result = await resolveBaseSpec('merge-base:foo', '/repo/path');
+      const result = await resolveBaseSpec('merge-base:foo', '/repo/path', null);
 
       expect(result).toBe('mb-hash');
-      expect(mockGit.getMergeBaseSafe).toHaveBeenCalledWith('foo', 'HEAD', '/repo/path');
+      expect(mockGit.getMergeBaseSafe).toHaveBeenCalledWith('foo', 'HEAD', '/repo/path', null);
     });
 
     it('returns null when merge-base:<ref> cannot be resolved (unrelated histories / deleted ref)', async () => {
       mockGit.getMergeBaseSafe.mockResolvedValue(null);
 
-      const result = await resolveBaseSpec('merge-base:foo', '/repo/path');
+      const result = await resolveBaseSpec('merge-base:foo', '/repo/path', null);
 
       expect(result).toBeNull();
     });
@@ -138,19 +139,19 @@ describe('GitDiffService', () => {
       const hash = '0123456789abcdef0123456789abcdef01234567';
       mockGit.gitSafe.mockResolvedValue(hash);
 
-      const result = await resolveBaseSpec(hash, '/repo/path');
+      const result = await resolveBaseSpec(hash, '/repo/path', null);
 
       expect(result).toBe(hash);
-      expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', hash], '/repo/path');
+      expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', hash], '/repo/path', null);
     });
 
     it('re-resolves a branch name to its current tip', async () => {
       mockGit.gitSafe.mockResolvedValue('branch-tip-hash');
 
-      const result = await resolveBaseSpec('feature-branch', '/repo/path');
+      const result = await resolveBaseSpec('feature-branch', '/repo/path', null);
 
       expect(result).toBe('branch-tip-hash');
-      expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', 'feature-branch'], '/repo/path');
+      expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', 'feature-branch'], '/repo/path', null);
     });
 
     // Namespace fix: the sentinel lives in the reserved: namespace
@@ -161,10 +162,10 @@ describe('GitDiffService', () => {
     it('resolves a real ref literally named "default-fork-point" via rev-parse (not the sentinel path)', async () => {
       mockGit.gitSafe.mockResolvedValue('real-ref-hash');
 
-      const result = await resolveBaseSpec('default-fork-point', '/repo/path');
+      const result = await resolveBaseSpec('default-fork-point', '/repo/path', null);
 
       expect(result).toBe('real-ref-hash');
-      expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', 'default-fork-point'], '/repo/path');
+      expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', 'default-fork-point'], '/repo/path', null);
       // The sentinel chain (computeDefaultBaseSpec) must not have been invoked.
       expect(mockGit.getMergeBaseSafe).not.toHaveBeenCalled();
     });
@@ -174,16 +175,16 @@ describe('GitDiffService', () => {
     it('should resolve valid ref to commit hash', async () => {
       mockGit.gitSafe.mockResolvedValue('resolved-hash-123');
 
-      const result = await resolveRef('main', '/repo/path');
+      const result = await resolveRef('main', '/repo/path', null);
 
       expect(result).toBe('resolved-hash-123');
-      expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', 'main'], '/repo/path');
+      expect(mockGit.gitSafe).toHaveBeenCalledWith(['rev-parse', 'main'], '/repo/path', null);
     });
 
     it('should return null for invalid ref', async () => {
       mockGit.gitSafe.mockResolvedValue(null);
 
-      const result = await resolveRef('invalid-ref', '/repo/path');
+      const result = await resolveRef('invalid-ref', '/repo/path', null);
 
       expect(result).toBeNull();
     });
@@ -197,7 +198,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue(' M file.ts');
       mockGit.getUntrackedFiles.mockResolvedValue([]);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       expect(result.summary.baseCommit).toBe('base-commit');
       expect(result.summary.files).toHaveLength(1);
@@ -215,7 +216,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue('?? new-file.ts');
       mockGit.getUntrackedFiles.mockResolvedValue(['new-file.ts']);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       expect(result.summary.files.some(f => f.path === 'new-file.ts')).toBe(true);
       expect(result.summary.files.find(f => f.path === 'new-file.ts')?.status).toBe('untracked');
@@ -229,7 +230,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue('?? file-a.ts\n?? file-b.ts\n?? file-c.ts');
       mockGit.getUntrackedFiles.mockResolvedValue(['file-a.ts', 'file-b.ts', 'file-c.ts']);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       // All three untracked files should be included
       expect(result.summary.files).toHaveLength(3);
@@ -248,7 +249,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue('');
       mockGit.getUntrackedFiles.mockResolvedValue([]);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       expect(result.summary.files).toEqual([]);
       expect(result.summary.totalAdditions).toBe(0);
@@ -261,7 +262,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockRejectedValue(new Error('git error'));
       mockGit.getUntrackedFiles.mockRejectedValue(new Error('git error'));
 
-      const result = await getDiffData('/repo/path', 'invalid-commit');
+      const result = await getDiffData('/repo/path', 'invalid-commit', null);
 
       expect(result.summary.files).toEqual([]);
       expect(result.rawDiff).toBe('');
@@ -273,7 +274,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue('A  staged-file.ts');
       mockGit.getUntrackedFiles.mockResolvedValue([]);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       const file = result.summary.files.find(f => f.path === 'staged-file.ts');
       expect(file).toBeDefined();
@@ -286,7 +287,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue('MM partial-file.ts');
       mockGit.getUntrackedFiles.mockResolvedValue([]);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       const file = result.summary.files.find(f => f.path === 'partial-file.ts');
       expect(file).toBeDefined();
@@ -299,7 +300,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue(' M image.png');
       mockGit.getUntrackedFiles.mockResolvedValue([]);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       const file = result.summary.files.find(f => f.path === 'image.png');
       expect(file).toBeDefined();
@@ -313,7 +314,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue(' M "file with spaces.ts"');
       mockGit.getUntrackedFiles.mockResolvedValue([]);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       const file = result.summary.files.find(f => f.path === 'file with spaces.ts');
       expect(file).toBeDefined();
@@ -326,7 +327,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue('R  old-name.ts -> new-name.ts');
       mockGit.getUntrackedFiles.mockResolvedValue([]);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       const file = result.summary.files.find(f => f.path === 'new-name.ts');
       expect(file).toBeDefined();
@@ -341,7 +342,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue('R  "old file.ts" -> "new file.ts"');
       mockGit.getUntrackedFiles.mockResolvedValue([]);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       const file = result.summary.files.find(f => f.path === 'new file.ts');
       expect(file).toBeDefined();
@@ -356,7 +357,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue('R  simple.ts -> "file with spaces.ts"');
       mockGit.getUntrackedFiles.mockResolvedValue([]);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       const file = result.summary.files.find(f => f.path === 'file with spaces.ts');
       expect(file).toBeDefined();
@@ -372,7 +373,7 @@ describe('GitDiffService', () => {
       mockGit.getStatusPorcelain.mockResolvedValue(' M valid-file.ts\nX');
       mockGit.getUntrackedFiles.mockResolvedValue([]);
 
-      const result = await getDiffData('/repo/path', 'base-commit');
+      const result = await getDiffData('/repo/path', 'base-commit', null);
 
       // Should still process the valid file
       expect(result.summary.files).toHaveLength(1);
@@ -385,19 +386,21 @@ describe('GitDiffService', () => {
       const expectedDiff = 'diff --git a/src/file.ts b/src/file.ts\n--- a/src/file.ts\n+++ b/src/file.ts\n@@ -1,3 +1,4 @@\n line1\n+new line\n line2\n';
       mockGit.gitRaw.mockResolvedValue(expectedDiff);
 
-      const result = await getFileDiff('/repo/path', 'base-commit', 'src/file.ts');
+      const result = await getFileDiff('/repo/path', 'base-commit', 'src/file.ts', null);
 
       expect(result).toBe(expectedDiff);
       expect(mockGit.gitRaw).toHaveBeenCalledWith(
         ['diff', 'base-commit', '--', 'src/file.ts'],
-        '/repo/path'
+        '/repo/path',
+        undefined,
+        null
       );
       // Should NOT call getDiff (full repo diff)
       expect(mockGit.getDiff).not.toHaveBeenCalled();
     });
 
     it('should return empty string for invalid file path', async () => {
-      const result = await getFileDiff('/repo/path', 'base-commit', '../etc/passwd');
+      const result = await getFileDiff('/repo/path', 'base-commit', '../etc/passwd', null);
 
       expect(result).toBe('');
       expect(mockGit.gitRaw).not.toHaveBeenCalled();
@@ -413,11 +416,11 @@ describe('GitDiffService', () => {
         mockGit.gitRaw.mockResolvedValue('');
         mockGit.getUntrackedFiles.mockResolvedValue(['new-file.ts']);
 
-        const result = await getFileDiff(tmpDir, 'base-commit', 'new-file.ts');
+        const result = await getFileDiff(tmpDir, 'base-commit', 'new-file.ts', null);
 
         expect(result).not.toBe('');
         expect(result).toContain('diff --git a/new-file.ts b/new-file.ts');
-        expect(mockGit.getUntrackedFiles).toHaveBeenCalledWith(tmpDir);
+        expect(mockGit.getUntrackedFiles).toHaveBeenCalledWith(tmpDir, null);
       } finally {
         rmSync(tmpDir, { recursive: true, force: true });
       }
@@ -427,7 +430,7 @@ describe('GitDiffService', () => {
       mockGit.gitRaw.mockResolvedValue('');
       mockGit.getUntrackedFiles.mockResolvedValue([]);
 
-      const result = await getFileDiff('/repo/path', 'base-commit', 'unchanged-file.ts');
+      const result = await getFileDiff('/repo/path', 'base-commit', 'unchanged-file.ts', null);
 
       expect(result).toBe('');
     });
@@ -435,7 +438,7 @@ describe('GitDiffService', () => {
     it('should return empty string on git error', async () => {
       mockGit.gitRaw.mockRejectedValue(new Error('git error'));
 
-      const result = await getFileDiff('/repo/path', 'bad-commit', 'src/file.ts');
+      const result = await getFileDiff('/repo/path', 'bad-commit', 'src/file.ts', null);
 
       expect(result).toBe('');
     });
@@ -457,7 +460,7 @@ describe('GitDiffService', () => {
       const content = 'line1\nline2\nline3\nline4\nline5\n';
       writeFileSync(join(tmpDir, 'file.ts'), content);
 
-      const result = await getFileLines(tmpDir, 'file.ts', 2, 4, 'working-dir');
+      const result = await getFileLines(tmpDir, 'file.ts', 2, 4, 'working-dir', null);
 
       expect(result).toEqual(['line2', 'line3', 'line4']);
     });
@@ -466,9 +469,9 @@ describe('GitDiffService', () => {
       const content = 'alpha\nbeta\ngamma\ndelta\n';
       mockGit.gitSafe.mockResolvedValue(content);
 
-      const result = await getFileLines('/repo/path', 'src/file.ts', 1, 2, 'abc123');
+      const result = await getFileLines('/repo/path', 'src/file.ts', 1, 2, 'abc123', null);
 
-      expect(mockGit.gitSafe).toHaveBeenCalledWith(['show', 'abc123:src/file.ts'], '/repo/path');
+      expect(mockGit.gitSafe).toHaveBeenCalledWith(['show', 'abc123:src/file.ts'], '/repo/path', null);
       expect(result).toEqual(['alpha', 'beta']);
     });
 
@@ -476,7 +479,7 @@ describe('GitDiffService', () => {
       const content = 'line1\nline2\nline3\n';
       writeFileSync(join(tmpDir, 'file.ts'), content);
 
-      const result = await getFileLines(tmpDir, 'file.ts', 2, 100, 'working-dir');
+      const result = await getFileLines(tmpDir, 'file.ts', 2, 100, 'working-dir', null);
 
       // Content splits to ['line1', 'line2', 'line3', ''], so allLines.length=4
       // clampedEnd = min(4, 100) = 4, slice(1, 4) = ['line2', 'line3', '']
@@ -487,26 +490,26 @@ describe('GitDiffService', () => {
       const content = 'line1\nline2\nline3\n';
       writeFileSync(join(tmpDir, 'file.ts'), content);
 
-      const result = await getFileLines(tmpDir, 'file.ts', 100, 200, 'working-dir');
+      const result = await getFileLines(tmpDir, 'file.ts', 100, 200, 'working-dir', null);
 
       expect(result).toEqual([]);
     });
 
     it('throws on invalid file path (path traversal)', async () => {
       await expect(
-        getFileLines(tmpDir, '../etc/passwd', 1, 10, 'working-dir')
+        getFileLines(tmpDir, '../etc/passwd', 1, 10, 'working-dir', null)
       ).rejects.toThrow('Invalid file path');
     });
 
     it('throws on absolute path', async () => {
       await expect(
-        getFileLines(tmpDir, '/etc/passwd', 1, 10, 'working-dir')
+        getFileLines(tmpDir, '/etc/passwd', 1, 10, 'working-dir', null)
       ).rejects.toThrow('Invalid file path');
     });
 
     it('throws when file does not exist in working-dir', async () => {
       await expect(
-        getFileLines(tmpDir, 'nonexistent.ts', 1, 10, 'working-dir')
+        getFileLines(tmpDir, 'nonexistent.ts', 1, 10, 'working-dir', null)
       ).rejects.toThrow('Failed to read nonexistent.ts from working directory');
     });
 
@@ -514,7 +517,7 @@ describe('GitDiffService', () => {
       const content = 'line1\nline2\nline3\n';
       writeFileSync(join(tmpDir, 'file.ts'), content);
 
-      const result = await getFileLines(tmpDir, 'file.ts', -5, 2, 'working-dir');
+      const result = await getFileLines(tmpDir, 'file.ts', -5, 2, 'working-dir', null);
 
       expect(result).toEqual(['line1', 'line2']);
     });
@@ -523,7 +526,7 @@ describe('GitDiffService', () => {
       mockGit.gitSafe.mockResolvedValue(null);
 
       await expect(
-        getFileLines('/repo/path', 'src/file.ts', 1, 5, 'abc123')
+        getFileLines('/repo/path', 'src/file.ts', 1, 5, 'abc123', null)
       ).rejects.toThrow('Failed to read src/file.ts at ref abc123');
     });
   });

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -211,6 +211,32 @@ describe('WorkerLifecycleManager', () => {
       expect(ptyFactory.instances.length).toBe(0);
     });
 
+    it('resolves the worktree-owning username for the initial computeDefaultBaseSpec call (Issue #869)', async () => {
+      // The git-diff branch of createWorker must call resolveSpawnUsername so
+      // multi-user mode runs the initial `git symbolic-ref / rev-parse` ops as
+      // the worktree owner, not the server process user — otherwise git
+      // refuses with "dubious ownership in repository".
+      let resolveSpawnCalls = 0;
+      const lifecycleWithSpy = new WorkerLifecycleManager(
+        createDeps({
+          resolveSpawnUsername: async (createdBy) => {
+            resolveSpawnCalls++;
+            expect(createdBy).toBeUndefined();
+            return 'worktreeowner';
+          },
+        }),
+      );
+
+      const session = createTestSession();
+      sessions.set(session.id, session);
+
+      const worker = await lifecycleWithSpy.createWorker(session.id, { type: 'git-diff' });
+
+      expect(worker).not.toBeNull();
+      expect(worker!.type).toBe('git-diff');
+      expect(resolveSpawnCalls).toBe(1);
+    });
+
     it('should return null when session is not found', async () => {
       const request: CreateWorkerParams = {
         type: 'terminal',

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -157,6 +157,7 @@ describe('WorkerManager', () => {
         name: 'Diff',
         createdAt: new Date().toISOString(),
         locationPath: '/repo',
+        requestUser: null,
       });
 
       expect(worker.type).toBe('git-diff');
@@ -174,6 +175,7 @@ describe('WorkerManager', () => {
         name: 'Diff',
         createdAt: new Date().toISOString(),
         locationPath: '/repo',
+        requestUser: null,
       });
 
       expect(worker.baseCommit).toBe('merge-base:develop');
@@ -186,6 +188,7 @@ describe('WorkerManager', () => {
         createdAt: new Date().toISOString(),
         locationPath: '/repo',
         baseCommit: 'merge-base:origin/develop',
+        requestUser: null,
       });
 
       expect(worker.baseCommit).toBe('merge-base:origin/develop');
@@ -201,10 +204,38 @@ describe('WorkerManager', () => {
         createdAt: new Date().toISOString(),
         locationPath: '/repo',
         baseCommit: 'deadbeef1234',
+        requestUser: null,
       });
 
       expect(worker.baseCommit).toBe('deadbeef1234');
       expect(mockGit.gitSafe).not.toHaveBeenCalled();
+    });
+
+    it('threads requestUser into computeDefaultBaseSpec for multi-user mode (Issue #869)', async () => {
+      // The git-diff branch must propagate requestUser into the lib/git.ts
+      // calls that computeDefaultBaseSpec makes. Asserts the username
+      // reaches the mockGit helpers as the trailing argument.
+      mockGit.getDefaultBranch.mockImplementation(() => Promise.resolve('main'));
+      mockGit.gitRefExists.mockImplementation((ref: string) =>
+        Promise.resolve(ref === 'origin/main'),
+      );
+
+      const worker = await workerManager.initializeGitDiffWorker({
+        id: 'git-diff-elevated',
+        name: 'Diff',
+        createdAt: new Date().toISOString(),
+        locationPath: '/elevated/worktree',
+        requestUser: 'workspaceuser',
+      });
+
+      expect(worker.baseCommit).toBe('merge-base:origin/main');
+      // Verify the requestUser threaded through getDefaultBranch and gitRefExists.
+      // mockGit.getDefaultBranch is called with (cwd, requestUser).
+      const getDefaultBranchCalls = mockGit.getDefaultBranch.mock.calls;
+      expect(getDefaultBranchCalls.length).toBeGreaterThan(0);
+      expect(getDefaultBranchCalls[0][0]).toBe('/elevated/worktree');
+      // The second argument is the requestUser.
+      expect((getDefaultBranchCalls[0] as unknown as [string, string | null])[1]).toBe('workspaceuser');
     });
   });
 

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -910,6 +910,39 @@ detached
       expect(result.remote).toEqual([]);
       expect(result.defaultBranch).toBeNull();
     });
+
+    // Issue #870: listBranches now forwards an optional `requestUsername`
+    // through to lib/git.ts so multi-user mode runs git as that user
+    // (picking up their SSH credentials / gitconfig).
+    it('forwards requestUsername=null to lib/git.ts when no argument is passed', async () => {
+      mockGit.listLocalBranches.mockClear();
+      mockGit.listRemoteBranches.mockClear();
+      mockGit.getDefaultBranch.mockClear();
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      await service.listBranches('/repo');
+
+      expect(mockGit.listLocalBranches).toHaveBeenCalledWith('/repo', null);
+      expect(mockGit.listRemoteBranches).toHaveBeenCalledWith('/repo', null);
+      expect(mockGit.getDefaultBranch).toHaveBeenCalledWith('/repo', null);
+    });
+
+    it('forwards a non-null requestUsername through to every lib/git.ts call (Issue #870)', async () => {
+      mockGit.listLocalBranches.mockClear();
+      mockGit.listRemoteBranches.mockClear();
+      mockGit.getDefaultBranch.mockClear();
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      await service.listBranches('/repo', 'alice');
+
+      expect(mockGit.listLocalBranches).toHaveBeenCalledWith('/repo', 'alice');
+      expect(mockGit.listRemoteBranches).toHaveBeenCalledWith('/repo', 'alice');
+      expect(mockGit.getDefaultBranch).toHaveBeenCalledWith('/repo', 'alice');
+    });
   });
 
   describe('getDefaultBranch', () => {
@@ -929,6 +962,64 @@ detached
 
       const result = await service.getDefaultBranch('/repo');
       expect(result).toBeNull();
+    });
+
+    it('forwards requestUsername to lib/git.ts (Issue #870)', async () => {
+      mockGit.getDefaultBranch.mockClear();
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      await service.getDefaultBranch('/repo', 'alice');
+
+      expect(mockGit.getDefaultBranch).toHaveBeenCalledWith('/repo', 'alice');
+    });
+  });
+
+  describe('refreshDefaultBranch', () => {
+    it('forwards requestUsername=null when no argument is passed', async () => {
+      mockGit.refreshDefaultBranch.mockClear();
+      mockGit.refreshDefaultBranch.mockImplementation(() => Promise.resolve('main'));
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      const result = await service.refreshDefaultBranch('/repo');
+
+      expect(result).toBe('main');
+      expect(mockGit.refreshDefaultBranch).toHaveBeenCalledWith('/repo', null);
+    });
+
+    it('forwards a non-null requestUsername to lib/git.ts (Issue #870)', async () => {
+      mockGit.refreshDefaultBranch.mockClear();
+      mockGit.refreshDefaultBranch.mockImplementation(() => Promise.resolve('develop'));
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      const result = await service.refreshDefaultBranch('/repo', 'alice');
+
+      expect(result).toBe('develop');
+      expect(mockGit.refreshDefaultBranch).toHaveBeenCalledWith('/repo', 'alice');
+    });
+
+    it('propagates GitError from the underlying lib/git.ts helper', async () => {
+      mockGit.refreshDefaultBranch.mockClear();
+      mockGit.refreshDefaultBranch.mockImplementation(() =>
+        Promise.reject(new GitError('git remote set-head failed: network unreachable', 128, 'fatal: network unreachable')),
+      );
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      let caught: unknown;
+      try {
+        await service.refreshDefaultBranch('/repo', 'alice');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(GitError);
+      expect((caught as Error).message).toContain('network unreachable');
     });
   });
 

--- a/packages/server/src/services/git-diff-service.ts
+++ b/packages/server/src/services/git-diff-service.ts
@@ -48,9 +48,11 @@ interface FileStatusInfo {
  * Resolve the repository's first (root) commit hash. `rev-list --max-parents=0`
  * can emit multiple root hashes when unrelated histories were merged, so take
  * only the first line. Returns null when there is no commit.
+ *
+ * @param requestUser - OS username to run git as. See {@link computeDefaultBaseSpec}.
  */
-async function getFirstCommit(repoPath: string): Promise<string | null> {
-  const result = await gitSafe(['rev-list', '--max-parents=0', 'HEAD'], repoPath);
+async function getFirstCommit(repoPath: string, requestUser: string | null): Promise<string | null> {
+  const result = await gitSafe(['rev-list', '--max-parents=0', 'HEAD'], repoPath, requestUser);
   return result?.split('\n')[0] ?? null;
 }
 
@@ -66,28 +68,29 @@ async function getFirstCommit(repoPath: string): Promise<string | null> {
  * default branch and no first commit).
  *
  * @param repoPath - Path to the git repository
+ * @param requestUser - OS username to run git as (null = no elevation)
  * @returns Base commit hash, or null if cannot be determined
  */
-async function resolveDefaultForkPoint(repoPath: string): Promise<string | null> {
-  const defaultBranch = await getDefaultBranch(repoPath);
+async function resolveDefaultForkPoint(repoPath: string, requestUser: string | null): Promise<string | null> {
+  const defaultBranch = await getDefaultBranch(repoPath, requestUser);
 
   if (defaultBranch) {
     const originRef = `origin/${defaultBranch}`;
-    if (await gitRefExists(originRef, repoPath)) {
-      const mergeBase = await getMergeBaseSafe(originRef, 'HEAD', repoPath);
+    if (await gitRefExists(originRef, repoPath, requestUser)) {
+      const mergeBase = await getMergeBaseSafe(originRef, 'HEAD', repoPath, requestUser);
       if (mergeBase) {
         return mergeBase;
       }
     }
 
-    const localMergeBase = await getMergeBaseSafe(defaultBranch, 'HEAD', repoPath);
+    const localMergeBase = await getMergeBaseSafe(defaultBranch, 'HEAD', repoPath, requestUser);
     if (localMergeBase) {
       return localMergeBase;
     }
   }
 
   // No default branch (or merge-base unavailable): fall back to first commit.
-  return getFirstCommit(repoPath);
+  return getFirstCommit(repoPath, requestUser);
 }
 
 /**
@@ -104,20 +107,23 @@ async function resolveDefaultForkPoint(repoPath: string): Promise<string | null>
  *   even that cannot be resolved.
  *
  * @param repoPath - Path to the git repository
+ * @param requestUser - OS username to run git as (null = no elevation). In
+ *   multi-user mode this is the worktree-owning user so git does not refuse
+ *   with "dubious ownership in repository". (Issue #869.)
  * @returns A base spec string (never null)
  */
-export async function computeDefaultBaseSpec(repoPath: string): Promise<string> {
-  const defaultBranch = await getDefaultBranch(repoPath);
+export async function computeDefaultBaseSpec(repoPath: string, requestUser: string | null): Promise<string> {
+  const defaultBranch = await getDefaultBranch(repoPath, requestUser);
 
   if (defaultBranch) {
-    if (await gitRefExists(`origin/${defaultBranch}`, repoPath)) {
+    if (await gitRefExists(`origin/${defaultBranch}`, repoPath, requestUser)) {
       return `${MERGE_BASE_REF_PREFIX}origin/${defaultBranch}`;
     }
     return `${MERGE_BASE_REF_PREFIX}${defaultBranch}`;
   }
 
   // No default branch: pin to the first commit (no branch to track).
-  const firstCommit = await getFirstCommit(repoPath);
+  const firstCommit = await getFirstCommit(repoPath, requestUser);
   return firstCommit ?? 'HEAD';
 }
 
@@ -136,20 +142,25 @@ export async function computeDefaultBaseSpec(repoPath: string): Promise<string> 
  *
  * @param spec - The persisted base spec
  * @param repoPath - Path to the git repository
+ * @param requestUser - See {@link computeDefaultBaseSpec}.
  * @returns Resolved commit hash, or null on genuine resolution failure
  */
-export async function resolveBaseSpec(spec: string, repoPath: string): Promise<string | null> {
+export async function resolveBaseSpec(
+  spec: string,
+  repoPath: string,
+  requestUser: string | null,
+): Promise<string | null> {
   if (spec === DEFAULT_FORK_POINT_SPEC) {
-    return resolveDefaultForkPoint(repoPath);
+    return resolveDefaultForkPoint(repoPath, requestUser);
   }
 
   if (spec.startsWith(MERGE_BASE_REF_PREFIX)) {
     const ref = spec.slice(MERGE_BASE_REF_PREFIX.length);
-    return getMergeBaseSafe(ref, 'HEAD', repoPath);
+    return getMergeBaseSafe(ref, 'HEAD', repoPath, requestUser);
   }
 
   // Branch name or explicit commit hash.
-  return resolveRef(spec, repoPath);
+  return resolveRef(spec, repoPath, requestUser);
 }
 
 /**
@@ -157,10 +168,15 @@ export async function resolveBaseSpec(spec: string, repoPath: string): Promise<s
  *
  * @param ref - Branch name or commit hash
  * @param repoPath - Path to the git repository
+ * @param requestUser - See {@link computeDefaultBaseSpec}.
  * @returns Resolved commit hash, or null if invalid
  */
-export async function resolveRef(ref: string, repoPath: string): Promise<string | null> {
-  return gitSafe(['rev-parse', ref], repoPath);
+export async function resolveRef(
+  ref: string,
+  repoPath: string,
+  requestUser: string | null,
+): Promise<string | null> {
+  return gitSafe(['rev-parse', ref], repoPath, requestUser);
 }
 
 /**
@@ -443,12 +459,14 @@ function parseNumstat(numstatOutput: string): Map<string, { additions: number; d
  *
  * @param repoPath - Path to the git repository
  * @param baseCommit - Base commit hash for comparison
+ * @param requestUser - OS username to run git as. See {@link computeDefaultBaseSpec}.
  * @param targetRef - Target reference: 'working-dir' (default) or a commit hash
  * @returns GitDiffData containing summary and raw diff
  */
 export async function getDiffData(
   repoPath: string,
   baseCommit: string,
+  requestUser: string | null,
   targetRef: GitDiffTarget = 'working-dir'
 ): Promise<GitDiffData> {
   const isWorkingDir = targetRef === 'working-dir';
@@ -457,7 +475,7 @@ export async function getDiffData(
   // Get raw diff (from baseCommit to target)
   let rawDiff: string;
   try {
-    rawDiff = await getDiff(baseCommit, gitTargetRef, repoPath);
+    rawDiff = await getDiff(baseCommit, gitTargetRef, repoPath, requestUser);
   } catch (error) {
     logger.warn({ error, repoPath, baseCommit, targetRef: gitTargetRef }, 'Git diff failed, using empty diff');
     rawDiff = '';
@@ -466,7 +484,7 @@ export async function getDiffData(
   // Get numstat for statistics
   let numstatOutput: string;
   try {
-    numstatOutput = await getDiffNumstat(baseCommit, gitTargetRef, repoPath);
+    numstatOutput = await getDiffNumstat(baseCommit, gitTargetRef, repoPath, requestUser);
   } catch (error) {
     logger.warn({ error, repoPath, baseCommit, targetRef: gitTargetRef }, 'Git diff numstat failed, using empty output');
     numstatOutput = '';
@@ -477,14 +495,14 @@ export async function getDiffData(
   let untrackedFiles: string[];
   if (isWorkingDir) {
     try {
-      statusOutput = await getStatusPorcelain(repoPath);
+      statusOutput = await getStatusPorcelain(repoPath, requestUser);
     } catch (error) {
       logger.warn({ error, repoPath }, 'Git status porcelain failed, using empty output');
       statusOutput = '';
     }
 
     try {
-      untrackedFiles = await getUntrackedFiles(repoPath);
+      untrackedFiles = await getUntrackedFiles(repoPath, requestUser);
     } catch (error) {
       logger.warn({ error, repoPath }, 'Git untracked files failed, using empty list');
       untrackedFiles = [];
@@ -631,12 +649,14 @@ function isValidFilePath(filePath: string): boolean {
  * @param repoPath - Path to the git repository
  * @param baseCommit - Base commit hash for comparison
  * @param filePath - Path to the file (relative to repo root)
+ * @param requestUser - OS username to run git as. See {@link computeDefaultBaseSpec}.
  * @returns Raw diff text for the file, or empty string if no changes
  */
 export async function getFileDiff(
   repoPath: string,
   baseCommit: string,
-  filePath: string
+  filePath: string,
+  requestUser: string | null,
 ): Promise<string> {
   // SECURITY: Validate filePath to prevent path traversal attacks
   if (!isValidFilePath(filePath)) {
@@ -646,14 +666,14 @@ export async function getFileDiff(
 
   try {
     // Use targeted git diff command for the specific file
-    const rawDiff = await gitRaw(['diff', baseCommit, '--', filePath], repoPath);
+    const rawDiff = await gitRaw(['diff', baseCommit, '--', filePath], repoPath, undefined, requestUser);
 
     if (rawDiff) {
       return rawDiff;
     }
 
     // File not found in regular diff - check if it's an untracked file
-    const untrackedFiles = await getUntrackedFiles(repoPath);
+    const untrackedFiles = await getUntrackedFiles(repoPath, requestUser);
     if (untrackedFiles.includes(filePath)) {
       const { diff } = await generateUntrackedFileDiff(filePath, repoPath);
       return diff;
@@ -778,6 +798,8 @@ export function stopWatching(repoPath: string): void {
  * @param startLine - Start line number (1-based, inclusive)
  * @param endLine - End line number (1-based, inclusive)
  * @param ref - 'working-dir' or a commit hash
+ * @param requestUser - OS username to run git as. See {@link computeDefaultBaseSpec}.
+ *   Ignored on the 'working-dir' branch (direct filesystem read).
  * @returns Array of line contents
  */
 export async function getFileLines(
@@ -785,7 +807,8 @@ export async function getFileLines(
   filePath: string,
   startLine: number,
   endLine: number,
-  ref: GitDiffTarget
+  ref: GitDiffTarget,
+  requestUser: string | null,
 ): Promise<string[]> {
   if (!isValidFilePath(filePath)) {
     throw new Error(`Invalid file path: ${filePath}`);
@@ -800,7 +823,7 @@ export async function getFileLines(
       throw new Error(`Failed to read ${filePath} from working directory: ${error instanceof Error ? error.message : String(error)}`);
     }
   } else {
-    const result = await gitSafe(['show', `${ref}:${filePath}`], repoPath);
+    const result = await gitSafe(['show', `${ref}:${filePath}`], repoPath, requestUser);
     if (result === null) {
       throw new Error(`Failed to read ${filePath} at ref ${ref}`);
     }

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -180,13 +180,18 @@ export class WorkerLifecycleManager {
       });
       worker = terminalWorker;
     } else {
-      // git-diff worker (async initialization for base commit calculation)
+      // git-diff worker (async initialization for base commit calculation).
+      // Issue #869: resolve the worktree-owning OS username so the initial
+      // `computeDefaultBaseSpec` git invocation runs as that user in
+      // multi-user mode (avoiding "dubious ownership in repository").
+      const username = await this.deps.resolveSpawnUsername(session.createdBy);
       worker = await this.deps.workerManager.initializeGitDiffWorker({
         id: workerId,
         name: workerName,
         createdAt,
         locationPath: session.locationPath,
         baseCommit: request.baseCommit,
+        requestUser: username,
       });
     }
 

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -94,6 +94,14 @@ export interface GitDiffWorkerInitParams {
   createdAt: string;
   locationPath: string;
   baseCommit?: string;
+  /**
+   * Issue #869: OS username to run git as during the initial
+   * `computeDefaultBaseSpec` call. In multi-user mode this is the
+   * worktree-owning user (resolved from the session's `createdBy`), so git
+   * does not refuse with "dubious ownership in repository". Pass `null` in
+   * single-user mode or when elevation is not required.
+   */
+  requestUser: string | null;
 }
 
 /**
@@ -266,12 +274,12 @@ export class WorkerManager {
    * commits (Issue #800).
    */
   async initializeGitDiffWorker(params: GitDiffWorkerInitParams): Promise<InternalGitDiffWorker> {
-    const { id, name, createdAt, locationPath, baseCommit } = params;
+    const { id, name, createdAt, locationPath, baseCommit, requestUser } = params;
 
     // An explicitly-provided baseCommit is treated as a verbatim spec (caller
     // intent — e.g. a branch name or commit hash), not pre-resolved. Otherwise
     // compute the default base spec for this repository.
-    const baseSpec = baseCommit ?? (await computeDefaultBaseSpec(locationPath));
+    const baseSpec = baseCommit ?? (await computeDefaultBaseSpec(locationPath, requestUser));
 
     const worker: InternalGitDiffWorker = {
       id,

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -13,6 +13,10 @@ import {
   refreshDefaultBranch as gitRefreshDefaultBranch,
   GitError,
 } from '../lib/git.js';
+// listLocalBranches, listRemoteBranches, getDefaultBranch, refreshDefaultBranch
+// are thin pass-throughs after Issue #870: lib/git.ts now accepts requestUser
+// directly so multi-user mode runs git as the worktree-owning user (picking
+// up that user's PATH, gitconfig, and SSH_AUTH_SOCK via sudo -i).
 import { createLogger } from '../lib/logger.js';
 import { substituteVariables } from '../lib/template-variables.js';
 import { getCleanChildProcessEnv } from './env-filter.js';
@@ -688,14 +692,31 @@ export class WorktreeService {
   }
 
   /**
-   * List branches in a repository
+   * List branches in a repository.
+   *
+   * Routes each constituent git invocation through `lib/git.ts` with the
+   * provided `requestUsername`. When non-null, lib/git.ts uses `runAsUser`
+   * so multi-user mode runs git as the requesting user — picking up that
+   * user's PATH, `~/.gitconfig`, and SSH_AUTH_SOCK from their login shell
+   * via `sudo -i`. The server's own SSH_AUTH_SOCK is intentionally NOT
+   * forwarded: the server runs as a system user (`agentconsole`) which has
+   * no useful agent socket of its own. See Issue #870 for the user-facing
+   * symptom (the "Could not check remote status" banner / dubious
+   * ownership errors).
+   *
+   * Preserves the existing swallow contract: any overall failure returns
+   * `{ local: [], remote: [], defaultBranch: null }` so the UI can render a
+   * neutral "no branches" view instead of propagating an error.
    */
-  async listBranches(repoPath: string): Promise<{ local: string[]; remote: string[]; defaultBranch: string | null }> {
+  async listBranches(
+    repoPath: string,
+    requestUsername: string | null = null,
+  ): Promise<{ local: string[]; remote: string[]; defaultBranch: string | null }> {
     try {
       const [local, remote, defaultBranch] = await Promise.all([
-        listLocalBranches(repoPath),
-        listRemoteBranches(repoPath),
-        this.getDefaultBranch(repoPath),
+        listLocalBranches(repoPath, requestUsername),
+        listRemoteBranches(repoPath, requestUsername),
+        this.getDefaultBranch(repoPath, requestUsername),
       ]);
 
       return { local, remote, defaultBranch };
@@ -706,21 +727,33 @@ export class WorktreeService {
   }
 
   /**
-   * Get the default branch name from remote origin
+   * Get the default branch name from remote origin.
+   *
+   * See {@link listBranches} for the multi-user / SSH credential rationale.
    */
-  async getDefaultBranch(repoPath: string): Promise<string | null> {
-    return gitGetDefaultBranch(repoPath);
+  async getDefaultBranch(
+    repoPath: string,
+    requestUsername: string | null = null,
+  ): Promise<string | null> {
+    return gitGetDefaultBranch(repoPath, requestUsername);
   }
 
   /**
    * Refresh the default branch reference from remote origin.
    * This updates the local refs/remotes/origin/HEAD to match the remote's default branch.
    *
+   * See {@link listBranches} for the multi-user / SSH credential rationale.
+   * The network call (`git remote set-head origin -a`) is the SSH-using git
+   * invocation here, so running it as the requesting user is critical.
+   *
    * @returns The updated default branch name
    * @throws GitError if the command fails (e.g., network error, no remote)
    */
-  async refreshDefaultBranch(repoPath: string): Promise<string> {
-    return gitRefreshDefaultBranch(repoPath);
+  async refreshDefaultBranch(
+    repoPath: string,
+    requestUsername: string | null = null,
+  ): Promise<string> {
+    return gitRefreshDefaultBranch(repoPath, requestUsername);
   }
 
   /**

--- a/packages/server/src/websocket/__tests__/git-diff-handler.test.ts
+++ b/packages/server/src/websocket/__tests__/git-diff-handler.test.ts
@@ -81,8 +81,8 @@ describe('GitDiffHandler', () => {
   });
 
   /** Helper to establish a connection before sending messages */
-  async function connectWorker(baseCommit: string = 'base-commit'): Promise<void> {
-    await handlers.handleConnection(mockWs, 'session-1', 'worker-1', '/repo/path', baseCommit);
+  async function connectWorker(baseCommit: string = 'base-commit', requestUser: string | null = null): Promise<void> {
+    await handlers.handleConnection(mockWs, 'session-1', 'worker-1', '/repo/path', baseCommit, requestUser);
     sentMessages = [];
     mockGetDiffData.mockClear();
   }
@@ -99,7 +99,8 @@ describe('GitDiffHandler', () => {
         'session-1',
         'worker-1',
         '/repo/path',
-        'base-commit'
+        'base-commit',
+        null
       );
 
       expect(mockWs.send).toHaveBeenCalled();
@@ -116,10 +117,11 @@ describe('GitDiffHandler', () => {
         'session-1',
         'worker-1',
         '/repo/path',
-        'specific-commit'
+        'specific-commit',
+        null
       );
 
-      expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'specific-commit', 'working-dir');
+      expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'specific-commit', null, 'working-dir');
     });
 
     it('should start file watching on connection', async () => {
@@ -128,10 +130,27 @@ describe('GitDiffHandler', () => {
         'session-1',
         'worker-1',
         '/repo/path',
-        'base-commit'
+        'base-commit',
+        null
       );
 
       expect(mockStartWatching).toHaveBeenCalledWith('/repo/path', expect.any(Function));
+    });
+
+    it('threads the captured requestUser into resolveBaseSpec / getDiffData (Issue #869)', async () => {
+      // A non-null requestUser must reach the underlying service so
+      // multi-user mode can elevate git to the worktree-owning user.
+      await handlers.handleConnection(
+        mockWs,
+        'session-1',
+        'worker-1',
+        '/repo/path',
+        'base-commit',
+        'workspaceuser'
+      );
+
+      expect(mockResolveBaseSpec).toHaveBeenCalledWith('base-commit', '/repo/path', 'workspaceuser');
+      expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'base-commit', 'workspaceuser', 'working-dir');
     });
 
     it('should send error if getDiffData throws', async () => {
@@ -144,7 +163,8 @@ describe('GitDiffHandler', () => {
         'session-1',
         'worker-1',
         '/repo/path',
-        'base-commit'
+        'base-commit',
+        null
       );
 
       expect(sentMessages.length).toBe(1);
@@ -168,7 +188,8 @@ describe('GitDiffHandler', () => {
         'session-1',
         'worker-1',
         '/repo/path',
-        'base-commit'
+        'base-commit',
+        null
       );
 
       // Then disconnect
@@ -196,11 +217,23 @@ describe('GitDiffHandler', () => {
 
         await sendMessage(JSON.stringify({ type: 'refresh' }));
 
-        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'current-base', 'working-dir');
+        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'current-base', null, 'working-dir');
         expect(sentMessages.length).toBe(1);
 
         const sentMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
         expect(sentMsg.type).toBe('diff-data');
+      });
+
+      it('forwards the captured requestUser into refresh re-resolution and diff (Issue #869)', async () => {
+        // File-change / refresh paths must keep using the same requestUser
+        // captured at connection time, not silently drop it.
+        await connectWorker('current-base', 'workspaceuser');
+        mockResolveBaseSpec.mockClear();
+
+        await sendMessage(JSON.stringify({ type: 'refresh' }));
+
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('current-base', '/repo/path', 'workspaceuser');
+        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'current-base', 'workspaceuser', 'working-dir');
       });
     });
 
@@ -211,8 +244,8 @@ describe('GitDiffHandler', () => {
         await sendMessage(JSON.stringify({ type: 'set-base-commit', ref: 'main' }));
 
         // The raw ref is stored as the spec and re-resolved via resolveBaseSpec.
-        expect(mockResolveBaseSpec).toHaveBeenCalledWith('main', '/repo/path');
-        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'resolved-commit-hash', 'working-dir');
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('main', '/repo/path', null);
+        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'resolved-commit-hash', null, 'working-dir');
 
         const sentMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
         expect(sentMsg.type).toBe('diff-data');
@@ -223,7 +256,7 @@ describe('GitDiffHandler', () => {
 
         await sendMessage(JSON.stringify({ type: 'set-base-commit', ref: 'invalid-branch' }));
 
-        expect(mockResolveBaseSpec).toHaveBeenCalledWith('invalid-branch', '/repo/path');
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('invalid-branch', '/repo/path', null);
         expect(mockGetDiffData).not.toHaveBeenCalled();
 
         const sentMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
@@ -236,8 +269,8 @@ describe('GitDiffHandler', () => {
 
         await sendMessage(JSON.stringify({ type: 'set-base-commit', ref: 'merge-base:main' }));
 
-        expect(mockResolveBaseSpec).toHaveBeenCalledWith('merge-base:main', '/repo/path');
-        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'merge-base-commit-hash', 'working-dir');
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('merge-base:main', '/repo/path', null);
+        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'merge-base-commit-hash', null, 'working-dir');
 
         const sentMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
         expect(sentMsg.type).toBe('diff-data');
@@ -248,7 +281,7 @@ describe('GitDiffHandler', () => {
 
         await sendMessage(JSON.stringify({ type: 'set-base-commit', ref: 'merge-base:nonexistent-branch' }));
 
-        expect(mockResolveBaseSpec).toHaveBeenCalledWith('merge-base:nonexistent-branch', '/repo/path');
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('merge-base:nonexistent-branch', '/repo/path', null);
         expect(mockGetDiffData).not.toHaveBeenCalled();
 
         const sentMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
@@ -276,8 +309,8 @@ describe('GitDiffHandler', () => {
         // A subsequent refresh must diff against the OLD good spec, not the bad one.
         await sendMessage(JSON.stringify({ type: 'refresh' }));
 
-        expect(mockResolveBaseSpec).toHaveBeenCalledWith('old-base', '/repo/path');
-        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'old-base', 'working-dir');
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('old-base', '/repo/path', null);
+        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'old-base', null, 'working-dir');
 
         const refreshMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
         expect(refreshMsg.type).toBe('diff-data');
@@ -297,8 +330,8 @@ describe('GitDiffHandler', () => {
         // A subsequent refresh uses the newly committed spec, not 'old-base'.
         await sendMessage(JSON.stringify({ type: 'refresh' }));
 
-        expect(mockResolveBaseSpec).toHaveBeenCalledWith('main', '/repo/path');
-        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'resolved-commit-hash', 'working-dir');
+        expect(mockResolveBaseSpec).toHaveBeenCalledWith('main', '/repo/path', null);
+        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'resolved-commit-hash', null, 'working-dir');
       });
     });
 
@@ -314,7 +347,7 @@ describe('GitDiffHandler', () => {
         // Refresh should use updated base, not 'old-base'
         await sendMessage(JSON.stringify({ type: 'refresh' }));
 
-        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'resolved-commit-hash', 'working-dir');
+        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'resolved-commit-hash', null, 'working-dir');
       });
     });
 
@@ -330,7 +363,7 @@ describe('GitDiffHandler', () => {
         // Set target should use updated base, not 'old-base'
         await sendMessage(JSON.stringify({ type: 'set-target-commit', ref: 'HEAD' }));
 
-        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'resolved-commit-hash', 'resolved-commit-hash');
+        expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'resolved-commit-hash', null, 'resolved-commit-hash');
       });
     });
 
@@ -342,7 +375,8 @@ describe('GitDiffHandler', () => {
           'session-1',
           'worker-1',
           '/repo/path',
-          'base-commit'
+          'base-commit',
+          null
         );
         sentMessages = [];
 
@@ -363,7 +397,8 @@ describe('GitDiffHandler', () => {
           'session-1',
           'worker-2',
           '/repo/path',
-          'base-commit'
+          'base-commit',
+          null
         );
         sentMessages = [];
 
@@ -391,6 +426,42 @@ describe('GitDiffHandler', () => {
         expect(sentMsg).toHaveProperty('lines', ['line1', 'line2', 'line3']);
       });
 
+      it('threads requestUser into getFileLines for ref-based reads (Issue #869)', async () => {
+        // File-line reads at a ref must run as the worktree owner so
+        // `git show` does not fail with dubious ownership.
+        const getFileLinesMock = mock(() => Promise.resolve(['line1']));
+        const deps: GitDiffHandlerDependencies = {
+          getDiffData: mockGetDiffData,
+          resolveRef: mockResolveRef,
+          resolveBaseSpec: mockResolveBaseSpec,
+          startWatching: mockStartWatching,
+          stopWatching: mockStopWatching,
+          getFileLines: getFileLinesMock,
+          annotationService: new AnnotationService(),
+        };
+        const localHandlers = createGitDiffHandlers(deps);
+
+        await localHandlers.handleConnection(
+          mockWs,
+          'session-1',
+          'worker-elevated-lines',
+          '/repo/path',
+          'base-commit',
+          'workspaceuser'
+        );
+        sentMessages = [];
+
+        await localHandlers.handleMessage(
+          mockWs,
+          'session-1',
+          'worker-elevated-lines',
+          '/repo/path',
+          JSON.stringify({ type: 'get-file-lines', path: 'src/file.ts', startLine: 1, endLine: 1, ref: 'abc123' }),
+        );
+
+        expect(getFileLinesMock).toHaveBeenCalledWith('/repo/path', 'src/file.ts', 1, 1, 'abc123', 'workspaceuser');
+      });
+
       it('sends error for path traversal attempt', async () => {
         const deps: GitDiffHandlerDependencies = {
           getDiffData: mockGetDiffData,
@@ -408,7 +479,8 @@ describe('GitDiffHandler', () => {
           'session-1',
           'worker-traversal',
           '/repo/path',
-          'base-commit'
+          'base-commit',
+          null
         );
         sentMessages = [];
 
@@ -451,7 +523,8 @@ describe('GitDiffHandler', () => {
           'session-1',
           'worker-3',
           '/repo/path',
-          'base-commit'
+          'base-commit',
+          null
         );
         sentMessages = [];
 
@@ -498,7 +571,7 @@ describe('GitDiffHandler', () => {
 
       await handlers.updateBaseCommit('worker-1', 'new-base-commit');
 
-      expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'new-base-commit', 'working-dir');
+      expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'new-base-commit', null, 'working-dir');
       expect(sentMessages.length).toBe(1);
 
       const sentMsg: GitDiffServerMessage = JSON.parse(sentMessages[0]);
@@ -524,7 +597,7 @@ describe('GitDiffHandler', () => {
       // A subsequent refresh should also use the updated base commit
       await sendMessage(JSON.stringify({ type: 'refresh' }));
 
-      expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'updated-base', 'working-dir');
+      expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'updated-base', null, 'working-dir');
     });
 
     // Validate-before-replace: a server-pushed spec that fails to resolve must
@@ -545,7 +618,19 @@ describe('GitDiffHandler', () => {
       // A subsequent refresh must diff against the OLD good spec, not the bad one.
       await sendMessage(JSON.stringify({ type: 'refresh' }));
 
-      expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'original-base', 'working-dir');
+      expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'original-base', null, 'working-dir');
+    });
+
+    it('threads the captured requestUser through updateBaseCommit (Issue #869)', async () => {
+      // Server-pushed base-commit updates (e.g. from onDiffBaseCommitChanged)
+      // must keep using the same requestUser captured at connection time.
+      await connectWorker('original-base', 'workspaceuser');
+      mockResolveBaseSpec.mockClear();
+
+      await handlers.updateBaseCommit('worker-1', 'updated-base');
+
+      expect(mockResolveBaseSpec).toHaveBeenCalledWith('updated-base', '/repo/path', 'workspaceuser');
+      expect(mockGetDiffData).toHaveBeenCalledWith('/repo/path', 'updated-base', 'workspaceuser', 'working-dir');
     });
   });
 });

--- a/packages/server/src/websocket/git-diff-handler.ts
+++ b/packages/server/src/websocket/git-diff-handler.ts
@@ -10,13 +10,19 @@ const log = createLogger('git-diff-handler');
 // ============================================================
 
 export interface GitDiffHandlerDependencies {
-  getDiffData: (repoPath: string, baseCommit: string, targetRef?: GitDiffTarget) => Promise<GitDiffData>;
-  resolveRef: (ref: string, repoPath: string) => Promise<string | null>;
+  /**
+   * Issue #869 / #870: each dep that runs git accepts `requestUser` so
+   * multi-user mode can elevate git to the worktree-owning user. Pass
+   * `null` when no elevation is needed; the underlying helpers bypass
+   * elevation in that case.
+   */
+  getDiffData: (repoPath: string, baseCommit: string, requestUser: string | null, targetRef?: GitDiffTarget) => Promise<GitDiffData>;
+  resolveRef: (ref: string, repoPath: string, requestUser: string | null) => Promise<string | null>;
   /** Resolve a persisted base *spec* to a concrete commit hash at diff time. */
-  resolveBaseSpec: (spec: string, repoPath: string) => Promise<string | null>;
+  resolveBaseSpec: (spec: string, repoPath: string, requestUser: string | null) => Promise<string | null>;
   startWatching: (repoPath: string, onChange: () => void) => void;
   stopWatching: (repoPath: string) => void;
-  getFileLines: (repoPath: string, filePath: string, startLine: number, endLine: number, ref: GitDiffTarget) => Promise<string[]>;
+  getFileLines: (repoPath: string, filePath: string, startLine: number, endLine: number, ref: GitDiffTarget, requestUser: string | null) => Promise<string[]>;
   annotationService: AnnotationService;
 }
 
@@ -30,6 +36,12 @@ interface ConnectionState {
   /** Persisted base *spec* (intent), re-resolved to a hash on every diff. */
   baseSpec: string;
   targetRef: GitDiffTarget;
+  /**
+   * Issue #869: OS username captured at WS connection time, threaded into
+   * every git invocation so multi-user mode runs git as the worktree owner.
+   * `null` in single-user / no-elevation contexts.
+   */
+  requestUser: string | null;
 }
 
 // Track active connections by workerId
@@ -59,15 +71,16 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
     ws: WSContext,
     locationPath: string,
     baseSpec: string,
+    requestUser: string | null,
     targetRef: GitDiffTarget = 'working-dir'
   ): Promise<boolean> {
     try {
-      const resolved = await resolveBaseSpec(baseSpec, locationPath);
+      const resolved = await resolveBaseSpec(baseSpec, locationPath, requestUser);
       if (resolved === null) {
         sendError(ws, `Could not resolve diff base: ${baseSpec}`);
         return false;
       }
-      const diffData = await getDiffData(locationPath, resolved, targetRef);
+      const diffData = await getDiffData(locationPath, resolved, requestUser, targetRef);
       const msg: GitDiffServerMessage = {
         type: 'diff-data',
         data: diffData,
@@ -101,14 +114,15 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
     sessionId: string,
     workerId: string,
     locationPath: string,
-    baseSpec: string
+    baseSpec: string,
+    requestUser: string | null,
   ): Promise<void> {
     log.info({ sessionId, workerId, locationPath }, 'Git diff WebSocket connected');
 
     // Store connection state (default target is working-dir)
     const connectionKey = workerId;
     const targetRef: GitDiffTarget = 'working-dir';
-    activeConnections.set(connectionKey, { ws, locationPath, baseSpec, targetRef });
+    activeConnections.set(connectionKey, { ws, locationPath, baseSpec, targetRef, requestUser });
 
     // Start file watching - when files change, send updated diff data
     // Note: File watching only makes sense for working-dir target
@@ -116,14 +130,14 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
       const state = activeConnections.get(connectionKey);
       if (state && state.targetRef === 'working-dir') {
         log.debug({ locationPath }, 'File change detected, sending updated diff');
-        sendDiffData(state.ws, state.locationPath, state.baseSpec, state.targetRef).catch((err) => {
+        sendDiffData(state.ws, state.locationPath, state.baseSpec, state.requestUser, state.targetRef).catch((err) => {
           log.error({ err }, 'Failed to send diff data on file change');
         });
       }
     });
 
     // Send initial diff data
-    await sendDiffData(ws, locationPath, baseSpec, targetRef);
+    await sendDiffData(ws, locationPath, baseSpec, requestUser, targetRef);
   }
 
   /**
@@ -168,7 +182,7 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
 
       switch (parsed.type) {
         case 'refresh':
-          await sendDiffData(ws, locationPath, state.baseSpec, currentTargetRef);
+          await sendDiffData(ws, locationPath, state.baseSpec, state.requestUser, currentTargetRef);
           break;
 
         case 'set-base-commit': {
@@ -178,7 +192,7 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
           // and state.baseSpec retains its last good value, so later refreshes
           // and file-watch sends keep producing the previous diff instead of
           // reusing a bad spec. This change is connection-local (not persisted).
-          const ok = await sendDiffData(ws, locationPath, parsed.ref, currentTargetRef);
+          const ok = await sendDiffData(ws, locationPath, parsed.ref, state.requestUser, currentTargetRef);
           if (ok) state.baseSpec = parsed.ref;
           break;
         }
@@ -189,7 +203,7 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
           if (parsed.ref === 'working-dir') {
             targetRef = 'working-dir';
           } else {
-            const resolved = await resolveRef(parsed.ref, locationPath);
+            const resolved = await resolveRef(parsed.ref, locationPath, state.requestUser);
             if (resolved) {
               targetRef = resolved;
             } else {
@@ -199,13 +213,13 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
           }
 
           state.targetRef = targetRef;
-          await sendDiffData(ws, locationPath, state.baseSpec, targetRef);
+          await sendDiffData(ws, locationPath, state.baseSpec, state.requestUser, targetRef);
           break;
         }
 
         case 'get-file-lines': {
           try {
-            const lines = await getFileLines(locationPath, parsed.path, parsed.startLine, parsed.endLine, parsed.ref);
+            const lines = await getFileLines(locationPath, parsed.path, parsed.startLine, parsed.endLine, parsed.ref, state.requestUser);
             const msg: GitDiffServerMessage = {
               type: 'file-lines',
               path: parsed.path,
@@ -257,7 +271,7 @@ export function createGitDiffHandlers(deps: GitDiffHandlerDependencies) {
       return;
     }
 
-    const ok = await sendDiffData(state.ws, state.locationPath, newBaseSpec, state.targetRef);
+    const ok = await sendDiffData(state.ws, state.locationPath, newBaseSpec, state.requestUser, state.targetRef);
     if (ok) state.baseSpec = newBaseSpec;
   }
 

--- a/packages/server/src/websocket/routes.ts
+++ b/packages/server/src/websocket/routes.ts
@@ -23,6 +23,7 @@ import { setOutputTruncatedCallback } from '../lib/worker-output-file.js';
 import { BufferedWebSocketSender } from './buffered-ws-sender.js';
 import { WebSocketConnectionRegistry } from './connection-registry.js';
 import { withRepositoryRemote } from '../lib/repository-remote.js';
+import { resolveSpawnUsername } from '../services/resolve-spawn-username.js';
 
 const logger = createLogger('websocket');
 
@@ -713,13 +714,28 @@ export async function setupWebSocketRoutes(
 
           // Handle git-diff workers differently
           if (worker.type === 'git-diff') {
-            handleGitDiffConnection(
-              ws,
-              sessionId,
-              workerId,
-              session.locationPath,
-              (worker as GitDiffWorker).baseCommit
-            ).catch((err) => {
+            // Issue #869 / CodeRabbit lesson from PR #874: resolve the
+            // session's effective spawn user (the worktree-owning OS user),
+            // NOT the authenticated viewer. For shared sessions the spawn
+            // user is the shared account; using the viewer's identity would
+            // reintroduce dubious-ownership errors on user-owned worktrees.
+            // The auth guard (`wsAuthGuard`) above guarantees the viewer is
+            // authenticated; the username threaded to git is the worktree
+            // owner's, not the viewer's.
+            (async () => {
+              const spawnUsername = await resolveSpawnUsername(
+                session.createdBy,
+                appContext.userRepository,
+              );
+              await handleGitDiffConnection(
+                ws,
+                sessionId,
+                workerId,
+                session.locationPath,
+                (worker as GitDiffWorker).baseCommit,
+                spawnUsername,
+              );
+            })().catch((err) => {
               logger.error({ sessionId, workerId, err }, 'Error handling git-diff connection');
               // Send error to client and close WebSocket on critical connection errors
               try {


### PR DESCRIPTION
## Note on CodeRabbit

Both local CodeRabbit CLI (not installed in this development environment) and GitHub-side CodeRabbit bot (rate-limited: "Review limit reached" warning posted at PR open) were unavailable at this PR's review window. No CodeRabbit feedback obtainable from either source. Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority).

This follows the documented simultaneous-rate-limit fallback procedure in [`.claude/skills/coderabbit-ops/troubleshooting.md`](.claude/skills/coderabbit-ops/troubleshooting.md) Q3.

---

## Summary

Consolidates the fixes for Issues #869 (diff worker dubious-ownership) and #870 (worktree-dialog remote-status) by pushing privilege elevation down into `lib/git.ts` — the single source of truth for git invocations. Services consume `lib/git.ts` directly with a `requestUser` parameter; no service-layer `runAsUser` wrappers, no raw `git ...` strings outside `lib/git.ts`.

Closes #869
Closes #870

## Supersedes PR #874 and PR #875

These two PRs were both APPROVED but they layered a service-level `runAsUser` wrapper in front of each service that needed elevation. The owner reviewed both and decided the post-merge "unify into lib/git.ts" refactor was substantial enough to be worth doing the architecture right the first time, in a single cohesive change. This PR does that.

All correctness fixes from both supersededs are ported forward, including the CodeRabbit-discovered shared-session bug from PR #874.

## What changed

### `lib/git.ts` — the foundational refactor

- Internal `gitExec(args, cwd, timeoutMs, trim, requestUser?)` chooses between the existing `Bun.spawn(['git', ...args])` direct path (when `requestUser` is null/undefined) and `runAsUser({ command, username, cwd, timeoutMs })` (when set). `runAsUser` itself auto-bypasses elevation when `username` is null/empty or equals the server user, so the single-user path is byte-for-byte the prior behaviour.
- Read-side helpers (`git`, `gitRaw`, `gitSafe`, `gitRefExists`, `listLocalBranches`, `listRemoteBranches`, `getDefaultBranch`, `refreshDefaultBranch`, `getMergeBase`, `getMergeBaseSafe`, `getDiff`, `getDiffNumstat`, `getStatusPorcelain`, `getUntrackedFiles`) gain an optional trailing `requestUser?: string | null`. Default `null` preserves every existing caller's behaviour with no signature break.
- Write-side helpers (`createWorktree`, `removeWorktree`) intentionally untouched — their elevation already lives in `worktree-creation-service` / `worktree-deletion-service` (out of scope per the orchestrator's brief).
- New `'preserve'` trim variant for `gitExec`, used by `getStatusPorcelain`. **Latent bug fixed:** the porcelain output's leading whitespace IS the staged/unstaged status column; the prior `git()` helper's unconditional `.trim()` was silently corrupting the first line. PR #875 originally fixed this via a separate `getStatusPorcelainAsUser` helper; folded into `lib/git.ts:getStatusPorcelain` directly here.
- Module-internal `__setRunAsUserForTesting(fn | null)` seam for tests. Documented `@internal`.

### Services

- `worktree-service.ts` `listBranches` / `getDefaultBranch` / `refreshDefaultBranch` accept `requestUsername` and pass through to `lib/git.ts` directly. The local `runGitAsUserSafe` / `listLocalBranchesAsUser` / `listRemoteBranchesAsUser` / `resolveDefaultBranch` helpers from PR #874 are removed.
- `git-diff-service.ts` `computeDefaultBaseSpec`, `resolveBaseSpec`, `resolveRef`, `getDiffData`, `getFileDiff`, `getFileLines` accept `requestUser` and call `lib/git.ts` directly. The local `_runAsUser` / `__setRunAsUserForTesting` / `runGit*` / `*AsUser` helpers from PR #875 are removed.
- `worker-manager.ts` `GitDiffWorkerInitParams` gains required `requestUser`; `initializeGitDiffWorker` threads it into `computeDefaultBaseSpec`.
- `worker-lifecycle-manager.ts` resolves the worktree-owning username via `this.deps.resolveSpawnUsername(session.createdBy)` for the initial spec computation (port forward from PR #875).

### Routes / WS — CodeRabbit's shared-session lesson applied uniformly

Routes that operate on a **SESSION's worktree** resolve the spawn user via `resolveSpawnUsername(session.createdBy, userRepository)`, NOT `authUser.username`. CodeRabbit caught this on PR #874 for `/sessions/:id/branches`; the same correctness fix is applied here to every session-bound surface that PR #875 had used the viewer's identity for:

- ✅ `routes/sessions.ts` `/sessions/:sessionId/branches` (GET) — already fixed in PR #874, preserved.
- 🆕 `routes/workers.ts` `/sessions/:sessionId/workers/:workerId/diff` (GET) and `/diff/file` (GET) — uses the session's spawn user (was `authUser.username` in PR #875).
- 🆕 `websocket/routes.ts` git-diff WS handshake — resolves the spawn user before invoking `handleGitDiffConnection` (was `wsAuthUser?.username` in PR #875).

Routes that operate on the **registered REPOSITORY** use `authUser.username` (correct for both single-user and multi-user, since the main worktree is owned by the requesting user):

- `routes/repositories.ts` `/:id/branches` (GET) and `/:id/refresh-default-branch` (POST) — unchanged from PR #874.

**WebSocket handler:** `git-diff-handler.ts` captures `requestUser` at connection time in `ConnectionState`; every subsequent message handler (refresh, set-base-commit, set-target-commit, get-file-lines, updateBaseCommit) threads it through.

## SSH_AUTH_SOCK probe finding (carried forward from PR #874)

The elevated user must have `SSH_AUTH_SOCK` configured in their login shell startup (`~/.bashrc` / `~/.profile` / 1Password CLI snippet) for git over SSH to authenticate. `sudo -i` sources the user's login env from those files; the server's own `SSH_AUTH_SOCK` is intentionally NOT forwarded because the server runs as a system user (`agentconsole`, `/usr/sbin/nologin`) with no useful agent socket of its own.

**Documented limitation:** users whose SSH agent is set up only by a graphical session (gnome-keyring's `/run/user/$UID/keyring/ssh`, or a 1Password GUI without a bashrc snippet) will not have `SSH_AUTH_SOCK` set after elevation. They must add the agent export to their shell startup. This is also called out in an in-code comment on the new elevated paths. A reproducible probe script lives in scratchpad (`ssh-auth-sock-probe.ts`) for operators who want to verify on a specific host.

## Process gotchas worth noting in retrospect

- **The preflight CI gate requires sibling test diffs at `routes/__tests__/`,** even when API-level tests in `__tests__/api.test.ts` cover the route. The local-vs-CI behavior differs from what you might expect: local preflight passes a soft "Integration test gap" warning, CI hard-fails on missing sibling tests. Worth knowing.

## Scope NOT in this PR (intentional deferrals)

- `interactive-process-manager.ts` / MCP `run_process` elevation — separate Issue + PR per orchestrator's decision (the architectural mismatch with `runAsUser`'s one-shot semantics requires a `spawnAsUser` helper that returns a Subprocess handle).
- The repository-level `/branches/:branch/remote-status` route (uses `fetchRemote` + `getCommitsBehind`/`Ahead`) — not in the migration path here. Functions still get `requestUser?` parameter for future use, but the route is not updated. Follow-up if needed.

## Test plan

- [x] `bun run typecheck` — pass.
- [x] `bun run test` — TEST_EXIT 0. Server: 2808 pass + 1 skip. Client: 1425 pass + 2 skip. Integration: 29 pass. Shared: 349 pass. Scripts/hooks/skills: 362 pass. **5378 total tests, 0 failures.**
- [x] `bun run check:lang` — pass (104 files scanned).
- [x] `node .claude/skills/orchestrator/preflight-check.js` — pass.
- [ ] Manual verification in a `AUTH_MODE=multi-user` environment: open Create Worktree dialog (#870 symptom), confirm the remote default branch loads and the banner does not fire. Open a git-diff worker against a user-owned worktree (#869 symptom), confirm diff data renders.
- [ ] CodeRabbit CRITICAL/HIGH/MEDIUM findings: **N/A — simultaneous rate-limit fallback** (see "Note on CodeRabbit" above).

## After merge

PRs #874 and #875 should be closed as superseded with a comment pointing here.