### PR TITLE
fix(server): elevate executeHookCommand to requesting OS user (closes #883)

### DIFF
--- a/packages/server/src/services/__tests__/worktree-creation-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-creation-service.test.ts
@@ -27,7 +27,12 @@ const mockRemoveWorktree = mock<
   ) => Promise<{ success: boolean; error?: string }>
 >(() => Promise.resolve({ success: true }));
 const mockExecuteHookCommand = mock<
-  (cmd: string, cwd: string, vars: Record<string, unknown>) => Promise<HookCommandResult>
+  (
+    cmd: string,
+    cwd: string,
+    vars: Record<string, unknown>,
+    requestUsername?: string | null,
+  ) => Promise<HookCommandResult>
 >(() => Promise.resolve({ success: true }));
 
 const mockWorktreeService = {
@@ -346,6 +351,26 @@ describe('createWorktreeWithSession', () => {
     // multi-user installs create the worktree as the requesting user.
     expect(mockCreateWorktree).toHaveBeenCalledWith(
       '/repos/my-repo', 'feature-new', 'repo-1', 'origin/main', 'alice',
+    );
+  });
+
+  it('threads requestUsername to executeHookCommand for the setup hook (Issue #883)', async () => {
+    // Without this threading, the setup hook would run as the server user
+    // (`agentconsole`) inside a worktree owned by the requesting user, with
+    // no access to that user's gh / ssh credentials and unable to write
+    // user-owned files. Mirrors the same one-line plumbing as Issue #838.
+    const sm = createMockSessionManager();
+    await createWorktreeWithSession(
+      { ...DEFAULT_PARAMS, setupCommand: 'npm install', requestUsername: 'alice' },
+      sm,
+      mockWorktreeService,
+    );
+
+    expect(mockExecuteHookCommand).toHaveBeenCalledWith(
+      'npm install',
+      CREATED_PATH,
+      { worktreeNum: 2, branch: 'feature-new', repo: 'my-repo' },
+      'alice',
     );
   });
 

--- a/packages/server/src/services/__tests__/worktree-deletion-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-deletion-service.test.ts
@@ -26,7 +26,12 @@ const mockRemoveWorktree = mock<
   ) => Promise<{ success: boolean; error?: string }>
 >(() => Promise.resolve({ success: true }));
 const mockExecuteHookCommand = mock<
-  (cmd: string, cwd: string, vars: Record<string, unknown>) => Promise<HookCommandResult>
+  (
+    cmd: string,
+    cwd: string,
+    vars: Record<string, unknown>,
+    requestUsername?: string | null,
+  ) => Promise<HookCommandResult>
 >(() => Promise.resolve({ success: true }));
 const mockIsWorktreeOf = mock<
   (repoPath: string, worktreePath: string, repoId: string) => Promise<boolean>
@@ -703,6 +708,34 @@ describe('deleteWorktree', () => {
 
       // null username explicitly threaded through — runAsUser will bypass.
       expect(mockRemoveWorktree).toHaveBeenCalledWith(REPO_PATH, WORKTREE_PATH, true, null);
+    });
+
+    it('threads requestUsername to executeHookCommand for the cleanup hook (Issue #883)', async () => {
+      // Without this threading, the cleanup hook would run as the server
+      // user (`agentconsole`) inside a worktree owned by the requesting
+      // user, and would lack access to that user's gh / ssh credentials.
+      const deps = createMockDeps({
+        sessions: [DEFAULT_WORKTREE_SESSION],
+        repo: { name: 'my-repo', path: REPO_PATH, cleanupCommand: 'echo cleanup' },
+      });
+
+      const result = await deleteWorktree(
+        {
+          repoId: 'repo-1',
+          worktreePath: WORKTREE_PATH,
+          force: false,
+          requestUsername: 'alice',
+        },
+        deps,
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockExecuteHookCommand).toHaveBeenCalledWith(
+        'echo cleanup',
+        WORKTREE_PATH,
+        { worktreeNum: 1, branch: 'feature-1', repo: 'my-repo' },
+        'alice',
+      );
     });
   });
 

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -1897,5 +1897,207 @@ detached
         expect(spawnCalls[0].args[2]).toBe('npm install && npm run build');
       });
     });
+
+    // Issue #883 — executeHookCommand routes through runAsUser when elevation
+    // would engage (AUTH_MODE=multi-user AND requestUsername differs from the
+    // server-process user). Otherwise the historical direct-spawn behaviour
+    // is preserved verbatim, including the getCleanChildProcessEnv() env
+    // filter — see services/env-filter.ts.
+    describe('privilege elevation (Issue #883)', () => {
+      let originalAuthMode: string | undefined;
+
+      beforeEach(() => {
+        originalAuthMode = process.env.AUTH_MODE;
+      });
+
+      afterEach(() => {
+        if (originalAuthMode === undefined) {
+          delete process.env.AUTH_MODE;
+        } else {
+          process.env.AUTH_MODE = originalAuthMode;
+        }
+      });
+
+      it('omitted requestUsername preserves direct Bun.spawn (legacy single-user)', async () => {
+        delete process.env.AUTH_MODE;
+        setMockSpawnResult('hello');
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        const result = await service.executeHookCommand(
+          'echo hello',
+          '/test/worktree',
+          { worktreeNum: 1, branch: 'main', repo: 'my-repo' },
+        );
+
+        expect(result.success).toBe(true);
+        expect(spawnCalls.length).toBe(1);
+        expect(runAsUserMock.calls.length).toBe(0);
+      });
+
+      it('null requestUsername preserves direct Bun.spawn (explicit single-user)', async () => {
+        delete process.env.AUTH_MODE;
+        setMockSpawnResult('');
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        await service.executeHookCommand(
+          'echo hello',
+          '/test/worktree',
+          { worktreeNum: 1, branch: 'main', repo: 'my-repo' },
+          null,
+        );
+
+        expect(spawnCalls.length).toBe(1);
+        expect(runAsUserMock.calls.length).toBe(0);
+      });
+
+      it('non-null requestUsername with AUTH_MODE unset bypasses elevation', async () => {
+        // shouldElevateForUser gates on BOTH AUTH_MODE=multi-user AND a
+        // non-server username. With AUTH_MODE unset, even a non-null
+        // username must NOT elevate — this preserves the single-user
+        // env-filter path verbatim.
+        delete process.env.AUTH_MODE;
+        setMockSpawnResult('');
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        await service.executeHookCommand(
+          'echo hello',
+          '/test/worktree',
+          { worktreeNum: 1, branch: 'main', repo: 'my-repo' },
+          'alice-multiuser-test',
+        );
+
+        expect(spawnCalls.length).toBe(1);
+        expect(runAsUserMock.calls.length).toBe(0);
+      });
+
+      it('multi-user mode with non-server username routes through runAsUser', async () => {
+        process.env.AUTH_MODE = 'multi-user';
+        runAsUserMock.responder.fn = async () => ({
+          stdout: 'hook output',
+          stderr: '',
+          exitCode: 0,
+          timedOut: false,
+        });
+
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        const result = await service.executeHookCommand(
+          'echo hello',
+          '/test/worktree',
+          { worktreeNum: 7, branch: 'feature/x', repo: 'my-repo' },
+          'alice-multiuser-test',
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.output).toBe('hook output');
+        // Bun.spawn must NOT have been called — the elevated branch routes
+        // exclusively through runAsUser.
+        expect(spawnCalls.length).toBe(0);
+
+        expect(runAsUserMock.calls.length).toBe(1);
+        const call = runAsUserMock.calls[0];
+        expect(call.username).toBe('alice-multiuser-test');
+        expect(call.cwd).toBe('/test/worktree');
+        expect(call.command).toBe('echo hello');
+        // The four hook variables are threaded through opts.env so
+        // runAsUser embeds them via `export K=v` inside the elevated shell.
+        expect(call.env).toEqual({
+          WORKTREE_NUM: '7',
+          BRANCH: 'feature/x',
+          REPO: 'my-repo',
+          WORKTREE_PATH: '/test/worktree',
+        });
+      });
+
+      it('multi-user mode substitutes template variables before runAsUser', async () => {
+        process.env.AUTH_MODE = 'multi-user';
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        await service.executeHookCommand(
+          'export PORT={{WORKTREE_NUM + 3000}} && echo {{REPO}}',
+          '/wt',
+          { worktreeNum: 5, branch: 'feature/a', repo: 'my-repo' },
+          'alice-multiuser-test',
+        );
+
+        expect(runAsUserMock.calls.length).toBe(1);
+        expect(runAsUserMock.calls[0].command).toBe(
+          'export PORT=3005 && echo my-repo',
+        );
+      });
+
+      it('multi-user mode surfaces non-zero exit from runAsUser as failed result', async () => {
+        process.env.AUTH_MODE = 'multi-user';
+        runAsUserMock.responder.fn = async () => ({
+          stdout: 'partial',
+          stderr: 'permission denied',
+          exitCode: 1,
+          timedOut: false,
+        });
+
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        const result = await service.executeHookCommand(
+          'cmd',
+          '/wt',
+          { worktreeNum: 1, branch: 'main', repo: 'r' },
+          'alice-multiuser-test',
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.output).toBe('partial');
+        expect(result.error).toBe('permission denied');
+      });
+
+      it('multi-user mode falls back to exit-code message when stderr is empty', async () => {
+        process.env.AUTH_MODE = 'multi-user';
+        runAsUserMock.responder.fn = async () => ({
+          stdout: '',
+          stderr: '',
+          exitCode: 127,
+          timedOut: false,
+        });
+
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        const result = await service.executeHookCommand(
+          'cmd',
+          '/wt',
+          { worktreeNum: 1, branch: 'main', repo: 'r' },
+          'alice-multiuser-test',
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('127');
+      });
+    });
   });
 });

--- a/packages/server/src/services/worktree-creation-service.ts
+++ b/packages/server/src/services/worktree-creation-service.ts
@@ -187,6 +187,7 @@ export async function createWorktreeWithSession(
           branch: worktree.branch,
           repo: repoName,
         },
+        requestUsername,
       );
     }
 

--- a/packages/server/src/services/worktree-deletion-service.ts
+++ b/packages/server/src/services/worktree-deletion-service.ts
@@ -77,6 +77,7 @@ async function executeCleanupCommandIfConfigured(
   repo: { path: string; name: string; cleanupCommand?: string | null },
   repoId: string,
   worktreePath: string,
+  requestUsername: string | null | undefined,
 ): Promise<HookCommandResult | undefined> {
   if (!repo.cleanupCommand) return undefined;
 
@@ -94,6 +95,7 @@ async function executeCleanupCommandIfConfigured(
       branch: targetWorktree.branch,
       repo: repo.name,
     },
+    requestUsername,
   );
 }
 
@@ -364,6 +366,7 @@ export async function deleteWorktree(
       { path: repo.path, name: repo.name, cleanupCommand: repo.cleanupCommand },
       repoId,
       worktreePath,
+      requestUsername,
     );
 
     // 6b. Kill PTY processes to release directory handles (await exit before worktree remove)

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -970,15 +970,35 @@ export class WorktreeService {
    * Supports template variables: {{WORKTREE_NUM}}, {{BRANCH}}, {{REPO}}, {{WORKTREE_PATH}}
    * Also supports arithmetic expressions like {{WORKTREE_NUM + 3000}}
    *
+   * In `AUTH_MODE=multi-user` with a `requestUsername` that differs from the
+   * server-process user (Issue #883), the command is routed through
+   * `runAsUser` so the hook executes as the worktree-owning user. This is
+   * required because the worktree directory and its credentials (gh, ssh)
+   * are owned by the requesting user; running the hook as the server user
+   * (`agentconsole`) would fail to write user-owned files and would not see
+   * the user's gh / ssh auth.
+   *
+   * The `getCleanChildProcessEnv()` env filter only applies to the
+   * non-elevated branch — on the elevated path `sudo -i` resets the env
+   * entirely, so the user gets their normal login env plus the four hook
+   * variables (`WORKTREE_NUM`, `BRANCH`, `REPO`, `WORKTREE_PATH`) exported
+   * via `runAsUser`'s inner-shell `export` mechanism. The branch is gated
+   * at this caller (per `.claude/rules/elevation-helpers.md` strict-thin-
+   * wrapper contract) rather than threading the filter through `runAsUser`.
+   *
    * @param command - The command template to execute
    * @param worktreePath - The worktree directory path (command will run here)
    * @param vars - Template variables for substitution
+   * @param requestUsername - When set and elevation would engage, the hook
+   *   runs as this user via `runAsUser`. Null / undefined / single-user mode
+   *   preserves the historical direct-spawn behaviour verbatim.
    * @returns Result with success status, output, and any error message
    */
   async executeHookCommand(
     command: string,
     worktreePath: string,
-    vars: { worktreeNum: number; branch: string; repo: string }
+    vars: { worktreeNum: number; branch: string; repo: string },
+    requestUsername?: string | null,
   ): Promise<HookCommandResult> {
     // Substitute template variables in the command
     const substitutedCommand = substituteVariables(command, {
@@ -988,7 +1008,66 @@ export class WorktreeService {
       worktreePath,
     });
 
+    const hookEnv = {
+      WORKTREE_NUM: String(vars.worktreeNum),
+      BRANCH: vars.branch,
+      REPO: vars.repo,
+      WORKTREE_PATH: worktreePath,
+    };
+
     logger.info({ worktreePath, command: substitutedCommand }, 'Executing hook command');
+
+    // Elevated branch (Issue #883): route through runAsUser so the hook runs
+    // as the worktree-owning user. Only engaged when AUTH_MODE=multi-user AND
+    // requestUsername differs from the server-process user — otherwise the
+    // historical direct-spawn path below is preserved verbatim (including
+    // the getCleanChildProcessEnv() env filter).
+    if (shouldElevateForUser(requestUsername)) {
+      try {
+        const result = await this._runAsUser({
+          username: requestUsername!,
+          command: substitutedCommand,
+          cwd: worktreePath,
+          env: hookEnv,
+        });
+
+        if (result.exitCode === 0) {
+          logger.info(
+            { worktreePath, exitCode: result.exitCode, requestUsername },
+            'Hook command completed successfully (elevated)',
+          );
+          return {
+            success: true,
+            output: result.stdout || undefined,
+          };
+        } else {
+          logger.warn(
+            {
+              worktreePath,
+              exitCode: result.exitCode,
+              stderr: result.stderr,
+              requestUsername,
+            },
+            'Hook command failed (elevated)',
+          );
+          return {
+            success: false,
+            output: result.stdout || undefined,
+            error: result.stderr || `Command exited with code ${result.exitCode}`,
+          };
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        logger.error(
+          { worktreePath, err: error, requestUsername },
+          'Hook command execution error (elevated)',
+        );
+        return {
+          success: false,
+          error: errorMessage,
+        };
+      }
+    }
 
     try {
       // Execute command using Bun.spawn with shell
@@ -998,10 +1077,7 @@ export class WorktreeService {
         stderr: 'pipe',
         env: {
           ...getCleanChildProcessEnv(),
-          WORKTREE_NUM: String(vars.worktreeNum),
-          BRANCH: vars.branch,
-          REPO: vars.repo,
-          WORKTREE_PATH: worktreePath,
+          ...hookEnv,
         },
       });
 


### PR DESCRIPTION
## Summary

- In `AUTH_MODE=multi-user`, `WorktreeService.executeHookCommand` now routes setup / cleanup hooks through `runAsUser` so they execute as the worktree-owning user — gaining access to the user's gh / ssh credentials and the ability to write user-owned files.
- Single-user mode preserves the existing direct `Bun.spawn` path verbatim, including the `getCleanChildProcessEnv()` env filter. Per `.claude/rules/elevation-helpers.md` strict-thin-wrapper contract, the env-filter discipline is gated at this caller rather than threading semantic layering into `runAsUser`.
- `requestUsername` is threaded from `createWorktreeWithSession` (setup hook) and `deleteWorktree` (cleanup hook) into the new 4th parameter on `executeHookCommand`.

## Background

The Wave-2 elevation series (PRs #843 / #888 / #889 / #890 / #891 / #892) elevated other server-side operations to the requesting user. `executeHookCommand` was the remaining hook surface that still ran as the server user (`agentconsole`), so user-configured setup / cleanup commands could not see the requesting user's auth or write into a user-owned worktree.

## Implementation

- `packages/server/src/services/worktree-service.ts` — `executeHookCommand` gains `requestUsername?: string | null` (4th positional arg). Branch on `shouldElevateForUser(requestUsername)`: elevated path goes through `this._runAsUser({ username, command, cwd, env })` with the four hook vars (`WORKTREE_NUM`, `BRANCH`, `REPO`, `WORKTREE_PATH`) in `opts.env` so they get embedded via `runAsUser`'s inner-shell `export`. The non-elevated path is unchanged. JSDoc explains why the env filter only applies to the non-elevated branch.
- `packages/server/src/services/worktree-creation-service.ts` — threads `requestUsername` to the setup-hook `executeHookCommand` call.
- `packages/server/src/services/worktree-deletion-service.ts` — adds `requestUsername` parameter to `executeCleanupCommandIfConfigured` and forwards it to the cleanup-hook `executeHookCommand` call.
- No changes to `privilege-elevation.ts`; `runAsUser` already supports everything needed via `opts.username` / `opts.command` / `opts.cwd` / `opts.env`.

## Tests

- `packages/server/src/services/__tests__/worktree-service.test.ts` — new `describe('privilege elevation (Issue #883)')` block (7 cases): null / undefined / non-null-in-single-user all preserve direct `Bun.spawn`; multi-user with a non-server username routes through `runAsUser` with the correct cwd / env / command; template-variable substitution applies before elevation; non-zero exit and empty-stderr fallback are mapped to `HookCommandResult` symmetric with the direct path.
- TDD polarity verified before the production change landed — the 4 multi-user tests failed against unmodified code; the 3 single-user tests passed (existing direct-spawn behaviour unchanged).
- `worktree-creation-service.test.ts` and `worktree-deletion-service.test.ts` mock signatures widened to accept the optional 4th arg, plus one new test each verifying `requestUsername` is forwarded to `executeHookCommand` for the setup hook (Issue #883) and the cleanup hook (Issue #883) respectively.

## Verification

- `bun run typecheck` — exit 0 across `@agent-console/shared`, `@agent-console/server`, and `@agent-console/client`.
- `bun run test:only` — 4,069 pass / 0 fail / 3 skip across all packages (client 1,425 / shared 349 / integration 29 / server 2,904 / scripts+hooks+skills 362).
- `bun run check:lang` — clean (105 files scanned).
- `node .claude/skills/orchestrator/preflight-check.js` — all production files have corresponding tests; no rule/skill drift; language check clean.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test:only` passes (full suite)
- [x] `bun run check:lang` passes
- [x] preflight passes (coverage + drift + language)
- [ ] CI green
- [ ] CodeRabbit clean

Closes #883
