### PR TITLE
fix(server): recover orphan worktree-dir via prune+delete in removeWorktree

### DIFF
--- a/packages/server/src/__tests__/utils/mock-git-helper.ts
+++ b/packages/server/src/__tests__/utils/mock-git-helper.ts
@@ -57,6 +57,7 @@ export const mockGit = {
   listWorktrees: mock(() => Promise.resolve('')) as Mock<AsyncStringFn>,
   createWorktree: mock(() => Promise.resolve()) as Mock<AsyncVoidFn>,
   removeWorktree: mock(() => Promise.resolve()) as Mock<AsyncVoidFn>,
+  pruneWorktrees: mock(() => Promise.resolve()) as Mock<(cwd: string, requestUser?: string | null) => Promise<void>>,
 
   // Org/Repo extraction (sync functions)
   parseOrgRepo: mock((remoteUrl: string) => {
@@ -115,6 +116,7 @@ export function resetGitMocks(): void {
   mockGit.listWorktrees.mockReset();
   mockGit.createWorktree.mockReset();
   mockGit.removeWorktree.mockReset();
+  mockGit.pruneWorktrees.mockReset();
   mockGit.parseOrgRepo.mockReset();
   mockGit.getOrgRepoFromPath.mockReset();
   mockGit.fetchRemote.mockReset();
@@ -148,6 +150,7 @@ export function resetGitMocks(): void {
   mockGit.listWorktrees.mockImplementation(() => Promise.resolve(''));
   mockGit.createWorktree.mockImplementation(() => Promise.resolve());
   mockGit.removeWorktree.mockImplementation(() => Promise.resolve());
+  mockGit.pruneWorktrees.mockImplementation(() => Promise.resolve());
   mockGit.parseOrgRepo.mockImplementation((remoteUrl: string) => {
     const sshMatch = remoteUrl.match(/git@[^:]+:([^/]+\/[^/]+?)(?:\.git)?$/);
     if (sshMatch) return sshMatch[1];

--- a/packages/server/src/__tests__/utils/mock-git-helper.ts
+++ b/packages/server/src/__tests__/utils/mock-git-helper.ts
@@ -57,7 +57,6 @@ export const mockGit = {
   listWorktrees: mock(() => Promise.resolve('')) as Mock<AsyncStringFn>,
   createWorktree: mock(() => Promise.resolve()) as Mock<AsyncVoidFn>,
   removeWorktree: mock(() => Promise.resolve()) as Mock<AsyncVoidFn>,
-  pruneWorktrees: mock(() => Promise.resolve()) as Mock<(cwd: string, requestUser?: string | null) => Promise<void>>,
 
   // Org/Repo extraction (sync functions)
   parseOrgRepo: mock((remoteUrl: string) => {
@@ -116,7 +115,6 @@ export function resetGitMocks(): void {
   mockGit.listWorktrees.mockReset();
   mockGit.createWorktree.mockReset();
   mockGit.removeWorktree.mockReset();
-  mockGit.pruneWorktrees.mockReset();
   mockGit.parseOrgRepo.mockReset();
   mockGit.getOrgRepoFromPath.mockReset();
   mockGit.fetchRemote.mockReset();
@@ -150,7 +148,6 @@ export function resetGitMocks(): void {
   mockGit.listWorktrees.mockImplementation(() => Promise.resolve(''));
   mockGit.createWorktree.mockImplementation(() => Promise.resolve());
   mockGit.removeWorktree.mockImplementation(() => Promise.resolve());
-  mockGit.pruneWorktrees.mockImplementation(() => Promise.resolve());
   mockGit.parseOrgRepo.mockImplementation((remoteUrl: string) => {
     const sshMatch = remoteUrl.match(/git@[^:]+:([^/]+\/[^/]+?)(?:\.git)?$/);
     if (sshMatch) return sshMatch[1];

--- a/packages/server/src/lib/__tests__/git.test.ts
+++ b/packages/server/src/lib/__tests__/git.test.ts
@@ -643,10 +643,13 @@ index abc1234..def5678 100644
 
         await removeWorktree(tempWorktreePath, tempRepoPath, { force: true });
 
-        // Should have called git worktree remove first, then git worktree prune
+        // Should have called git worktree remove first, then git worktree prune.
+        // `--expire=now` is required because the fallback just deleted the
+        // worktree dir; git's default 3-month grace would leave the
+        // freshly-stale registry entry behind otherwise (#895).
         expect(spawnCalls.length).toBe(2);
         expect(spawnCalls[0].args).toEqual(['git', 'worktree', 'remove', tempWorktreePath, '--force', '--force']);
-        expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune']);
+        expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune', '--expire=now']);
         expect(spawnCalls[1].options.cwd).toBe(tempRepoPath);
       } finally {
         // Clean up temp directories (worktree may already be removed by removeWorktree)
@@ -701,10 +704,13 @@ index abc1234..def5678 100644
 
         await removeWorktree(tempWorktreePath, tempRepoPath, { force: true });
 
-        // Should have called git worktree remove first, then git worktree prune
+        // Should have called git worktree remove first, then git worktree prune.
+        // `--expire=now` is required: the fallback just deleted the worktree
+        // dir, and git's default 3-month grace would leave the freshly-stale
+        // registry entry behind (#895).
         expect(spawnCalls.length).toBe(2);
         expect(spawnCalls[0].args).toEqual(['git', 'worktree', 'remove', tempWorktreePath, '--force', '--force']);
-        expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune']);
+        expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune', '--expire=now']);
         expect(spawnCalls[1].options.cwd).toBe(tempRepoPath);
       } finally {
         // Clean up temp directories (worktree may already be removed by removeWorktree)
@@ -811,7 +817,7 @@ index abc1234..def5678 100644
 
         // Both remove and prune were attempted (prune threw and was swallowed).
         expect(spawnCalls.length).toBe(2);
-        expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune']);
+        expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune', '--expire=now']);
       } finally {
         await fs.rm(tempWorktreePath, { recursive: true, force: true });
         await fs.rm(tempRepoPath, { recursive: true, force: true });

--- a/packages/server/src/lib/__tests__/git.test.ts
+++ b/packages/server/src/lib/__tests__/git.test.ts
@@ -601,19 +601,10 @@ index abc1234..def5678 100644
       // (which may be memfs when running in the full test suite).
       const tempWorktreePath = `/tmp/git-test-worktree-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       await fs.mkdir(tempWorktreePath, { recursive: true });
-      // cwd (primary repo) used to be probed by an explicit fs.stat check in
-      // removeWorktree; after the PR #897 consolidation that guard is gone
-      // (the prune is now `.catch`-swallowed unconditionally inside
-      // `removeWorktreeWithFallback`), but the test still uses a real temp dir
-      // so the surrounding mock environment stays predictable.
       const tempRepoPath = `/tmp/git-test-repo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       await fs.mkdir(tempRepoPath, { recursive: true });
 
       try {
-        // First call fails with a narrow stale-`.git` pattern, second call
-        // (worktree prune) succeeds. The matcher was narrowed during the PR
-        // #897 consolidation; the original broad `.git` substring would have
-        // over-triggered on `fatal: not a git repository ... .git`.
         let callCount = 0;
         (Bun as { spawn: typeof Bun.spawn }).spawn = ((args: string[], options?: Record<string, unknown>) => {
           spawnCalls.push({ args, options: options || {} });
@@ -649,10 +640,9 @@ index abc1234..def5678 100644
 
         await removeWorktree(tempWorktreePath, tempRepoPath, { force: true });
 
-        // Should have called git worktree remove first, then git worktree prune.
         // `--expire=now` is required because the fallback just deleted the
         // worktree dir; git's default 3-month grace would leave the
-        // freshly-stale registry entry behind otherwise (#895).
+        // freshly-stale registry entry behind otherwise.
         expect(spawnCalls.length).toBe(2);
         expect(spawnCalls[0].args).toEqual(['git', 'worktree', 'remove', tempWorktreePath, '--force', '--force']);
         expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune', '--expire=now']);
@@ -710,10 +700,9 @@ index abc1234..def5678 100644
 
         await removeWorktree(tempWorktreePath, tempRepoPath, { force: true });
 
-        // Should have called git worktree remove first, then git worktree prune.
         // `--expire=now` is required: the fallback just deleted the worktree
         // dir, and git's default 3-month grace would leave the freshly-stale
-        // registry entry behind (#895).
+        // registry entry behind.
         expect(spawnCalls.length).toBe(2);
         expect(spawnCalls[0].args).toEqual(['git', 'worktree', 'remove', tempWorktreePath, '--force', '--force']);
         expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune', '--expire=now']);
@@ -724,24 +713,6 @@ index abc1234..def5678 100644
         await fs.rm(tempRepoPath, { recursive: true, force: true });
       }
     });
-
-    // PR #897 consolidation note: three previous tests were removed when the
-    // explicit cwd-existence guard and the `code === ENOENT/ENOTDIR` prune
-    // re-throw were collapsed into `removeWorktreeWithFallback`:
-    //   - "should skip prune when force is true and the primary repo dir
-    //     (cwd) does not exist" — the guard is gone; prune is unconditionally
-    //     attempted and best-effort swallowed.
-    //   - "should swallow an ENOENT-coded prune error after worktree
-    //     cleanup" — covered now by the runner's ENOENT/ENOTDIR conversion
-    //     to `exitCode: -1` plus the helper's `.catch(() => {})`.
-    //   - "should propagate a non-ENOENT prune error (guard is narrow)" —
-    //     intentional behaviour change: all prune failures (including EPERM
-    //     etc.) are now swallowed because rm already succeeded; the stale
-    //     registry entry is the only cost. The owner's spec for PR #897
-    //     explicitly opts into this trade-off.
-    // The runner-level invariants (ENOENT short-circuit on the initial remove
-    // throwing GitError; prune swallow) are covered directly by
-    // `worktree-removal.test.ts`'s `removeWorktreeWithFallback` unit tests.
   });
 
   // =========================================================================

--- a/packages/server/src/lib/__tests__/git.test.ts
+++ b/packages/server/src/lib/__tests__/git.test.ts
@@ -588,26 +588,32 @@ index abc1234..def5678 100644
     });
 
     it('should throw GitError when removal fails without force even if .git error', async () => {
-      setMockSpawnResult('', 128, "fatal: '.git' does not exist");
+      setMockSpawnResult('', 128, 'fatal: cannot read .git file');
       const { removeWorktree, GitError } = await getGitModule();
 
       await expect(removeWorktree('/path/to/worktree', '/repo')).rejects.toBeInstanceOf(GitError);
     });
 
-    it('should fall back to manual cleanup when force is true and .git does not exist', async () => {
+    it('should fall back to manual cleanup when force is true and the .git file cannot be read', async () => {
       const fs = await import('node:fs/promises');
 
       // Create a temp directory using the same fs module that removeWorktree will use
       // (which may be memfs when running in the full test suite).
       const tempWorktreePath = `/tmp/git-test-worktree-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       await fs.mkdir(tempWorktreePath, { recursive: true });
-      // cwd (primary repo) must exist on disk for the prune step to run, since the
-      // fallback now skips prune when the primary repo dir is missing.
+      // cwd (primary repo) used to be probed by an explicit fs.stat check in
+      // removeWorktree; after the PR #897 consolidation that guard is gone
+      // (the prune is now `.catch`-swallowed unconditionally inside
+      // `removeWorktreeWithFallback`), but the test still uses a real temp dir
+      // so the surrounding mock environment stays predictable.
       const tempRepoPath = `/tmp/git-test-repo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       await fs.mkdir(tempRepoPath, { recursive: true });
 
       try {
-        // First call fails with .git error, second call (worktree prune) succeeds
+        // First call fails with a narrow stale-`.git` pattern, second call
+        // (worktree prune) succeeds. The matcher was narrowed during the PR
+        // #897 consolidation; the original broad `.git` substring would have
+        // over-triggered on `fatal: not a git repository ... .git`.
         let callCount = 0;
         (Bun as { spawn: typeof Bun.spawn }).spawn = ((args: string[], options?: Record<string, unknown>) => {
           spawnCalls.push({ args, options: options || {} });
@@ -621,7 +627,7 @@ index abc1234..def5678 100644
               }),
               stderr: new ReadableStream({
                 start(controller) {
-                  controller.enqueue(new TextEncoder().encode("fatal: '.git' does not exist"));
+                  controller.enqueue(new TextEncoder().encode('fatal: cannot read .git file'));
                   controller.close();
                 },
               }),
@@ -719,148 +725,23 @@ index abc1234..def5678 100644
       }
     });
 
-    it('should skip prune when force is true and the primary repo dir (cwd) does not exist', async () => {
-      const fs = await import('node:fs/promises');
-
-      const tempWorktreePath = `/tmp/git-test-worktree-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      await fs.mkdir(tempWorktreePath, { recursive: true });
-      // Primary repo dir (cwd) deliberately does NOT exist on disk.
-      const missingRepoPath = `/tmp/git-test-missing-repo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-
-      try {
-        // First (and only) call: git worktree remove fails with a .git-class error.
-        // Prune must NOT be attempted because cwd is missing.
-        (Bun as { spawn: typeof Bun.spawn }).spawn = ((args: string[], options?: Record<string, unknown>) => {
-          spawnCalls.push({ args, options: options || {} });
-          return {
-            exited: Promise.resolve(128),
-            stdout: new ReadableStream({
-              start(controller) { controller.close(); },
-            }),
-            stderr: new ReadableStream({
-              start(controller) {
-                controller.enqueue(new TextEncoder().encode("fatal: '.git' does not exist"));
-                controller.close();
-              },
-            }),
-          };
-        }) as typeof Bun.spawn;
-
-        const { removeWorktree } = await getGitModule();
-
-        // Must not throw even though the primary repo dir is gone.
-        await removeWorktree(tempWorktreePath, missingRepoPath, { force: true });
-
-        // fs.rm happened: the worktree dir is gone.
-        let worktreeStillExists = true;
-        try {
-          await fs.stat(tempWorktreePath);
-        } catch {
-          worktreeStillExists = false;
-        }
-        expect(worktreeStillExists).toBe(false);
-
-        // Only the remove was attempted; prune was skipped (cwd missing).
-        expect(spawnCalls.length).toBe(1);
-        expect(spawnCalls[0].args).toEqual(['git', 'worktree', 'remove', tempWorktreePath, '--force', '--force']);
-      } finally {
-        await fs.rm(tempWorktreePath, { recursive: true, force: true });
-      }
-    });
-
-    it('should swallow an ENOENT-coded prune error after worktree cleanup (stat→spawn race)', async () => {
-      const fs = await import('node:fs/promises');
-
-      const tempWorktreePath = `/tmp/git-test-worktree-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      await fs.mkdir(tempWorktreePath, { recursive: true });
-      // cwd exists at stat() time so the prune is attempted...
-      const tempRepoPath = `/tmp/git-test-repo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      await fs.mkdir(tempRepoPath, { recursive: true });
-
-      try {
-        // First call (remove) fails with a .git-class error; second call (prune)
-        // throws synchronously with an ENOENT code, simulating cwd vanishing
-        // between stat() and spawn().
-        let callCount = 0;
-        (Bun as { spawn: typeof Bun.spawn }).spawn = ((args: string[], options?: Record<string, unknown>) => {
-          spawnCalls.push({ args, options: options || {} });
-          callCount++;
-          if (callCount === 1) {
-            return {
-              exited: Promise.resolve(128),
-              stdout: new ReadableStream({ start(controller) { controller.close(); } }),
-              stderr: new ReadableStream({
-                start(controller) {
-                  controller.enqueue(new TextEncoder().encode("fatal: '.git' does not exist"));
-                  controller.close();
-                },
-              }),
-            };
-          }
-          // Second call (prune): spawn itself throws ENOENT (cwd gone).
-          throw Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
-        }) as typeof Bun.spawn;
-
-        const { removeWorktree } = await getGitModule();
-
-        // Must resolve without throwing: the worktree fs.rm already succeeded.
-        await removeWorktree(tempWorktreePath, tempRepoPath, { force: true });
-
-        // Worktree dir was removed.
-        let worktreeStillExists = true;
-        try {
-          await fs.stat(tempWorktreePath);
-        } catch {
-          worktreeStillExists = false;
-        }
-        expect(worktreeStillExists).toBe(false);
-
-        // Both remove and prune were attempted (prune threw and was swallowed).
-        expect(spawnCalls.length).toBe(2);
-        expect(spawnCalls[1].args).toEqual(['git', 'worktree', 'prune', '--expire=now']);
-      } finally {
-        await fs.rm(tempWorktreePath, { recursive: true, force: true });
-        await fs.rm(tempRepoPath, { recursive: true, force: true });
-      }
-    });
-
-    it('should propagate a non-ENOENT prune error (guard is narrow)', async () => {
-      const fs = await import('node:fs/promises');
-
-      const tempWorktreePath = `/tmp/git-test-worktree-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      await fs.mkdir(tempWorktreePath, { recursive: true });
-      const tempRepoPath = `/tmp/git-test-repo-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      await fs.mkdir(tempRepoPath, { recursive: true });
-
-      try {
-        let callCount = 0;
-        (Bun as { spawn: typeof Bun.spawn }).spawn = ((args: string[], options?: Record<string, unknown>) => {
-          spawnCalls.push({ args, options: options || {} });
-          callCount++;
-          if (callCount === 1) {
-            return {
-              exited: Promise.resolve(128),
-              stdout: new ReadableStream({ start(controller) { controller.close(); } }),
-              stderr: new ReadableStream({
-                start(controller) {
-                  controller.enqueue(new TextEncoder().encode("fatal: '.git' does not exist"));
-                  controller.close();
-                },
-              }),
-            };
-          }
-          // Second call (prune): a non-ENOENT error must propagate.
-          throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' });
-        }) as typeof Bun.spawn;
-
-        const { removeWorktree } = await getGitModule();
-
-        await expect(removeWorktree(tempWorktreePath, tempRepoPath, { force: true })).rejects.toThrow('EPERM');
-      } finally {
-        await fs.rm(tempWorktreePath, { recursive: true, force: true });
-        await fs.rm(tempRepoPath, { recursive: true, force: true });
-      }
-    });
+    // PR #897 consolidation note: three previous tests were removed when the
+    // explicit cwd-existence guard and the `code === ENOENT/ENOTDIR` prune
+    // re-throw were collapsed into `removeWorktreeWithFallback`:
+    //   - "should skip prune when force is true and the primary repo dir
+    //     (cwd) does not exist" — the guard is gone; prune is unconditionally
+    //     attempted and best-effort swallowed.
+    //   - "should swallow an ENOENT-coded prune error after worktree
+    //     cleanup" — covered now by the runner's ENOENT/ENOTDIR conversion
+    //     to `exitCode: -1` plus the helper's `.catch(() => {})`.
+    //   - "should propagate a non-ENOENT prune error (guard is narrow)" —
+    //     intentional behaviour change: all prune failures (including EPERM
+    //     etc.) are now swallowed because rm already succeeded; the stale
+    //     registry entry is the only cost. The owner's spec for PR #897
+    //     explicitly opts into this trade-off.
+    // The runner-level invariants (ENOENT short-circuit on the initial remove
+    // throwing GitError; prune swallow) are covered directly by
+    // `worktree-removal.test.ts`'s `removeWorktreeWithFallback` unit tests.
   });
 
   // =========================================================================

--- a/packages/server/src/lib/__tests__/worktree-removal.test.ts
+++ b/packages/server/src/lib/__tests__/worktree-removal.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  removeWorktreeWithFallback,
+  GitError,
+  type WorktreeRemovalRunner,
+} from '../git.js';
+
+/**
+ * Unit tests for the consolidated `removeWorktreeWithFallback` helper
+ * (PR #897). Both `lib/git.ts:removeWorktree` (server-process direct spawn)
+ * and `worktree-service.ts:invokeGitWorktreeRemove` (multi-user elevated)
+ * are thin runner constructors that delegate the orchestration here.
+ *
+ * Hand-rolled fake runners — no mock library state — so the test reads as
+ * a sequence of runner calls. Each test asserts the runner call order /
+ * args directly.
+ */
+
+interface RunGitCall {
+  args: string[];
+}
+
+interface RmCall {
+  path: string;
+}
+
+function makeRunner(
+  responder: (
+    call: number,
+    args: string[],
+  ) =>
+    | { exitCode: number; stderr: string; timedOut?: boolean }
+    | Promise<{ exitCode: number; stderr: string; timedOut?: boolean }>
+    | Error,
+  rmBehavior?: (path: string) => void | Promise<void>,
+): {
+  runner: WorktreeRemovalRunner;
+  runGitCalls: RunGitCall[];
+  rmCalls: RmCall[];
+} {
+  const runGitCalls: RunGitCall[] = [];
+  const rmCalls: RmCall[] = [];
+
+  const runner: WorktreeRemovalRunner = {
+    runGit: async (args) => {
+      runGitCalls.push({ args });
+      const result = await Promise.resolve(responder(runGitCalls.length, args));
+      if (result instanceof Error) throw result;
+      return result;
+    },
+    rmRecursive: async (path) => {
+      rmCalls.push({ path });
+      if (rmBehavior) await rmBehavior(path);
+    },
+  };
+
+  return { runner, runGitCalls, rmCalls };
+}
+
+describe('removeWorktreeWithFallback', () => {
+  it('returns after a single successful runGit (exit 0, force=false)', async () => {
+    const { runner, runGitCalls, rmCalls } = makeRunner(() => ({
+      exitCode: 0,
+      stderr: '',
+      timedOut: false,
+    }));
+
+    await removeWorktreeWithFallback('/wt/feat', runner, { force: false });
+
+    expect(runGitCalls.length).toBe(1);
+    expect(runGitCalls[0].args).toEqual(['worktree', 'remove', '/wt/feat']);
+    expect(rmCalls.length).toBe(0);
+  });
+
+  it('passes --force --force when force=true', async () => {
+    const { runner, runGitCalls } = makeRunner(() => ({
+      exitCode: 0,
+      stderr: '',
+    }));
+
+    await removeWorktreeWithFallback('/wt/feat', runner, { force: true });
+
+    expect(runGitCalls[0].args).toEqual([
+      'worktree',
+      'remove',
+      '/wt/feat',
+      '--force',
+      '--force',
+    ]);
+  });
+
+  it('falls back to rmRecursive + prune --expire=now on a stale-worktree stderr (force=true)', async () => {
+    const { runner, runGitCalls, rmCalls } = makeRunner((call) => {
+      if (call === 1) {
+        return {
+          exitCode: 128,
+          stderr: "fatal: '/wt/feat' is not a working tree",
+          timedOut: false,
+        };
+      }
+      // Prune call: success.
+      return { exitCode: 0, stderr: '' };
+    });
+
+    await removeWorktreeWithFallback('/wt/feat', runner, { force: true });
+
+    expect(runGitCalls.length).toBe(2);
+    expect(runGitCalls[0].args).toEqual([
+      'worktree',
+      'remove',
+      '/wt/feat',
+      '--force',
+      '--force',
+    ]);
+    expect(rmCalls).toEqual([{ path: '/wt/feat' }]);
+    expect(runGitCalls[1].args).toEqual(['worktree', 'prune', '--expire=now']);
+  });
+
+  it('matches `cannot read .git file` as a stale-worktree pattern', async () => {
+    const { runner, runGitCalls, rmCalls } = makeRunner((call) => {
+      if (call === 1) {
+        return {
+          exitCode: 128,
+          stderr: 'fatal: cannot read .git file',
+          timedOut: false,
+        };
+      }
+      return { exitCode: 0, stderr: '' };
+    });
+
+    await removeWorktreeWithFallback('/wt/feat', runner, { force: true });
+
+    expect(rmCalls).toEqual([{ path: '/wt/feat' }]);
+    expect(runGitCalls.length).toBe(2);
+  });
+
+  it('matches `invalid gitfile format` as a stale-worktree pattern', async () => {
+    const { runner, runGitCalls, rmCalls } = makeRunner((call) => {
+      if (call === 1) {
+        return {
+          exitCode: 128,
+          stderr: 'fatal: invalid gitfile format: /wt/feat/.git',
+          timedOut: false,
+        };
+      }
+      return { exitCode: 0, stderr: '' };
+    });
+
+    await removeWorktreeWithFallback('/wt/feat', runner, { force: true });
+
+    expect(rmCalls).toEqual([{ path: '/wt/feat' }]);
+    expect(runGitCalls.length).toBe(2);
+  });
+
+  it("matches `'.git' file` substring as a stale-worktree pattern", async () => {
+    const { runner, runGitCalls, rmCalls } = makeRunner((call) => {
+      if (call === 1) {
+        return {
+          exitCode: 128,
+          stderr: "fatal: '.git' file is corrupt",
+          timedOut: false,
+        };
+      }
+      return { exitCode: 0, stderr: '' };
+    });
+
+    await removeWorktreeWithFallback('/wt/feat', runner, { force: true });
+
+    expect(rmCalls).toEqual([{ path: '/wt/feat' }]);
+    expect(runGitCalls.length).toBe(2);
+  });
+
+  it('propagates rmRecursive errors when fallback is triggered', async () => {
+    const { runner, runGitCalls, rmCalls } = makeRunner(
+      (call) => {
+        if (call === 1) {
+          return {
+            exitCode: 128,
+            stderr: "fatal: '/wt/feat' is not a working tree",
+            timedOut: false,
+          };
+        }
+        return { exitCode: 0, stderr: '' };
+      },
+      () => {
+        throw new GitError(
+          'elevated rm failed: exit code 1',
+          1,
+          'rm: cannot remove',
+        );
+      },
+    );
+
+    await expect(
+      removeWorktreeWithFallback('/wt/feat', runner, { force: true }),
+    ).rejects.toBeInstanceOf(GitError);
+
+    // The initial remove ran and rm ran; prune was NOT attempted (rm threw).
+    expect(runGitCalls.length).toBe(1);
+    expect(rmCalls).toEqual([{ path: '/wt/feat' }]);
+  });
+
+  it('does NOT propagate prune failures (best-effort swallow)', async () => {
+    const { runner, runGitCalls, rmCalls } = makeRunner((call) => {
+      if (call === 1) {
+        return {
+          exitCode: 128,
+          stderr: "fatal: '/wt/feat' is not a working tree",
+          timedOut: false,
+        };
+      }
+      // Prune call: unexpected synchronous throw from the runner.
+      return new Error('prune blew up');
+    });
+
+    // Must resolve without throwing: rm already succeeded so the stale
+    // registry entry is the only cost, and `.catch(() => {})` in the
+    // helper swallows the rejection.
+    await removeWorktreeWithFallback('/wt/feat', runner, { force: true });
+
+    expect(runGitCalls.length).toBe(2);
+    expect(runGitCalls[1].args).toEqual(['worktree', 'prune', '--expire=now']);
+    expect(rmCalls).toEqual([{ path: '/wt/feat' }]);
+  });
+
+  it('throws GitError on a non-stale stderr even when force=true (narrow matcher regression guard)', async () => {
+    // Regression guard for the consolidation: the original
+    // `lib/git.ts:482` broad `.git` substring match would have triggered
+    // destructive recovery on this stderr. The narrow matcher must not.
+    const { runner, runGitCalls, rmCalls } = makeRunner(() => ({
+      exitCode: 128,
+      stderr: 'fatal: not a git repository (or any of the parent directories): .git',
+      timedOut: false,
+    }));
+
+    await expect(
+      removeWorktreeWithFallback('/wt/feat', runner, { force: true }),
+    ).rejects.toBeInstanceOf(GitError);
+
+    expect(runGitCalls.length).toBe(1);
+    expect(rmCalls.length).toBe(0);
+  });
+
+  it('throws GitError when force=false even on a stale-worktree stderr (no recovery without force)', async () => {
+    const { runner, runGitCalls, rmCalls } = makeRunner(() => ({
+      exitCode: 128,
+      stderr: "fatal: '/wt/feat' is not a working tree",
+      timedOut: false,
+    }));
+
+    await expect(
+      removeWorktreeWithFallback('/wt/feat', runner, { force: false }),
+    ).rejects.toBeInstanceOf(GitError);
+
+    expect(runGitCalls.length).toBe(1);
+    expect(rmCalls.length).toBe(0);
+  });
+
+  it('throws GitError when timedOut=true even with a stale-worktree stderr (timeout suppresses recovery)', async () => {
+    const { runner, runGitCalls, rmCalls } = makeRunner(() => ({
+      exitCode: 137,
+      stderr: "fatal: '/wt/feat' is not a working tree",
+      timedOut: true,
+    }));
+
+    await expect(
+      removeWorktreeWithFallback('/wt/feat', runner, { force: true }),
+    ).rejects.toBeInstanceOf(GitError);
+
+    expect(runGitCalls.length).toBe(1);
+    expect(rmCalls.length).toBe(0);
+  });
+
+  it('treats omitted timedOut as not-timed-out (default false)', async () => {
+    // Helper's contract: timedOut is optional; omitted === false. A stale
+    // stderr with force=true should still recover.
+    const { runner, runGitCalls, rmCalls } = makeRunner((call) => {
+      if (call === 1) {
+        return {
+          exitCode: 128,
+          stderr: "fatal: '/wt/feat' is not a working tree",
+        };
+      }
+      return { exitCode: 0, stderr: '' };
+    });
+
+    await removeWorktreeWithFallback('/wt/feat', runner, { force: true });
+
+    expect(runGitCalls.length).toBe(2);
+    expect(rmCalls).toEqual([{ path: '/wt/feat' }]);
+  });
+});

--- a/packages/server/src/lib/__tests__/worktree-removal.test.ts
+++ b/packages/server/src/lib/__tests__/worktree-removal.test.ts
@@ -5,17 +5,6 @@ import {
   type WorktreeRemovalRunner,
 } from '../git.js';
 
-/**
- * Unit tests for the consolidated `removeWorktreeWithFallback` helper
- * (PR #897). Both `lib/git.ts:removeWorktree` (server-process direct spawn)
- * and `worktree-service.ts:invokeGitWorktreeRemove` (multi-user elevated)
- * are thin runner constructors that delegate the orchestration here.
- *
- * Hand-rolled fake runners — no mock library state — so the test reads as
- * a sequence of runner calls. Each test asserts the runner call order /
- * args directly.
- */
-
 interface RunGitCall {
   args: string[];
 }
@@ -98,7 +87,6 @@ describe('removeWorktreeWithFallback', () => {
           timedOut: false,
         };
       }
-      // Prune call: success.
       return { exitCode: 0, stderr: '' };
     });
 
@@ -195,7 +183,6 @@ describe('removeWorktreeWithFallback', () => {
       removeWorktreeWithFallback('/wt/feat', runner, { force: true }),
     ).rejects.toBeInstanceOf(GitError);
 
-    // The initial remove ran and rm ran; prune was NOT attempted (rm threw).
     expect(runGitCalls.length).toBe(1);
     expect(rmCalls).toEqual([{ path: '/wt/feat' }]);
   });
@@ -209,13 +196,9 @@ describe('removeWorktreeWithFallback', () => {
           timedOut: false,
         };
       }
-      // Prune call: unexpected synchronous throw from the runner.
       return new Error('prune blew up');
     });
 
-    // Must resolve without throwing: rm already succeeded so the stale
-    // registry entry is the only cost, and `.catch(() => {})` in the
-    // helper swallows the rejection.
     await removeWorktreeWithFallback('/wt/feat', runner, { force: true });
 
     expect(runGitCalls.length).toBe(2);
@@ -224,9 +207,6 @@ describe('removeWorktreeWithFallback', () => {
   });
 
   it('throws GitError on a non-stale stderr even when force=true (narrow matcher regression guard)', async () => {
-    // Regression guard for the consolidation: the original
-    // `lib/git.ts:482` broad `.git` substring match would have triggered
-    // destructive recovery on this stderr. The narrow matcher must not.
     const { runner, runGitCalls, rmCalls } = makeRunner(() => ({
       exitCode: 128,
       stderr: 'fatal: not a git repository (or any of the parent directories): .git',
@@ -272,8 +252,6 @@ describe('removeWorktreeWithFallback', () => {
   });
 
   it('treats omitted timedOut as not-timed-out (default false)', async () => {
-    // Helper's contract: timedOut is optional; omitted === false. A stale
-    // stderr with force=true should still recover.
     const { runner, runGitCalls, rmCalls } = makeRunner((call) => {
       if (call === 1) {
         return {

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -448,19 +448,9 @@ export async function createWorktree(
 }
 
 /**
- * Runner abstraction used by {@link removeWorktreeWithFallback}.
- *
- * - `runGit` invokes `git` with the given args. Args do NOT include the `git`
- *   binary itself; the runner is responsible for binding to git (direct
- *   `Bun.spawn` vs sudo-elevated invocation via `runAsUser`) and for cwd.
- *   A non-zero `exitCode` or `timedOut: true` is signalled in the returned
- *   tuple; the runner must NOT throw for ordinary command failure. The
- *   runner may throw only for unexpected exceptions outside the command's
- *   own exit semantics (e.g. sudo missing, spawn-level fatal that cannot
- *   be normalized to an exit code).
- * - `rmRecursive` removes a directory tree force-style (no error if absent).
- *   Errors that are NOT no-op-on-absent (permission, timeout) MUST throw so
- *   the orchestration helper can propagate them to the caller's outer catch.
+ * Runner abstraction for {@link removeWorktreeWithFallback}: `runGit`
+ * dispatches a `git` argv (direct spawn or elevated) and reports exit via
+ * the returned tuple; `rmRecursive` removes a directory tree force-style.
  */
 export interface WorktreeRemovalRunner {
   runGit(args: string[]): Promise<{ exitCode: number; stderr: string; timedOut?: boolean }>;
@@ -470,35 +460,15 @@ export interface WorktreeRemovalRunner {
 /**
  * Shared orchestration for `git worktree remove` with force-fallback recovery.
  *
- * Strategy:
- * 1. `git worktree remove <path>` (+`--force --force` when `options.force`).
- * 2. If exit 0 and !timedOut → return.
- * 3. If `options.force && !timedOut && stderr matches a narrow stale-worktree
- *    pattern`:
- *      - `runner.rmRecursive(worktreePath)` (rm errors propagate to the caller).
- *      - `runner.runGit(['worktree', 'prune', '--expire=now'])` (best-effort:
- *        `.catch(() => {})` so unexpected exceptions from the runner do not
- *        propagate; a non-zero `exitCode` result is silently accepted).
- *      - return.
- * 4. Otherwise → throw {@link GitError}.
+ * `--expire=now` on the fallback prune is required because the rm has just
+ * deleted the worktree dir itself: git's default `gc.worktreePruneExpire`
+ * is 3 months, so a plain `git worktree prune` would leave the freshly-stale
+ * registry entry behind and a subsequent `worktree add` at the same path
+ * could collide.
  *
- * `--expire=now` is required because the fallback just deleted the worktree
- * directory ourselves: git's default `gc.worktreePruneExpire` is 3 months, so
- * a plain `git worktree prune` would NOT shed the freshly-stale entry we just
- * created, and a subsequent `worktree add` at the same path could collide.
- * Forcing immediate expiration is correct because the recovery branch only
- * runs after the rm has already succeeded (Issue #895).
- *
- * The `force` external contract is "unclean / locked / orphan-dir recovery
- * override". The matcher uses the narrow pattern consolidated from
- * `worktree-service.ts:invokeGitWorktreeRemove` (post-CodeRabbit-feedback on
- * Issue #882); it never matches a bare `.git` substring, which over-triggered
- * destructive recovery on `fatal: not a git repository ... .git`.
- *
- * Security note: this helper performs no path-safety validation. It is a
- * low-level git orchestration; security checks (path traversal prevention,
- * `isWorktreeOf` ownership, boundary validation) are the caller's
- * responsibility.
+ * The stale-worktree matcher is intentionally narrow — it never matches a
+ * bare `.git` substring, which over-triggered destructive recovery on
+ * `fatal: not a git repository ... .git`.
  */
 export async function removeWorktreeWithFallback(
   worktreePath: string,
@@ -535,12 +505,9 @@ export async function removeWorktreeWithFallback(
 }
 
 /**
- * Remove a worktree.
- *
- * Thin wrapper around {@link removeWorktreeWithFallback} bound to the
- * server-process git invocation path (`Bun.spawn` via `git()`) and the
- * server-process `fs.rm` for the fallback removal. The elevated, user-owned
- * sibling is `worktree-service.ts:invokeGitWorktreeRemove`.
+ * Remove a worktree (server-process `Bun.spawn` runner over
+ * {@link removeWorktreeWithFallback}). The elevated sibling is
+ * `worktree-service.ts:invokeGitWorktreeRemove`.
  */
 export async function removeWorktree(
   worktreePath: string,
@@ -554,16 +521,11 @@ export async function removeWorktree(
         return { exitCode: 0, stderr: '', timedOut: false };
       } catch (error) {
         if (error instanceof GitError) {
-          // Includes timeouts (GitError with stderr='Timeout') and ordinary
-          // non-zero exits. The matcher in the orchestration helper is
-          // narrow enough that 'Timeout' falls through to the throw branch.
           return { exitCode: error.exitCode, stderr: error.stderr, timedOut: false };
         }
-        // ENOENT/ENOTDIR on the spawn itself (e.g., cwd vanished between
-        // the caller's check and this invocation): surface as a non-stale
-        // result so the helper's matcher falls through to its throw branch
-        // on the initial remove call, or so the swallow `.catch` accepts
-        // it harmlessly on the prune call.
+        // ENOENT/ENOTDIR on the spawn itself (cwd vanished): surface as a
+        // non-stale result so the helper falls through to its throw branch
+        // on the remove call, or is silently swallowed on the prune call.
         const code = (error as NodeJS.ErrnoException | undefined)?.code;
         if (code === 'ENOENT' || code === 'ENOTDIR') {
           return { exitCode: -1, stderr: `spawn ${code}`, timedOut: false };

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -448,74 +448,138 @@ export async function createWorktree(
 }
 
 /**
+ * Runner abstraction used by {@link removeWorktreeWithFallback}.
+ *
+ * - `runGit` invokes `git` with the given args. Args do NOT include the `git`
+ *   binary itself; the runner is responsible for binding to git (direct
+ *   `Bun.spawn` vs sudo-elevated invocation via `runAsUser`) and for cwd.
+ *   A non-zero `exitCode` or `timedOut: true` is signalled in the returned
+ *   tuple; the runner must NOT throw for ordinary command failure. The
+ *   runner may throw only for unexpected exceptions outside the command's
+ *   own exit semantics (e.g. sudo missing, spawn-level fatal that cannot
+ *   be normalized to an exit code).
+ * - `rmRecursive` removes a directory tree force-style (no error if absent).
+ *   Errors that are NOT no-op-on-absent (permission, timeout) MUST throw so
+ *   the orchestration helper can propagate them to the caller's outer catch.
+ */
+export interface WorktreeRemovalRunner {
+  runGit(args: string[]): Promise<{ exitCode: number; stderr: string; timedOut?: boolean }>;
+  rmRecursive(path: string): Promise<void>;
+}
+
+/**
+ * Shared orchestration for `git worktree remove` with force-fallback recovery.
+ *
+ * Strategy:
+ * 1. `git worktree remove <path>` (+`--force --force` when `options.force`).
+ * 2. If exit 0 and !timedOut → return.
+ * 3. If `options.force && !timedOut && stderr matches a narrow stale-worktree
+ *    pattern`:
+ *      - `runner.rmRecursive(worktreePath)` (rm errors propagate to the caller).
+ *      - `runner.runGit(['worktree', 'prune', '--expire=now'])` (best-effort:
+ *        `.catch(() => {})` so unexpected exceptions from the runner do not
+ *        propagate; a non-zero `exitCode` result is silently accepted).
+ *      - return.
+ * 4. Otherwise → throw {@link GitError}.
+ *
+ * `--expire=now` is required because the fallback just deleted the worktree
+ * directory ourselves: git's default `gc.worktreePruneExpire` is 3 months, so
+ * a plain `git worktree prune` would NOT shed the freshly-stale entry we just
+ * created, and a subsequent `worktree add` at the same path could collide.
+ * Forcing immediate expiration is correct because the recovery branch only
+ * runs after the rm has already succeeded (Issue #895).
+ *
+ * The `force` external contract is "unclean / locked / orphan-dir recovery
+ * override". The matcher uses the narrow pattern consolidated from
+ * `worktree-service.ts:invokeGitWorktreeRemove` (post-CodeRabbit-feedback on
+ * Issue #882); it never matches a bare `.git` substring, which over-triggered
+ * destructive recovery on `fatal: not a git repository ... .git`.
+ *
+ * Security note: this helper performs no path-safety validation. It is a
+ * low-level git orchestration; security checks (path traversal prevention,
+ * `isWorktreeOf` ownership, boundary validation) are the caller's
+ * responsibility.
+ */
+export async function removeWorktreeWithFallback(
+  worktreePath: string,
+  runner: WorktreeRemovalRunner,
+  options: { force: boolean },
+): Promise<void> {
+  const args = ['worktree', 'remove', worktreePath];
+  if (options.force) {
+    // --force twice removes unclean worktrees AND locked worktrees.
+    args.push('--force', '--force');
+  }
+
+  const result = await runner.runGit(args);
+  if (result.exitCode === 0 && !result.timedOut) return;
+
+  const stderr = result.stderr;
+  const isStaleWorktreeError =
+    stderr.includes('is not a working tree') ||
+    stderr.includes('cannot read .git file') ||
+    stderr.includes('invalid gitfile format') ||
+    stderr.includes("'.git' file");
+
+  if (options.force && !result.timedOut && isStaleWorktreeError) {
+    await runner.rmRecursive(worktreePath);
+    await runner.runGit(['worktree', 'prune', '--expire=now']).catch(() => {});
+    return;
+  }
+
+  throw new GitError(
+    `git worktree remove failed: ${stderr.trim() || `exit code ${result.exitCode}`}`,
+    result.exitCode,
+    stderr,
+  );
+}
+
+/**
  * Remove a worktree.
+ *
+ * Thin wrapper around {@link removeWorktreeWithFallback} bound to the
+ * server-process git invocation path (`Bun.spawn` via `git()`) and the
+ * server-process `fs.rm` for the fallback removal. The elevated, user-owned
+ * sibling is `worktree-service.ts:invokeGitWorktreeRemove`.
  */
 export async function removeWorktree(
   worktreePath: string,
   cwd: string,
   options?: { force?: boolean }
 ): Promise<void> {
-  const args = ['worktree', 'remove', worktreePath];
-
-  if (options?.force) {
-    // --force twice: removes unclean worktrees AND locked worktrees
-    args.push('--force', '--force');
-  }
-
-  try {
-    await git(args, cwd, HEAVY_GIT_TIMEOUT_MS);
-  } catch (error) {
-    // When force is enabled, fall back to manual cleanup for cases where
-    // git cannot remove the worktree on its own:
-    // - The .git file is missing (race condition / partial cleanup)
-    // - The path is not recognized as a working tree (orphaned worktree)
-    //
-    // Security note: This function intentionally does NOT validate path safety.
-    // It is a low-level git utility; security checks (path traversal prevention,
-    // isWorktreeOf ownership, boundary validation) are the caller's responsibility.
-    // See the route handler in repositories.ts which performs all validation before
-    // calling here. The `force` flag is only set when the caller has already
-    // verified the path is safe to delete.
-    if (
-      options?.force &&
-      error instanceof GitError &&
-      (error.stderr.includes('.git') || error.stderr.includes('is not a working tree'))
-    ) {
-      const fs = await import('node:fs/promises');
-      await fs.rm(worktreePath, { recursive: true, force: true });
-      // Only prune when the primary repo dir (cwd) still exists. If the primary
-      // was deleted out-of-band, `git worktree prune` would run against a dead
-      // cwd and Bun.spawn throws ENOENT. Pruning against an absent common dir is
-      // a no-op anyway, so skipping it is safe.
-      //
-      // `--expire=now` is required here because we just deleted the worktree
-      // directory ourselves: git's default `gc.worktreePruneExpire` is 3 months,
-      // so a plain `git worktree prune` would NOT shed the freshly-stale entry
-      // we just created, and a subsequent `worktree add` at the same path
-      // could collide. Forcing immediate expiration is correct because the
-      // recovery path has already confirmed the worktree dir is gone.
-      let cwdExists = false;
+  const runner: WorktreeRemovalRunner = {
+    runGit: async (args) => {
       try {
-        await fs.stat(cwd);
-        cwdExists = true;
-      } catch {
-        cwdExists = false;
-      }
-      if (cwdExists) {
-        try {
-          await git(['worktree', 'prune', '--expire=now'], cwd, HEAVY_GIT_TIMEOUT_MS);
-        } catch (pruneError) {
-          const code = (pruneError as NodeJS.ErrnoException | undefined)?.code;
-          // cwd may vanish between stat() and spawn(); cleanup already succeeded.
-          if (code !== 'ENOENT' && code !== 'ENOTDIR') {
-            throw pruneError;
-          }
+        await git(args, cwd, HEAVY_GIT_TIMEOUT_MS);
+        return { exitCode: 0, stderr: '', timedOut: false };
+      } catch (error) {
+        if (error instanceof GitError) {
+          // Includes timeouts (GitError with stderr='Timeout') and ordinary
+          // non-zero exits. The matcher in the orchestration helper is
+          // narrow enough that 'Timeout' falls through to the throw branch.
+          return { exitCode: error.exitCode, stderr: error.stderr, timedOut: false };
         }
+        // ENOENT/ENOTDIR on the spawn itself (e.g., cwd vanished between
+        // the caller's check and this invocation): surface as a non-stale
+        // result so the helper's matcher falls through to its throw branch
+        // on the initial remove call, or so the swallow `.catch` accepts
+        // it harmlessly on the prune call.
+        const code = (error as NodeJS.ErrnoException | undefined)?.code;
+        if (code === 'ENOENT' || code === 'ENOTDIR') {
+          return { exitCode: -1, stderr: `spawn ${code}`, timedOut: false };
+        }
+        throw error;
       }
-      return;
-    }
-    throw error;
-  }
+    },
+    rmRecursive: async (target) => {
+      const fs = await import('node:fs/promises');
+      await fs.rm(target, { recursive: true, force: true });
+    },
+  };
+
+  await removeWorktreeWithFallback(worktreePath, runner, {
+    force: options?.force ?? false,
+  });
 }
 
 // ============================================================

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -487,6 +487,13 @@ export async function removeWorktree(
       // was deleted out-of-band, `git worktree prune` would run against a dead
       // cwd and Bun.spawn throws ENOENT. Pruning against an absent common dir is
       // a no-op anyway, so skipping it is safe.
+      //
+      // `--expire=now` is required here because we just deleted the worktree
+      // directory ourselves: git's default `gc.worktreePruneExpire` is 3 months,
+      // so a plain `git worktree prune` would NOT shed the freshly-stale entry
+      // we just created, and a subsequent `worktree add` at the same path
+      // could collide. Forcing immediate expiration is correct because the
+      // recovery path has already confirmed the worktree dir is gone.
       let cwdExists = false;
       try {
         await fs.stat(cwd);
@@ -496,7 +503,7 @@ export async function removeWorktree(
       }
       if (cwdExists) {
         try {
-          await git(['worktree', 'prune'], cwd, HEAVY_GIT_TIMEOUT_MS);
+          await git(['worktree', 'prune', '--expire=now'], cwd, HEAVY_GIT_TIMEOUT_MS);
         } catch (pruneError) {
           const code = (pruneError as NodeJS.ErrnoException | undefined)?.code;
           // cwd may vanish between stat() and spawn(); cleanup already succeeded.
@@ -509,34 +516,6 @@ export async function removeWorktree(
     }
     throw error;
   }
-}
-
-/**
- * Prune stale worktree registry entries (`git worktree prune --expire=now`).
- *
- * Used by `WorktreeService.removeWorktree` when the worktree directory was
- * externally removed but the primary repo (cwd) still exists — `git worktree
- * remove` would fail with `fatal: '<path>' is not a working tree`, so the
- * recovery is to prune the registry directly. See Issue #895.
- *
- * `--expire=now` is required: git's default expiration is 3 months
- * (`gc.worktreePruneExpire`), so a plain `git worktree prune` directly
- * after the dir was deleted would NOT shed the freshly stale entry, and a
- * subsequent `worktree add` at the same path could collide. Forcing
- * immediate expiration is correct here because the caller has already
- * verified the directory is gone.
- *
- * @param cwd - The primary repo directory (must still exist).
- * @param requestUser - When non-null, run as this OS user via `runAsUser`
- *   (multi-user mode picks up that user's PATH/gitconfig/SSH_AUTH_SOCK). When
- *   null/undefined (the default), spawn directly as the server user.
- * @throws GitError on prune failure.
- */
-export async function pruneWorktrees(
-  cwd: string,
-  requestUser?: string | null,
-): Promise<void> {
-  await git(['worktree', 'prune', '--expire=now'], cwd, HEAVY_GIT_TIMEOUT_MS, requestUser);
 }
 
 // ============================================================

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -511,6 +511,27 @@ export async function removeWorktree(
   }
 }
 
+/**
+ * Prune stale worktree registry entries (`git worktree prune`).
+ *
+ * Used by `WorktreeService.removeWorktree` when the worktree directory was
+ * externally removed but the primary repo (cwd) still exists — `git worktree
+ * remove` would fail with `fatal: '<path>' is not a working tree`, so the
+ * recovery is to prune the registry directly. See Issue #895.
+ *
+ * @param cwd - The primary repo directory (must still exist).
+ * @param requestUser - When non-null, run as this OS user via `runAsUser`
+ *   (multi-user mode picks up that user's PATH/gitconfig/SSH_AUTH_SOCK). When
+ *   null/undefined (the default), spawn directly as the server user.
+ * @throws GitError on prune failure.
+ */
+export async function pruneWorktrees(
+  cwd: string,
+  requestUser?: string | null,
+): Promise<void> {
+  await git(['worktree', 'prune'], cwd, HEAVY_GIT_TIMEOUT_MS, requestUser);
+}
+
 // ============================================================
 // Diff Operations
 // ============================================================

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -512,12 +512,19 @@ export async function removeWorktree(
 }
 
 /**
- * Prune stale worktree registry entries (`git worktree prune`).
+ * Prune stale worktree registry entries (`git worktree prune --expire=now`).
  *
  * Used by `WorktreeService.removeWorktree` when the worktree directory was
  * externally removed but the primary repo (cwd) still exists — `git worktree
  * remove` would fail with `fatal: '<path>' is not a working tree`, so the
  * recovery is to prune the registry directly. See Issue #895.
+ *
+ * `--expire=now` is required: git's default expiration is 3 months
+ * (`gc.worktreePruneExpire`), so a plain `git worktree prune` directly
+ * after the dir was deleted would NOT shed the freshly stale entry, and a
+ * subsequent `worktree add` at the same path could collide. Forcing
+ * immediate expiration is correct here because the caller has already
+ * verified the directory is gone.
  *
  * @param cwd - The primary repo directory (must still exist).
  * @param requestUser - When non-null, run as this OS user via `runAsUser`
@@ -529,7 +536,7 @@ export async function pruneWorktrees(
   cwd: string,
   requestUser?: string | null,
 ): Promise<void> {
-  await git(['worktree', 'prune'], cwd, HEAVY_GIT_TIMEOUT_MS, requestUser);
+  await git(['worktree', 'prune', '--expire=now'], cwd, HEAVY_GIT_TIMEOUT_MS, requestUser);
 }
 
 // ============================================================

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -2594,11 +2594,10 @@ describe('MCP Server Tools', () => {
       const repoPath = opts.repoPath ?? WT_REPO_PATH;
       const worktreePaths = opts.worktreePaths ?? [WT_WORKTREE_PATH];
 
-      // Ensure repo paths exist in memfs. Each worktree path also gets a
-      // `.keep` marker so the directory exists on the in-memory volume —
-      // `WorktreeService.removeWorktree` now stats the worktree path (#895)
-      // and routes to prune+delete when missing, which would bypass the
-      // mocked `git worktree remove` path that several deletion tests rely on.
+      // Worktree paths get a `.keep` marker so the directory exists on
+      // memfs — `WorktreeService.removeWorktree` stats the worktree path
+      // and would otherwise route to the orphan-recovery branch, bypassing
+      // the mocked `git worktree remove`.
       const fsEntries: Record<string, string> = {
         [`${TEST_CONFIG_DIR}/.keep`]: '',
         [`${repoPath}/.git/HEAD`]: 'ref: refs/heads/main',

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -2594,11 +2594,18 @@ describe('MCP Server Tools', () => {
       const repoPath = opts.repoPath ?? WT_REPO_PATH;
       const worktreePaths = opts.worktreePaths ?? [WT_WORKTREE_PATH];
 
-      // Ensure repo paths exist in memfs
+      // Ensure repo paths exist in memfs. Each worktree path also gets a
+      // `.keep` marker so the directory exists on the in-memory volume —
+      // `WorktreeService.removeWorktree` now stats the worktree path (#895)
+      // and routes to prune+delete when missing, which would bypass the
+      // mocked `git worktree remove` path that several deletion tests rely on.
       const fsEntries: Record<string, string> = {
         [`${TEST_CONFIG_DIR}/.keep`]: '',
         [`${repoPath}/.git/HEAD`]: 'ref: refs/heads/main',
       };
+      for (const wtPath of worktreePaths) {
+        fsEntries[`${wtPath}/.keep`] = '';
+      }
       setupMemfs(fsEntries);
       process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
 

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -639,11 +639,7 @@ detached
 
   describe('removeWorktree', () => {
     // ① Primary repo dir exists + clean: behavior unchanged (normal git path).
-    //   Both the primary and the worktree dir must exist in memfs so the
-    //   pre-checks (repoExists + worktreeExists, the latter added for #895)
-    //   pass and the normal git path runs.
     it('should remove worktree successfully', async () => {
-      // Primary repo dir and worktree dir must exist for the normal git path.
       fs.mkdirSync('/repo', { recursive: true });
       fs.mkdirSync('/worktrees/feature', { recursive: true });
       // Pre-populate DB record for the worktree being removed
@@ -819,12 +815,9 @@ detached
     });
 
     // ⑥ Primary repo dir present + worktree dir MISSING: upgrade `force=true`
-    //    internally and route through the existing fallback in
-    //    `lib/git.ts:removeWorktree` (which already catches `is not a working
-    //    tree` and runs fs.rm + `git worktree prune --expire=now`). Issue #895.
+    //    internally and route through the existing fallback (#895).
     it('should upgrade force=true internally when worktree path is missing (#895)', async () => {
       fs.mkdirSync('/repo', { recursive: true });
-      // /worktrees/feature does NOT exist on disk — externally removed.
       mockRepo.records.push({
         id: 'wt-1',
         repositoryId: 'repo-1',
@@ -836,30 +829,21 @@ detached
       const WorktreeService = await getWorktreeService();
       const service = new WorktreeService({ worktreeRepository: mockRepo });
 
-      // Caller did NOT pass force=true; the pre-check upgrades it internally.
       const result = await service.removeWorktree('/repo', '/worktrees/feature');
 
       expect(result.success).toBe(true);
       expect(result.error).toBeUndefined();
-      // lib/git.ts removeWorktree called with force=true (upgraded internally).
-      // The recovery itself (fs.rm + prune) is the responsibility of
-      // lib/git.ts:removeWorktree's force-fallback catch block, which is
-      // covered by that module's own tests.
       expect(mockGit.removeWorktree).toHaveBeenCalledWith(
         '/worktrees/feature',
         '/repo',
         { force: true },
       );
-      // DB record removed.
       expect(mockRepo.records.length).toBe(0);
     });
 
-    // ⑦ Idempotent: a second call after the DB row + worktree dir are
-    //    both already gone still returns success. The upgraded force=true
-    //    routes through lib/git.ts's idempotent fallback.
+    // ⑦ Idempotent: second orphan-recovery call (no DB row, no dir) still succeeds.
     it('should be idempotent on the second orphan worktree-dir recovery call (#895)', async () => {
       fs.mkdirSync('/repo', { recursive: true });
-      // No DB record (already cleaned up by a prior call) and no on-disk worktree.
 
       const WorktreeService = await getWorktreeService();
       const service = new WorktreeService({ worktreeRepository: mockRepo });
@@ -868,7 +852,6 @@ detached
 
       expect(result.success).toBe(true);
       expect(result.error).toBeUndefined();
-      // Same upgrade contract: force=true routed to lib/git.ts.
       expect(mockGit.removeWorktree).toHaveBeenCalledWith(
         '/worktrees/already-pruned',
         '/repo',
@@ -876,15 +859,9 @@ detached
       );
     });
 
-    // Single-user EACCES on the worktreePath stat is a genuine
-    // misconfiguration and must NOT be silently routed to recovery. This
-    // locks the narrow scope of the EACCES carve-out from PR #897 CodeRabbit
-    // — only multi-user mode skips the throw on EACCES/EPERM (#895).
+    // Single-user EACCES: carve-out does NOT engage; failure surfaces. This
+    // locks the narrow scope of the multi-user EACCES carve-out (#895).
     it('still surfaces { success: false } on EACCES in single-user mode (no elevation) (#895)', async () => {
-      // Single-user: AUTH_MODE is unset (top-level beforeEach restores it),
-      // and requestUsername is null — so `shouldElevateForUser(null)` is
-      // false regardless of AUTH_MODE, and the EACCES carve-out does not
-      // engage.
       fs.mkdirSync('/repo', { recursive: true });
       mockRepo.records.push({
         id: 'wt-1',
@@ -915,26 +892,23 @@ detached
           '/repo',
           '/worktrees/feature',
           false,
-          null, // single-user (no elevation)
+          null,
         );
 
         expect(result.success).toBe(false);
         expect(result.error).toBeDefined();
         expect(mockGit.removeWorktree).not.toHaveBeenCalled();
         expect(runAsUserMock.calls.length).toBe(0);
-        // DB row preserved on failure.
         expect(mockRepo.records.length).toBe(1);
       } finally {
         statSpy.mockRestore();
       }
     });
 
-    // ⑧ Non-directory at worktreePath (stale file/symlink) MUST NOT route
-    //    to destructive recovery — surface as { success: false } (#895).
+    // ⑧ Non-directory at worktreePath MUST NOT route to destructive recovery (#895).
     it('should fail without recovery when worktreePath exists as a non-directory (#895)', async () => {
       fs.mkdirSync('/repo', { recursive: true });
       fs.mkdirSync('/worktrees', { recursive: true });
-      // Worktree path is a regular FILE, not a directory.
       fs.writeFileSync('/worktrees/feature-file', 'stale leftover');
       mockRepo.records.push({
         id: 'wt-1',
@@ -951,9 +925,7 @@ detached
 
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
-      // git worktree remove was NOT attempted (pre-check rejected before it).
       expect(mockGit.removeWorktree).not.toHaveBeenCalled();
-      // DB row preserved.
       expect(mockRepo.records.length).toBe(1);
     });
   });
@@ -1188,11 +1160,6 @@ detached
       expect(runAsUserMock.calls.length).toBe(4);
       expect(runAsUserMock.calls[2].command).toBe(`rm -rf -- '/worktrees/feature'`);
       expect(runAsUserMock.calls[2].cwd).toBe('/');
-      // Post-PR-#897 consolidation: the fallback prune is now constructed by
-      // the shared `removeWorktreeWithFallback` runner, which `shellEscape`s
-      // every argv element (matching the remove call's escape policy). The
-      // resulting command is `'git' 'worktree' 'prune' '--expire=now'`
-      // (each element single-quoted), not the previous unquoted form.
       expect(runAsUserMock.calls[3].command).toBe(
         `'git' 'worktree' 'prune' '--expire=now'`,
       );
@@ -1230,7 +1197,6 @@ detached
 
     it('routes force=true through runAsUser when worktree-dir is missing (#895)', async () => {
       fs.mkdirSync('/repo', { recursive: true });
-      // worktree dir absent
       mockRepo.records.push({
         id: 'wt-1',
         repositoryId: 'repo-1',
@@ -1245,9 +1211,6 @@ detached
         runAsUserImpl: runAsUserMock.runAsUserImpl,
       });
 
-      // Caller passes force=false; pre-check upgrades force=true internally.
-      // The `git worktree remove` succeeds (default responder), so the
-      // fallback chain (rm + prune) does NOT engage in this happy path.
       const result = await service.removeWorktree(
         '/repo',
         '/worktrees/feature',
@@ -1256,8 +1219,6 @@ detached
       );
 
       expect(result.success).toBe(true);
-      // Two runAsUser calls: safe.directory bootstrap, then
-      // `git worktree remove --force --force` (force upgraded internally).
       expect(runAsUserMock.calls.length).toBe(2);
       const bootstrap = runAsUserMock.calls[0];
       expect(bootstrap.username).toBe('alice-multiuser-test');
@@ -1266,15 +1227,12 @@ detached
       expect(runAsUserMock.calls[1].command).toBe(
         `'git' 'worktree' 'remove' '/worktrees/feature' '--force' '--force'`,
       );
-      // lib/git removeWorktree NOT called (elevated branch bypasses it).
       expect(mockGit.removeWorktree).not.toHaveBeenCalled();
-      // DB row removed.
       expect(mockRepo.records.length).toBe(0);
     });
 
     it('uses --expire=now in fallback prune when worktree-dir is missing and force=true triggers fallback (#895)', async () => {
       fs.mkdirSync('/repo', { recursive: true });
-      // worktree dir absent — pre-check upgrades to force=true.
       mockRepo.records.push({
         id: 'wt-1',
         repositoryId: 'repo-1',
@@ -1283,11 +1241,9 @@ detached
         createdAt: new Date().toISOString(),
       });
 
-      // Call 1 (bootstrap): success
-      // Call 2 (`git worktree remove --force --force`): is-not-a-working-tree
-      //   error (triggers the fallback chain in `invokeGitWorktreeRemove`)
-      // Call 3 (`rm -rf -- '/worktrees/feature'`): success
-      // Call 4 (`git worktree prune --expire=now`): success
+      // Call sequence: 1 bootstrap, 2 `git worktree remove` (returns the
+      // is-not-a-working-tree error to trigger the fallback), 3 `rm -rf`,
+      // 4 `git worktree prune --expire=now`.
       let callIdx = 0;
       runAsUserMock.responder.fn = async () => {
         callIdx += 1;
@@ -1317,26 +1273,16 @@ detached
 
       expect(result.success).toBe(true);
       expect(runAsUserMock.calls.length).toBe(4);
-      // Post-PR-#897 consolidation: the shared runner shellEscapes every
-      // argv element including the prune call (matches the remove call's
-      // escape policy). The unquoted shape from the previous in-service
-      // implementation is gone.
       expect(runAsUserMock.calls[3].command).toBe(
         `'git' 'worktree' 'prune' '--expire=now'`,
       );
       expect(runAsUserMock.calls[3].cwd).toBe('/repo');
-      // DB record removed on success.
       expect(mockRepo.records.length).toBe(0);
     });
 
-    // CodeRabbit on PR #897: the worktreePath stat pre-check was too strict
-    // in multi-user mode. When the server process lacks stat access on a
-    // user-owned worktree path (parent dir mode 0700), it sees EACCES even
-    // though the elevated `git worktree remove` running as the owner can
-    // still resolve and remove the worktree. The carve-out skips the throw
-    // for EACCES/EPERM when elevation will engage; `effectiveForce` stays at
-    // the caller's value (no upgrade) so the elevated branch handles its own
-    // existence check (#895).
+    // EACCES/EPERM carve-out: only multi-user mode skips the throw and
+    // defers the existence check to the elevated remove. `effectiveForce`
+    // stays at the caller's value (no upgrade) — see worktree-service.ts.
     it('proceeds to elevated remove path when stat(worktreePath) rejects with EACCES (#895)', async () => {
       fs.mkdirSync('/repo', { recursive: true });
       mockRepo.records.push({
@@ -1347,8 +1293,6 @@ detached
         createdAt: new Date().toISOString(),
       });
 
-      // Reject stat() only for the worktreePath probe; the repoPath probe
-      // (which runs first) keeps its normal memfs behaviour and succeeds.
       const realStat = fs.promises.stat;
       const statSpy = spyOn(fs.promises, 'stat').mockImplementation(((p: fs.PathLike) => {
         if (typeof p === 'string' && p === '/worktrees/feature') {
@@ -1375,16 +1319,11 @@ detached
 
         expect(result.success).toBe(true);
         expect(result.error).toBeUndefined();
-        // 2 calls: safe.directory bootstrap + elevated `git worktree
-        // remove`. `force` kept at the caller's value (false) because the
-        // EACCES carve-out does NOT upgrade effectiveForce — only
-        // ENOENT/ENOTDIR does.
         expect(runAsUserMock.calls.length).toBe(2);
         const removeCall = runAsUserMock.calls[1];
         expect(removeCall.command).toBe(
           `'git' 'worktree' 'remove' '/worktrees/feature'`,
         );
-        // DB row removed on success.
         expect(mockRepo.records.length).toBe(0);
       } finally {
         statSpy.mockRestore();

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -1188,7 +1188,14 @@ detached
       expect(runAsUserMock.calls.length).toBe(4);
       expect(runAsUserMock.calls[2].command).toBe(`rm -rf -- '/worktrees/feature'`);
       expect(runAsUserMock.calls[2].cwd).toBe('/');
-      expect(runAsUserMock.calls[3].command).toBe('git worktree prune --expire=now');
+      // Post-PR-#897 consolidation: the fallback prune is now constructed by
+      // the shared `removeWorktreeWithFallback` runner, which `shellEscape`s
+      // every argv element (matching the remove call's escape policy). The
+      // resulting command is `'git' 'worktree' 'prune' '--expire=now'`
+      // (each element single-quoted), not the previous unquoted form.
+      expect(runAsUserMock.calls[3].command).toBe(
+        `'git' 'worktree' 'prune' '--expire=now'`,
+      );
       expect(runAsUserMock.calls[3].cwd).toBe('/repo');
     });
 
@@ -1310,7 +1317,13 @@ detached
 
       expect(result.success).toBe(true);
       expect(runAsUserMock.calls.length).toBe(4);
-      expect(runAsUserMock.calls[3].command).toBe('git worktree prune --expire=now');
+      // Post-PR-#897 consolidation: the shared runner shellEscapes every
+      // argv element including the prune call (matches the remove call's
+      // escape policy). The unquoted shape from the previous in-service
+      // implementation is gone.
+      expect(runAsUserMock.calls[3].command).toBe(
+        `'git' 'worktree' 'prune' '--expire=now'`,
+      );
       expect(runAsUserMock.calls[3].cwd).toBe('/repo');
       // DB record removed on success.
       expect(mockRepo.records.length).toBe(0);

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -868,6 +868,36 @@ detached
       expect(mockGit.pruneWorktrees).toHaveBeenCalledWith('/repo');
       expect(mockGit.removeWorktree).not.toHaveBeenCalled();
     });
+
+    // ⑧ Non-directory at worktreePath (stale file/symlink) MUST NOT route
+    //    to destructive recovery — surface as { success: false } (#895).
+    it('should fail without recovery when worktreePath exists as a non-directory (#895)', async () => {
+      fs.mkdirSync('/repo', { recursive: true });
+      fs.mkdirSync('/worktrees', { recursive: true });
+      // Worktree path is a regular FILE, not a directory.
+      fs.writeFileSync('/worktrees/feature-file', 'stale leftover');
+      mockRepo.records.push({
+        id: 'wt-1',
+        repositoryId: 'repo-1',
+        path: '/worktrees/feature-file',
+        indexNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      const result = await service.removeWorktree('/repo', '/worktrees/feature-file');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      // Prune was NOT run.
+      expect(mockGit.pruneWorktrees).not.toHaveBeenCalled();
+      // git worktree remove was NOT attempted either (pre-check rejected before it).
+      expect(mockGit.removeWorktree).not.toHaveBeenCalled();
+      // DB row preserved.
+      expect(mockRepo.records.length).toBe(1);
+    });
   });
 
   describe('removeWorktree (multi-user, Issue #882)', () => {
@@ -1167,7 +1197,7 @@ detached
       const pruneCall = runAsUserMock.calls[1];
       expect(pruneCall.username).toBe('alice-multiuser-test');
       expect(pruneCall.cwd).toBe('/repo');
-      expect(pruneCall.command).toBe('git worktree prune');
+      expect(pruneCall.command).toBe('git worktree prune --expire=now');
       // lib/git pruneWorktrees NOT called (elevated branch bypasses it).
       expect(mockGit.pruneWorktrees).not.toHaveBeenCalled();
       // lib/git removeWorktree NOT called.

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -876,6 +876,59 @@ detached
       );
     });
 
+    // Single-user EACCES on the worktreePath stat is a genuine
+    // misconfiguration and must NOT be silently routed to recovery. This
+    // locks the narrow scope of the EACCES carve-out from PR #897 CodeRabbit
+    // — only multi-user mode skips the throw on EACCES/EPERM (#895).
+    it('still surfaces { success: false } on EACCES in single-user mode (no elevation) (#895)', async () => {
+      // Single-user: AUTH_MODE is unset (top-level beforeEach restores it),
+      // and requestUsername is null — so `shouldElevateForUser(null)` is
+      // false regardless of AUTH_MODE, and the EACCES carve-out does not
+      // engage.
+      fs.mkdirSync('/repo', { recursive: true });
+      mockRepo.records.push({
+        id: 'wt-1',
+        repositoryId: 'repo-1',
+        path: '/worktrees/feature',
+        indexNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
+
+      const realStat = fs.promises.stat;
+      const statSpy = spyOn(fs.promises, 'stat').mockImplementation(((p: fs.PathLike) => {
+        if (typeof p === 'string' && p === '/worktrees/feature') {
+          return Promise.reject(
+            Object.assign(new Error('EACCES: permission denied, stat'), { code: 'EACCES' }),
+          );
+        }
+        return realStat(p as fs.PathLike);
+      }) as typeof fs.promises.stat);
+
+      try {
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        const result = await service.removeWorktree(
+          '/repo',
+          '/worktrees/feature',
+          false,
+          null, // single-user (no elevation)
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(mockGit.removeWorktree).not.toHaveBeenCalled();
+        expect(runAsUserMock.calls.length).toBe(0);
+        // DB row preserved on failure.
+        expect(mockRepo.records.length).toBe(1);
+      } finally {
+        statSpy.mockRestore();
+      }
+    });
+
     // ⑧ Non-directory at worktreePath (stale file/symlink) MUST NOT route
     //    to destructive recovery — surface as { success: false } (#895).
     it('should fail without recovery when worktreePath exists as a non-directory (#895)', async () => {
@@ -1261,6 +1314,68 @@ detached
       expect(runAsUserMock.calls[3].cwd).toBe('/repo');
       // DB record removed on success.
       expect(mockRepo.records.length).toBe(0);
+    });
+
+    // CodeRabbit on PR #897: the worktreePath stat pre-check was too strict
+    // in multi-user mode. When the server process lacks stat access on a
+    // user-owned worktree path (parent dir mode 0700), it sees EACCES even
+    // though the elevated `git worktree remove` running as the owner can
+    // still resolve and remove the worktree. The carve-out skips the throw
+    // for EACCES/EPERM when elevation will engage; `effectiveForce` stays at
+    // the caller's value (no upgrade) so the elevated branch handles its own
+    // existence check (#895).
+    it('proceeds to elevated remove path when stat(worktreePath) rejects with EACCES (#895)', async () => {
+      fs.mkdirSync('/repo', { recursive: true });
+      mockRepo.records.push({
+        id: 'wt-1',
+        repositoryId: 'repo-1',
+        path: '/worktrees/feature',
+        indexNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
+
+      // Reject stat() only for the worktreePath probe; the repoPath probe
+      // (which runs first) keeps its normal memfs behaviour and succeeds.
+      const realStat = fs.promises.stat;
+      const statSpy = spyOn(fs.promises, 'stat').mockImplementation(((p: fs.PathLike) => {
+        if (typeof p === 'string' && p === '/worktrees/feature') {
+          return Promise.reject(
+            Object.assign(new Error('EACCES: permission denied, stat'), { code: 'EACCES' }),
+          );
+        }
+        return realStat(p as fs.PathLike);
+      }) as typeof fs.promises.stat);
+
+      try {
+        const WorktreeService = await getWorktreeService();
+        const service = new WorktreeService({
+          worktreeRepository: mockRepo,
+          runAsUserImpl: runAsUserMock.runAsUserImpl,
+        });
+
+        const result = await service.removeWorktree(
+          '/repo',
+          '/worktrees/feature',
+          false,
+          'alice-multiuser-test',
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.error).toBeUndefined();
+        // 2 calls: safe.directory bootstrap + elevated `git worktree
+        // remove`. `force` kept at the caller's value (false) because the
+        // EACCES carve-out does NOT upgrade effectiveForce — only
+        // ENOENT/ENOTDIR does.
+        expect(runAsUserMock.calls.length).toBe(2);
+        const removeCall = runAsUserMock.calls[1];
+        expect(removeCall.command).toBe(
+          `'git' 'worktree' 'remove' '/worktrees/feature'`,
+        );
+        // DB row removed on success.
+        expect(mockRepo.records.length).toBe(0);
+      } finally {
+        statSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -115,6 +115,7 @@ describe('WorktreeService', () => {
     mockGit.parseOrgRepo.mockReset();
     mockGit.listWorktrees.mockReset();
     mockGit.removeWorktree.mockReset();
+    mockGit.pruneWorktrees.mockReset();
     mockGit.listLocalBranches.mockReset();
     mockGit.listRemoteBranches.mockReset();
     mockGit.getDefaultBranch.mockReset();
@@ -131,6 +132,7 @@ HEAD def456
 branch refs/heads/feature-1
 `));
     mockGit.removeWorktree.mockImplementation(() => Promise.resolve());
+    mockGit.pruneWorktrees.mockImplementation(() => Promise.resolve());
     mockGit.listLocalBranches.mockImplementation(() => Promise.resolve(['main', 'feature-1', 'feature-2']));
     mockGit.listRemoteBranches.mockImplementation(() => Promise.resolve(['origin/main', 'origin/develop']));
     mockGit.getDefaultBranch.mockImplementation(() => Promise.resolve('main'));
@@ -639,11 +641,13 @@ detached
 
   describe('removeWorktree', () => {
     // ① Primary repo dir exists + clean: behavior unchanged (normal git path).
-    //   The pre-check stats repoPath against memfs, so the primary must exist in
-    //   the in-memory volume for the normal git path to run.
+    //   Both the primary and the worktree dir must exist in memfs so the
+    //   pre-checks (repoExists + worktreeExists, the latter added for #895)
+    //   pass and the normal git path runs.
     it('should remove worktree successfully', async () => {
-      // Primary repo dir must exist for the normal git path (pre-check passes)
+      // Primary repo dir and worktree dir must exist for the normal git path.
       fs.mkdirSync('/repo', { recursive: true });
+      fs.mkdirSync('/worktrees/feature', { recursive: true });
       // Pre-populate DB record for the worktree being removed
       mockRepo.records.push({
         id: 'wt-1',
@@ -672,6 +676,7 @@ detached
 
     it('should use force flag when specified', async () => {
       fs.mkdirSync('/repo', { recursive: true });
+      fs.mkdirSync('/worktrees/feature', { recursive: true });
       // Pre-populate DB record
       mockRepo.records.push({
         id: 'wt-1',
@@ -695,6 +700,7 @@ detached
 
     it('should return error on failure', async () => {
       fs.mkdirSync('/repo', { recursive: true });
+      fs.mkdirSync('/worktrees/feature', { recursive: true });
       mockGit.removeWorktree.mockImplementation(() =>
         Promise.reject(new GitError('worktree has changes', 128, 'fatal: worktree has uncommitted changes'))
       );
@@ -813,6 +819,55 @@ detached
         statSpy.mockRestore();
       }
     });
+
+    // ⑥ Primary repo dir present + worktree dir MISSING: orphan
+    //    worktree-dir recovery via `git worktree prune` + DB-row delete
+    //    (Issue #895).
+    it('should recover orphan worktree-dir via prune+delete when worktree path is missing (#895)', async () => {
+      fs.mkdirSync('/repo', { recursive: true });
+      // /worktrees/feature does NOT exist on disk — externally removed.
+      mockRepo.records.push({
+        id: 'wt-1',
+        repositoryId: 'repo-1',
+        path: '/worktrees/feature',
+        indexNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      const result = await service.removeWorktree('/repo', '/worktrees/feature');
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+      // Prune ran in repoPath (single-user lib/git path).
+      expect(mockGit.pruneWorktrees).toHaveBeenCalledWith('/repo');
+      // `git worktree remove` was NOT attempted (would have failed with
+      // `is not a working tree`).
+      expect(mockGit.removeWorktree).not.toHaveBeenCalled();
+      // DB record removed.
+      expect(mockRepo.records.length).toBe(0);
+    });
+
+    // ⑦ Idempotent: a second call after the DB row + worktree dir are
+    //    both already gone still returns success. The prune is a cheap
+    //    no-op on a clean registry.
+    it('should be idempotent on the second orphan worktree-dir recovery call (#895)', async () => {
+      fs.mkdirSync('/repo', { recursive: true });
+      // No DB record (already cleaned up by a prior call) and no on-disk worktree.
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({ worktreeRepository: mockRepo });
+
+      const result = await service.removeWorktree('/repo', '/worktrees/already-pruned');
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+      // Prune still runs (cheap no-op on a clean registry).
+      expect(mockGit.pruneWorktrees).toHaveBeenCalledWith('/repo');
+      expect(mockGit.removeWorktree).not.toHaveBeenCalled();
+    });
   });
 
   describe('removeWorktree (multi-user, Issue #882)', () => {
@@ -833,6 +888,7 @@ detached
 
     it('routes git worktree remove through runAsUser when requestUsername is provided', async () => {
       fs.mkdirSync('/repo', { recursive: true });
+      fs.mkdirSync('/worktrees/feature', { recursive: true });
       mockRepo.records.push({
         id: 'wt-1',
         repositoryId: 'repo-1',
@@ -877,6 +933,7 @@ detached
 
     it('emits --force --force in the elevated command when force=true', async () => {
       fs.mkdirSync('/repo', { recursive: true });
+      fs.mkdirSync('/worktrees/feature', { recursive: true });
       mockRepo.records.push({
         id: 'wt-1',
         repositoryId: 'repo-1',
@@ -902,6 +959,7 @@ detached
 
     it('returns { success: false } with actionable error when elevated git remove fails', async () => {
       fs.mkdirSync('/repo', { recursive: true });
+      fs.mkdirSync('/worktrees/feature', { recursive: true });
       mockRepo.records.push({
         id: 'wt-1',
         repositoryId: 'repo-1',
@@ -950,6 +1008,7 @@ detached
       // even though the error is not a stale-worktree case. Narrowed matcher
       // must NOT match `fatal: not a git repository ... .git`.
       fs.mkdirSync('/repo', { recursive: true });
+      fs.mkdirSync('/worktrees/feature', { recursive: true });
       mockRepo.records.push({
         id: 'wt-1',
         repositoryId: 'repo-1',
@@ -996,6 +1055,7 @@ detached
 
     it('falls back to elevated rm + prune when force=true and stderr matches a stale-worktree pattern', async () => {
       fs.mkdirSync('/repo', { recursive: true });
+      fs.mkdirSync('/worktrees/feature', { recursive: true });
       mockRepo.records.push({
         id: 'wt-1',
         repositoryId: 'repo-1',
@@ -1046,6 +1106,7 @@ detached
 
     it('skips runAsUser when requestUsername is null (single-user path preserved)', async () => {
       fs.mkdirSync('/repo', { recursive: true });
+      fs.mkdirSync('/worktrees/feature', { recursive: true });
       mockRepo.records.push({
         id: 'wt-1',
         repositoryId: 'repo-1',
@@ -1070,6 +1131,94 @@ detached
         '/repo',
         { force: false },
       );
+    });
+
+    it('routes prune through runAsUser when worktree-dir is missing and requestUsername is provided (#895)', async () => {
+      fs.mkdirSync('/repo', { recursive: true });
+      // worktree dir absent
+      mockRepo.records.push({
+        id: 'wt-1',
+        repositoryId: 'repo-1',
+        path: '/worktrees/feature',
+        indexNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      const result = await service.removeWorktree(
+        '/repo',
+        '/worktrees/feature',
+        false,
+        'alice-multiuser-test',
+      );
+
+      expect(result.success).toBe(true);
+      // Two runAsUser calls: safe.directory bootstrap, then prune.
+      expect(runAsUserMock.calls.length).toBe(2);
+      const bootstrap = runAsUserMock.calls[0];
+      expect(bootstrap.username).toBe('alice-multiuser-test');
+      expect(bootstrap.command).toContain('safe.directory');
+      expect(bootstrap.command).toContain("'/repo'");
+      const pruneCall = runAsUserMock.calls[1];
+      expect(pruneCall.username).toBe('alice-multiuser-test');
+      expect(pruneCall.cwd).toBe('/repo');
+      expect(pruneCall.command).toBe('git worktree prune');
+      // lib/git pruneWorktrees NOT called (elevated branch bypasses it).
+      expect(mockGit.pruneWorktrees).not.toHaveBeenCalled();
+      // lib/git removeWorktree NOT called.
+      expect(mockGit.removeWorktree).not.toHaveBeenCalled();
+      // DB row removed.
+      expect(mockRepo.records.length).toBe(0);
+    });
+
+    it('surfaces { success: false } when elevated prune fails (orphan worktree-dir, #895)', async () => {
+      fs.mkdirSync('/repo', { recursive: true });
+      // worktree dir absent
+      mockRepo.records.push({
+        id: 'wt-1',
+        repositoryId: 'repo-1',
+        path: '/worktrees/feature',
+        indexNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
+
+      // Bootstrap [0] succeeds; prune [1] fails.
+      let callIdx = 0;
+      runAsUserMock.responder.fn = async () => {
+        callIdx += 1;
+        if (callIdx === 1) {
+          return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+        }
+        return {
+          stdout: '',
+          stderr: 'fatal: bad bare repository',
+          exitCode: 128,
+          timedOut: false,
+        };
+      };
+
+      const WorktreeService = await getWorktreeService();
+      const service = new WorktreeService({
+        worktreeRepository: mockRepo,
+        runAsUserImpl: runAsUserMock.runAsUserImpl,
+      });
+
+      const result = await service.removeWorktree(
+        '/repo',
+        '/worktrees/feature',
+        false,
+        'alice-multiuser-test',
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('bad bare repository');
+      // DB record preserved on prune failure.
+      expect(mockRepo.records.length).toBe(1);
     });
   });
 

--- a/packages/server/src/services/__tests__/worktree-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-service.test.ts
@@ -115,7 +115,6 @@ describe('WorktreeService', () => {
     mockGit.parseOrgRepo.mockReset();
     mockGit.listWorktrees.mockReset();
     mockGit.removeWorktree.mockReset();
-    mockGit.pruneWorktrees.mockReset();
     mockGit.listLocalBranches.mockReset();
     mockGit.listRemoteBranches.mockReset();
     mockGit.getDefaultBranch.mockReset();
@@ -132,7 +131,6 @@ HEAD def456
 branch refs/heads/feature-1
 `));
     mockGit.removeWorktree.mockImplementation(() => Promise.resolve());
-    mockGit.pruneWorktrees.mockImplementation(() => Promise.resolve());
     mockGit.listLocalBranches.mockImplementation(() => Promise.resolve(['main', 'feature-1', 'feature-2']));
     mockGit.listRemoteBranches.mockImplementation(() => Promise.resolve(['origin/main', 'origin/develop']));
     mockGit.getDefaultBranch.mockImplementation(() => Promise.resolve('main'));
@@ -820,10 +818,11 @@ detached
       }
     });
 
-    // ⑥ Primary repo dir present + worktree dir MISSING: orphan
-    //    worktree-dir recovery via `git worktree prune` + DB-row delete
-    //    (Issue #895).
-    it('should recover orphan worktree-dir via prune+delete when worktree path is missing (#895)', async () => {
+    // ⑥ Primary repo dir present + worktree dir MISSING: upgrade `force=true`
+    //    internally and route through the existing fallback in
+    //    `lib/git.ts:removeWorktree` (which already catches `is not a working
+    //    tree` and runs fs.rm + `git worktree prune --expire=now`). Issue #895.
+    it('should upgrade force=true internally when worktree path is missing (#895)', async () => {
       fs.mkdirSync('/repo', { recursive: true });
       // /worktrees/feature does NOT exist on disk — externally removed.
       mockRepo.records.push({
@@ -837,22 +836,27 @@ detached
       const WorktreeService = await getWorktreeService();
       const service = new WorktreeService({ worktreeRepository: mockRepo });
 
+      // Caller did NOT pass force=true; the pre-check upgrades it internally.
       const result = await service.removeWorktree('/repo', '/worktrees/feature');
 
       expect(result.success).toBe(true);
       expect(result.error).toBeUndefined();
-      // Prune ran in repoPath (single-user lib/git path).
-      expect(mockGit.pruneWorktrees).toHaveBeenCalledWith('/repo');
-      // `git worktree remove` was NOT attempted (would have failed with
-      // `is not a working tree`).
-      expect(mockGit.removeWorktree).not.toHaveBeenCalled();
+      // lib/git.ts removeWorktree called with force=true (upgraded internally).
+      // The recovery itself (fs.rm + prune) is the responsibility of
+      // lib/git.ts:removeWorktree's force-fallback catch block, which is
+      // covered by that module's own tests.
+      expect(mockGit.removeWorktree).toHaveBeenCalledWith(
+        '/worktrees/feature',
+        '/repo',
+        { force: true },
+      );
       // DB record removed.
       expect(mockRepo.records.length).toBe(0);
     });
 
     // ⑦ Idempotent: a second call after the DB row + worktree dir are
-    //    both already gone still returns success. The prune is a cheap
-    //    no-op on a clean registry.
+    //    both already gone still returns success. The upgraded force=true
+    //    routes through lib/git.ts's idempotent fallback.
     it('should be idempotent on the second orphan worktree-dir recovery call (#895)', async () => {
       fs.mkdirSync('/repo', { recursive: true });
       // No DB record (already cleaned up by a prior call) and no on-disk worktree.
@@ -864,9 +868,12 @@ detached
 
       expect(result.success).toBe(true);
       expect(result.error).toBeUndefined();
-      // Prune still runs (cheap no-op on a clean registry).
-      expect(mockGit.pruneWorktrees).toHaveBeenCalledWith('/repo');
-      expect(mockGit.removeWorktree).not.toHaveBeenCalled();
+      // Same upgrade contract: force=true routed to lib/git.ts.
+      expect(mockGit.removeWorktree).toHaveBeenCalledWith(
+        '/worktrees/already-pruned',
+        '/repo',
+        { force: true },
+      );
     });
 
     // ⑧ Non-directory at worktreePath (stale file/symlink) MUST NOT route
@@ -891,9 +898,7 @@ detached
 
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
-      // Prune was NOT run.
-      expect(mockGit.pruneWorktrees).not.toHaveBeenCalled();
-      // git worktree remove was NOT attempted either (pre-check rejected before it).
+      // git worktree remove was NOT attempted (pre-check rejected before it).
       expect(mockGit.removeWorktree).not.toHaveBeenCalled();
       // DB row preserved.
       expect(mockRepo.records.length).toBe(1);
@@ -1130,7 +1135,7 @@ detached
       expect(runAsUserMock.calls.length).toBe(4);
       expect(runAsUserMock.calls[2].command).toBe(`rm -rf -- '/worktrees/feature'`);
       expect(runAsUserMock.calls[2].cwd).toBe('/');
-      expect(runAsUserMock.calls[3].command).toBe('git worktree prune');
+      expect(runAsUserMock.calls[3].command).toBe('git worktree prune --expire=now');
       expect(runAsUserMock.calls[3].cwd).toBe('/repo');
     });
 
@@ -1163,7 +1168,7 @@ detached
       );
     });
 
-    it('routes prune through runAsUser when worktree-dir is missing and requestUsername is provided (#895)', async () => {
+    it('routes force=true through runAsUser when worktree-dir is missing (#895)', async () => {
       fs.mkdirSync('/repo', { recursive: true });
       // worktree dir absent
       mockRepo.records.push({
@@ -1180,6 +1185,9 @@ detached
         runAsUserImpl: runAsUserMock.runAsUserImpl,
       });
 
+      // Caller passes force=false; pre-check upgrades force=true internally.
+      // The `git worktree remove` succeeds (default responder), so the
+      // fallback chain (rm + prune) does NOT engage in this happy path.
       const result = await service.removeWorktree(
         '/repo',
         '/worktrees/feature',
@@ -1188,27 +1196,25 @@ detached
       );
 
       expect(result.success).toBe(true);
-      // Two runAsUser calls: safe.directory bootstrap, then prune.
+      // Two runAsUser calls: safe.directory bootstrap, then
+      // `git worktree remove --force --force` (force upgraded internally).
       expect(runAsUserMock.calls.length).toBe(2);
       const bootstrap = runAsUserMock.calls[0];
       expect(bootstrap.username).toBe('alice-multiuser-test');
       expect(bootstrap.command).toContain('safe.directory');
       expect(bootstrap.command).toContain("'/repo'");
-      const pruneCall = runAsUserMock.calls[1];
-      expect(pruneCall.username).toBe('alice-multiuser-test');
-      expect(pruneCall.cwd).toBe('/repo');
-      expect(pruneCall.command).toBe('git worktree prune --expire=now');
-      // lib/git pruneWorktrees NOT called (elevated branch bypasses it).
-      expect(mockGit.pruneWorktrees).not.toHaveBeenCalled();
-      // lib/git removeWorktree NOT called.
+      expect(runAsUserMock.calls[1].command).toBe(
+        `'git' 'worktree' 'remove' '/worktrees/feature' '--force' '--force'`,
+      );
+      // lib/git removeWorktree NOT called (elevated branch bypasses it).
       expect(mockGit.removeWorktree).not.toHaveBeenCalled();
       // DB row removed.
       expect(mockRepo.records.length).toBe(0);
     });
 
-    it('surfaces { success: false } when elevated prune fails (orphan worktree-dir, #895)', async () => {
+    it('uses --expire=now in fallback prune when worktree-dir is missing and force=true triggers fallback (#895)', async () => {
       fs.mkdirSync('/repo', { recursive: true });
-      // worktree dir absent
+      // worktree dir absent — pre-check upgrades to force=true.
       mockRepo.records.push({
         id: 'wt-1',
         repositoryId: 'repo-1',
@@ -1217,19 +1223,23 @@ detached
         createdAt: new Date().toISOString(),
       });
 
-      // Bootstrap [0] succeeds; prune [1] fails.
+      // Call 1 (bootstrap): success
+      // Call 2 (`git worktree remove --force --force`): is-not-a-working-tree
+      //   error (triggers the fallback chain in `invokeGitWorktreeRemove`)
+      // Call 3 (`rm -rf -- '/worktrees/feature'`): success
+      // Call 4 (`git worktree prune --expire=now`): success
       let callIdx = 0;
       runAsUserMock.responder.fn = async () => {
         callIdx += 1;
-        if (callIdx === 1) {
-          return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+        if (callIdx === 2) {
+          return {
+            stdout: '',
+            stderr: "fatal: '/worktrees/feature' is not a working tree",
+            exitCode: 128,
+            timedOut: false,
+          };
         }
-        return {
-          stdout: '',
-          stderr: 'fatal: bad bare repository',
-          exitCode: 128,
-          timedOut: false,
-        };
+        return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
       };
 
       const WorktreeService = await getWorktreeService();
@@ -1245,10 +1255,12 @@ detached
         'alice-multiuser-test',
       );
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('bad bare repository');
-      // DB record preserved on prune failure.
-      expect(mockRepo.records.length).toBe(1);
+      expect(result.success).toBe(true);
+      expect(runAsUserMock.calls.length).toBe(4);
+      expect(runAsUserMock.calls[3].command).toBe('git worktree prune --expire=now');
+      expect(runAsUserMock.calls[3].cwd).toBe('/repo');
+      // DB record removed on success.
+      expect(mockRepo.records.length).toBe(0);
     });
   });
 

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -7,6 +7,7 @@ import {
   parseOrgRepo,
   listWorktrees as gitListWorktrees,
   removeWorktree as gitRemoveWorktree,
+  pruneWorktrees as gitPruneWorktrees,
   listLocalBranches,
   listRemoteBranches,
   getDefaultBranch as gitGetDefaultBranch,
@@ -676,6 +677,63 @@ export class WorktreeService {
         logger.warn(
           { worktreePath, repoPath },
           'Primary repo dir missing; removed orphaned worktree without git'
+        );
+        return { success: true };
+      }
+
+      // Detect the orphan-worktree-dir case (#895): primary repo OK, but
+      // `worktreePath` itself was externally removed. `git worktree remove`
+      // would fail with `fatal: '<path>' is not a working tree`. Skip the
+      // remove and run `git worktree prune` + DB-row delete in repoPath
+      // instead. `removeOrphanedWorktree` is not reusable here because prune
+      // still needs the primary repo for context.
+      //
+      // ENOENT/ENOTDIR-only narrowing mirrors the repoExists block above:
+      // other stat errors (EACCES/EPERM/IO) MUST surface as failure, not
+      // route to destructive recovery.
+      let worktreeExists = false;
+      try {
+        const stat = await fsPromises.stat(worktreePath);
+        worktreeExists = stat.isDirectory();
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException | undefined)?.code;
+        if (code === 'ENOENT' || code === 'ENOTDIR') {
+          worktreeExists = false;
+        } else {
+          throw error; // caught by the outer catch → { success: false, error }
+        }
+      }
+
+      if (!worktreeExists) {
+        if (shouldElevateForUser(requestUsername)) {
+          const elevatedUsername = requestUsername!;
+          // Bootstrap safe.directory so the elevated `git worktree prune`
+          // does not hit `fatal: detected dubious ownership` on the
+          // server-owned source repo. Mirrors the normal elevated remove
+          // path below.
+          await this.bootstrapSafeDirectoryForUser(elevatedUsername, repoPath);
+          const pruneResult = await this._runAsUser({
+            username: elevatedUsername,
+            command: 'git worktree prune',
+            cwd: repoPath,
+            timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS,
+          });
+          if (pruneResult.timedOut || pruneResult.exitCode !== 0) {
+            const detail =
+              pruneResult.stderr.trim() || `exit code ${pruneResult.exitCode}`;
+            throw new GitError(
+              `git worktree prune (orphan worktree-dir recovery, #895) failed: ${detail}`,
+              pruneResult.exitCode,
+              pruneResult.stderr,
+            );
+          }
+        } else {
+          await gitPruneWorktrees(repoPath);
+        }
+        await this.worktreeRepository.deleteByPath(worktreePath);
+        logger.warn(
+          { worktreePath, repoPath },
+          'Worktree dir missing; pruned registry and removed DB row (#895)',
         );
         return { success: true };
       }

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -7,11 +7,13 @@ import {
   parseOrgRepo,
   listWorktrees as gitListWorktrees,
   removeWorktree as gitRemoveWorktree,
+  removeWorktreeWithFallback,
   listLocalBranches,
   listRemoteBranches,
   getDefaultBranch as gitGetDefaultBranch,
   refreshDefaultBranch as gitRefreshDefaultBranch,
   GitError,
+  type WorktreeRemovalRunner,
 } from '../lib/git.js';
 // listLocalBranches, listRemoteBranches, getDefaultBranch, refreshDefaultBranch
 // are thin pass-throughs after Issue #870: lib/git.ts now accepts requestUser
@@ -765,12 +767,12 @@ export class WorktreeService {
 
   /**
    * Invoke `git worktree remove` via `runAsUser` (multi-user elevated path
-   * for Issue #882). Mirrors the fallback semantics of `lib/git.ts`'s
-   * `removeWorktree`: when `force` is true and the failure stderr indicates
-   * a stale `.git` file or unrecognized worktree, fall back to a manual
-   * `rm -rf` plus a best-effort `git worktree prune` — both routed through
-   * `runAsUser` so they execute as the worktree-owning user. Prune failure
-   * is logged but does not propagate (the rm already succeeded).
+   * for Issue #882). Constructs a {@link WorktreeRemovalRunner} that binds
+   * the elevated `runAsUser` and `rmRecursiveAsUser` to the requesting user,
+   * then delegates the orchestration (force-fallback recovery, narrow
+   * stale-worktree matcher, best-effort prune) to the shared
+   * {@link removeWorktreeWithFallback} helper in `lib/git.ts`. The
+   * single-user sibling is `lib/git.ts:removeWorktree`.
    *
    * Throws `GitError` on non-recoverable failure so the outer `removeWorktree`
    * catch keeps its existing `extractErrorMessage` / `instanceof GitError`
@@ -782,94 +784,40 @@ export class WorktreeService {
     force: boolean;
     requestUsername: string;
   }): Promise<void> {
-    const args = ['git', 'worktree', 'remove', opts.worktreePath];
-    if (opts.force) {
-      // `--force` twice mirrors `lib/git.ts removeWorktree`: removes unclean
-      // worktrees AND locked worktrees.
-      args.push('--force', '--force');
-    }
-    const command = args.map(shellEscape).join(' ');
-
-    const result = await this._runAsUser({
-      username: opts.requestUsername,
-      command,
-      cwd: opts.repoPath,
-      timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS,
-    });
-
-    if (!result.timedOut && result.exitCode === 0) {
-      return;
-    }
-
-    const stderr = result.stderr;
-
-    // Narrow stale-worktree matcher: only patterns that genuinely indicate
-    // git can no longer manage the worktree (so a manual removal is the
-    // correct recovery). Avoids over-broad matches like `fatal: not a git
-    // repository ... .git` that would trigger destructive cleanup against
-    // a healthy repo (CodeRabbit, 2026-06-25).
-    const isStaleWorktreeError =
-      stderr.includes('is not a working tree') ||
-      stderr.includes('cannot read .git file') ||
-      stderr.includes('invalid gitfile format') ||
-      stderr.includes("'.git' file");
-
-    if (opts.force && !result.timedOut && isStaleWorktreeError) {
-      const rmResult = await rmRecursiveAsUser(
-        opts.worktreePath,
-        opts.requestUsername,
-        {
+    const runner: WorktreeRemovalRunner = {
+      runGit: async (args) => {
+        const command = ['git', ...args].map(shellEscape).join(' ');
+        const result = await this._runAsUser({
+          username: opts.requestUsername,
+          command,
+          cwd: opts.repoPath,
+          timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS,
+        });
+        return {
+          exitCode: result.exitCode,
+          stderr: result.stderr,
+          timedOut: result.timedOut,
+        };
+      },
+      rmRecursive: async (target) => {
+        const rm = await rmRecursiveAsUser(target, opts.requestUsername, {
           timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS,
           runAsUserImpl: this._runAsUser,
-        },
-      );
-      if (rmResult.timedOut || rmResult.exitCode !== 0) {
-        const detail =
-          rmResult.stderr.trim() || `exit code ${rmResult.exitCode}`;
-        throw new GitError(
-          `git worktree remove (elevated rm fallback) failed: ${detail}`,
-          rmResult.exitCode,
-          rmResult.stderr,
-        );
-      }
+        });
+        if (rm.timedOut || rm.exitCode !== 0) {
+          const detail = rm.stderr.trim() || `exit code ${rm.exitCode}`;
+          throw new GitError(
+            `git worktree remove (elevated rm fallback) failed: ${detail}`,
+            rm.exitCode,
+            rm.stderr,
+          );
+        }
+      },
+    };
 
-      // Best-effort prune as the user; failure is logged but not propagated
-      // (the rm already succeeded, so git's stale registry is the only cost).
-      //
-      // `--expire=now` is required here because we just deleted the worktree
-      // directory ourselves: git's default `gc.worktreePruneExpire` is 3
-      // months, so a plain `git worktree prune` would NOT shed the freshly
-      // stale entry we just created, and a subsequent `worktree add` at the
-      // same path could collide. Forcing immediate expiration is correct
-      // because this prune is gated inside the stale-`.git` / `is not a
-      // working tree` recovery branch — by the time we get here the rm has
-      // already succeeded.
-      const pruneResult = await this._runAsUser({
-        username: opts.requestUsername,
-        command: 'git worktree prune --expire=now',
-        cwd: opts.repoPath,
-        timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS,
-      });
-      if (pruneResult.timedOut || pruneResult.exitCode !== 0) {
-        logger.warn(
-          {
-            username: opts.requestUsername,
-            repoPath: opts.repoPath,
-            stderr: pruneResult.stderr.trim(),
-            timedOut: pruneResult.timedOut,
-          },
-          'git worktree prune failed after elevated rm fallback; rm already succeeded so continuing',
-        );
-      }
-      return;
-    }
-
-    const detail = stderr.trim() || `exit code ${result.exitCode}`;
-    throw new GitError(
-      `git worktree remove failed: ${detail}`,
-      result.exitCode,
-      stderr,
-    );
+    await removeWorktreeWithFallback(opts.worktreePath, runner, {
+      force: opts.force,
+    });
   }
 
   /**

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -682,32 +682,20 @@ export class WorktreeService {
         return { success: true };
       }
 
-      // Detect the orphan-worktree-dir case (#895): primary repo OK, but
-      // `worktreePath` itself was externally removed. `git worktree remove`
-      // would fail with `fatal: '<path>' is not a working tree`. Rather than
-      // duplicate recovery here, upgrade `force` to true so the call routes
-      // through the existing fallback path in `lib/git.ts:removeWorktree`
-      // (line 479-510) or `invokeGitWorktreeRemove` (line 764-803), both of
-      // which already catch `is not a working tree` and run fs.rm /
-      // rmRecursiveAsUser + `git worktree prune --expire=now`. The external
-      // `force` contract is unchanged — caller-visible meaning stays
-      // "unclean/locked override"; this is an internal correctness lift only.
+      // Orphan-worktree-dir case: worktreePath is gone but the primary
+      // repo is OK. Upgrade `force` so the call routes through the existing
+      // fallback in `removeWorktreeWithFallback` (rm + prune --expire=now)
+      // rather than duplicating recovery here.
       //
-      // ENOENT/ENOTDIR-only narrowing mirrors the repoExists block above:
-      // other stat errors (EACCES/EPERM/IO) MUST surface as failure, not
-      // route to destructive recovery. A stat success on a non-directory
-      // (file, symlink, socket) is also a surfaced error — the path exists
-      // in some form, so the orphan-recovery upgrade is not justified.
+      // ENOENT/ENOTDIR-only: other stat errors (EACCES/EPERM/IO) and
+      // non-directory hits MUST surface as failure rather than route to
+      // destructive recovery.
       //
-      // Multi-user carve-out (CodeRabbit on PR #897): when elevation will
-      // engage, the server process may lack stat access on a user-owned
-      // worktree path (parent dir mode 0700). The elevated `git worktree
-      // remove` running as the owner handles its own existence check, so
-      // EACCES/EPERM on the probe should fall through to the elevated path
-      // with `effectiveForce` at the caller's value rather than surfacing
-      // as a failure. In single-user mode, EACCES is a genuine
-      // misconfiguration (the server user lacks stat on its own data root)
-      // that must surface as failure — the elevated branch cannot help.
+      // Multi-user carve-out: when elevation engages, the server process
+      // may lack stat on a user-owned worktree (parent dir mode 0700). The
+      // elevated `git worktree remove` handles its own existence check, so
+      // EACCES/EPERM fall through to the elevated path with the caller's
+      // `force` unchanged.
       const willElevateRemoval = shouldElevateForUser(requestUsername);
       let effectiveForce = force;
       try {
@@ -725,13 +713,10 @@ export class WorktreeService {
           willElevateRemoval &&
           (code === 'EACCES' || code === 'EPERM')
         ) {
-          // Multi-user carve-out: skip the throw and proceed to the
-          // elevated path. `effectiveForce` stays at the caller's value
-          // (no upgrade) — we cannot tell whether the dir is missing or
-          // present-but-unreadable, and the elevated `git worktree
-          // remove` will resolve that ambiguity itself.
+          // Multi-user carve-out: defer the existence check to the elevated
+          // remove. `effectiveForce` stays at the caller's value.
         } else {
-          throw error; // caught by the outer catch → { success: false, error }
+          throw error;
         }
       }
 
@@ -766,17 +751,10 @@ export class WorktreeService {
   }
 
   /**
-   * Invoke `git worktree remove` via `runAsUser` (multi-user elevated path
-   * for Issue #882). Constructs a {@link WorktreeRemovalRunner} that binds
-   * the elevated `runAsUser` and `rmRecursiveAsUser` to the requesting user,
-   * then delegates the orchestration (force-fallback recovery, narrow
-   * stale-worktree matcher, best-effort prune) to the shared
-   * {@link removeWorktreeWithFallback} helper in `lib/git.ts`. The
-   * single-user sibling is `lib/git.ts:removeWorktree`.
-   *
-   * Throws `GitError` on non-recoverable failure so the outer `removeWorktree`
-   * catch keeps its existing `extractErrorMessage` / `instanceof GitError`
-   * branching contract.
+   * Elevated runner over {@link removeWorktreeWithFallback}: binds
+   * `runAsUser` / `rmRecursiveAsUser` to the requesting user. Throws
+   * `GitError` on non-recoverable failure so the outer `removeWorktree`
+   * catch keeps its existing branching contract.
    */
   private async invokeGitWorktreeRemove(opts: {
     worktreePath: string;

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -690,21 +690,26 @@ export class WorktreeService {
       //
       // ENOENT/ENOTDIR-only narrowing mirrors the repoExists block above:
       // other stat errors (EACCES/EPERM/IO) MUST surface as failure, not
-      // route to destructive recovery.
-      let worktreeExists = false;
+      // route to destructive recovery. A stat success on a non-directory
+      // (file, symlink, socket) is also a surfaced error — the path exists
+      // in some form, so silently pruning + deleting the DB row would
+      // strand the on-disk artifact.
+      let worktreeMissing = false;
       try {
         const stat = await fsPromises.stat(worktreePath);
-        worktreeExists = stat.isDirectory();
+        if (!stat.isDirectory()) {
+          throw new Error(`Worktree path exists but is not a directory: ${worktreePath}`);
+        }
       } catch (error) {
         const code = (error as NodeJS.ErrnoException | undefined)?.code;
         if (code === 'ENOENT' || code === 'ENOTDIR') {
-          worktreeExists = false;
+          worktreeMissing = true;
         } else {
           throw error; // caught by the outer catch → { success: false, error }
         }
       }
 
-      if (!worktreeExists) {
+      if (worktreeMissing) {
         if (shouldElevateForUser(requestUsername)) {
           const elevatedUsername = requestUsername!;
           // Bootstrap safe.directory so the elevated `git worktree prune`
@@ -714,7 +719,7 @@ export class WorktreeService {
           await this.bootstrapSafeDirectoryForUser(elevatedUsername, repoPath);
           const pruneResult = await this._runAsUser({
             username: elevatedUsername,
-            command: 'git worktree prune',
+            command: 'git worktree prune --expire=now',
             cwd: repoPath,
             timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS,
           });

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -7,7 +7,6 @@ import {
   parseOrgRepo,
   listWorktrees as gitListWorktrees,
   removeWorktree as gitRemoveWorktree,
-  pruneWorktrees as gitPruneWorktrees,
   listLocalBranches,
   listRemoteBranches,
   getDefaultBranch as gitGetDefaultBranch,
@@ -683,64 +682,35 @@ export class WorktreeService {
 
       // Detect the orphan-worktree-dir case (#895): primary repo OK, but
       // `worktreePath` itself was externally removed. `git worktree remove`
-      // would fail with `fatal: '<path>' is not a working tree`. Skip the
-      // remove and run `git worktree prune` + DB-row delete in repoPath
-      // instead. `removeOrphanedWorktree` is not reusable here because prune
-      // still needs the primary repo for context.
+      // would fail with `fatal: '<path>' is not a working tree`. Rather than
+      // duplicate recovery here, upgrade `force` to true so the call routes
+      // through the existing fallback path in `lib/git.ts:removeWorktree`
+      // (line 479-510) or `invokeGitWorktreeRemove` (line 764-803), both of
+      // which already catch `is not a working tree` and run fs.rm /
+      // rmRecursiveAsUser + `git worktree prune --expire=now`. The external
+      // `force` contract is unchanged — caller-visible meaning stays
+      // "unclean/locked override"; this is an internal correctness lift only.
       //
       // ENOENT/ENOTDIR-only narrowing mirrors the repoExists block above:
       // other stat errors (EACCES/EPERM/IO) MUST surface as failure, not
       // route to destructive recovery. A stat success on a non-directory
       // (file, symlink, socket) is also a surfaced error — the path exists
-      // in some form, so silently pruning + deleting the DB row would
-      // strand the on-disk artifact.
-      let worktreeMissing = false;
+      // in some form, so the orphan-recovery upgrade is not justified.
+      let effectiveForce = force;
       try {
         const stat = await fsPromises.stat(worktreePath);
         if (!stat.isDirectory()) {
-          throw new Error(`Worktree path exists but is not a directory: ${worktreePath}`);
+          throw new Error(
+            `Worktree path exists but is not a directory: ${worktreePath}`,
+          );
         }
       } catch (error) {
         const code = (error as NodeJS.ErrnoException | undefined)?.code;
         if (code === 'ENOENT' || code === 'ENOTDIR') {
-          worktreeMissing = true;
+          effectiveForce = true;
         } else {
           throw error; // caught by the outer catch → { success: false, error }
         }
-      }
-
-      if (worktreeMissing) {
-        if (shouldElevateForUser(requestUsername)) {
-          const elevatedUsername = requestUsername!;
-          // Bootstrap safe.directory so the elevated `git worktree prune`
-          // does not hit `fatal: detected dubious ownership` on the
-          // server-owned source repo. Mirrors the normal elevated remove
-          // path below.
-          await this.bootstrapSafeDirectoryForUser(elevatedUsername, repoPath);
-          const pruneResult = await this._runAsUser({
-            username: elevatedUsername,
-            command: 'git worktree prune --expire=now',
-            cwd: repoPath,
-            timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS,
-          });
-          if (pruneResult.timedOut || pruneResult.exitCode !== 0) {
-            const detail =
-              pruneResult.stderr.trim() || `exit code ${pruneResult.exitCode}`;
-            throw new GitError(
-              `git worktree prune (orphan worktree-dir recovery, #895) failed: ${detail}`,
-              pruneResult.exitCode,
-              pruneResult.stderr,
-            );
-          }
-        } else {
-          await gitPruneWorktrees(repoPath);
-        }
-        await this.worktreeRepository.deleteByPath(worktreePath);
-        logger.warn(
-          { worktreePath, repoPath },
-          'Worktree dir missing; pruned registry and removed DB row (#895)',
-        );
-        return { success: true };
       }
 
       if (shouldElevateForUser(requestUsername)) {
@@ -754,11 +724,11 @@ export class WorktreeService {
         await this.invokeGitWorktreeRemove({
           worktreePath,
           repoPath,
-          force,
+          force: effectiveForce,
           requestUsername: elevatedUsername,
         });
       } else {
-        await gitRemoveWorktree(worktreePath, repoPath, { force });
+        await gitRemoveWorktree(worktreePath, repoPath, { force: effectiveForce });
       }
 
       // Remove DB record
@@ -845,9 +815,18 @@ export class WorktreeService {
 
       // Best-effort prune as the user; failure is logged but not propagated
       // (the rm already succeeded, so git's stale registry is the only cost).
+      //
+      // `--expire=now` is required here because we just deleted the worktree
+      // directory ourselves: git's default `gc.worktreePruneExpire` is 3
+      // months, so a plain `git worktree prune` would NOT shed the freshly
+      // stale entry we just created, and a subsequent `worktree add` at the
+      // same path could collide. Forcing immediate expiration is correct
+      // because this prune is gated inside the stale-`.git` / `is not a
+      // working tree` recovery branch — by the time we get here the rm has
+      // already succeeded.
       const pruneResult = await this._runAsUser({
         username: opts.requestUsername,
-        command: 'git worktree prune',
+        command: 'git worktree prune --expire=now',
         cwd: opts.repoPath,
         timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS,
       });

--- a/packages/server/src/services/worktree-service.ts
+++ b/packages/server/src/services/worktree-service.ts
@@ -696,6 +696,17 @@ export class WorktreeService {
       // route to destructive recovery. A stat success on a non-directory
       // (file, symlink, socket) is also a surfaced error — the path exists
       // in some form, so the orphan-recovery upgrade is not justified.
+      //
+      // Multi-user carve-out (CodeRabbit on PR #897): when elevation will
+      // engage, the server process may lack stat access on a user-owned
+      // worktree path (parent dir mode 0700). The elevated `git worktree
+      // remove` running as the owner handles its own existence check, so
+      // EACCES/EPERM on the probe should fall through to the elevated path
+      // with `effectiveForce` at the caller's value rather than surfacing
+      // as a failure. In single-user mode, EACCES is a genuine
+      // misconfiguration (the server user lacks stat on its own data root)
+      // that must surface as failure — the elevated branch cannot help.
+      const willElevateRemoval = shouldElevateForUser(requestUsername);
       let effectiveForce = force;
       try {
         const stat = await fsPromises.stat(worktreePath);
@@ -708,12 +719,21 @@ export class WorktreeService {
         const code = (error as NodeJS.ErrnoException | undefined)?.code;
         if (code === 'ENOENT' || code === 'ENOTDIR') {
           effectiveForce = true;
+        } else if (
+          willElevateRemoval &&
+          (code === 'EACCES' || code === 'EPERM')
+        ) {
+          // Multi-user carve-out: skip the throw and proceed to the
+          // elevated path. `effectiveForce` stays at the caller's value
+          // (no upgrade) — we cannot tell whether the dir is missing or
+          // present-but-unreadable, and the elevated `git worktree
+          // remove` will resolve that ambiguity itself.
         } else {
           throw error; // caught by the outer catch → { success: false, error }
         }
       }
 
-      if (shouldElevateForUser(requestUsername)) {
+      if (willElevateRemoval) {
         const elevatedUsername = requestUsername!;
         // Bootstrap the user's `safe.directory` for `repoPath` so the
         // elevated `git worktree remove` (running as the user) does not hit


### PR DESCRIPTION
## Summary

Closes #895.

Sprint 2026-06-25 dogfood cleanup smoke surfaced 4/10 worktrees failing with `fatal: '<path>' is not a working tree` when the worktree directory had been externally removed while the primary repo was still present. The existing `repoExists` pre-check in `WorktreeService.removeWorktree` only handles the OPPOSITE orphan (primary-repo-gone, #811). This adds a sibling pre-check for `worktreePath`.

When `worktreePath` is missing (ENOENT/ENOTDIR only), the recovery path is:

1. `git worktree prune` in `repoPath` (elevated via `runAsUser` when `requestUsername` is set; single-user otherwise).
2. `worktreeRepository.deleteByPath(worktreePath)`.
3. Idempotent — a second call returns success even after both row and dir are gone.

Other stat errors (EACCES/EPERM/IO) surface as failure rather than routing to destructive recovery, matching the existing `repoExists` narrowing at `worktree-service.ts:660-666`.

## Changes

- **`packages/server/src/lib/git.ts`**: new `pruneWorktrees(cwd, requestUser?)` thin wrapper over `git(['worktree', 'prune'], ...)`.
- **`packages/server/src/services/worktree-service.ts`**: extends `removeWorktree` with the new `worktreeExists` pre-check. Multi-user path routes prune through `this._runAsUser` after the existing `safe.directory` bootstrap (mirrors the established split between elevated and single-user paths). Single-user path uses the new lib/git helper.
- **`packages/server/src/__tests__/utils/mock-git-helper.ts`**: adds `pruneWorktrees` to the mock surface.
- **`packages/server/src/services/__tests__/worktree-service.test.ts`**: adds 4 new tests (single-user happy path, single-user idempotency, multi-user prune via runAsUser, multi-user prune failure surfaces `{ success: false }`). Updates 7 existing tests that previously did not materialize the worktree dir on disk so they keep taking the normal git path (the new pre-check would otherwise route them through prune).
- **`packages/server/src/mcp/__tests__/mcp-server.test.ts`**: `setupForDeletion` now materializes each worktree path with a `.keep` entry for the same reason.

## Test plan

- [x] `bun run typecheck` — exit 0
- [x] `bun run test` — 5064 pass / 3 skip / 0 fail
- [x] `bun run check:lang` — clean (105 files scanned)
- [x] `node .claude/skills/orchestrator/preflight-check.js` — coverage / duplication / language all clean
- [x] **TDD polarity verified** per `workflow.md`: stashing only `lib/git.ts` + `worktree-service.ts` production diffs produces 3 failures across the new `#895` tests (the elevated-prune-failure case still passes under the negative because `force=false` gives the same `{ success: false }` shape — the other three cases lock the contract).
- [ ] CodeRabbit clean (will verify on the PR once posted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)