### PR TITLE
fix(server): elevate CLEANUP_REPOSITORY job rm to requesting user

### DIFF
--- a/packages/server/src/jobs/__tests__/handlers.test.ts
+++ b/packages/server/src/jobs/__tests__/handlers.test.ts
@@ -20,30 +20,49 @@ import type { JobQueue, JobHandler } from '../job-queue.js';
 import { registerJobHandlers } from '../handlers.js';
 import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
-import type { RunAsUserOpts, RunAsUserResult } from '../../services/privilege-elevation.js';
+import type { RunAsUserResult } from '../../services/privilege-elevation.js';
 
 const TEST_CONFIG = '/test/config';
 
 /**
- * Capture-and-respond fake for `runAsUser`, mirroring the pattern used by
- * `repository-manager.test.ts`. Default response succeeds; tests override
- * `responder.fn` for failure / timeout scenarios.
+ * Captured arguments for `rmRecursiveAsUser` (PR #888). Mirrors the helper's
+ * positional signature so the test seam can assert path / username / opts
+ * directly — no need to inspect the underlying `rm -rf -- '<...>'` command
+ * shape (the helper's own unit tests already cover that argv).
  */
-function createRunAsUserMock() {
-  const calls: RunAsUserOpts[] = [];
+interface RmRecursiveAsUserCall {
+  path: string;
+  username: string | null | undefined;
+  opts: { timeoutMs?: number } | undefined;
+}
+
+/**
+ * Capture-and-respond fake for `rmRecursiveAsUser`. Default response succeeds;
+ * tests override `responder.fn` for failure / timeout scenarios.
+ */
+function createRmRecursiveAsUserMock() {
+  const calls: RmRecursiveAsUserCall[] = [];
   const responder = {
-    fn: async (_opts: RunAsUserOpts): Promise<RunAsUserResult> => ({
+    fn: async (
+      _path: string,
+      _username: string | null | undefined,
+      _opts: { timeoutMs?: number } | undefined,
+    ): Promise<RunAsUserResult> => ({
       stdout: '',
       stderr: '',
       exitCode: 0,
       timedOut: false,
     }),
   };
-  const runAsUserImpl = (opts: RunAsUserOpts) => {
-    calls.push(opts);
-    return responder.fn(opts);
+  const rmRecursiveAsUserImpl = (
+    path: string,
+    username: string | null | undefined,
+    opts?: { timeoutMs?: number },
+  ) => {
+    calls.push({ path, username, opts });
+    return responder.fn(path, username, opts);
   };
-  return { calls, runAsUserImpl, responder };
+  return { calls, rmRecursiveAsUserImpl, responder };
 }
 
 describe('cleanup job handlers', () => {
@@ -51,7 +70,7 @@ describe('cleanup job handlers', () => {
   let workerOutputFileManager: WorkerOutputFileManager;
   let deleteSessionOutputs: ReturnType<typeof mock>;
   let deleteWorkerOutput: ReturnType<typeof mock>;
-  let runAsUserMock: ReturnType<typeof createRunAsUserMock>;
+  let rmRecursiveAsUserMock: ReturnType<typeof createRmRecursiveAsUserMock>;
   const originalAuthMode = process.env.AUTH_MODE;
 
   beforeEach(() => {
@@ -78,9 +97,9 @@ describe('cleanup job handlers', () => {
     } as unknown as JobQueue;
 
     process.env.AGENT_CONSOLE_HOME = TEST_CONFIG;
-    runAsUserMock = createRunAsUserMock();
+    rmRecursiveAsUserMock = createRmRecursiveAsUserMock();
     registerJobHandlers(fakeQueue, workerOutputFileManager, {
-      runAsUserImpl: runAsUserMock.runAsUserImpl,
+      rmRecursiveAsUserImpl: rmRecursiveAsUserMock.rmRecursiveAsUserImpl,
     });
   });
 
@@ -179,7 +198,7 @@ describe('cleanup job handlers', () => {
       return me === 'tester' ? 'other-user' : 'tester';
     }
 
-    it('bypasses runAsUser when requestUsername is null (direct fs.rm path)', async () => {
+    it('bypasses rmRecursiveAsUser when requestUsername is null (direct fs.rm path)', async () => {
       // Multi-user mode still falls back to direct fs.rm when no username is
       // threaded (e.g., a non-route caller). The ENOENT on the non-existent
       // path is swallowed by the handler's idempotent-skip branch -- no throw.
@@ -188,7 +207,7 @@ describe('cleanup job handlers', () => {
         repoDir: '/var/lib/agent-console/repositories/no-such-org/no-such-repo',
         requestUsername: null,
       });
-      expect(runAsUserMock.calls.length).toBe(0);
+      expect(rmRecursiveAsUserMock.calls.length).toBe(0);
     });
 
     it('treats ENOENT as success on the direct fs.rm path (idempotent)', async () => {
@@ -197,25 +216,27 @@ describe('cleanup job handlers', () => {
         repoDir: '/var/lib/agent-console/repositories/missing/' + Date.now(),
         requestUsername: null,
       });
-      // No throw = success. runAsUser must not have been touched.
-      expect(runAsUserMock.calls.length).toBe(0);
+      // No throw = success. The helper must not have been touched.
+      expect(rmRecursiveAsUserMock.calls.length).toBe(0);
     });
 
-    it('elevates via runAsUser when AUTH_MODE=multi-user and requestUsername targets another user', async () => {
+    it('elevates via rmRecursiveAsUser when AUTH_MODE=multi-user and requestUsername targets another user', async () => {
       process.env.AUTH_MODE = 'multi-user';
       const other = pickOtherUser();
       const repoDir = '/var/lib/agent-console/repositories/org/repo';
 
       await runPayload({ repoDir, requestUsername: other });
 
-      expect(runAsUserMock.calls.length).toBe(1);
-      const call = runAsUserMock.calls[0]!;
+      // Layering contract: handler invokes rmRecursiveAsUser with the raw
+      // path + username and a timeout. The helper's own unit tests cover the
+      // underlying `rm -rf --` argv shape -- the handler test does not
+      // re-assert it here (would be a layer leak from the handler to the
+      // helper).
+      expect(rmRecursiveAsUserMock.calls.length).toBe(1);
+      const call = rmRecursiveAsUserMock.calls[0]!;
+      expect(call.path).toBe(repoDir);
       expect(call.username).toBe(other);
-      // shell-escaped repoDir guards against future drift in how repoDir is composed.
-      expect(call.command).toBe(`rm -rf -- '${repoDir}'`);
-      // cwd is NOT set: runAsUser pins the outer spawn to SUDO_NEUTRAL_CWD and
-      // the inner command operates on an absolute path.
-      expect(call.cwd).toBeUndefined();
+      expect(call.opts?.timeoutMs).toBeGreaterThan(0);
     });
 
     it('falls back to direct fs.rm when AUTH_MODE is none (single-user) even with a username', async () => {
@@ -227,12 +248,12 @@ describe('cleanup job handlers', () => {
         repoDir: '/var/lib/agent-console/repositories/no-such-org/no-such-repo',
         requestUsername: 'someone',
       });
-      expect(runAsUserMock.calls.length).toBe(0);
+      expect(rmRecursiveAsUserMock.calls.length).toBe(0);
     });
 
     it('throws when the elevated rm returns non-zero so the job queue retries', async () => {
       process.env.AUTH_MODE = 'multi-user';
-      runAsUserMock.responder.fn = async () => ({
+      rmRecursiveAsUserMock.responder.fn = async () => ({
         stdout: '',
         stderr: "rm: cannot remove '...': Permission denied\n",
         exitCode: 1,
@@ -248,7 +269,7 @@ describe('cleanup job handlers', () => {
 
     it('throws when the elevated rm times out', async () => {
       process.env.AUTH_MODE = 'multi-user';
-      runAsUserMock.responder.fn = async () => ({
+      rmRecursiveAsUserMock.responder.fn = async () => ({
         stdout: '',
         stderr: '',
         exitCode: 137,
@@ -262,9 +283,9 @@ describe('cleanup job handlers', () => {
       ).rejects.toThrow(/cleanup:repository elevated rm failed/);
     });
 
-    it('propagates spawn failures from runAsUser', async () => {
+    it('propagates spawn failures from the helper', async () => {
       process.env.AUTH_MODE = 'multi-user';
-      runAsUserMock.responder.fn = async () => {
+      rmRecursiveAsUserMock.responder.fn = async () => {
         throw new Error('sudo: command not found');
       };
       await expect(

--- a/packages/server/src/jobs/__tests__/handlers.test.ts
+++ b/packages/server/src/jobs/__tests__/handlers.test.ts
@@ -7,22 +7,52 @@
  * - Invalid payloads (bad scope, path-escape slug) MUST be logged and skipped
  *   without any filesystem operation.
  */
-import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import * as os from 'os';
 import * as path from 'path';
 import { JOB_TYPES } from '@agent-console/shared';
-import type { CleanupSessionOutputsPayload, CleanupWorkerOutputPayload } from '@agent-console/shared';
+import type {
+  CleanupRepositoryPayload,
+  CleanupSessionOutputsPayload,
+  CleanupWorkerOutputPayload,
+} from '@agent-console/shared';
 import type { JobQueue, JobHandler } from '../job-queue.js';
 import { registerJobHandlers } from '../handlers.js';
 import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import { SessionDataPathResolver } from '../../lib/session-data-path-resolver.js';
+import type { RunAsUserOpts, RunAsUserResult } from '../../services/privilege-elevation.js';
 
 const TEST_CONFIG = '/test/config';
+
+/**
+ * Capture-and-respond fake for `runAsUser`, mirroring the pattern used by
+ * `repository-manager.test.ts`. Default response succeeds; tests override
+ * `responder.fn` for failure / timeout scenarios.
+ */
+function createRunAsUserMock() {
+  const calls: RunAsUserOpts[] = [];
+  const responder = {
+    fn: async (_opts: RunAsUserOpts): Promise<RunAsUserResult> => ({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+    }),
+  };
+  const runAsUserImpl = (opts: RunAsUserOpts) => {
+    calls.push(opts);
+    return responder.fn(opts);
+  };
+  return { calls, runAsUserImpl, responder };
+}
 
 describe('cleanup job handlers', () => {
   let handlers: Map<string, JobHandler<unknown>>;
   let workerOutputFileManager: WorkerOutputFileManager;
   let deleteSessionOutputs: ReturnType<typeof mock>;
   let deleteWorkerOutput: ReturnType<typeof mock>;
+  let runAsUserMock: ReturnType<typeof createRunAsUserMock>;
+  const originalAuthMode = process.env.AUTH_MODE;
 
   beforeEach(() => {
     handlers = new Map();
@@ -48,7 +78,18 @@ describe('cleanup job handlers', () => {
     } as unknown as JobQueue;
 
     process.env.AGENT_CONSOLE_HOME = TEST_CONFIG;
-    registerJobHandlers(fakeQueue, workerOutputFileManager);
+    runAsUserMock = createRunAsUserMock();
+    registerJobHandlers(fakeQueue, workerOutputFileManager, {
+      runAsUserImpl: runAsUserMock.runAsUserImpl,
+    });
+  });
+
+  afterEach(() => {
+    if (originalAuthMode === undefined) {
+      delete process.env.AUTH_MODE;
+    } else {
+      process.env.AUTH_MODE = originalAuthMode;
+    }
   });
 
   describe('CLEANUP_SESSION_OUTPUTS', () => {
@@ -118,6 +159,120 @@ describe('cleanup job handlers', () => {
     it('logs and skips on invalid slug', async () => {
       await runPayload({ sessionId: 'sid', workerId: 'wid', scope: 'repository', slug: '/absolute/path' });
       expect(deleteWorkerOutput).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('CLEANUP_REPOSITORY (Issue #884)', () => {
+    async function runPayload(payload: CleanupRepositoryPayload): Promise<void> {
+      const handler = handlers.get(JOB_TYPES.CLEANUP_REPOSITORY)!;
+      await handler(payload);
+    }
+
+    /**
+     * Pick a username guaranteed to differ from the server process user so
+     * `shouldElevateForUser` returns true under `AUTH_MODE=multi-user`. We
+     * avoid hard-coding 'ms2sato' / similar because tests must pass on any
+     * developer's box.
+     */
+    function pickOtherUser(): string {
+      const me = os.userInfo().username;
+      return me === 'tester' ? 'other-user' : 'tester';
+    }
+
+    it('bypasses runAsUser when requestUsername is null (direct fs.rm path)', async () => {
+      // Multi-user mode still falls back to direct fs.rm when no username is
+      // threaded (e.g., a non-route caller). The ENOENT on the non-existent
+      // path is swallowed by the handler's idempotent-skip branch -- no throw.
+      process.env.AUTH_MODE = 'multi-user';
+      await runPayload({
+        repoDir: '/var/lib/agent-console/repositories/no-such-org/no-such-repo',
+        requestUsername: null,
+      });
+      expect(runAsUserMock.calls.length).toBe(0);
+    });
+
+    it('treats ENOENT as success on the direct fs.rm path (idempotent)', async () => {
+      delete process.env.AUTH_MODE;
+      await runPayload({
+        repoDir: '/var/lib/agent-console/repositories/missing/' + Date.now(),
+        requestUsername: null,
+      });
+      // No throw = success. runAsUser must not have been touched.
+      expect(runAsUserMock.calls.length).toBe(0);
+    });
+
+    it('elevates via runAsUser when AUTH_MODE=multi-user and requestUsername targets another user', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const other = pickOtherUser();
+      const repoDir = '/var/lib/agent-console/repositories/org/repo';
+
+      await runPayload({ repoDir, requestUsername: other });
+
+      expect(runAsUserMock.calls.length).toBe(1);
+      const call = runAsUserMock.calls[0]!;
+      expect(call.username).toBe(other);
+      // shell-escaped repoDir guards against future drift in how repoDir is composed.
+      expect(call.command).toBe(`rm -rf -- '${repoDir}'`);
+      // cwd is NOT set: runAsUser pins the outer spawn to SUDO_NEUTRAL_CWD and
+      // the inner command operates on an absolute path.
+      expect(call.cwd).toBeUndefined();
+    });
+
+    it('falls back to direct fs.rm when AUTH_MODE is none (single-user) even with a username', async () => {
+      // Same-user / non-multi-user means shouldElevateForUser returns false,
+      // so the handler stays on the direct fs.rm path. We pass a missing
+      // path so the ENOENT branch silently returns.
+      delete process.env.AUTH_MODE;
+      await runPayload({
+        repoDir: '/var/lib/agent-console/repositories/no-such-org/no-such-repo',
+        requestUsername: 'someone',
+      });
+      expect(runAsUserMock.calls.length).toBe(0);
+    });
+
+    it('throws when the elevated rm returns non-zero so the job queue retries', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      runAsUserMock.responder.fn = async () => ({
+        stdout: '',
+        stderr: "rm: cannot remove '...': Permission denied\n",
+        exitCode: 1,
+        timedOut: false,
+      });
+      await expect(
+        runPayload({
+          repoDir: '/var/lib/agent-console/repositories/org/repo',
+          requestUsername: pickOtherUser(),
+        })
+      ).rejects.toThrow(/cleanup:repository elevated rm failed: rm: cannot remove/);
+    });
+
+    it('throws when the elevated rm times out', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      runAsUserMock.responder.fn = async () => ({
+        stdout: '',
+        stderr: '',
+        exitCode: 137,
+        timedOut: true,
+      });
+      await expect(
+        runPayload({
+          repoDir: '/var/lib/agent-console/repositories/org/repo',
+          requestUsername: pickOtherUser(),
+        })
+      ).rejects.toThrow(/cleanup:repository elevated rm failed/);
+    });
+
+    it('propagates spawn failures from runAsUser', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      runAsUserMock.responder.fn = async () => {
+        throw new Error('sudo: command not found');
+      };
+      await expect(
+        runPayload({
+          repoDir: '/var/lib/agent-console/repositories/org/repo',
+          requestUsername: pickOtherUser(),
+        })
+      ).rejects.toThrow(/sudo: command not found/);
     });
   });
 });

--- a/packages/server/src/jobs/handlers.ts
+++ b/packages/server/src/jobs/handlers.ts
@@ -20,14 +20,44 @@ import {
 } from '../lib/session-data-path.js';
 import { getConfigDir } from '../lib/config.js';
 import { createLogger } from '../lib/logger.js';
+import {
+  runAsUser as defaultRunAsUser,
+  shellEscape,
+  shouldElevateForUser,
+  type RunAsUserOpts,
+  type RunAsUserResult,
+} from '../services/privilege-elevation.js';
 
 const logger = createLogger('job-handlers');
 
 /**
+ * Type of the privilege-elevation helper, mirrored from
+ * `repository-manager.ts` so tests can inject a fake without importing
+ * `Bun.spawn`. Production callers use the real `runAsUser`.
+ * @internal Exported for testing.
+ */
+export type RunAsUserFn = (opts: RunAsUserOpts) => Promise<RunAsUserResult>;
+
+/**
+ * Optional dependencies injected by tests. Defaults bind to the real
+ * `runAsUser`; production callers omit this argument.
+ */
+export interface JobHandlerDeps {
+  runAsUserImpl?: RunAsUserFn;
+}
+
+/**
  * Register all job handlers with the job queue.
  * @param jobQueue The JobQueue instance to register handlers with
+ * @param workerOutputFileManager Manager used by output-cleanup handlers
+ * @param deps Test-only dependency injection. Production callers omit.
  */
-export function registerJobHandlers(jobQueue: JobQueue, workerOutputFileManager: WorkerOutputFileManager): void {
+export function registerJobHandlers(
+  jobQueue: JobQueue,
+  workerOutputFileManager: WorkerOutputFileManager,
+  deps: JobHandlerDeps = {},
+): void {
+  const runAsUserImpl: RunAsUserFn = deps.runAsUserImpl ?? defaultRunAsUser;
   // Handler for deleting all output files for a session
   jobQueue.registerHandler<CleanupSessionOutputsPayload>(
     JOB_TYPES.CLEANUP_SESSION_OUTPUTS,
@@ -75,11 +105,60 @@ export function registerJobHandlers(jobQueue: JobQueue, workerOutputFileManager:
     }
   );
 
-  // Handler for removing repository data directory
+  // Handler for removing repository data directory.
+  //
+  // Issue #884: in `AUTH_MODE=multi-user`, `repoDir` contains a `worktrees/*`
+  // subtree owned by individual users (Issue #838 / PR #843). The historical
+  // direct `fs.rm` here ran as the server process (`agentconsole`) and failed
+  // with `EACCES` on the first user-owned descendant, surfacing as the
+  // silent-unregister symptom reported in Issue #871. When `requestUsername`
+  // is set AND elevation actually applies (`shouldElevateForUser`), route the
+  // recursive removal through `runAsUser` so it executes as that user.
+  // Single-user / null / same-user preserves the original direct `fs.rm` path.
   jobQueue.registerHandler<CleanupRepositoryPayload>(
     JOB_TYPES.CLEANUP_REPOSITORY,
-    async ({ repoDir }) => {
-      logger.debug({ repoDir }, 'Executing cleanup:repository job');
+    async ({ repoDir, requestUsername }) => {
+      const elevate = shouldElevateForUser(requestUsername);
+      logger.debug({ repoDir, requestUsername, elevate }, 'Executing cleanup:repository job');
+
+      if (elevate) {
+        // runAsUser pins the outer spawn to `/` via SUDO_NEUTRAL_CWD, so we
+        // do NOT need to pass `cwd` here -- `rm -rf -- <repoDir>` operates on
+        // an absolute path. `--` guards the rare case where repoDir starts
+        // with `-`. `repoDir` is server-controlled (built from
+        // `getRepositoryDir(orgRepo)`), but shellEscape is cheap insurance
+        // against any future drift in how that path is composed.
+        const command = `rm -rf -- ${shellEscape(repoDir)}`;
+        let result: RunAsUserResult;
+        try {
+          result = await runAsUserImpl({
+            username: requestUsername,
+            command,
+          });
+        } catch (error) {
+          // Spawn failure (e.g., sudo missing). Re-throw so the job queue
+          // retries; we do NOT swallow this as ENOENT — the directory may
+          // still exist.
+          logger.error({ repoDir, requestUsername, err: error }, 'cleanup:repository elevated rm spawn failed');
+          throw error;
+        }
+
+        if (result.timedOut || result.exitCode !== 0) {
+          // `rm -rf` is idempotent on a missing path -- exit 0, no stderr.
+          // Any non-zero exit therefore signals a real permission /
+          // filesystem error; surface it so the job queue retries.
+          const message = result.stderr.trim() || `exit code ${result.exitCode}`;
+          logger.error(
+            { repoDir, requestUsername, exitCode: result.exitCode, timedOut: result.timedOut, stderr: result.stderr },
+            'cleanup:repository elevated rm returned non-zero',
+          );
+          throw new Error(`cleanup:repository elevated rm failed: ${message}`);
+        }
+
+        logger.info({ repoDir, requestUsername }, 'Repository data cleanup completed (elevated)');
+        return;
+      }
+
       try {
         await fs.rm(repoDir, { recursive: true });
         logger.info({ repoDir }, 'Repository data cleanup completed');

--- a/packages/server/src/jobs/handlers.ts
+++ b/packages/server/src/jobs/handlers.ts
@@ -21,29 +21,40 @@ import {
 import { getConfigDir } from '../lib/config.js';
 import { createLogger } from '../lib/logger.js';
 import {
-  runAsUser as defaultRunAsUser,
-  shellEscape,
+  rmRecursiveAsUser as defaultRmRecursiveAsUser,
   shouldElevateForUser,
-  type RunAsUserOpts,
   type RunAsUserResult,
 } from '../services/privilege-elevation.js';
 
 const logger = createLogger('job-handlers');
 
 /**
- * Type of the privilege-elevation helper, mirrored from
- * `repository-manager.ts` so tests can inject a fake without importing
- * `Bun.spawn`. Production callers use the real `runAsUser`.
+ * Timeout for the elevated `rm -rf` of an entire repository data directory.
+ * The dir may contain multiple per-user worktrees plus templates, so this is
+ * generous relative to `WORKTREE_REMOVE_TIMEOUT_MS` in `worktree-service.ts`.
+ * If the helper times out, the result surfaces as `timedOut: true` and the
+ * handler throws so the job queue retries.
+ */
+const CLEANUP_REPOSITORY_TIMEOUT_MS = 300000;
+
+/**
+ * Signature of the elevated recursive-removal helper. Mirrored from
+ * `privilege-elevation.ts` so tests can inject a fake without touching the
+ * module export.
  * @internal Exported for testing.
  */
-export type RunAsUserFn = (opts: RunAsUserOpts) => Promise<RunAsUserResult>;
+export type RmRecursiveAsUserFn = (
+  path: string,
+  username: string | null | undefined,
+  opts?: { timeoutMs?: number },
+) => Promise<RunAsUserResult>;
 
 /**
  * Optional dependencies injected by tests. Defaults bind to the real
- * `runAsUser`; production callers omit this argument.
+ * `rmRecursiveAsUser`; production callers omit this argument.
  */
 export interface JobHandlerDeps {
-  runAsUserImpl?: RunAsUserFn;
+  rmRecursiveAsUserImpl?: RmRecursiveAsUserFn;
 }
 
 /**
@@ -57,7 +68,8 @@ export function registerJobHandlers(
   workerOutputFileManager: WorkerOutputFileManager,
   deps: JobHandlerDeps = {},
 ): void {
-  const runAsUserImpl: RunAsUserFn = deps.runAsUserImpl ?? defaultRunAsUser;
+  const rmRecursiveAsUserImpl: RmRecursiveAsUserFn =
+    deps.rmRecursiveAsUserImpl ?? defaultRmRecursiveAsUser;
   // Handler for deleting all output files for a session
   jobQueue.registerHandler<CleanupSessionOutputsPayload>(
     JOB_TYPES.CLEANUP_SESSION_OUTPUTS,
@@ -113,8 +125,14 @@ export function registerJobHandlers(
   // with `EACCES` on the first user-owned descendant, surfacing as the
   // silent-unregister symptom reported in Issue #871. When `requestUsername`
   // is set AND elevation actually applies (`shouldElevateForUser`), route the
-  // recursive removal through `runAsUser` so it executes as that user.
-  // Single-user / null / same-user preserves the original direct `fs.rm` path.
+  // recursive removal through `rmRecursiveAsUser` (PR #888) so it executes
+  // as that user. Single-user / null / same-user preserves the original
+  // direct `fs.rm` path (and its ENOENT idempotency).
+  //
+  // Layering note: the elevated branch uses the dedicated layer helper rather
+  // than inlining a `rm -rf -- <shellEscape(path)>` command at this site;
+  // `rmRecursiveAsUser` is the canonical encapsulation, analogous to how
+  // `lib/git.ts` encapsulates git command construction.
   jobQueue.registerHandler<CleanupRepositoryPayload>(
     JOB_TYPES.CLEANUP_REPOSITORY,
     async ({ repoDir, requestUsername }) => {
@@ -122,18 +140,10 @@ export function registerJobHandlers(
       logger.debug({ repoDir, requestUsername, elevate }, 'Executing cleanup:repository job');
 
       if (elevate) {
-        // runAsUser pins the outer spawn to `/` via SUDO_NEUTRAL_CWD, so we
-        // do NOT need to pass `cwd` here -- `rm -rf -- <repoDir>` operates on
-        // an absolute path. `--` guards the rare case where repoDir starts
-        // with `-`. `repoDir` is server-controlled (built from
-        // `getRepositoryDir(orgRepo)`), but shellEscape is cheap insurance
-        // against any future drift in how that path is composed.
-        const command = `rm -rf -- ${shellEscape(repoDir)}`;
         let result: RunAsUserResult;
         try {
-          result = await runAsUserImpl({
-            username: requestUsername,
-            command,
+          result = await rmRecursiveAsUserImpl(repoDir, requestUsername, {
+            timeoutMs: CLEANUP_REPOSITORY_TIMEOUT_MS,
           });
         } catch (error) {
           // Spawn failure (e.g., sudo missing). Re-throw so the job queue
@@ -144,9 +154,11 @@ export function registerJobHandlers(
         }
 
         if (result.timedOut || result.exitCode !== 0) {
-          // `rm -rf` is idempotent on a missing path -- exit 0, no stderr.
-          // Any non-zero exit therefore signals a real permission /
-          // filesystem error; surface it so the job queue retries.
+          // `rm -rf` is idempotent on a missing path (POSIX contract: exit 0,
+          // no stderr). Any non-zero exit therefore signals a real permission
+          // / filesystem error; surface it so the job queue retries. The
+          // helper itself stays strict — semantic interpretation is the
+          // handler's job.
           const message = result.stderr.trim() || `exit code ${result.exitCode}`;
           logger.error(
             { repoDir, requestUsername, exitCode: result.exitCode, timedOut: result.timedOut, stderr: result.stderr },

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -24,7 +24,11 @@ const repositoryManager = {
   getAllRepositories: mock(() => []),
   registerRepository: mock(() => Promise.resolve({} as any)),
   updateRepository: mock(() => Promise.resolve(undefined as any)),
-  unregisterRepository: mock(() => Promise.resolve(true)),
+  // Typed signature so tests can assert the route forwarded `authUser.username`
+  // as the second argument (Issue #884; see DELETE route test below).
+  unregisterRepository: mock<
+    (id: string, requestUsername?: string | null) => Promise<boolean>
+  >(() => Promise.resolve(true)),
 };
 
 const sessionManager = {
@@ -183,10 +187,9 @@ describe('Repositories API', () => {
       expect(res.status).toBe(200);
 
       expect(repositoryManager.unregisterRepository).toHaveBeenCalledTimes(1);
-      const [repoIdArg, requestUsernameArg] =
-        repositoryManager.unregisterRepository.mock.calls[0] as [string, string];
-      expect(repoIdArg).toBe('repo1');
-      expect(requestUsernameArg).toBe('testuser');
+      const callArgs = repositoryManager.unregisterRepository.mock.calls[0];
+      expect(callArgs[0]).toBe('repo1');
+      expect(callArgs[1]).toBe('testuser');
     });
   });
 

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -167,6 +167,27 @@ describe('Repositories API', () => {
       expect(body.success).toBe(true);
       expect(repositorySlackIntegrationService.deleteIntegration).toHaveBeenCalled();
     });
+
+    it('forwards authUser.username to unregisterRepository for CLEANUP_REPOSITORY elevation (Issue #884)', async () => {
+      // Backend half of #871: the CLEANUP_REPOSITORY job needs to elevate its
+      // recursive rm to the requesting user (worktree subtrees are owned per
+      // #838 / PR #843). The route's responsibility is to thread the
+      // authenticated username. The default test app wires SingleUserMode
+      // with TEST_AUTH_USER = 'testuser'.
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      sessionManager.getSessionsUsingRepository.mockReturnValue([]);
+      sessionManager.getAllPersistedSessions.mockReturnValue(Promise.resolve([]));
+      repositoryManager.unregisterRepository.mockReturnValue(Promise.resolve(true));
+
+      const res = await app.request('/api/repositories/repo1', { method: 'DELETE' });
+      expect(res.status).toBe(200);
+
+      expect(repositoryManager.unregisterRepository).toHaveBeenCalledTimes(1);
+      const [repoIdArg, requestUsernameArg] =
+        repositoryManager.unregisterRepository.mock.calls[0] as [string, string];
+      expect(repoIdArg).toBe('repo1');
+      expect(requestUsernameArg).toBe('testuser');
+    });
   });
 
   // =========================================================================

--- a/packages/server/src/routes/repositories.ts
+++ b/packages/server/src/routes/repositories.ts
@@ -143,6 +143,7 @@ const repositories = new Hono<AppBindings>()
   .delete('/:id', async (c) => {
     const repoId = c.req.param('id');
     const { repositoryManager, sessionManager } = c.get('appContext');
+    const authUser = c.get('authUser');
 
     // Check if repository exists
     const repo = repositoryManager.getRepository(repoId);
@@ -186,7 +187,11 @@ const repositories = new Hono<AppBindings>()
       logger.debug({ repositoryId: repoId }, 'No Slack integration to cleanup for repository');
     }
 
-    const success = await repositoryManager.unregisterRepository(repoId);
+    // Issue #884: thread the authenticated username so the CLEANUP_REPOSITORY
+    // job can elevate the recursive `rm` to that user under multi-user mode
+    // (worktree subtrees are owned by the requesting user per #838 / PR #843).
+    // Backend half of #871 (frontend in PR #873).
+    const success = await repositoryManager.unregisterRepository(repoId, authUser.username);
 
     if (!success) {
       // Repository was likely deleted between the check and unregister (race condition)

--- a/packages/server/src/services/__tests__/repository-manager.test.ts
+++ b/packages/server/src/services/__tests__/repository-manager.test.ts
@@ -598,6 +598,46 @@ describe('RepositoryManager', () => {
       const savedRepos = await repositoryRepository.findAll();
       expect(savedRepos.length).toBe(0);
     });
+
+    it('threads requestUsername into the CLEANUP_REPOSITORY job payload (Issue #884)', async () => {
+      // Backend half of #871: the DELETE route resolves authUser.username and
+      // hands it to unregisterRepository(); the handler then uses it to
+      // elevate the recursive rm under multi-user mode.
+      const manager = await getRepositoryManager();
+      const repo = await manager.registerRepository(TEST_REPO_DIR);
+
+      await manager.unregisterRepository(repo.id, 'alice');
+
+      // Read the persisted job back from the test JobQueue (which is the
+      // production JobQueue against an in-memory SQLite). The payload column
+      // is JSON-encoded; decode and assert the requestUsername field.
+      const jobs = await testJobQueue!.getJobs({ type: 'cleanup:repository' });
+      expect(jobs.length).toBe(1);
+      const payload = JSON.parse(jobs[0]!.payload) as {
+        repoDir: string;
+        requestUsername: string | null;
+      };
+      expect(payload.requestUsername).toBe('alice');
+      expect(payload.repoDir).toContain('test-org');
+    });
+
+    it('defaults requestUsername to null when not provided (back-compat)', async () => {
+      const manager = await getRepositoryManager();
+      const repo = await manager.registerRepository(TEST_REPO_DIR);
+
+      // Call site that does not pass requestUsername (e.g., a non-route
+      // caller). The payload field should be null, which the handler reads
+      // as "use the historical direct fs.rm path".
+      await manager.unregisterRepository(repo.id);
+
+      const jobs = await testJobQueue!.getJobs({ type: 'cleanup:repository' });
+      expect(jobs.length).toBe(1);
+      const payload = JSON.parse(jobs[0]!.payload) as {
+        repoDir: string;
+        requestUsername: string | null;
+      };
+      expect(payload.requestUsername).toBeNull();
+    });
   });
 
   describe('getRepository', () => {

--- a/packages/server/src/services/repository-manager.ts
+++ b/packages/server/src/services/repository-manager.ts
@@ -245,7 +245,17 @@ export class RepositoryManager {
     return repository;
   }
 
-  async unregisterRepository(id: string): Promise<boolean> {
+  /**
+   * Unregister a repository, deleting its data subtree and DB row.
+   *
+   * @param id Repository ID to unregister.
+   * @param requestUsername OS username of the operator triggering the
+   *   unregister. Threaded into the CLEANUP_REPOSITORY job so the handler can
+   *   elevate the recursive `fs.rm` to that user when the worktree subtree is
+   *   user-owned (`AUTH_MODE=multi-user`, Issue #884). Pass `null` for the
+   *   historical direct `fs.rm` path (single-user mode, or non-route callers).
+   */
+  async unregisterRepository(id: string, requestUsername: string | null = null): Promise<boolean> {
     const repo = this.repositories.get(id);
     if (!repo) return false;
 
@@ -260,7 +270,7 @@ export class RepositoryManager {
     }
 
     // Clean up related directories
-    await this.cleanupRepositoryData(repo.path);
+    await this.cleanupRepositoryData(repo.path, requestUsername);
 
     this.repositories.delete(id);
     await this.repository.delete(id);
@@ -529,9 +539,18 @@ export class RepositoryManager {
 
   /**
    * Clean up repository data directory (worktrees and templates)
+   * @param repoPath Absolute path of the registered repository (used to
+   *   resolve the data dir under `<AGENT_CONSOLE_HOME>/repositories/<org/repo>`).
+   * @param requestUsername OS username threaded into the CLEANUP_REPOSITORY
+   *   payload so the handler can elevate the recursive `rm` to that user
+   *   under `AUTH_MODE=multi-user` when the worktree subtree is user-owned
+   *   (Issue #884). `null` keeps the historical direct `fs.rm` path.
    * @throws Error if jobQueue is not available
    */
-  private async cleanupRepositoryData(repoPath: string): Promise<void> {
+  private async cleanupRepositoryData(
+    repoPath: string,
+    requestUsername: string | null,
+  ): Promise<void> {
     if (!this.jobQueue) {
       throw new Error('JobQueue not available for repository cleanup. Ensure RepositoryManager.create() was called with jobQueue.');
     }
@@ -540,7 +559,10 @@ export class RepositoryManager {
     const repoDir = getRepositoryDir(orgRepo);
 
     // Clean up entire repository directory via job queue
-    await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_REPOSITORY, { repoDir });
+    await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_REPOSITORY, {
+      repoDir,
+      requestUsername,
+    });
   }
 
   getRepository(id: string): Repository | undefined {

--- a/packages/shared/src/types/job.ts
+++ b/packages/shared/src/types/job.ts
@@ -85,9 +85,19 @@ export interface CleanupWorkerOutputPayload {
 
 /**
  * Payload for cleanup:repository job.
+ *
+ * `requestUsername` carries the OS username of the operator who triggered the
+ * unregister. In `AUTH_MODE=multi-user` the worktree subtree under `repoDir`
+ * is owned by individual users (Issue #838 / PR #843), so a recursive `rm` as
+ * the server process fails with `EACCES` on the first user-owned descendant.
+ * When set (and elevation actually applies), the handler routes the removal
+ * through `runAsUser` so the user-owned subtree is removable. `null` (or
+ * single-user / same-user) preserves the historical direct `fs.rm` path.
+ * Issue #884.
  */
 export interface CleanupRepositoryPayload {
   repoDir: string;
+  requestUsername: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Backend half of [#871](https://github.com/ms2sato/agent-console/issues/871) (frontend in [PR #873](https://github.com/ms2sato/agent-console/pull/873)). Closes #884.

`CLEANUP_REPOSITORY` job's recursive `fs.rm` ran as the server process (`agentconsole`). In `AUTH_MODE=multi-user` the data dir's `worktrees/*` subtree is owned by individual users (#838 / PR #843), so the rm failed with `EACCES` on the first user-owned descendant — exactly the silent-unregister symptom #871 reported.

This PR threads `requestUsername: string | null` from the `DELETE /api/repositories/:id` route through `unregisterRepository` and into the `CleanupRepositoryPayload`. When `shouldElevateForUser(requestUsername)` is true, the handler routes the removal through `runAsUser` (`rm -rf -- <shellEscape(repoDir)>`) so the user-owned subtree can be deleted. Single-user / null / same-user keeps the historical direct `fs.rm` path (preserving ENOENT idempotency).

## Changes

- `packages/shared/src/types/job.ts` — add `requestUsername: string | null` to `CleanupRepositoryPayload`
- `packages/server/src/services/repository-manager.ts` — `unregisterRepository(id, requestUsername?)` -> `cleanupRepositoryData(repoPath, requestUsername)` -> enqueue with the threaded field
- `packages/server/src/routes/repositories.ts` — `DELETE /:id` reads `authUser.username` and forwards to `unregisterRepository`
- `packages/server/src/jobs/handlers.ts` — `CLEANUP_REPOSITORY` handler picks the elevated `runAsUser` path or the direct `fs.rm` based on `shouldElevateForUser`. Optional `JobHandlerDeps.runAsUserImpl` allows test injection without monkey-patching.

## Tests

- `packages/server/src/jobs/__tests__/handlers.test.ts` — 6 new cases: null bypasses elevation, ENOENT idempotency, elevated argv shape, single-user fallthrough, non-zero exit surfaced for retry, timeout surfaced, spawn-error propagated.
- `packages/server/src/services/__tests__/repository-manager.test.ts` — 2 new cases verifying the persisted job payload includes the threaded `requestUsername` (and defaults to `null` when omitted).
- `packages/server/src/routes/__tests__/repositories.test.ts` — sibling test that the DELETE route forwards `authUser.username` as the second arg.

## Verification

```
bun run typecheck       # ok
bun run test            # 4636 pass / 0 fail across all packages
bun run check:lang      # ok
node .claude/skills/orchestrator/preflight-check.js    # ok
```

CodeRabbit local CLI hit a rate-limit window during pre-push; relying on the GitHub-side bot for review per `coderabbit-ops` fallback.

## Out of scope

- Worktree-deletion `fs.rm` (#882, in flight)
- MCP caller-auth binding (#878)

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run check:lang`
- [x] `node .claude/skills/orchestrator/preflight-check.js`
- [ ] CI green
- [ ] CodeRabbit clean (CRITICAL / HIGH / MEDIUM addressed)
- [ ] Multi-user dogfood: register a repo, create a worktree, click Unregister -> DB row removed AND data dir gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
