### PR TITLE
feat(client): add removeSourceRepo opt-in to Unregister flow (#905 frontend half)

### DIFF
--- a/packages/client/src/components/ui/__tests__/confirm-dialog.test.tsx
+++ b/packages/client/src/components/ui/__tests__/confirm-dialog.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Tests for `ConfirmDialog`.
+ *
+ * Covers the new optional `children` slot (Issue #905) that lets callers
+ * inject content — for example, an opt-in checkbox — between the dialog
+ * description and the action footer. The slot is rendered as a sibling
+ * of `AlertDialogDescription`, NOT inside it: descriptions render as
+ * `<p>`, and nesting form controls inside a `<p>` is invalid HTML that
+ * browsers split implicitly.
+ *
+ * The base props path (title / description / confirm / cancel) is also
+ * smoke-tested so future regressions are caught at the dialog level.
+ */
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+import { ConfirmDialog } from '../confirm-dialog';
+
+describe('ConfirmDialog', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the title, description, confirm label, and cancel label', () => {
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="Delete Item"
+        description="Are you sure?"
+        confirmLabel="Delete"
+        cancelLabel="Keep"
+        onConfirm={() => {}}
+      />
+    );
+
+    expect(screen.getByRole('heading', { name: 'Delete Item' })).toBeTruthy();
+    expect(screen.getByText('Are you sure?')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Keep' })).toBeTruthy();
+  });
+
+  it('invokes onConfirm when the confirm button is clicked', () => {
+    const onConfirm = mock(() => {});
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="Stop"
+        description="Stop now?"
+        confirmLabel="Stop"
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT render children when the children prop is omitted', () => {
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="Confirm"
+        description="Sure?"
+        onConfirm={() => {}}
+      />
+    );
+
+    // No checkbox should appear (no children slot used).
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+
+  it('renders children between the description and the action footer when provided', () => {
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="Confirm"
+        description="Sure?"
+        onConfirm={() => {}}
+      >
+        <label>
+          <input type="checkbox" />
+          Extra opt-in
+        </label>
+      </ConfirmDialog>
+    );
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeTruthy();
+    expect((checkbox as HTMLInputElement).checked).toBe(false);
+
+    // The checkbox label text should be present.
+    expect(screen.getByText('Extra opt-in')).toBeTruthy();
+
+    // The injected control must NOT be nested inside the description's <p>
+    // (invalid HTML). The description renders as a paragraph.
+    const description = screen.getByText('Sure?');
+    expect(description.tagName.toLowerCase()).toBe('p');
+    expect(description.contains(checkbox)).toBe(false);
+  });
+});

--- a/packages/client/src/components/ui/confirm-dialog.tsx
+++ b/packages/client/src/components/ui/confirm-dialog.tsx
@@ -21,6 +21,13 @@ export interface ConfirmDialogProps {
   variant?: 'default' | 'danger';
   onConfirm: () => void;
   isLoading?: boolean;
+  /**
+   * Optional content rendered between the description and the action footer.
+   * Use to inject form controls (e.g., an additional opt-in checkbox) that
+   * would not be valid HTML inside `AlertDialogDescription` (which renders
+   * as a `<p>`).
+   */
+  children?: React.ReactNode;
 }
 
 /**
@@ -37,6 +44,7 @@ export function ConfirmDialog({
   variant = 'default',
   onConfirm,
   isLoading = false,
+  children,
 }: ConfirmDialogProps) {
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
@@ -47,6 +55,7 @@ export function ConfirmDialog({
           </AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
+        {children}
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isLoading}>
             {cancelLabel}

--- a/packages/client/src/lib/__tests__/api.test.ts
+++ b/packages/client/src/lib/__tests__/api.test.ts
@@ -378,12 +378,13 @@ describe('API Client', () => {
     });
 
     it('throws ApiError when DELETE fails', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-        json: mock(() => Promise.resolve({ error: 'cleanup failed' })),
-      } as unknown as Response);
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ error: 'cleanup failed' }), {
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
 
       await expect(
         unregisterRepository('repo-id', { removeSourceRepo: true })

--- a/packages/client/src/lib/__tests__/api.test.ts
+++ b/packages/client/src/lib/__tests__/api.test.ts
@@ -343,6 +343,52 @@ describe('API Client', () => {
       expect(getLastFetchUrl()).toContain('/api/repositories/repo-id');
       expect(getLastFetchMethod()).toBe('DELETE');
     });
+
+    it('sends DELETE without a body when called with id only', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({ success: true }));
+
+      await unregisterRepository('repo-id');
+
+      expect(getLastFetchUrl()).toContain('/api/repositories/repo-id');
+      expect(getLastFetchMethod()).toBe('DELETE');
+      const body = await getLastFetchBody();
+      expect(body).toBeUndefined();
+    });
+
+    it('sends DELETE with body { removeSourceRepo: true } when opts.removeSourceRepo is true', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({ success: true }));
+
+      await unregisterRepository('repo-id', { removeSourceRepo: true });
+
+      expect(getLastFetchUrl()).toContain('/api/repositories/repo-id');
+      expect(getLastFetchMethod()).toBe('DELETE');
+      const body = await getLastFetchBody();
+      expect(body).toEqual({ removeSourceRepo: true });
+    });
+
+    it('sends DELETE with body { removeSourceRepo: false } when opts.removeSourceRepo is false', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({ success: true }));
+
+      await unregisterRepository('repo-id', { removeSourceRepo: false });
+
+      expect(getLastFetchUrl()).toContain('/api/repositories/repo-id');
+      expect(getLastFetchMethod()).toBe('DELETE');
+      const body = await getLastFetchBody();
+      expect(body).toEqual({ removeSourceRepo: false });
+    });
+
+    it('throws ApiError when DELETE fails', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: mock(() => Promise.resolve({ error: 'cleanup failed' })),
+      } as unknown as Response);
+
+      await expect(
+        unregisterRepository('repo-id', { removeSourceRepo: true })
+      ).rejects.toThrow('cleanup failed');
+    });
   });
 
   describe('fetchWorktrees', () => {

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -312,8 +312,8 @@ export async function unregisterRepository(
  * Accepted); the client polls `fetchCloneJobStatus(jobId)` until the
  * status reaches a terminal state (`succeeded` or `failed`).
  *
- * Uses raw `fetch` because the server endpoint may not yet be in the
- * Hono RPC client types (parallel implementation in Issue #834).
+ * Uses raw `fetch` because the server endpoint is not in the Hono RPC
+ * client types.
  */
 export async function cloneRepository(
   request: CloneRepositoryRequest
@@ -334,8 +334,8 @@ export async function cloneRepository(
  * Callers should stop polling when `status === 'succeeded'` or
  * `status === 'failed'`.
  *
- * Uses raw `fetch` because the server endpoint may not yet be in the
- * Hono RPC client types (parallel implementation in Issue #834).
+ * Uses raw `fetch` because the server endpoint is not in the Hono RPC
+ * client types.
  */
 export async function fetchCloneJobStatus(jobId: string): Promise<CloneJobStatusResponse> {
   const res = await fetch(`${API_BASE}/repositories/clone/${encodeURIComponent(jobId)}`);

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -284,8 +284,23 @@ export async function registerRepository(request: CreateRepositoryRequest): Prom
   return res.json() as Promise<CreateRepositoryResponse>;
 }
 
-export async function unregisterRepository(repositoryId: string): Promise<void> {
-  const res = await api.repositories[':id'].$delete({ param: { id: repositoryId } });
+/**
+ * Unregister a repository. When `opts.removeSourceRepo` is `true`, the server
+ * also removes the app-cloned source repository on disk (only meaningful when
+ * the repository was registered via "Clone from URL"; ignored otherwise).
+ * Sending no `opts` omits the request body entirely, which the server treats
+ * as the default `removeSourceRepo: false`.
+ */
+export async function unregisterRepository(
+  repositoryId: string,
+  opts?: { removeSourceRepo?: boolean },
+): Promise<void> {
+  const init: RequestInit = { method: 'DELETE' };
+  if (opts !== undefined) {
+    init.headers = { 'Content-Type': 'application/json' };
+    init.body = JSON.stringify({ removeSourceRepo: opts.removeSourceRepo });
+  }
+  const res = await fetch(`${API_BASE}/repositories/${repositoryId}`, init);
   if (!res.ok) {
     await handleApiError(res, 'Failed to unregister repository');
   }

--- a/packages/client/src/routes/__tests__/index.test.tsx
+++ b/packages/client/src/routes/__tests__/index.test.tsx
@@ -60,6 +60,13 @@ interface FetchResponses {
    * Recorded DELETE calls so tests can assert which repository id was sent.
    */
   deleteRepositoryCalls?: string[];
+  /**
+   * Recorded DELETE bodies so tests can assert the JSON payload (or its absence)
+   * that the client sent. Each entry is the parsed JSON body, or `undefined`
+   * when the DELETE was issued without a body. Indices align with
+   * `deleteRepositoryCalls`.
+   */
+  deleteRepositoryBodies?: unknown[];
 }
 
 let fetchResponses: FetchResponses = {
@@ -95,6 +102,18 @@ const mockFetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
     const match = url.match(/\/api\/repositories\/([^/]+)$/);
     const repoId = match?.[1] ?? '';
     fetchResponses.deleteRepositoryCalls?.push(repoId);
+    if (fetchResponses.deleteRepositoryBodies) {
+      const rawBody = init?.body;
+      let parsed: unknown = undefined;
+      if (typeof rawBody === 'string' && rawBody.length > 0) {
+        try {
+          parsed = JSON.parse(rawBody);
+        } catch {
+          parsed = rawBody;
+        }
+      }
+      fetchResponses.deleteRepositoryBodies.push(parsed);
+    }
     const override = fetchResponses.deleteRepositoryResponses?.[repoId];
     if (override) {
       const body = override.body === undefined ? null : override.body;
@@ -163,6 +182,7 @@ async function renderDashboard(
   options?: {
     deleteRepositoryResponses?: Record<string, { status: number; body?: unknown }>;
     deleteRepositoryCalls?: string[];
+    deleteRepositoryBodies?: unknown[];
   }
 ) {
   fetchResponses = {
@@ -170,6 +190,7 @@ async function renderDashboard(
     worktreesByRepoId: Object.fromEntries(repositories.map((r) => [r.id, []])),
     deleteRepositoryResponses: options?.deleteRepositoryResponses,
     deleteRepositoryCalls: options?.deleteRepositoryCalls,
+    deleteRepositoryBodies: options?.deleteRepositoryBodies,
   };
 
   const sessionDataValue = {
@@ -423,5 +444,179 @@ describe('DashboardPage / Unregister Repository', () => {
     // Radix's open AlertDialog marks the page background `aria-hidden`, so we
     // include hidden elements when querying for the still-mounted repo heading.
     expect(screen.getByRole('heading', { name: 'my-repo', level: 2, hidden: true })).toBeTruthy();
+  });
+});
+
+/**
+ * Tests for Issue #905 — source-repo cleanup opt-in checkbox on the Unregister
+ * Repository dialog. The checkbox is only meaningful (and only rendered) when
+ * the repository was registered via "Clone from URL" — i.e. when
+ * `clonedSourceRepoPath` is non-null. External-path repositories MUST NOT show
+ * the checkbox. When checked, the client sends `{ removeSourceRepo: true }`
+ * in the DELETE body; when unchecked, no body is sent.
+ */
+describe('DashboardPage / Unregister Repository — source-repo cleanup checkbox', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+    useAppWsEventSpy = spyOn(useAppWsModule, 'useAppWsEvent').mockImplementation(() => undefined);
+    useAppWsStateSpy = spyOn(useAppWsModule, 'useAppWsState').mockImplementation(
+      <T,>() => false as T
+    );
+    hasVSCodeSpy = spyOn(capabilitiesModule, 'hasVSCode').mockImplementation(() => false);
+  });
+
+  afterEach(() => {
+    cleanup();
+    useAppWsEventSpy.mockRestore();
+    useAppWsStateSpy.mockRestore();
+    hasVSCodeSpy.mockRestore();
+  });
+
+  it('does NOT render the checkbox when clonedSourceRepoPath is null', async () => {
+    await renderDashboard([
+      createTestRepository({ clonedSourceRepoPath: null }),
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'my-repo', level: 2 })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Unregister Repository' })).toBeTruthy();
+    });
+
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+
+  it('renders the checkbox with the path label when clonedSourceRepoPath is non-null', async () => {
+    const clonedPath = '/test/source-repos/my-repo';
+    await renderDashboard([
+      createTestRepository({ clonedSourceRepoPath: clonedPath }),
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'my-repo', level: 2 })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Unregister Repository' })).toBeTruthy();
+    });
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeTruthy();
+    expect((checkbox as HTMLInputElement).checked).toBe(false);
+
+    // Path appears inside the checkbox label.
+    expect(screen.getByText(clonedPath)).toBeTruthy();
+  });
+
+  it('passes removeSourceRepo: true in the DELETE body when checked and confirmed', async () => {
+    const deleteCalls: string[] = [];
+    const deleteBodies: unknown[] = [];
+    await renderDashboard(
+      [
+        createTestRepository({
+          clonedSourceRepoPath: '/test/source-repos/my-repo',
+        }),
+      ],
+      {
+        deleteRepositoryCalls: deleteCalls,
+        deleteRepositoryBodies: deleteBodies,
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'my-repo', level: 2 })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Unregister Repository' })).toBeTruthy();
+    });
+
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.click(checkbox);
+    expect((checkbox as HTMLInputElement).checked).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unregister' }));
+
+    await waitFor(() => {
+      expect(deleteCalls).toEqual(['repo-1']);
+    });
+
+    expect(deleteBodies).toEqual([{ removeSourceRepo: true }]);
+  });
+
+  it('omits the body when the checkbox stays unchecked and confirmed', async () => {
+    const deleteCalls: string[] = [];
+    const deleteBodies: unknown[] = [];
+    await renderDashboard(
+      [
+        createTestRepository({
+          clonedSourceRepoPath: '/test/source-repos/my-repo',
+        }),
+      ],
+      {
+        deleteRepositoryCalls: deleteCalls,
+        deleteRepositoryBodies: deleteBodies,
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'my-repo', level: 2 })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Unregister Repository' })).toBeTruthy();
+    });
+
+    // Don't click the checkbox — leave it unchecked.
+    fireEvent.click(screen.getByRole('button', { name: 'Unregister' }));
+
+    await waitFor(() => {
+      expect(deleteCalls).toEqual(['repo-1']);
+    });
+
+    expect(deleteBodies).toEqual([undefined]);
+  });
+
+  it('resets the checkbox state to unchecked after the dialog is dismissed and reopened', async () => {
+    await renderDashboard([
+      createTestRepository({
+        clonedSourceRepoPath: '/test/source-repos/my-repo',
+      }),
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'my-repo', level: 2 })).toBeTruthy();
+    });
+
+    // First open: check the box.
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Unregister Repository' })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
+
+    // Cancel the dialog (Radix AlertDialogCancel is rendered as the "Cancel" button).
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: 'Unregister Repository' })).toBeNull();
+    });
+
+    // Re-open: checkbox state should be reset to unchecked.
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Unregister Repository' })).toBeTruthy();
+    });
+    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(false);
   });
 });

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -144,6 +144,10 @@ export function DashboardPage() {
   const [showAddRepo, setShowAddRepo] = useState(false);
   // Repository to unregister (for confirmation dialog)
   const [repoToUnregister, setRepoToUnregister] = useState<Repository | null>(null);
+  // Opt-in for deleting the cloned source repo on unregister; only meaningful
+  // when `repoToUnregister.clonedSourceRepoPath != null` (the dialog hides the
+  // checkbox in the external-path case so this stays false).
+  const [removeSourceRepo, setRemoveSourceRepo] = useState(false);
 
   // Session data from root layout (single source of truth)
   const { sessions: allSessions, wsInitialized, workerActivityStates } = useSessionDataContext();
@@ -448,7 +452,8 @@ export function DashboardPage() {
   });
 
   const unregisterMutation = useMutation({
-    mutationFn: unregisterRepository,
+    mutationFn: ({ id, removeSourceRepo: remove }: { id: string; removeSourceRepo: boolean }) =>
+      unregisterRepository(id, remove ? { removeSourceRepo: true } : undefined),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: repositoryKeys.all() });
     },
@@ -581,7 +586,12 @@ export function DashboardPage() {
       {/* Unregister Repository Confirmation */}
       <ConfirmDialog
         open={repoToUnregister !== null}
-        onOpenChange={(open) => !open && setRepoToUnregister(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRepoToUnregister(null);
+            setRemoveSourceRepo(false);
+          }
+        }}
         title="Unregister Repository"
         description={`Are you sure you want to unregister "${repoToUnregister?.name}"?`}
         confirmLabel="Unregister"
@@ -590,7 +600,7 @@ export function DashboardPage() {
           if (!repoToUnregister) return;
           const repoId = repoToUnregister.id;
           try {
-            await unregisterMutation.mutateAsync(repoId);
+            await unregisterMutation.mutateAsync({ id: repoId, removeSourceRepo });
           } catch {
             // Error surfaced via mutation's onError -> showUnregisterError.
             // We swallow the rejection here purely to control dialog-close timing.
@@ -598,9 +608,25 @@ export function DashboardPage() {
             // Close the ConfirmDialog on both success and error so the operator
             // can see the ErrorDialog without the confirm dialog stacked behind it.
             setRepoToUnregister(null);
+            setRemoveSourceRepo(false);
           }
         }}
-      />
+      >
+        {repoToUnregister?.clonedSourceRepoPath != null && (
+          <label className="flex items-start gap-2 text-sm text-gray-300">
+            <input
+              type="checkbox"
+              checked={removeSourceRepo}
+              onChange={(e) => setRemoveSourceRepo(e.target.checked)}
+              className="mt-0.5 accent-indigo-600"
+            />
+            <span>
+              Also remove the cloned source repository at{' '}
+              <code className="text-xs text-gray-400 break-all">{repoToUnregister.clonedSourceRepoPath}</code>
+            </span>
+          </label>
+        )}
+      </ConfirmDialog>
       <ErrorDialog {...pullErrorDialogProps} />
       <ErrorDialog {...unregisterErrorDialogProps} />
       <AlertDialog open={pullSuccessMessage !== null} onOpenChange={(open) => { if (!open) setPullSuccessMessage(null); }}>

--- a/packages/client/src/routes/settings/repositories/$repositoryId/__tests__/index.test.tsx
+++ b/packages/client/src/routes/settings/repositories/$repositoryId/__tests__/index.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * Tests for the Repository Detail page Delete flow (Issue #905 source-repo
+ * cleanup checkbox).
+ *
+ * Mirrors the structure of `routes/__tests__/index.test.tsx`:
+ *  - `spyOn` (NOT `mock.module`) for any module-level hooks.
+ *  - fetch-level mocking for the repository GET / DELETE round-trips.
+ *  - `renderWithRouter` for QueryClient + minimal TanStack Router context
+ *    (needed because `useNavigate()` is used on success).
+ *
+ * The route's `RepositoryDetailPage` component uses `Route.useParams()` to
+ * read `repositoryId` from the matched route, which would require mounting
+ * the full route tree. To keep the test surface-area aligned with the unit
+ * under test, we render `RepositoryDetailView` directly — the presentational
+ * inner component extracted from the route handler. Production callers still
+ * go through `RepositoryDetailPage`; only the read of `repositoryId` differs.
+ */
+import { describe, it, expect, mock, beforeEach, afterEach, afterAll } from 'bun:test';
+import { Suspense } from 'react';
+import { screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+
+import { RepositoryDetailView } from '../index';
+import { renderWithRouter } from '../../../../../test/renderWithRouter';
+import type { Repository } from '@agent-console/shared';
+
+// --- Fetch-level mocking ---
+
+const originalFetch = globalThis.fetch;
+
+interface FetchResponses {
+  /** Repository returned by GET /api/repositories/:id */
+  repository: Repository | null;
+  /**
+   * Optional override for DELETE /api/repositories/:id responses.
+   * When absent, the DELETE returns 204 No Content.
+   */
+  deleteResponse?: { status: number; body?: unknown };
+  /** Recorded DELETE bodies (parsed JSON, or `undefined` when body is absent). */
+  deleteBodies?: unknown[];
+}
+
+let fetchResponses: FetchResponses = { repository: null };
+
+const mockFetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = input instanceof Request ? input.url : String(input);
+  const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
+
+  // GET /api/repositories/:id
+  if (method === 'GET' && /\/api\/repositories\/[^/]+(\?|$)/.test(url) && !/\/(worktrees|branches|integrations|generate-description|github-issue|refresh-default-branch)/.test(url)) {
+    return new Response(JSON.stringify({ repository: fetchResponses.repository }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // GET /api/agents (fallback for AgentSelector / lookup)
+  if (method === 'GET' && /\/api\/agents(\?|$)/.test(url)) {
+    return new Response(JSON.stringify({ agents: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // DELETE /api/repositories/:id
+  if (method === 'DELETE' && /\/api\/repositories\/[^/]+$/.test(url)) {
+    if (fetchResponses.deleteBodies) {
+      const rawBody = init?.body;
+      let parsed: unknown = undefined;
+      if (typeof rawBody === 'string' && rawBody.length > 0) {
+        try {
+          parsed = JSON.parse(rawBody);
+        } catch {
+          parsed = rawBody;
+        }
+      }
+      fetchResponses.deleteBodies.push(parsed);
+    }
+    const override = fetchResponses.deleteResponse;
+    if (override) {
+      const body = override.body === undefined ? null : override.body;
+      return new Response(body === null ? null : JSON.stringify(body), {
+        status: override.status,
+        headers: body === null ? undefined : { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response(null, { status: 204 });
+  }
+
+  return new Response(JSON.stringify({}), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+});
+
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// --- Test data factory ---
+
+function createTestRepository(overrides?: Partial<Repository>): Repository {
+  return {
+    id: 'repo-1',
+    name: 'my-repo',
+    path: '/test/repos/my-repo',
+    createdAt: new Date().toISOString(),
+    clonedSourceRepoPath: null,
+    ...overrides,
+  } as Repository;
+}
+
+async function renderDetailPage(
+  repository: Repository,
+  options?: {
+    deleteResponse?: { status: number; body?: unknown };
+    deleteBodies?: unknown[];
+  }
+) {
+  fetchResponses = {
+    repository,
+    deleteResponse: options?.deleteResponse,
+    deleteBodies: options?.deleteBodies,
+  };
+
+  return renderWithRouter(
+    <Suspense fallback={<div>Loading...</div>}>
+      <RepositoryDetailView repositoryId={repository.id} />
+    </Suspense>
+  );
+}
+
+describe('RepositoryDetailView / Delete Repository — source-repo cleanup checkbox', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does NOT render the checkbox when clonedSourceRepoPath is null', async () => {
+    await renderDetailPage(createTestRepository({ clonedSourceRepoPath: null }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'my-repo', level: 1 })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Delete Repository' })).toBeTruthy();
+    });
+
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+
+  it('renders the checkbox with the path label when clonedSourceRepoPath is non-null', async () => {
+    const clonedPath = '/test/source-repos/my-repo';
+    await renderDetailPage(
+      createTestRepository({ clonedSourceRepoPath: clonedPath })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'my-repo', level: 1 })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Delete Repository' })).toBeTruthy();
+    });
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeTruthy();
+    expect((checkbox as HTMLInputElement).checked).toBe(false);
+
+    expect(screen.getByText(clonedPath)).toBeTruthy();
+  });
+
+  it('passes removeSourceRepo: true in the DELETE body when checked and confirmed', async () => {
+    const deleteBodies: unknown[] = [];
+    await renderDetailPage(
+      createTestRepository({ clonedSourceRepoPath: '/test/source-repos/my-repo' }),
+      { deleteBodies }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'my-repo', level: 1 })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Delete Repository' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    // Radix's destructive AlertDialog renders the confirm button with label "Delete";
+    // there are two buttons named "Delete" at this point (the header trigger + the
+    // confirm in the dialog). The dialog's confirm button is the second/most recent one
+    // and is also accessible — use the role+name pair after dialog opens.
+    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
+    // The dialog's confirm button is the one inside the open AlertDialog.
+    // It's the only one whose closest dialog ancestor is non-null.
+    const confirmButton = deleteButtons.find(btn => btn.closest('[role="alertdialog"]') !== null);
+    expect(confirmButton).toBeTruthy();
+    fireEvent.click(confirmButton!);
+
+    await waitFor(() => {
+      expect(deleteBodies).toEqual([{ removeSourceRepo: true }]);
+    });
+  });
+
+  it('omits the body when the checkbox stays unchecked and confirmed', async () => {
+    const deleteBodies: unknown[] = [];
+    await renderDetailPage(
+      createTestRepository({ clonedSourceRepoPath: '/test/source-repos/my-repo' }),
+      { deleteBodies }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'my-repo', level: 1 })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Delete Repository' })).toBeTruthy();
+    });
+
+    // Don't click the checkbox.
+    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
+    const confirmButton = deleteButtons.find(btn => btn.closest('[role="alertdialog"]') !== null);
+    expect(confirmButton).toBeTruthy();
+    fireEvent.click(confirmButton!);
+
+    await waitFor(() => {
+      expect(deleteBodies).toEqual([undefined]);
+    });
+  });
+});

--- a/packages/client/src/routes/settings/repositories/$repositoryId/__tests__/index.test.tsx
+++ b/packages/client/src/routes/settings/repositories/$repositoryId/__tests__/index.test.tsx
@@ -86,10 +86,7 @@ const mockFetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
     return new Response(null, { status: 204 });
   }
 
-  return new Response(JSON.stringify({}), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  });
+  throw new Error(`Unhandled fetch request in RepositoryDetailView test: ${method} ${url}`);
 });
 
 globalThis.fetch = mockFetch as unknown as typeof fetch;

--- a/packages/client/src/routes/settings/repositories/$repositoryId/index.tsx
+++ b/packages/client/src/routes/settings/repositories/$repositoryId/index.tsx
@@ -44,9 +44,22 @@ export function RepositoryDetailError({ error, reset }: ErrorComponentProps) {
 
 function RepositoryDetailPage() {
   const { repositoryId } = Route.useParams();
+  return <RepositoryDetailView repositoryId={repositoryId} />;
+}
+
+/**
+ * Presentational view for the repository detail page. Exposed (and exported)
+ * so route-level tests can mount it without the TanStack Router route tree.
+ * Production callers go through `RepositoryDetailPage` which reads
+ * `repositoryId` from the route params.
+ */
+export function RepositoryDetailView({ repositoryId }: { repositoryId: string }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  // Opt-in for deleting the cloned source repo; only meaningful (and only
+  // rendered as a checkbox) when `repository.clonedSourceRepoPath != null`.
+  const [removeSourceRepo, setRemoveSourceRepo] = useState(false);
   const { errorDialogProps, showError } = useErrorDialog();
 
   const { data } = useSuspenseQuery({
@@ -68,13 +81,15 @@ function RepositoryDetailPage() {
     : undefined;
 
   const deleteMutation = useMutation({
-    mutationFn: unregisterRepository,
+    mutationFn: ({ id, removeSourceRepo: remove }: { id: string; removeSourceRepo: boolean }) =>
+      unregisterRepository(id, remove ? { removeSourceRepo: true } : undefined),
     onSuccess: () => {
       queryClient.removeQueries({ queryKey: repositoryKeys.detail(repositoryId) });
       navigate({ to: '/settings/repositories' });
     },
     onError: (error) => {
       setShowDeleteConfirm(false);
+      setRemoveSourceRepo(false);
       showError('Cannot Delete Repository', error.message);
     },
   });
@@ -168,14 +183,32 @@ function RepositoryDetailPage() {
       {/* Delete Confirmation */}
       <ConfirmDialog
         open={showDeleteConfirm}
-        onOpenChange={setShowDeleteConfirm}
+        onOpenChange={(open) => {
+          setShowDeleteConfirm(open);
+          if (!open) setRemoveSourceRepo(false);
+        }}
         title="Delete Repository"
         description={`Are you sure you want to delete "${repository.name}"?`}
         confirmLabel="Delete"
         variant="danger"
-        onConfirm={() => deleteMutation.mutate(repositoryId)}
+        onConfirm={() => deleteMutation.mutate({ id: repositoryId, removeSourceRepo })}
         isLoading={deleteMutation.isPending}
-      />
+      >
+        {repository.clonedSourceRepoPath != null && (
+          <label className="flex items-start gap-2 text-sm text-gray-300">
+            <input
+              type="checkbox"
+              checked={removeSourceRepo}
+              onChange={(e) => setRemoveSourceRepo(e.target.checked)}
+              className="mt-0.5 accent-indigo-600"
+            />
+            <span>
+              Also remove the cloned source repository at{' '}
+              <code className="text-xs text-gray-400 break-all">{repository.clonedSourceRepoPath}</code>
+            </span>
+          </label>
+        )}
+      </ConfirmDialog>
       <ErrorDialog {...errorDialogProps} />
     </div>
   );

--- a/packages/shared/src/schemas/__tests__/app-server-message.test.ts
+++ b/packages/shared/src/schemas/__tests__/app-server-message.test.ts
@@ -359,6 +359,23 @@ describe('AppServerMessageSchema', () => {
         },
       });
     });
+
+    it('should accept repository with clonedSourceRepoPath set to a string', () => {
+      expectValid({
+        type: 'repository-created',
+        repository: {
+          ...repository,
+          clonedSourceRepoPath: '/var/lib/agent-console/source-repos/org/repo',
+        },
+      });
+    });
+
+    it('should accept repository with clonedSourceRepoPath set to null', () => {
+      expectValid({
+        type: 'repository-created',
+        repository: { ...repository, clonedSourceRepoPath: null },
+      });
+    });
   });
 
   describe('worktree lifecycle messages', () => {


### PR DESCRIPTION
## Summary

Frontend half of [Issue #905](https://github.com/ms2sato/agent-console/issues/905) — source-repos cleanup on unregister.

When a repository was registered via "Clone from URL", the app manages the cloned source-repo on disk (tracked by `clonedSourceRepoPath`). Today's unregister deletes only the metadata row and leaks the clone. This PR adds an opt-in checkbox **"Also remove the cloned source repository at `<path>`"** to:

- Dashboard's Unregister ConfirmDialog (`packages/client/src/routes/index.tsx`)
- Settings > Repositories > $repositoryId Delete ConfirmDialog (`packages/client/src/routes/settings/repositories/$repositoryId/index.tsx`)

The checkbox renders only when `clonedSourceRepoPath != null`. External-path repos (null) keep the previous UX exactly — no checkbox, plain unregister.

Closes #905 (frontend half)

## Contract (frozen, parallel with #905 backend PR)

- `DELETE /api/repositories/:id` accepts JSON body `{ removeSourceRepo?: boolean }` (default `false`; response shape unchanged).
- `Repository` payload gains `clonedSourceRepoPath: string \| null`.

### Shared type — temporarily optional

`Repository.clonedSourceRepoPath` is added as **optional** (`?: string | null`) in this PR. This is a deliberate temporary loosening so the shared type compiles against the still-unchanged server code (`mappers.ts`, `repository-manager.ts`, and server tests that construct `Repository` objects). The frontend uses `!= null` so both `null` and `undefined` are handled identically.

**Merge order (coordinated by orchestrator):**
1. Backend PR (#905 backend) merges first — it tightens the field to required (`string | null`) everywhere the server constructs `Repository`.
2. This frontend PR rebases on `origin/main`, drops the optional marker (`?`) to match backend's required form, and re-pushes (force-push gated by per-PR owner approval per `workflow.md`).

## Design choices

- **`ConfirmDialog.children` slot.** Added an optional `children?: React.ReactNode` prop rendered **between** the description and the action footer — NOT inside `AlertDialogDescription` (which is a `<p>` and would produce invalid HTML around form controls like `<input>` / `<label>`). The new `confirm-dialog.test.tsx` explicitly asserts the input is NOT a descendant of the description paragraph.
- **`RepositoryDetailPage` split.** Extracted a presentational `RepositoryDetailView({ repositoryId })` (exported) so the new route-level test can mount the view without a full TanStack Router route tree. `RepositoryDetailPage` is now a 2-line wrapper that reads the route param and forwards it.
- **`unregisterRepository(id, opts?)`.** Switched from Hono RPC's `.$delete(...)` to raw `fetch(...)` so the optional body can be conditionally attached. No body sent when `opts` is omitted (matches backend default of `false`); `{ removeSourceRepo: true | false }` sent when `opts` is provided.

## Browser QA — skipped (3 justification per `workflow.md`)

Chrome DevTools MCP is not available in this delegated session, so live browser QA was not performed. Per `workflow.md` "Gated / conditional UI true-path requirement" skip-threshold:

1. **Backend contract covered by existing server tests** — once the backend PR lands, server-side serialization of `clonedSourceRepoPath` is verified by its own test suite.
2. **Client-side behavior fully covered by unit tests** — see "Test plan" below; both the **true-path** (checkbox renders with the path in the label and sends `{ removeSourceRepo: true }` on confirm) and the **false-path** (checkbox absent, no body sent) are explicitly asserted for both routes.
3. **Pure additive UX** — the change adds a new optional control gated on a new field; the existing unregister path (when `clonedSourceRepoPath` is null / undefined) is unchanged.

**Owner dogfood verification requested post-merge:** please verify the checkbox appears with the correct path and actually triggers source-repo cleanup for a Clone-from-URL-registered repository.

## Test plan

- [x] `bun run typecheck` clean (shared + client)
- [x] `bun run test` — client 1442 pass / 0 fail (+17 new tests), shared 349/0, integration 29/0. Server 2918 pass / 2 pre-existing fail (`Issue #800: git-diff base spec re-resolution (real repo)` — host-side 1Password agent signing limitation, verified pre-existing via `git stash` baseline on this branch).
- [x] `bun run check:lang` clean (105 files scanned).
- [x] `node .claude/skills/orchestrator/preflight-check.js` clean.
- [x] **Sibling tests added/updated for every modified production file** under coverage patterns:
  - `packages/client/src/lib/__tests__/api.test.ts` — 4 new tests covering no-body / `removeSourceRepo: true` / `removeSourceRepo: false` / error paths for `unregisterRepository`.
  - `packages/client/src/routes/__tests__/index.test.tsx` — 5 new tests under "DashboardPage / Unregister Repository — source-repo cleanup checkbox": hidden when null, rendered+labeled when non-null, body when checked, no body when unchecked, state reset on dialog reopen.
  - `packages/client/src/routes/settings/repositories/$repositoryId/__tests__/index.test.tsx` — NEW file mirroring the 4-shape coverage for the detail-page Delete flow via `RepositoryDetailView`.
  - `packages/client/src/components/ui/__tests__/confirm-dialog.test.tsx` — NEW sibling unit test for the `children` slot (base render, onConfirm wiring, no-children default, children-not-inside-description HTML-shape assertion).
- [ ] **Owner dogfood verification post-merge** (manual; substitutes for live browser QA).
- [ ] Rebase + drop optional marker after backend PR (#905 backend) merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)