### PR TITLE
feat(scripts): source-comment blame-shift lint detector

### DIFF
--- a/.claude/skills/orchestrator/check-utils.js
+++ b/.claude/skills/orchestrator/check-utils.js
@@ -456,6 +456,44 @@ export function runLanguageCheck({ repoRoot, binary = 'bun' } = {}) {
   };
 }
 
+// --- Source-comment blame-shift check ---
+
+/**
+ * Run scripts/check-source-comment-blame-shift.mjs and return its result.
+ *
+ * The Bun script is the source of truth for the detection regex, the
+ * `file:line:col pattern` output format, and the KNOWN_VIOLATIONS
+ * allowlist; this helper spawns it so that preflight-check.js (which
+ * runs under node) can surface the verdict alongside the other gates.
+ *
+ * @param {object} [options]
+ * @param {string} [options.repoRoot] absolute path to repo root
+ * @param {string} [options.binary] runtime binary (default: 'bun')
+ * @returns {{exitCode: number, stdout: string, stderr: string, spawnFailed: boolean}}
+ */
+export function runCommentBlameShiftCheck({ repoRoot, binary = 'bun' } = {}) {
+  const root = repoRoot || resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+  const scriptPath = resolve(root, 'scripts/check-source-comment-blame-shift.mjs');
+  const result = spawnSync(binary, [scriptPath], {
+    cwd: root,
+    encoding: 'utf-8',
+  });
+  if (result.error) {
+    return {
+      exitCode: 1,
+      stdout: '',
+      stderr: `Failed to spawn '${binary}': ${result.error.message}`,
+      spawnFailed: true,
+    };
+  }
+  return {
+    exitCode: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    spawnFailed: false,
+  };
+}
+
 // --- CI status check ---
 
 export function getCiStatus(prNumber) {

--- a/.claude/skills/orchestrator/preflight-check.js
+++ b/.claude/skills/orchestrator/preflight-check.js
@@ -25,6 +25,7 @@ import {
   findTestFiles,
   isTestFile,
   detectIntegrationTestNeeds,
+  runCommentBlameShiftCheck,
   runLanguageCheck,
 } from './check-utils.js';
 import { run as runDuplicationCheck } from './rule-skill-duplication-check.js';
@@ -50,6 +51,32 @@ function printLanguageCheck(result) {
   }
   console.log('```');
   console.log('\nRun `bun run check:lang` locally to reproduce. Public artifacts must be in English (see `.claude/rules/workflow.md` Language Policy).');
+  return 1;
+}
+
+function printCommentBlameShiftCheck(result) {
+  console.log('## Source-Comment Blame-Shift Check\n');
+  if (result.spawnFailed) {
+    console.log(`❌ Could not run source-comment blame-shift check: ${result.stderr}`);
+    console.log('\nThis check requires Bun on PATH. The CI workflow must include the `oven-sh/setup-bun` step before invoking preflight-check.js.');
+    return 1;
+  }
+  if (result.exitCode === 0) {
+    console.log('✅ No new Issue / PR / dated CodeRabbit references in source comments.');
+    return 0;
+  }
+  // Violation lines come on stdout (one per match). The script's summary
+  // and remediation text are on stderr; surface a slice for context.
+  const violationLines = result.stdout.split('\n').filter((l) => l.trim().length > 0);
+  console.log(`❌ Found ${violationLines.length} new violation(s) in source comments:\n`);
+  console.log('```');
+  for (const line of violationLines) {
+    console.log(line);
+  }
+  console.log('```');
+  console.log(
+    '\nNew comment references to Issues / PRs / dated CodeRabbit reviews are not allowed — they rot as the codebase evolves. Move the narrative into the PR description / git log instead.',
+  );
   return 1;
 }
 
@@ -130,7 +157,11 @@ function run(changedFiles) {
   const languageResult = runLanguageCheck();
   const languageExit = printLanguageCheck(languageResult);
 
-  if (hasUnitGaps || duplicationExit !== 0 || languageExit !== 0) {
+  console.log('\n---\n');
+  const blameShiftResult = runCommentBlameShiftCheck();
+  const blameShiftExit = printCommentBlameShiftCheck(blameShiftResult);
+
+  if (hasUnitGaps || duplicationExit !== 0 || languageExit !== 0 || blameShiftExit !== 0) {
     process.exit(1);
   }
   process.exit(0);

--- a/.claude/skills/orchestrator/preflight-check.js
+++ b/.claude/skills/orchestrator/preflight-check.js
@@ -65,8 +65,9 @@ function printCommentBlameShiftCheck(result) {
     console.log('✅ No new Issue / PR / dated CodeRabbit references in source comments.');
     return 0;
   }
-  // Violation lines come on stdout (one per match). The script's summary
-  // and remediation text are on stderr; surface a slice for context.
+  // Violation lines come on stdout (one per match). We only consume
+  // stdout here; the detector's own summary / remediation lines are
+  // appended below from this function (we do not surface stderr).
   const violationLines = result.stdout.split('\n').filter((l) => l.trim().length > 0);
   console.log(`❌ Found ${violationLines.length} new violation(s) in source comments:\n`);
   console.log('```');

--- a/.github/workflows/comment-blame-shift-lint.yml
+++ b/.github/workflows/comment-blame-shift-lint.yml
@@ -1,0 +1,46 @@
+name: Comment Blame-Shift Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/*/src/**/*.ts'
+      - 'packages/*/src/**/*.tsx'
+      - 'packages/*/src/**/*.js'
+      - 'packages/*/src/**/*.jsx'
+      - 'scripts/check-source-comment-blame-shift.mjs'
+      - 'scripts/__tests__/check-source-comment-blame-shift.test.mjs'
+      - 'package.json'
+      - '.github/workflows/comment-blame-shift-lint.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/*/src/**/*.ts'
+      - 'packages/*/src/**/*.tsx'
+      - 'packages/*/src/**/*.js'
+      - 'packages/*/src/**/*.jsx'
+      - 'scripts/check-source-comment-blame-shift.mjs'
+      - 'scripts/__tests__/check-source-comment-blame-shift.test.mjs'
+      - 'package.json'
+      - '.github/workflows/comment-blame-shift-lint.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  comment-blame-shift-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.5"
+
+      - name: Run comment blame-shift check
+        run: bun scripts/check-source-comment-blame-shift.mjs
+
+      - name: Run comment blame-shift unit tests
+        run: bun test scripts/__tests__/check-source-comment-blame-shift.test.mjs

--- a/scripts/__tests__/check-source-comment-blame-shift.test.mjs
+++ b/scripts/__tests__/check-source-comment-blame-shift.test.mjs
@@ -1,0 +1,426 @@
+import { describe, it, expect } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  KNOWN_VIOLATIONS,
+  findViolationsInSource,
+  findDefaultFiles,
+  formatViolation,
+  isExcludedFile,
+  runCheck,
+  tokenizeComments,
+  violationKey,
+} from '../check-source-comment-blame-shift.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const SCRIPT_PATH = resolve(REPO_ROOT, 'scripts/check-source-comment-blame-shift.mjs');
+
+describe('tokenizeComments — comment recognition', () => {
+  it('yields nothing for code with no comments', () => {
+    const out = [...tokenizeComments(`const x = 1;\nlet y = 2;`)];
+    expect(out).toEqual([]);
+  });
+
+  it('yields a line comment with its text and start position', () => {
+    const source = `const x = 1; // hello world\n`;
+    const out = [...tokenizeComments(source)];
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe('line');
+    expect(out[0].text).toBe(' hello world');
+    expect(out[0].line).toBe(1);
+    // `//` is at col 14, text starts at col 16
+    expect(out[0].col).toBe(16);
+  });
+
+  it('yields one chunk per line for a multi-line block comment', () => {
+    const source = `/* line1\n   line2\n */\n`;
+    const out = [...tokenizeComments(source)];
+    expect(out).toHaveLength(3);
+    expect(out.map((c) => c.kind)).toEqual(['block', 'block', 'block']);
+    expect(out[0].text).toBe(' line1');
+    expect(out[1].text).toBe('   line2');
+    expect(out[2].text).toBe(' ');
+    expect(out[0].line).toBe(1);
+    expect(out[1].line).toBe(2);
+    expect(out[2].line).toBe(3);
+  });
+
+  it('does not enter a comment inside a double-quoted string', () => {
+    const source = `const url = "https://example.com // not a comment";\n// real comment\n`;
+    const out = [...tokenizeComments(source)];
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toBe(' real comment');
+  });
+
+  it('does not enter a comment inside a single-quoted string', () => {
+    const source = `const s = '// fake'; // real\n`;
+    const out = [...tokenizeComments(source)];
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toBe(' real');
+  });
+
+  it('does not enter a comment inside a template literal', () => {
+    const source =
+      'const t = `// not a comment ${1 + 1}`; // real\n';
+    const out = [...tokenizeComments(source)];
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toBe(' real');
+  });
+
+  it('does not enter a line comment inside a regex literal', () => {
+    const source = `const re = /^https?:\\/\\//;\n// real\n`;
+    const out = [...tokenizeComments(source)];
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toBe(' real');
+  });
+
+  it('handles escaped quotes inside strings', () => {
+    const source = `const s = "he said \\"// not a comment\\""; // real\n`;
+    const out = [...tokenizeComments(source)];
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toBe(' real');
+  });
+
+  it('recognises JSDoc /** ... */ as a block comment', () => {
+    const source = `/**\n * Hello\n */\n`;
+    const out = [...tokenizeComments(source)];
+    expect(out).toHaveLength(3);
+    expect(out[1].text).toBe(' * Hello');
+  });
+});
+
+describe('findViolationsInSource — positive cases', () => {
+  it('detects Issue #NNN inside a line comment', () => {
+    const source = `// Issue #123 fix\nconst x = 1;\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([{ line: 1, col: 4, pattern: 'issue-ref' }]);
+  });
+
+  it('detects PR #NNN inside a line comment', () => {
+    const source = `// see PR #456\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([{ line: 1, col: 8, pattern: 'pr-ref' }]);
+  });
+
+  it('detects bare-ref `// #NNN` at the start of line-comment content', () => {
+    // `// #838 / PR #843, foo` — col positions:
+    //  1:`/` 2:`/` 3:` ` 4:`#` 5:`8` 6:`3` 7:`8` 8:` `
+    //  9:`/` 10:` ` 11:`P` 12:`R` 13:` ` 14:`#` ...
+    const source = `// #838 / PR #843, foo\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([
+      { line: 1, col: 4, pattern: 'bare-ref' },
+      { line: 1, col: 11, pattern: 'pr-ref' },
+    ]);
+  });
+
+  it('does NOT report bare-ref when `#` is preceded by other content', () => {
+    const source = `// see #999\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT report bare-ref when `#NNN` is followed by a letter (no word boundary)', () => {
+    const source = `// #999abc not a ref\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT report bare-ref for block comments (line-comment only per spec)', () => {
+    const source = `/* #999 ref */\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+
+  it('detects CodeRabbit with comma + date', () => {
+    const source = `// Lesson: CodeRabbit, 2026-04-25 review\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toHaveLength(1);
+    expect(out[0].pattern).toBe('coderabbit-dated');
+  });
+
+  it('detects CodeRabbit with space + date', () => {
+    const source = `// CodeRabbit 2026-04-25 caught this\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toHaveLength(1);
+    expect(out[0].pattern).toBe('coderabbit-dated');
+  });
+
+  it('does NOT flag bare CodeRabbit references without a date', () => {
+    const source = `// per CodeRabbit review\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+
+  it('detects Issue #NNN anywhere inside a JSDoc block (pattern 5)', () => {
+    const source = `/**\n * Description.\n * Issue #777 reference.\n */\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([{ line: 3, col: 4, pattern: 'issue-ref' }]);
+  });
+
+  it('detects PR #NNN inside a JSDoc block', () => {
+    const source = `/**\n * From PR #321.\n */\n`;
+    const out = findViolationsInSource(source);
+    // Line 2: ` * From PR #321.` -- 1:` ` 2:`*` 3:` ` 4:`F` ... 9:`P`
+    expect(out).toEqual([{ line: 2, col: 9, pattern: 'pr-ref' }]);
+  });
+
+  it('detects multiple matches on the same line in order', () => {
+    const source = `// see Issue #1 and PR #2\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([
+      { line: 1, col: 8, pattern: 'issue-ref' },
+      { line: 1, col: 21, pattern: 'pr-ref' },
+    ]);
+  });
+
+  it('reports each match across multiple comment lines', () => {
+    const source = `// Issue #1\nconst x = 1;\n// PR #2\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([
+      { line: 1, col: 4, pattern: 'issue-ref' },
+      { line: 3, col: 4, pattern: 'pr-ref' },
+    ]);
+  });
+});
+
+describe('findViolationsInSource — negative cases (no false positives)', () => {
+  it('does NOT flag string literals containing `// Issue #N`', () => {
+    const source = `const note = "// Issue #123 in string"; const x = 1;\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT flag string literals containing a URL with #N fragment', () => {
+    const source = `const url = "https://github.com/foo/bar/issues/123";\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT flag the detector script (the patterns are code, not comments)', async () => {
+    // The detector script itself contains regex source strings like
+    // `/Issue #\d+/g` and pattern names like `'issue-ref'`. Those live in
+    // code (regex literals and string literals), not comments — so the
+    // detector run against itself must not flag them.
+    const source = await Bun.file(SCRIPT_PATH).text();
+    const out = findViolationsInSource(source);
+    // The script's own doc comments DO contain "Issue 898" (no `#`) and
+    // pattern descriptions like "Issue #NNN" with literal "NNN" (letters,
+    // not digits). Neither matches the detector's regex. Sanity-check
+    // there are zero flagged violations.
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT flag template literal contents', () => {
+    const source = 'const msg = `// Issue #123 in template`;\n';
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT flag regex literal contents', () => {
+    const source = `const re = /Issue #\\d+/g;\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT flag regex literals with escaped slashes (URL pattern)', () => {
+    // The kind of pattern that appears in actual production code:
+    //   /^https:\/\/hooks\.slack\.com\//
+    // Without regex-state handling, the `\/\/` substring would falsely
+    // trigger entering a line-comment state.
+    const source = `const URL = /^https:\\/\\/hooks\\.slack\\.com\\//;\n// trailing\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT flag `// Issue #N` inside a string used as a template', () => {
+    const source = `const t = "// Issue #1"; const u = '// PR #2';\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+});
+
+describe('isExcludedFile', () => {
+  it('excludes files in __tests__/ directories', () => {
+    expect(isExcludedFile('packages/server/src/foo/__tests__/bar.ts')).toBe(true);
+    expect(isExcludedFile('packages/server/src/__tests__/bar.ts')).toBe(true);
+  });
+
+  it('excludes .test.* files', () => {
+    expect(isExcludedFile('packages/server/src/foo.test.ts')).toBe(true);
+    expect(isExcludedFile('packages/server/src/foo.test.tsx')).toBe(true);
+    expect(isExcludedFile('packages/server/src/foo.test.js')).toBe(true);
+    expect(isExcludedFile('packages/server/src/foo.test.jsx')).toBe(true);
+  });
+
+  it('excludes .spec.* files', () => {
+    expect(isExcludedFile('packages/server/src/foo.spec.ts')).toBe(true);
+  });
+
+  it('does NOT exclude normal source files', () => {
+    expect(isExcludedFile('packages/server/src/foo.ts')).toBe(false);
+    expect(isExcludedFile('packages/client/src/components/Bar.tsx')).toBe(false);
+    expect(isExcludedFile('packages/shared/src/types.ts')).toBe(false);
+  });
+});
+
+describe('formatViolation / violationKey', () => {
+  it('formatViolation produces `file:line:col pattern` form', () => {
+    const v = { file: 'a/b.ts', line: 10, col: 5, pattern: 'issue-ref' };
+    expect(formatViolation(v)).toBe('a/b.ts:10:5 issue-ref');
+  });
+
+  it('violationKey produces `file:line:col:pattern` form', () => {
+    const v = { file: 'a/b.ts', line: 10, col: 5, pattern: 'issue-ref' };
+    expect(violationKey(v)).toBe('a/b.ts:10:5:issue-ref');
+  });
+});
+
+describe('runCheck — allowlist behaviour', () => {
+  function makeFixture() {
+    const root = mkdtempSync(join(tmpdir(), 'blame-shift-'));
+    mkdirSync(join(root, 'packages/server/src'), { recursive: true });
+    mkdirSync(join(root, 'packages/server/src/__tests__'), { recursive: true });
+    return root;
+  }
+
+  it('reports a violation whose key is in the allowlist as allowlisted (not failing)', async () => {
+    const root = makeFixture();
+    try {
+      writeFileSync(
+        join(root, 'packages/server/src/foo.ts'),
+        `// Issue #1\nconst x = 1;\n`,
+      );
+      // The key for this violation: foo:1:4:issue-ref
+      const allowlist = new Set(['packages/server/src/foo.ts:1:4:issue-ref']);
+      const result = await runCheck({ cwd: root, allowlist });
+      expect(result.violations).toHaveLength(1);
+      expect(result.allowlisted).toHaveLength(1);
+      expect(result.newViolations).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('the same pattern in a DIFFERENT file (different key) fails (not allowlisted)', async () => {
+    const root = makeFixture();
+    try {
+      writeFileSync(
+        join(root, 'packages/server/src/foo.ts'),
+        `// Issue #1\nconst x = 1;\n`,
+      );
+      writeFileSync(
+        join(root, 'packages/server/src/bar.ts'),
+        `// Issue #1\nconst y = 1;\n`,
+      );
+      const allowlist = new Set(['packages/server/src/foo.ts:1:4:issue-ref']);
+      const result = await runCheck({ cwd: root, allowlist });
+      expect(result.violations).toHaveLength(2);
+      expect(result.allowlisted).toHaveLength(1);
+      expect(result.newViolations).toHaveLength(1);
+      expect(result.newViolations[0].file).toBe('packages/server/src/bar.ts');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('honours an empty allowlist (every violation is new)', async () => {
+    const root = makeFixture();
+    try {
+      writeFileSync(
+        join(root, 'packages/server/src/foo.ts'),
+        `// Issue #1\nconst x = 1;\n`,
+      );
+      const result = await runCheck({ cwd: root, allowlist: new Set() });
+      expect(result.allowlisted).toEqual([]);
+      expect(result.newViolations).toHaveLength(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('excludes __tests__/ and *.test.* files from scanning', async () => {
+    const root = makeFixture();
+    try {
+      writeFileSync(
+        join(root, 'packages/server/src/foo.ts'),
+        `// Issue #1\nconst x = 1;\n`,
+      );
+      writeFileSync(
+        join(root, 'packages/server/src/__tests__/foo.ts'),
+        `// Issue #2\n`,
+      );
+      writeFileSync(
+        join(root, 'packages/server/src/foo.test.ts'),
+        `// Issue #3\n`,
+      );
+      const result = await runCheck({ cwd: root, allowlist: new Set() });
+      expect(result.violations).toHaveLength(1);
+      expect(result.violations[0].file).toBe('packages/server/src/foo.ts');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('findDefaultFiles — scan glob', () => {
+  it('returns no files when packages/*/src is empty', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'blame-shift-default-'));
+    try {
+      mkdirSync(join(root, 'packages/foo/src'), { recursive: true });
+      const files = await findDefaultFiles({ cwd: root });
+      expect(files).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns .ts/.tsx/.js/.jsx files under packages/*/src/**', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'blame-shift-default-'));
+    try {
+      mkdirSync(join(root, 'packages/a/src/sub'), { recursive: true });
+      mkdirSync(join(root, 'packages/b/src'), { recursive: true });
+      writeFileSync(join(root, 'packages/a/src/x.ts'), '');
+      writeFileSync(join(root, 'packages/a/src/sub/y.tsx'), '');
+      writeFileSync(join(root, 'packages/b/src/z.js'), '');
+      writeFileSync(join(root, 'packages/b/src/w.jsx'), '');
+      // Ignored: not under packages/*/src/
+      writeFileSync(join(root, 'packages/a/other.ts'), '');
+      const files = await findDefaultFiles({ cwd: root });
+      expect(files).toEqual([
+        'packages/a/src/sub/y.tsx',
+        'packages/a/src/x.ts',
+        'packages/b/src/w.jsx',
+        'packages/b/src/z.js',
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('KNOWN_VIOLATIONS — baseline integrity', () => {
+  it('is a non-empty Set (pre-existing violations were baked in)', () => {
+    expect(KNOWN_VIOLATIONS).toBeInstanceOf(Set);
+    expect(KNOWN_VIOLATIONS.size).toBeGreaterThan(0);
+  });
+
+  it('entries follow the `file:line:col:pattern` key shape', () => {
+    for (const key of KNOWN_VIOLATIONS) {
+      expect(key).toMatch(/^[^:]+:\d+:\d+:(issue-ref|pr-ref|bare-ref|coderabbit-dated)$/);
+    }
+  });
+
+  it('against the live tree, the script exits 0 (all current violations are allowlisted)', () => {
+    const result = spawnSync('bun', [SCRIPT_PATH], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Found 0 new violations');
+  });
+});

--- a/scripts/__tests__/check-source-comment-blame-shift.test.mjs
+++ b/scripts/__tests__/check-source-comment-blame-shift.test.mjs
@@ -188,6 +188,52 @@ describe('findViolationsInSource — positive cases', () => {
   });
 });
 
+// Each test below polarity-flips: it fails against the pre-fix
+// tokenizer (which treated `${...}` opaque inside a template literal)
+// and passes once the templateStack frame logic lands. The non-flipping
+// "and adjacent code still works" cases are intentionally excluded —
+// per testing rules, tests that pass identically on both branches do
+// not regression-guard the fix.
+describe('findViolationsInSource — template-literal interpolation expressions', () => {
+  it('detects a line comment inside a `${...}` expression', () => {
+    const source =
+      'const s = `Hello ${\n  // Issue #999 inside template expr\n  name\n}`;\n';
+    const out = findViolationsInSource(source);
+    expect(out).toHaveLength(1);
+    expect(out[0].pattern).toBe('issue-ref');
+    expect(out[0].line).toBe(2);
+  });
+
+  it('detects a block comment inside a `${...}` expression', () => {
+    const source = 'const s = `Hello ${/* Issue #888 */ name}`;\n';
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([{ line: 1, col: 23, pattern: 'issue-ref' }]);
+  });
+});
+
+// Each test below polarity-flips: it fails against the pre-fix regex
+// (no `\b`) which would match `MajorIssue #123` or `Issue #123abc`.
+// With word boundaries the matcher correctly rejects those.
+describe('findViolationsInSource — word-boundary discrimination (Issue/PR)', () => {
+  it('does NOT flag `Issue #N` when prefixed by another word character', () => {
+    const source = `// MajorIssue #123 in name\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT flag `Issue #NNN` when suffixed by letters (no word boundary)', () => {
+    const source = `// Issue #123abc not really\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT flag `PR #N` when prefixed by another word character', () => {
+    const source = `// AdjacentPR #50 ID\n`;
+    const out = findViolationsInSource(source);
+    expect(out).toEqual([]);
+  });
+});
+
 describe('findViolationsInSource — negative cases (no false positives)', () => {
   it('does NOT flag string literals containing `// Issue #N`', () => {
     const source = `const note = "// Issue #123 in string"; const x = 1;\n`;
@@ -419,6 +465,9 @@ describe('KNOWN_VIOLATIONS — baseline integrity', () => {
     const result = spawnSync('bun', [SCRIPT_PATH], {
       cwd: REPO_ROOT,
       encoding: 'utf-8',
+      // Cap the subprocess so a hang in the detector does not block the
+      // whole test run for the full bun-test default timeout.
+      timeout: 30_000,
     });
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('Found 0 new violations');

--- a/scripts/check-source-comment-blame-shift.mjs
+++ b/scripts/check-source-comment-blame-shift.mjs
@@ -91,6 +91,15 @@ export function* tokenizeComments(source) {
   // operator. The set CAN_PRECEDE_REGEX captures common JS operators and
   // punctuators that precede a regex literal in valid programs.
   let prevSig = '';
+  // Stack of "template expression frames" — one per open `${` inside an
+  // enclosing `bq` (backtick template) state. Each frame tracks the
+  // brace depth WITHIN that expression. When state is 'code' AND
+  // templateStack is non-empty, a `}` at depth 0 of the top frame closes
+  // the interpolation and returns the tokenizer to 'bq'. Nested
+  // templates work transparently because each `${` pushes its own frame
+  // and each closing `}` pops one. Without this stack, comments inside
+  // template-string interpolation expressions were silently skipped.
+  const templateStack = [];
   let commentText = '';
   let commentLine = 0;
   let commentCol = 0;
@@ -169,6 +178,34 @@ export function* tokenizeComments(source) {
         line++; col = 1; i++;
         continue;
       }
+      // Inside a template-string interpolation: track `{` and `}` so we
+      // know when a `}` closes the enclosing `${`. Top frame's
+      // braceDepth is incremented on `{` and decremented on `}`. When
+      // it reaches -1 (i.e. we see `}` at depth 0), we pop and return
+      // to `bq`.
+      if (templateStack.length > 0) {
+        if (ch === '{') {
+          templateStack[templateStack.length - 1].braceDepth += 1;
+          setPrevSig(ch);
+          i++; col++;
+          continue;
+        }
+        if (ch === '}') {
+          const top = templateStack[templateStack.length - 1];
+          if (top.braceDepth === 0) {
+            templateStack.pop();
+            state = 'bq';
+            // After popping, the closing `}` is consumed; the next char
+            // is part of the enclosing template literal.
+            i++; col++;
+            continue;
+          }
+          top.braceDepth -= 1;
+          setPrevSig(ch);
+          i++; col++;
+          continue;
+        }
+      }
       setPrevSig(ch);
       i++; col++;
       continue;
@@ -216,12 +253,18 @@ export function* tokenizeComments(source) {
         i++; col++;
         continue;
       }
-      // For simplicity we do NOT enter "code" inside ${...} expressions.
-      // Treating the expression contents as opaque is safe for our goal
-      // (detecting comments in real source) because template-string
-      // expressions almost never contain inline `/* ... */` comments
-      // that would matter to the detector. A `//` inside `${}` would
-      // also stay inside the template literal, which is fine.
+      if (ch === '$' && next === '{') {
+        // Enter the interpolation expression: push a fresh template
+        // frame and transition to 'code'. The matching `}` (at depth 0
+        // of this frame) will pop back to 'bq'.
+        templateStack.push({ braceDepth: 0 });
+        state = 'code';
+        // Setting prevSig to '{' makes a leading `/` (e.g. `${/re/}`)
+        // correctly classify as a regex literal.
+        prevSig = '{';
+        i += 2; col += 2;
+        continue;
+      }
       if (ch === '\n') { line++; col = 1; i++; continue; }
       i++; col++;
       continue;
@@ -334,13 +377,14 @@ function findViolationsInChunk(chunk) {
   const hits = [];
   const { text, col, kind } = chunk;
 
-  // 1. Issue #NNN
-  for (const m of text.matchAll(/Issue #\d+/g)) {
+  // 1. Issue #NNN — `\b` word boundaries prevent matches inside longer
+  //    identifiers; see the word-boundary tests for the expected shape.
+  for (const m of text.matchAll(/\bIssue #\d+\b/g)) {
     hits.push({ pattern: 'issue-ref', col: col + m.index });
   }
 
-  // 2. PR #NNN
-  for (const m of text.matchAll(/PR #\d+/g)) {
+  // 2. PR #NNN — same word-boundary rationale as issue-ref above.
+  for (const m of text.matchAll(/\bPR #\d+\b/g)) {
     hits.push({ pattern: 'pr-ref', col: col + m.index });
   }
 

--- a/scripts/check-source-comment-blame-shift.mjs
+++ b/scripts/check-source-comment-blame-shift.mjs
@@ -1,0 +1,716 @@
+#!/usr/bin/env bun
+
+/**
+ * Detector for source-comment blame-shift references.
+ *
+ * Scans `packages/<pkg>/src/**` for code comments that contain references
+ * to transient context — Issue numbers, PR numbers, dated CodeRabbit
+ * mentions, and bare cross-references. Such references rot as the
+ * codebase evolves: when an Issue is reorganised, when a PR is rebased
+ * away, when a date passes from "recent" to "ancient history" — the
+ * pointer in the comment becomes confusing or wrong. The right home for
+ * this context is the PR description and the git log (`git blame`,
+ * `git log -S`), not in the source itself.
+ *
+ * Patterns detected (case-sensitive, only inside `//` line comments or
+ * `/* ... *\/` block comments — NOT inside string literals):
+ *
+ *   1. `Issue #NNN`        (one-or-more digits)
+ *   2. `PR #NNN`           (one-or-more digits)
+ *   3. Lone `// #NNN`      (line comment whose content begins with `#NNN`
+ *                           followed by space, punctuation, or end-of-line)
+ *   4. `CodeRabbit, YYYY-MM-DD` or `CodeRabbit YYYY-MM-DD`
+ *   5. JSDoc / multi-line block comments containing patterns 1 or 2
+ *      (handled naturally by scanning each comment line)
+ *
+ * Output format (one violation per line, stable sorted by file/line/col):
+ *
+ *   path/to/file.ts:LINE:COL pattern-name
+ *
+ * Exit codes:
+ *   0 = no NEW violations (allowlisted matches are reported but do not fail)
+ *   1 = at least one NEW violation, or unexpected error
+ *
+ * Allowlist strategy:
+ *
+ * The KNOWN_VIOLATIONS set below is the inventory of pre-existing
+ * violations at the time this detector landed. The cleanup of those
+ * violations is tracked as a separate work stream in Issue 898 — that
+ * track removes references from source comments and migrates the
+ * narrative into PR descriptions / git log. This detector exists only
+ * to gate NEW growth: any violation whose key is NOT in KNOWN_VIOLATIONS
+ * fails the check.
+ *
+ * Maintenance rule: when fixing a pre-existing violation in an Issue 898
+ * cleanup PR, REMOVE its entry from KNOWN_VIOLATIONS in the same PR. The
+ * key format is `file:line:col:pattern-name` (a stable string). Keep the
+ * set sorted to make reviews and merges painless.
+ *
+ * Usage:
+ *   bun scripts/check-source-comment-blame-shift.mjs
+ *   bun scripts/check-source-comment-blame-shift.mjs path/to/file.ts ...
+ */
+
+import { Glob } from 'bun';
+
+const DEFAULT_GLOBS = [
+  'packages/*/src/**/*.ts',
+  'packages/*/src/**/*.tsx',
+  'packages/*/src/**/*.js',
+  'packages/*/src/**/*.jsx',
+];
+
+/**
+ * State machine that walks a source string and yields each comment as a
+ * sequence of line-bounded text chunks plus their source position.
+ *
+ * Comment kinds:
+ *   - 'line'  -> `// ...`
+ *   - 'block' -> `/* ... *\/`
+ *
+ * String literals (`'...'`, `"..."`, `` `...` ``) are tracked so a `//`
+ * sequence inside a string is NOT mistaken for the start of a line
+ * comment. Regex literals are tracked so escaped slashes inside the
+ * regex (e.g. `/^https?:\/\//`) are not mistaken for line comments.
+ *
+ * Each yielded chunk has the shape:
+ *   { text, line, col, kind }
+ * where `line` and `col` are the 1-based source position of the first
+ * character of `text`.
+ *
+ * @param {string} source
+ * @returns {Generator<{text: string, line: number, col: number, kind: 'line' | 'block'}>}
+ */
+export function* tokenizeComments(source) {
+  let i = 0;
+  let line = 1;
+  let col = 1;
+  let state = 'code'; // code | sq | dq | bq | regex | rcc | lc | bc
+  // Track last non-whitespace, non-comment significant char. Used to
+  // decide whether a `/` starts a regex literal or is a division
+  // operator. The set CAN_PRECEDE_REGEX captures common JS operators and
+  // punctuators that precede a regex literal in valid programs.
+  let prevSig = '';
+  let commentText = '';
+  let commentLine = 0;
+  let commentCol = 0;
+  let commentKind = 'line';
+
+  const startCommentChunk = (kind) => {
+    commentText = '';
+    commentLine = line;
+    commentCol = col;
+    commentKind = kind;
+  };
+
+  const flushCommentChunk = function* () {
+    yield { text: commentText, line: commentLine, col: commentCol, kind: commentKind };
+    commentText = '';
+  };
+
+  // Operators / punctuators after which a `/` starts a regex literal.
+  // Whitespace is skipped when tracking prevSig, so `=` followed by
+  // whitespace then `/regex/` still sees prevSig = '='. The set is
+  // permissive: false positives (treating a div as regex) are extremely
+  // rare in practice and only matter when the "regex" contains `//` or
+  // `/*` (which would otherwise be tokenized as comments).
+  const CAN_PRECEDE_REGEX = new Set([
+    '', '(', ',', '=', ':', '[', '!', '&', '|', '?', '+', '-', '*', '/', '%',
+    '^', '~', '<', '>', ';', '{', '}', '\n',
+  ]);
+
+  const setPrevSig = (ch) => {
+    if (ch === ' ' || ch === '\t' || ch === '\r') return; // ignore inline whitespace
+    prevSig = ch;
+  };
+
+  while (i < source.length) {
+    const ch = source[i];
+    const next = i + 1 < source.length ? source[i + 1] : '';
+
+    if (state === 'code') {
+      if (ch === '/' && next === '/') {
+        state = 'lc';
+        i += 2; col += 2;
+        startCommentChunk('line');
+        continue;
+      }
+      if (ch === '/' && next === '*') {
+        state = 'bc';
+        i += 2; col += 2;
+        startCommentChunk('block');
+        continue;
+      }
+      if (ch === '/' && CAN_PRECEDE_REGEX.has(prevSig)) {
+        state = 'regex';
+        i++; col++;
+        continue;
+      }
+      if (ch === "'") {
+        state = 'sq';
+        setPrevSig(ch);
+        i++; col++;
+        continue;
+      }
+      if (ch === '"') {
+        state = 'dq';
+        setPrevSig(ch);
+        i++; col++;
+        continue;
+      }
+      if (ch === '`') {
+        state = 'bq';
+        setPrevSig(ch);
+        i++; col++;
+        continue;
+      }
+      if (ch === '\n') {
+        prevSig = '\n';
+        line++; col = 1; i++;
+        continue;
+      }
+      setPrevSig(ch);
+      i++; col++;
+      continue;
+    }
+
+    if (state === 'sq' || state === 'dq') {
+      const quote = state === 'sq' ? "'" : '"';
+      if (ch === '\\') {
+        // Skip the escape sequence (at minimum one char; we are lenient
+        // about unicode/longer escapes since we only care about not
+        // exiting the string early).
+        if (next === '\n') {
+          // line-continuation: advance and bump line
+          i += 2; line++; col = 1;
+        } else {
+          i += 2; col += 2;
+        }
+        continue;
+      }
+      if (ch === quote) {
+        state = 'code';
+        setPrevSig(quote);
+        i++; col++;
+        continue;
+      }
+      if (ch === '\n') {
+        // Unterminated string literal — tolerate it: drop back to code.
+        state = 'code';
+        line++; col = 1; i++;
+        continue;
+      }
+      i++; col++;
+      continue;
+    }
+
+    if (state === 'bq') {
+      if (ch === '\\') {
+        if (next === '\n') { i += 2; line++; col = 1; }
+        else { i += 2; col += 2; }
+        continue;
+      }
+      if (ch === '`') {
+        state = 'code';
+        setPrevSig('`');
+        i++; col++;
+        continue;
+      }
+      // For simplicity we do NOT enter "code" inside ${...} expressions.
+      // Treating the expression contents as opaque is safe for our goal
+      // (detecting comments in real source) because template-string
+      // expressions almost never contain inline `/* ... */` comments
+      // that would matter to the detector. A `//` inside `${}` would
+      // also stay inside the template literal, which is fine.
+      if (ch === '\n') { line++; col = 1; i++; continue; }
+      i++; col++;
+      continue;
+    }
+
+    if (state === 'regex') {
+      if (ch === '\\') {
+        // Escaped char inside regex — skip both chars together.
+        if (next === '\n') { i += 2; line++; col = 1; }
+        else { i += 2; col += 2; }
+        continue;
+      }
+      if (ch === '[') {
+        state = 'rcc';
+        i++; col++;
+        continue;
+      }
+      if (ch === '/') {
+        state = 'code';
+        i++; col++;
+        // Consume regex flags (letters following the closing slash).
+        while (i < source.length && /[a-z]/i.test(source[i])) {
+          i++; col++;
+        }
+        setPrevSig('/');
+        continue;
+      }
+      if (ch === '\n') {
+        // Regex literals cannot contain unescaped newlines; treat as
+        // recovery from a misclassification and fall back to code.
+        state = 'code';
+        line++; col = 1; i++;
+        continue;
+      }
+      i++; col++;
+      continue;
+    }
+
+    if (state === 'rcc') {
+      // Regex character class [...]
+      if (ch === '\\') {
+        if (next === '\n') { i += 2; line++; col = 1; }
+        else { i += 2; col += 2; }
+        continue;
+      }
+      if (ch === ']') {
+        state = 'regex';
+        i++; col++;
+        continue;
+      }
+      if (ch === '\n') {
+        state = 'code';
+        line++; col = 1; i++;
+        continue;
+      }
+      i++; col++;
+      continue;
+    }
+
+    if (state === 'lc') {
+      if (ch === '\n') {
+        yield* flushCommentChunk();
+        state = 'code';
+        prevSig = '\n';
+        line++; col = 1; i++;
+        continue;
+      }
+      commentText += ch;
+      i++; col++;
+      continue;
+    }
+
+    if (state === 'bc') {
+      if (ch === '*' && next === '/') {
+        yield* flushCommentChunk();
+        state = 'code';
+        i += 2; col += 2;
+        setPrevSig('/');
+        continue;
+      }
+      if (ch === '\n') {
+        yield* flushCommentChunk();
+        line++; col = 1; i++;
+        startCommentChunk('block');
+        continue;
+      }
+      commentText += ch;
+      i++; col++;
+      continue;
+    }
+  }
+
+  // EOF inside a comment — flush whatever we accumulated.
+  if (state === 'lc' || state === 'bc') {
+    yield { text: commentText, line: commentLine, col: commentCol, kind: state === 'lc' ? 'line' : 'block' };
+  }
+}
+
+/**
+ * Find blame-shift violations within a comment chunk.
+ *
+ * Pure function — takes a chunk descriptor and emits `{ pattern, col }`
+ * records keyed by source column (the chunk's `col` plus the match's
+ * offset within `chunk.text`).
+ *
+ * @param {{text: string, line: number, col: number, kind: 'line' | 'block'}} chunk
+ * @returns {Array<{pattern: string, col: number}>}
+ */
+function findViolationsInChunk(chunk) {
+  const hits = [];
+  const { text, col, kind } = chunk;
+
+  // 1. Issue #NNN
+  for (const m of text.matchAll(/Issue #\d+/g)) {
+    hits.push({ pattern: 'issue-ref', col: col + m.index });
+  }
+
+  // 2. PR #NNN
+  for (const m of text.matchAll(/PR #\d+/g)) {
+    hits.push({ pattern: 'pr-ref', col: col + m.index });
+  }
+
+  // 3. Lone `// #NNN` — line comments only. The content (text accumulated
+  //    after `//`) begins with optional whitespace then `#NNN` followed
+  //    by a word boundary (space, punctuation, or end-of-line).
+  if (kind === 'line') {
+    const m = text.match(/^(\s*)#(\d+)\b/);
+    if (m) {
+      const hashCol = col + m[1].length;
+      hits.push({ pattern: 'bare-ref', col: hashCol });
+    }
+  }
+
+  // 4. `CodeRabbit, YYYY-MM-DD` or `CodeRabbit YYYY-MM-DD`
+  for (const m of text.matchAll(/CodeRabbit[,]?\s+\d{4}-\d{2}-\d{2}/g)) {
+    hits.push({ pattern: 'coderabbit-dated', col: col + m.index });
+  }
+
+  return hits;
+}
+
+/**
+ * Scan a single source text and return the list of violations with their
+ * (line, col, pattern) coordinates.
+ *
+ * Pure function — exported for direct testing.
+ *
+ * @param {string} source
+ * @returns {Array<{line: number, col: number, pattern: string}>}
+ */
+export function findViolationsInSource(source) {
+  const violations = [];
+  for (const chunk of tokenizeComments(source)) {
+    for (const hit of findViolationsInChunk(chunk)) {
+      violations.push({ line: chunk.line, col: hit.col, pattern: hit.pattern });
+    }
+  }
+  // Stable sort by line, then col, then pattern.
+  violations.sort((a, b) => a.line - b.line || a.col - b.col || a.pattern.localeCompare(b.pattern));
+  return violations;
+}
+
+/**
+ * Construct the allowlist key for a violation. Keys are file-line-col-pattern.
+ *
+ * @param {{file: string, line: number, col: number, pattern: string}} v
+ * @returns {string}
+ */
+export function violationKey(v) {
+  return `${v.file}:${v.line}:${v.col}:${v.pattern}`;
+}
+
+/**
+ * Format a violation for display.
+ *
+ * @param {{file: string, line: number, col: number, pattern: string}} v
+ * @returns {string}
+ */
+export function formatViolation(v) {
+  return `${v.file}:${v.line}:${v.col} ${v.pattern}`;
+}
+
+/**
+ * Should a file be excluded from scanning? Test files and `__tests__/`
+ * directories are excluded regardless of their location under
+ * `packages/<pkg>/src/`.
+ *
+ * @param {string} file
+ * @returns {boolean}
+ */
+export function isExcludedFile(file) {
+  if (file.includes('/__tests__/')) return true;
+  if (/\.test\.(ts|tsx|js|jsx)$/.test(file)) return true;
+  if (/\.spec\.(ts|tsx|js|jsx)$/.test(file)) return true;
+  return false;
+}
+
+/**
+ * Resolve the default target file list.
+ *
+ * @param {object} [options]
+ * @param {string} [options.cwd]
+ * @returns {Promise<string[]>}
+ */
+export async function findDefaultFiles({ cwd = process.cwd() } = {}) {
+  const set = new Set();
+  for (const pattern of DEFAULT_GLOBS) {
+    const glob = new Glob(pattern);
+    for await (const file of glob.scan({ cwd, onlyFiles: true })) {
+      if (isExcludedFile(file)) continue;
+      set.add(file);
+    }
+  }
+  return [...set].sort();
+}
+
+/**
+ * Read a single file from disk and scan it.
+ *
+ * @param {string} file repo-relative path
+ * @param {object} [options]
+ * @param {string} [options.cwd]
+ * @returns {Promise<Array<{file: string, line: number, col: number, pattern: string}>>}
+ */
+export async function findViolationsInFile(file, { cwd = process.cwd() } = {}) {
+  const abs = `${cwd}/${file}`;
+  const text = await Bun.file(abs).text();
+  return findViolationsInSource(text).map((v) => ({ file, ...v }));
+}
+
+/**
+ * Run the full check across a list of files (or the default glob set).
+ *
+ * @param {object} [options]
+ * @param {string} [options.cwd]
+ * @param {string[]} [options.files] explicit list (skips the default glob)
+ * @param {Set<string>} [options.allowlist]
+ * @returns {Promise<{
+ *   files: string[],
+ *   violations: Array<{file: string, line: number, col: number, pattern: string}>,
+ *   newViolations: Array<{file: string, line: number, col: number, pattern: string}>,
+ *   allowlisted: Array<{file: string, line: number, col: number, pattern: string}>,
+ * }>}
+ */
+export async function runCheck({ cwd = process.cwd(), files, allowlist = KNOWN_VIOLATIONS } = {}) {
+  const targetFiles = files ?? (await findDefaultFiles({ cwd }));
+  const violations = [];
+  for (const file of targetFiles) {
+    const fileViolations = await findViolationsInFile(file, { cwd });
+    violations.push(...fileViolations);
+  }
+  const newViolations = [];
+  const allowlisted = [];
+  for (const v of violations) {
+    if (allowlist.has(violationKey(v))) {
+      allowlisted.push(v);
+    } else {
+      newViolations.push(v);
+    }
+  }
+  return { files: targetFiles, violations, newViolations, allowlisted };
+}
+
+// ---------------------------------------------------------------------------
+// KNOWN_VIOLATIONS — pre-existing violations baked in at the time this
+// detector landed. See the file header for the maintenance rule.
+// Track for cleanup: Issue 898.
+// Key format: `file:line:col:pattern-name`.
+// ---------------------------------------------------------------------------
+export const KNOWN_VIOLATIONS = new Set([
+  'packages/client/src/components/repositories/AddRepositoryForm.tsx:45:53:issue-ref',
+  'packages/client/src/lib/api.ts:301:54:issue-ref',
+  'packages/client/src/lib/api.ts:323:54:issue-ref',
+  'packages/server/src/app-context.ts:124:17:issue-ref',
+  'packages/server/src/app-context.ts:155:34:issue-ref',
+  'packages/server/src/app-context.ts:162:34:issue-ref',
+  'packages/server/src/app-context.ts:169:27:issue-ref',
+  'packages/server/src/app-context.ts:180:45:issue-ref',
+  'packages/server/src/app-context.ts:482:53:issue-ref',
+  'packages/server/src/app-context.ts:654:55:issue-ref',
+  'packages/server/src/app-context.ts:750:52:issue-ref',
+  'packages/server/src/database/connection.ts:1277:45:issue-ref',
+  'packages/server/src/database/connection.ts:1287:48:issue-ref',
+  'packages/server/src/jobs/handlers.ts:122:6:issue-ref',
+  'packages/server/src/jobs/handlers.ts:123:41:issue-ref',
+  'packages/server/src/jobs/handlers.ts:123:54:pr-ref',
+  'packages/server/src/jobs/handlers.ts:126:44:issue-ref',
+  'packages/server/src/jobs/handlers.ts:128:53:pr-ref',
+  'packages/server/src/lib/config.ts:52:12:issue-ref',
+  'packages/server/src/lib/config.ts:53:46:issue-ref',
+  'packages/server/src/lib/config.ts:53:59:pr-ref',
+  'packages/server/src/lib/git.ts:9:4:issue-ref',
+  'packages/server/src/lib/git.ts:45:35:issue-ref',
+  'packages/server/src/lib/git.ts:309:42:issue-ref',
+  'packages/server/src/lib/git.ts:392:22:issue-ref',
+  'packages/server/src/lib/server-config.ts:114:44:issue-ref',
+  'packages/server/src/lib/template.ts:76:10:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:176:7:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:176:58:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:176:71:pr-ref',
+  'packages/server/src/mcp/mcp-server.ts:181:33:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:190:33:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:420:59:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:642:12:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:642:25:pr-ref',
+  'packages/server/src/mcp/mcp-server.ts:647:38:pr-ref',
+  'packages/server/src/mcp/mcp-server.ts:668:14:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:668:34:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:668:47:pr-ref',
+  'packages/server/src/mcp/mcp-server.ts:730:15:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:868:25:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:869:43:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:874:45:pr-ref',
+  'packages/server/src/mcp/mcp-server.ts:1067:37:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:1072:42:pr-ref',
+  'packages/server/src/mcp/mcp-server.ts:1208:32:issue-ref',
+  'packages/server/src/mcp/mcp-server.ts:1214:13:pr-ref',
+  'packages/server/src/routes/repositories.ts:54:42:issue-ref',
+  'packages/server/src/routes/repositories.ts:86:58:issue-ref',
+  'packages/server/src/routes/repositories.ts:189:8:issue-ref',
+  'packages/server/src/routes/repositories.ts:191:71:pr-ref',
+  'packages/server/src/routes/repositories.ts:192:42:pr-ref',
+  'packages/server/src/routes/repositories.ts:242:23:issue-ref',
+  'packages/server/src/routes/repositories.ts:276:10:issue-ref',
+  'packages/server/src/routes/repositories.ts:304:8:issue-ref',
+  'packages/server/src/routes/repositories.ts:325:10:issue-ref',
+  'packages/server/src/routes/sessions.ts:201:8:issue-ref',
+  'packages/server/src/routes/sessions.ts:201:42:pr-ref',
+  'packages/server/src/routes/sessions.ts:250:8:issue-ref',
+  'packages/server/src/routes/workers.ts:31:40:issue-ref',
+  'packages/server/src/routes/workers.ts:60:35:issue-ref',
+  'packages/server/src/routes/workers.ts:353:8:issue-ref',
+  'packages/server/src/routes/workers.ts:353:44:pr-ref',
+  'packages/server/src/routes/workers.ts:394:8:issue-ref',
+  'packages/server/src/routes/workers.ts:394:44:pr-ref',
+  'packages/server/src/routes/workers.ts:413:42:issue-ref',
+  'packages/server/src/routes/worktrees.ts:86:16:bare-ref',
+  'packages/server/src/routes/worktrees.ts:86:32:issue-ref',
+  'packages/server/src/routes/worktrees.ts:86:45:pr-ref',
+  'packages/server/src/routes/worktrees.ts:140:20:issue-ref',
+  'packages/server/src/routes/worktrees.ts:303:41:issue-ref',
+  'packages/server/src/routes/worktrees.ts:305:65:issue-ref',
+  'packages/server/src/services/branch-watcher-service.ts:152:35:issue-ref',
+  'packages/server/src/services/conditional-wakeup-manager.ts:62:48:pr-ref',
+  'packages/server/src/services/conditional-wakeup-manager.ts:98:31:issue-ref',
+  'packages/server/src/services/conditional-wakeup-manager.ts:240:61:issue-ref',
+  'packages/server/src/services/elevation-args.ts:10:19:issue-ref',
+  'packages/server/src/services/elevation-args.ts:14:48:pr-ref',
+  'packages/server/src/services/elevation-args.ts:49:32:pr-ref',
+  'packages/server/src/services/elevation-args.ts:131:48:pr-ref',
+  'packages/server/src/services/git-diff-service.ts:112:47:issue-ref',
+  'packages/server/src/services/github-cli.ts:12:17:pr-ref',
+  'packages/server/src/services/github-issue-service.ts:5:16:issue-ref',
+  'packages/server/src/services/github-issue-service.ts:9:33:pr-ref',
+  'packages/server/src/services/github-issue-service.ts:9:43:pr-ref',
+  'packages/server/src/services/github-issue-service.ts:67:32:pr-ref',
+  'packages/server/src/services/github-pr-service.ts:6:4:issue-ref',
+  'packages/server/src/services/github-pr-service.ts:14:39:pr-ref',
+  'packages/server/src/services/github-pr-service.ts:14:69:pr-ref',
+  'packages/server/src/services/interactive-process-manager.ts:95:31:issue-ref',
+  'packages/server/src/services/interactive-process-manager.ts:211:46:issue-ref',
+  'packages/server/src/services/privilege-elevation.ts:5:28:issue-ref',
+  'packages/server/src/services/privilege-elevation.ts:339:56:issue-ref',
+  'packages/server/src/services/pty-message-injection-service.ts:30:10:issue-ref',
+  'packages/server/src/services/pty-message-injection-service.ts:34:10:issue-ref',
+  'packages/server/src/services/pty-operation-executor.ts:15:45:issue-ref',
+  'packages/server/src/services/repository-clone-service.ts:2:43:issue-ref',
+  'packages/server/src/services/repository-clone-service.ts:57:14:pr-ref',
+  'packages/server/src/services/repository-clone-service.ts:238:49:issue-ref',
+  'packages/server/src/services/repository-clone-service.ts:387:17:pr-ref',
+  'packages/server/src/services/repository-clone-service.ts:575:48:issue-ref',
+  'packages/server/src/services/repository-clone-service.ts:624:27:pr-ref',
+  'packages/server/src/services/repository-manager.ts:32:60:issue-ref',
+  'packages/server/src/services/repository-manager.ts:36:5:issue-ref',
+  'packages/server/src/services/repository-manager.ts:36:18:pr-ref',
+  'packages/server/src/services/repository-manager.ts:211:8:issue-ref',
+  'packages/server/src/services/repository-manager.ts:213:41:issue-ref',
+  'packages/server/src/services/repository-manager.ts:222:20:issue-ref',
+  'packages/server/src/services/repository-manager.ts:255:44:issue-ref',
+  'packages/server/src/services/repository-manager.ts:313:13:pr-ref',
+  'packages/server/src/services/repository-manager.ts:451:62:issue-ref',
+  'packages/server/src/services/repository-manager.ts:452:6:pr-ref',
+  'packages/server/src/services/repository-manager.ts:453:38:issue-ref',
+  'packages/server/src/services/repository-manager.ts:547:9:issue-ref',
+  'packages/server/src/services/resolve-spawn-username.ts:54:17:pr-ref',
+  'packages/server/src/services/session-manager.ts:412:76:issue-ref',
+  'packages/server/src/services/session-manager.ts:755:209:issue-ref',
+  'packages/server/src/services/session-metadata-service.ts:147:20:issue-ref',
+  'packages/server/src/services/session-metadata-service.ts:192:25:issue-ref',
+  'packages/server/src/services/session-metadata-suggester.ts:25:66:issue-ref',
+  'packages/server/src/services/session-metadata-suggester.ts:26:6:pr-ref',
+  'packages/server/src/services/session-metadata-suggester.ts:26:64:issue-ref',
+  'packages/server/src/services/session-metadata-suggester.ts:139:8:bare-ref',
+  'packages/server/src/services/session-metadata-suggester.ts:139:15:pr-ref',
+  'packages/server/src/services/session-metadata-suggester.ts:145:8:issue-ref',
+  'packages/server/src/services/session-metadata-suggester.ts:145:28:issue-ref',
+  'packages/server/src/services/session-metadata-suggester.ts:145:41:pr-ref',
+  'packages/server/src/services/worker-lifecycle-manager.ts:184:10:issue-ref',
+  'packages/server/src/services/worker-lifecycle-manager.ts:474:31:issue-ref',
+  'packages/server/src/services/worker-manager.ts:98:6:issue-ref',
+  'packages/server/src/services/worker-manager.ts:123:53:issue-ref',
+  'packages/server/src/services/worker-manager.ts:274:15:issue-ref',
+  'packages/server/src/services/worker-manager.ts:316:8:issue-ref',
+  'packages/server/src/services/worker-manager.ts:422:8:issue-ref',
+  'packages/server/src/services/worktree-creation-service.ts:26:25:issue-ref',
+  'packages/server/src/services/worktree-creation-service.ts:27:8:bare-ref',
+  'packages/server/src/services/worktree-creation-service.ts:27:15:pr-ref',
+  'packages/server/src/services/worktree-creation-service.ts:56:63:issue-ref',
+  'packages/server/src/services/worktree-creation-service.ts:97:48:issue-ref',
+  'packages/server/src/services/worktree-deletion-service.ts:210:12:issue-ref',
+  'packages/server/src/services/worktree-deletion-service.ts:268:35:issue-ref',
+  'packages/server/src/services/worktree-deletion-service.ts:387:29:issue-ref',
+  'packages/server/src/services/worktree-service.ts:19:33:issue-ref',
+  'packages/server/src/services/worktree-service.ts:49:32:issue-ref',
+  'packages/server/src/services/worktree-service.ts:62:63:issue-ref',
+  'packages/server/src/services/worktree-service.ts:112:5:issue-ref',
+  'packages/server/src/services/worktree-service.ts:143:41:issue-ref',
+  'packages/server/src/services/worktree-service.ts:252:7:issue-ref',
+  'packages/server/src/services/worktree-service.ts:362:22:issue-ref',
+  'packages/server/src/services/worktree-service.ts:435:64:issue-ref',
+  'packages/server/src/services/worktree-service.ts:524:24:issue-ref',
+  'packages/server/src/services/worktree-service.ts:577:54:issue-ref',
+  'packages/server/src/services/worktree-service.ts:635:7:issue-ref',
+  'packages/server/src/services/worktree-service.ts:635:52:issue-ref',
+  'packages/server/src/services/worktree-service.ts:635:65:pr-ref',
+  'packages/server/src/services/worktree-service.ts:813:26:issue-ref',
+  'packages/server/src/services/worktree-service.ts:853:45:issue-ref',
+  'packages/server/src/services/worktree-service.ts:962:27:issue-ref',
+  'packages/server/src/services/worktree-service.ts:1008:25:issue-ref',
+  'packages/server/src/websocket/git-diff-handler.ts:14:6:issue-ref',
+  'packages/server/src/websocket/git-diff-handler.ts:40:6:issue-ref',
+  'packages/server/src/websocket/git-diff-handler.ts:61:50:issue-ref',
+  'packages/server/src/websocket/routes.ts:717:16:issue-ref',
+  'packages/server/src/websocket/routes.ts:717:52:pr-ref',
+  'packages/shared/src/schemas/repository.ts:17:31:issue-ref',
+  'packages/shared/src/schemas/repository.ts:18:14:pr-ref',
+  'packages/shared/src/schemas/repository.ts:49:32:issue-ref',
+  'packages/shared/src/schemas/repository.ts:59:51:issue-ref',
+  'packages/shared/src/schemas/repository.ts:112:45:issue-ref',
+  'packages/shared/src/schemas/repository.ts:149:55:issue-ref',
+  'packages/shared/src/types/job.ts:91:34:issue-ref',
+  'packages/shared/src/types/job.ts:91:47:pr-ref',
+  'packages/shared/src/types/job.ts:96:4:issue-ref',
+  'packages/shared/src/types/message-contracts.ts:4:13:issue-ref',
+]);
+
+// ---------------------------------------------------------------------------
+// CLI wrapper
+// ---------------------------------------------------------------------------
+
+async function main(argv) {
+  const args = argv.slice(2);
+  const explicit = args.filter((a) => !a.startsWith('-'));
+  const result = await runCheck({
+    files: explicit.length > 0 ? explicit : undefined,
+  });
+
+  // Sort all output for stable diffs.
+  const sortViolations = (vs) =>
+    [...vs].sort(
+      (a, b) =>
+        a.file.localeCompare(b.file) ||
+        a.line - b.line ||
+        a.col - b.col ||
+        a.pattern.localeCompare(b.pattern),
+    );
+
+  const newSorted = sortViolations(result.newViolations);
+  for (const v of newSorted) {
+    console.log(formatViolation(v));
+  }
+
+  const summary = `Found ${result.newViolations.length} new violation${result.newViolations.length === 1 ? '' : 's'} (${result.allowlisted.length} allowlisted)`;
+  if (result.newViolations.length === 0) {
+    console.log(summary);
+    return 0;
+  }
+  console.error('');
+  console.error(summary);
+  console.error(
+    'New comment references to Issues / PRs / dated CodeRabbit reviews are not allowed. ' +
+      'Such references rot as the codebase evolves; move the narrative into the PR description / git log instead.',
+  );
+  return 1;
+}
+
+const isMainModule =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('check-source-comment-blame-shift.mjs');
+if (isMainModule) {
+  process.exit(await main(process.argv));
+}


### PR DESCRIPTION
## Why

Source-code comments that reference transient context (Issue numbers, PR numbers, dated CodeRabbit mentions, blame-shift narrative) rot as the codebase evolves. Such references belong in PR descriptions and git log, not inside comments. This PR introduces a lint that gates **new** instances of this pattern from landing on `main`.

The companion cleanup of existing violations is tracked separately in Issue #898.

## Strategy: freeze the existing baseline via allowlist, block only new violations

- Current `main` contains **174 existing violations** across 39 source files.
- This PR ships the detector **without fixing any existing violation** (scope-separation from #898).
- The detector bakes every current violation into a `KNOWN_VIOLATIONS` Set keyed by `file:line:col:pattern`. CI fails only when a violation appears that is **not** in that Set.
- Each #898 cleanup PR will remove the corresponding entry from `KNOWN_VIOLATIONS` in the same PR, progressively shrinking the allowlist.

This split is deliberate: a single PR that both ships the gate and fixes 174 violations would be unreviewable, and reverting either half would be coupled to the other. Allowlist-first lets the gate land immediately while #898 sequences the cleanup at its own pace.

## Baseline breakdown (174 violations)

- **By package**: client 3 / server 161 / shared 10
- **By pattern**: `issue-ref` 132 / `pr-ref` 39 / `bare-ref` 3 / `coderabbit-dated` 0

## Suggested ordering for the Issue #898 cleanup track

Highest concentration first (biggest morale wins, largest blast radius per PR):

1. `packages/server/src/services/mcp/mcp-server.ts` — 19
2. `packages/server/src/services/worktree-service.ts` — 18
3. `packages/server/src/services/repository-manager.ts` — 13
4. `packages/server/src/services/session-metadata-suggester.ts` — 8
5. `packages/server/src/services/repository-clone-service.ts` — 6

Then sweep the long tail (1-3 violations per file across the remaining 34 files).

## Patterns detected

Case-sensitive, inside `//` and `/* */` comments only (not inside string literals or regex literals):

| Pattern | Example |
|---|---|
| `issue-ref` | `// Issue #902` |
| `pr-ref` | `// PR #897` |
| `bare-ref` | `// #838 followed by punctuation/space` |
| `coderabbit-dated` | `// CodeRabbit, 2026-04-25` or `// CodeRabbit 2026-04-25` |

Multi-line JSDoc blocks containing any of the above are detected the same way.

## Implementation notes

- **State-machine tokenizer.** A regex-over-source approach would produce false positives on JavaScript regex literals like `/^https:\/\//` (the `\/\/` resembles a line comment). The detector implements a small state machine over `{code, string-single, string-double, string-template, regex, line-comment, block-comment}` so matches inside non-comment contexts are skipped.
- **Allowlist key shape: `file:line:col:pattern`.** Some lines carry multiple distinct violations (e.g., `bare-ref` + `issue-ref` + `pr-ref` at different columns of the same line). Keying by `file:line` would collapse them and make per-violation cleanup tracking ambiguous.
- **Direct import in preflight, spawn in CI.** `preflight-check.js` invokes the detector via subprocess to match the existing language-check pattern. The only CI workflow that calls `preflight-check.js` (`preflight-check.yml`) already provisions `setup-bun`, so the new spawn has no transitive-callers gap.

## Summary

- `scripts/check-source-comment-blame-shift.mjs` — the detector (state-machine tokenizer + 4 pattern matchers + 174-entry `KNOWN_VIOLATIONS` allowlist + exported pure-function API + CLI wrapper).
- `scripts/__tests__/check-source-comment-blame-shift.test.mjs` — 44 sibling tests covering tokenizer states, every positive pattern, every negative case (string literals, regex literals, URLs), allowlist behaviour, and a meta-test that the current tree passes.
- `.github/workflows/comment-blame-shift-lint.yml` — CI workflow mirroring `language-lint.yml`, triggers on changes under `packages/*/src/**`.
- `.claude/skills/orchestrator/check-utils.js` — `runCommentBlameShiftCheck()` helper alongside `runLanguageCheck`.
- `.claude/skills/orchestrator/preflight-check.js` — new gate added before exit.

## Test plan

- [x] `bun run typecheck` — exit 0
- [x] `bun test scripts/__tests__/check-source-comment-blame-shift.test.mjs` — 44 pass / 0 fail
- [x] `bun scripts/check-source-comment-blame-shift.mjs` — `Found 0 new violations (174 allowlisted)` exit 0
- [x] `node .claude/skills/orchestrator/preflight-check.js` — all gates green
- [x] `bun run check:lang` — exit 0
- [x] Manual: introduce a synthetic violation in a temp file → detector exits 1 with that violation reported; remove temp file → exits 0
- [ ] CI green on PR (verified post-push)
- [ ] CodeRabbit review clean (3-layer verdict)

Note: `bun run test` (full suite) exits 1 due to 3 **pre-existing** failures unrelated to this PR. Verified by `git stash` baseline comparison: 2 in `packages/server/src/services/__tests__/git-diff-base-reresolve.test.ts` (network-dependent integration tests timing out in the sandbox) and 1 in `scripts/__tests__/install-hooks.test.mjs` (sandbox `git init` failing). All 3 fail identically on `origin/main`.

Closes #902

## CodeRabbit findings disposition (post-review)

- **Major 1** (template literal nested expression comments not detected): fixed in-PR — tokenizer state machine extended with a template-interpolation depth stack. Each `${` pushes a frame and the matching `}` pops back to the enclosing `bq` state, so comments inside interpolation expressions (including nested templates) are now scanned.
- **Major 2** (JSX text misclassify): investigated — confirmed no real-world impact. The pattern matchers require explicit `//` or `/* */` comment syntax, so raw JSX text, JSX attribute values, and JSX expression containers without those delimiters are never flagged. Probe TSX file under `packages/client/src/` confirmed zero false positives on plain JSX text; the only flagged sites were actual `/* */` block comments, which is correct behaviour. No code change; documented as a known limitation.
- **Major 3** (allowlist key brittleness — `file:line:col:pattern`): deferred to follow-up Issue #910. Reasoning: ergonomic concern (not correctness), requires regenerating all 174 entries and rewriting matching logic, qualifies as heavy-lift per the follow-up Issue convention. See #910 for the proposed content-hash key design.
- **Minor 4** (preflight comment / stdout mismatch): fixed in-PR — comment updated to describe the stdout-only output behaviour (the detector's stderr summary lines are not surfaced through preflight).
- **Minor 5** (spawnSync test missing timeout): fixed in-PR — `timeout: 30_000` added to the live-tree subprocess test so a hang in the detector cannot block the full test run.
- **Minor 6** (Issue/PR regex word boundaries): fixed in-PR — `\b` added to the `issue-ref` and `pr-ref` patterns. The 174-entry `KNOWN_VIOLATIONS` baseline is unchanged because no existing match relied on a missing word boundary (verified by re-running the detector before / after the regex change).