### PR TITLE
feat(scripts): add update-and-deploy-for-multiuser-ubuntu.sh

### DIFF
--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -416,6 +416,29 @@ curl -X POST http://localhost:8080/api/auth/login \
 > isolation), run the Docker verification: `scripts/verify-multiuser-docker.sh`
 > (see [`docker/README.md`](../docker/README.md)).
 
+## Iterative Updates (after the initial setup)
+
+After the bootstrap script has completed once, ongoing source-code updates and
+restarts are performed by `scripts/update-and-deploy-for-multiuser-ubuntu.sh`.
+The script assumes the source-repo at `${AGENT_CONSOLE_DATA_ROOT}/source-repos/agent-console`
+has already been advanced to the target ref (the orchestrator-driven update
+cycle: fetch + checkout + this script).
+
+```bash
+# Default invocation (matches bootstrap defaults: agentconsole / port 8080).
+sudo scripts/update-and-deploy-for-multiuser-ubuntu.sh
+
+# Overrides (env vars; CLI flags not supported):
+sudo AGENT_CONSOLE_PORT=9000 \
+     AGENT_CONSOLE_SERVICE_USER=ac-svc \
+     scripts/update-and-deploy-for-multiuser-ubuntu.sh
+```
+
+The full list of override env vars is documented in the script's top comment.
+The script does not perform `git pull` itself — sync the source-repo to the
+intended commit before invoking, and confirm via the printed HEAD line in the
+script's `==> Pre-check` step before the build proceeds.
+
 ## Environment Variables
 
 | Variable | Default | Description |

--- a/scripts/update-and-deploy-for-multiuser-ubuntu.sh
+++ b/scripts/update-and-deploy-for-multiuser-ubuntu.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Update-and-deploy Agent Console in multi-user mode on Ubuntu / Debian.
+#
+# Counterpart to scripts/setup-multiuser-for-ubuntu.sh: setup performs the
+# one-shot bootstrap, this script performs the iterative redeploy after
+# source updates (the typical orchestrator-driven update cycle).
+#
+# Steps:
+#   1. Pre-check: print the source-repo HEAD so the operator confirms the
+#      build will use the intended commit. (The orchestrator is responsible
+#      for syncing the source-repo to the target ref before invoking this
+#      script; this script does NOT git pull on its own.)
+#   2. bun install (all deps) @ source-repo so build tooling is present.
+#   3. NODE_ENV=production bun run build @ source-repo.
+#   4. rsync source-repo -> deploy target (excludes node_modules + .git).
+#   5. bun install --production @ deploy target (runtime deps only).
+#   6. systemctl restart <service> + status snapshot.
+#   7. Health probe via curl.
+#
+# Run as your login user (sudo required for the inner elevation to the
+# service user, and for the system-level systemctl restart).
+#
+# Usage:
+#   sudo scripts/update-and-deploy-for-multiuser-ubuntu.sh
+#
+# Env overrides (CLI flags not supported; override via env vars):
+#   AGENT_CONSOLE_SERVICE_USER       Service user owning source + target.
+#                                    Default: agentconsole
+#   AGENT_CONSOLE_DATA_ROOT          Shared data root.
+#                                    Default: /var/lib/agent-console
+#   AGENT_CONSOLE_APP_SOURCE_DIR     Build source directory.
+#                                    Default: ${AGENT_CONSOLE_DATA_ROOT}/source-repos/agent-console
+#   AGENT_CONSOLE_DEPLOY_TARGET_DIR  rsync deploy target.
+#                                    Default: /home/${AGENT_CONSOLE_SERVICE_USER}/agent-console
+#   AGENT_CONSOLE_SERVICE_NAME       systemd unit to restart.
+#                                    Default: agent-console.service
+#   AGENT_CONSOLE_PORT               Port used by the health probe URL.
+#                                    Default: 8080
+#
+# Example with overrides:
+#   sudo AGENT_CONSOLE_PORT=9000 AGENT_CONSOLE_SERVICE_USER=ac-svc \
+#     scripts/update-and-deploy-for-multiuser-ubuntu.sh
+#
+# Prerequisites (set up by scripts/setup-multiuser-for-ubuntu.sh):
+#   - service user exists with the configured home directory
+#   - sudoers fragment permits root -> service user without password
+#   - source-repo cloned at ${AGENT_CONSOLE_APP_SOURCE_DIR}, owned by service user
+#   - systemd unit installed and enabled
+#
+# Documentation: docs/multi-user-setup-guide.md
+
+set -euo pipefail
+
+SERVICE_USER="${AGENT_CONSOLE_SERVICE_USER:-agentconsole}"
+DATA_ROOT="${AGENT_CONSOLE_DATA_ROOT:-/var/lib/agent-console}"
+SRC="${AGENT_CONSOLE_APP_SOURCE_DIR:-${DATA_ROOT}/source-repos/agent-console}"
+DST="${AGENT_CONSOLE_DEPLOY_TARGET_DIR:-/home/${SERVICE_USER}/agent-console}"
+SERVICE_NAME="${AGENT_CONSOLE_SERVICE_NAME:-agent-console.service}"
+PORT="${AGENT_CONSOLE_PORT:-8080}"
+HEALTH_URL="http://localhost:${PORT}/api/auth/me"
+
+echo "==> Config"
+echo "    SERVICE_USER : ${SERVICE_USER}"
+echo "    APP_SOURCE   : ${SRC}"
+echo "    DEPLOY_TARGET: ${DST}"
+echo "    SERVICE_NAME : ${SERVICE_NAME}"
+echo "    HEALTH_URL   : ${HEALTH_URL}"
+echo ""
+
+echo "==> Pre-check: source-repo HEAD"
+sudo -u "${SERVICE_USER}" bash -lc "cd '${SRC}' && git log --oneline -1"
+
+echo ""
+echo "==> 1/4 bun install (all deps, build needs dev tooling) @ source-repo"
+sudo -u "${SERVICE_USER}" bash -lc "
+  export PATH=\$HOME/.bun/bin:\$PATH
+  cd '${SRC}' && bun install
+"
+
+echo ""
+echo "==> 2/4 NODE_ENV=production bun run build @ source-repo"
+sudo -u "${SERVICE_USER}" bash -lc "
+  export PATH=\$HOME/.bun/bin:\$PATH
+  cd '${SRC}' && NODE_ENV=production bun run build
+"
+
+echo ""
+echo "==> 3/4 rsync source-repo -> deploy target (excludes node_modules, .git)"
+sudo -u "${SERVICE_USER}" rsync -a --delete \
+  --exclude=node_modules \
+  --exclude='.git' \
+  "${SRC}/" "${DST}/"
+
+echo ""
+echo "==> 4/4 bun install --production @ deploy target (runtime deps only)"
+sudo -u "${SERVICE_USER}" bash -lc "
+  export PATH=\$HOME/.bun/bin:\$PATH
+  cd '${DST}' && bun install --production
+"
+
+echo ""
+echo "==> systemctl restart ${SERVICE_NAME}"
+sudo systemctl restart "${SERVICE_NAME}"
+sleep 2
+sudo systemctl status "${SERVICE_NAME}" --no-pager | head -10
+
+echo ""
+echo "==> Post-deploy: quick health probe"
+if curl -sf -m 5 "${HEALTH_URL}" >/dev/null; then
+  echo "    ${HEALTH_URL} OK"
+else
+  echo "    ${HEALTH_URL} FAILED"
+fi
+
+echo ""
+echo "==> Done."


### PR DESCRIPTION
## Summary

- Promote `/tmp/deploy-prod.sh` (previously ad-hoc, made by an earlier orchestrator) into `scripts/update-and-deploy-for-multiuser-ubuntu.sh`, aligned with the existing `update-and-deploy-for-{mac,ubuntu}.sh` naming pattern.
- This is the counterpart to `setup-multiuser-for-ubuntu.sh`: setup performs the one-shot bootstrap, this script performs the iterative redeploy after source updates (the typical orchestrator-driven update cycle).
- Hardcoded paths replaced with `AGENT_CONSOLE_*` env overrides whose defaults match the bootstrap script. The full override list is documented in the script's top comment.
- `docs/multi-user-setup-guide.md` gains a brief "Iterative Updates" section linking the script and clarifying that source-repo sync is the orchestrator's responsibility (the script does not `git pull`).

## Env overrides

| Env var | Default |
|---|---|
| `AGENT_CONSOLE_SERVICE_USER` | `agentconsole` |
| `AGENT_CONSOLE_DATA_ROOT` | `/var/lib/agent-console` |
| `AGENT_CONSOLE_APP_SOURCE_DIR` | `${DATA_ROOT}/source-repos/agent-console` |
| `AGENT_CONSOLE_DEPLOY_TARGET_DIR` | `/home/${SERVICE_USER}/agent-console` |
| `AGENT_CONSOLE_SERVICE_NAME` | `agent-console.service` |
| `AGENT_CONSOLE_PORT` | `8080` |

## Test plan

- [x] `bash -n scripts/update-and-deploy-for-multiuser-ubuntu.sh` — syntax check passes
- [x] `bun run check:lang` — language check passes (105 files scanned)
- [ ] Real-machine smoke (per `os-environment-coupling.md`): run on the dogfood multi-user host and confirm: build succeeds, rsync completes, `systemctl restart` succeeds, health probe returns OK. This is the operator's post-merge verification (the next iterative deploy cycle is itself the smoke).

## Notes

- The script does NOT `git pull` the source-repo. The orchestrator is responsible for advancing the source-repo to the intended commit beforehand. The script's `==> Pre-check` step prints the source-repo HEAD so the operator can confirm before the build proceeds.
- Hooks/lint were exercised on commit (`check-public-artifacts-language.mjs` via the commit-msg hook is the only auto-check for shell scripts; CI's `language-lint.yml` will run on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)