### PR TITLE
fix(server): elevate fetchRemote/fetchAllRemote to authenticated user (#912)

### DIFF
--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -1360,8 +1360,9 @@ describe('API Routes Integration', () => {
         expect(body.behind).toBe(3);
         expect(body.ahead).toBe(2);
 
-        // Verify fetchRemote was called with correct branch
-        expect(mockGit.fetchRemote).toHaveBeenCalledWith('main', repo.path);
+        // Verify fetchRemote was called with correct branch + the
+        // authenticated username (Issue #912: multi-user SSH elevation).
+        expect(mockGit.fetchRemote).toHaveBeenCalledWith('main', repo.path, TEST_AUTH_USER.username);
       });
 
       it('should return 404 for non-existent repository', async () => {
@@ -1437,8 +1438,9 @@ describe('API Routes Integration', () => {
         const body = (await res.json()) as { success: boolean };
         expect(body.success).toBe(true);
 
-        // Verify fetchAllRemote was called with correct path
-        expect(mockGit.fetchAllRemote).toHaveBeenCalledWith(repo.path);
+        // Verify fetchAllRemote was called with the correct path + the
+        // authenticated username (Issue #912: multi-user SSH elevation).
+        expect(mockGit.fetchAllRemote).toHaveBeenCalledWith(repo.path, TEST_AUTH_USER.username);
       });
 
       it('should return 404 for non-existent repository', async () => {

--- a/packages/server/src/__tests__/utils/mock-git-helper.ts
+++ b/packages/server/src/__tests__/utils/mock-git-helper.ts
@@ -69,8 +69,12 @@ export const mockGit = {
   getOrgRepoFromPath: mock(() => Promise.resolve('owner/repo')) as Mock<AsyncStringNullFn>,
 
   // Remote fetch operations
-  fetchRemote: mock(() => Promise.resolve()) as Mock<(branch: string, cwd: string) => Promise<void>>,
-  fetchAllRemote: mock(() => Promise.resolve()) as Mock<(cwd: string) => Promise<void>>,
+  fetchRemote: mock(() => Promise.resolve()) as Mock<
+    (branch: string, cwd: string, requestUser?: string | null) => Promise<void>
+  >,
+  fetchAllRemote: mock(() => Promise.resolve()) as Mock<
+    (cwd: string, requestUser?: string | null) => Promise<void>
+  >,
   getCommitsBehind: mock(() => Promise.resolve(0)) as Mock<(branch: string, cwd: string) => Promise<number>>,
   getCommitsAhead: mock(() => Promise.resolve(0)) as Mock<(branch: string, cwd: string) => Promise<number>>,
 

--- a/packages/server/src/lib/__tests__/git.test.ts
+++ b/packages/server/src/lib/__tests__/git.test.ts
@@ -102,6 +102,40 @@ describe('git remote operations', () => {
 
       await expect(fetchRemote('nonexistent', '/repo')).rejects.toBeInstanceOf(GitError);
     });
+
+    it('uses Bun.spawn directly when requestUser is omitted (default path)', async () => {
+      setMockSpawnResult('');
+      const { fetchRemote } = await getGitModule();
+
+      await fetchRemote('main', '/repo');
+
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args).toEqual(['git', 'fetch', 'origin', 'main']);
+      expect(spawnCalls[0].options.cwd).toBe('/repo');
+    });
+
+    it('routes through runAsUser when requestUser is non-empty (elevated path)', async () => {
+      const runAsUserCalls: Array<Record<string, unknown>> = [];
+      const fakeRunAsUser = async (opts: Record<string, unknown>) => {
+        runAsUserCalls.push(opts);
+        return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+      };
+
+      const mod = await getGitModule();
+      mod.__setRunAsUserForTesting(fakeRunAsUser);
+      try {
+        await mod.fetchRemote('main', '/repo', 'alice');
+
+        // Direct-spawn path was NOT used.
+        expect(spawnCalls.length).toBe(0);
+        expect(runAsUserCalls.length).toBe(1);
+        expect(runAsUserCalls[0].username).toBe('alice');
+        expect(runAsUserCalls[0].cwd).toBe('/repo');
+        expect(runAsUserCalls[0].command).toBe("'git' 'fetch' 'origin' 'main'");
+      } finally {
+        mod.__setRunAsUserForTesting(null);
+      }
+    });
   });
 
   describe('fetchAllRemote', () => {
@@ -132,6 +166,39 @@ describe('git remote operations', () => {
       const { fetchAllRemote, GitError } = await getGitModule();
 
       await expect(fetchAllRemote('/repo')).rejects.toBeInstanceOf(GitError);
+    });
+
+    it('uses Bun.spawn directly when requestUser is omitted (default path)', async () => {
+      setMockSpawnResult('');
+      const { fetchAllRemote } = await getGitModule();
+
+      await fetchAllRemote('/repo');
+
+      expect(spawnCalls.length).toBe(1);
+      expect(spawnCalls[0].args).toEqual(['git', 'fetch', 'origin']);
+      expect(spawnCalls[0].options.cwd).toBe('/repo');
+    });
+
+    it('routes through runAsUser when requestUser is non-empty (elevated path)', async () => {
+      const runAsUserCalls: Array<Record<string, unknown>> = [];
+      const fakeRunAsUser = async (opts: Record<string, unknown>) => {
+        runAsUserCalls.push(opts);
+        return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+      };
+
+      const mod = await getGitModule();
+      mod.__setRunAsUserForTesting(fakeRunAsUser);
+      try {
+        await mod.fetchAllRemote('/repo', 'alice');
+
+        expect(spawnCalls.length).toBe(0);
+        expect(runAsUserCalls.length).toBe(1);
+        expect(runAsUserCalls[0].username).toBe('alice');
+        expect(runAsUserCalls[0].cwd).toBe('/repo');
+        expect(runAsUserCalls[0].command).toBe("'git' 'fetch' 'origin'");
+      } finally {
+        mod.__setRunAsUserForTesting(null);
+      }
     });
   });
 

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -803,16 +803,27 @@ export async function pullFastForward(cwd: string): Promise<number> {
 
 /**
  * Fetch a specific branch from remote origin.
+ *
+ * @param requestUser - See {@link git}.
  */
-export async function fetchRemote(branch: string, cwd: string): Promise<void> {
-  await git(['fetch', 'origin', branch], cwd, NETWORK_GIT_TIMEOUT_MS);
+export async function fetchRemote(
+  branch: string,
+  cwd: string,
+  requestUser?: string | null,
+): Promise<void> {
+  await git(['fetch', 'origin', branch], cwd, NETWORK_GIT_TIMEOUT_MS, requestUser);
 }
 
 /**
  * Fetch all branches from remote origin.
+ *
+ * @param requestUser - See {@link git}.
  */
-export async function fetchAllRemote(cwd: string): Promise<void> {
-  await git(['fetch', 'origin'], cwd, NETWORK_GIT_TIMEOUT_MS);
+export async function fetchAllRemote(
+  cwd: string,
+  requestUser?: string | null,
+): Promise<void> {
+  await git(['fetch', 'origin'], cwd, NETWORK_GIT_TIMEOUT_MS, requestUser);
 }
 
 /**

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -1511,8 +1511,10 @@ describe('MCP Server Tools', () => {
 
       expect(response.result?.isError).toBeUndefined();
 
-      // Verify fetchRemote was called (the baseBranch defaults to 'main')
-      expect(mockGit.fetchRemote).toHaveBeenCalledWith('main', TEST_REPO_PATH);
+      // Verify fetchRemote was called (the baseBranch defaults to 'main').
+      // The 3rd arg is `requestUsername` — null here because no parent
+      // session context is provided in this test (Issue #912).
+      expect(mockGit.fetchRemote).toHaveBeenCalledWith('main', TEST_REPO_PATH, null);
     });
 
     it('should skip fetchRemote when useRemote is explicitly false', async () => {

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -384,6 +384,15 @@ describe('Repositories API', () => {
   // =========================================================================
 
   describe('GET /api/repositories/:id/branches/:branch/remote-status', () => {
+    beforeEach(() => {
+      mockGit.fetchRemote.mockReset();
+      mockGit.fetchRemote.mockImplementation(() => Promise.resolve());
+      mockGit.getCommitsBehind.mockReset();
+      mockGit.getCommitsBehind.mockImplementation(() => Promise.resolve(0));
+      mockGit.getCommitsAhead.mockReset();
+      mockGit.getCommitsAhead.mockImplementation(() => Promise.resolve(0));
+    });
+
     it('should return 400 when GitError occurs', async () => {
       repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
       mockGit.fetchRemote.mockImplementation(() => {
@@ -409,6 +418,77 @@ describe('Repositories API', () => {
       const body = (await res.json()) as { behind: number; ahead: number };
       expect(body.behind).toBe(3);
       expect(body.ahead).toBe(1);
+    });
+
+    it('forwards authUser.username to fetchRemote for multi-user SSH elevation (Issue #912)', async () => {
+      // Without this threading, `git fetch origin <branch>` runs as the
+      // `agentconsole` server user, which has no SSH credentials and fails
+      // against SSH-URL remotes with Permission denied (publickey). The
+      // default test app wires SingleUserMode with TEST_AUTH_USER.username
+      // = 'testuser'.
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      mockGit.fetchRemote.mockImplementation(() => Promise.resolve());
+      mockGit.getCommitsBehind.mockImplementation(() => Promise.resolve(0));
+      mockGit.getCommitsAhead.mockImplementation(() => Promise.resolve(0));
+
+      const res = await app.request('/api/repositories/repo1/branches/main/remote-status');
+      expect(res.status).toBe(200);
+
+      expect(mockGit.fetchRemote).toHaveBeenCalledTimes(1);
+      const callArgs = mockGit.fetchRemote.mock.calls[0];
+      expect(callArgs[0]).toBe('main');
+      expect(callArgs[1]).toBe('/repo');
+      expect(callArgs[2]).toBe('testuser');
+    });
+  });
+
+  // =========================================================================
+  // POST /api/repositories/:id/fetch (Issue #912)
+  // =========================================================================
+
+  describe('POST /api/repositories/:id/fetch', () => {
+    beforeEach(() => {
+      mockGit.fetchAllRemote.mockReset();
+      mockGit.fetchAllRemote.mockImplementation(() => Promise.resolve());
+    });
+
+    it('forwards authUser.username to fetchAllRemote for multi-user SSH elevation (Issue #912)', async () => {
+      // Same rationale as the remote-status fetch above -- the UI Fetch
+      // button must run as the requesting user so SSH-URL remotes
+      // authenticate.
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+
+      const res = await app.request('/api/repositories/repo1/fetch', { method: 'POST' });
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as { success: boolean };
+      expect(body.success).toBe(true);
+
+      expect(mockGit.fetchAllRemote).toHaveBeenCalledTimes(1);
+      const callArgs = mockGit.fetchAllRemote.mock.calls[0];
+      expect(callArgs[0]).toBe('/repo');
+      expect(callArgs[1]).toBe('testuser');
+    });
+
+    it('returns 404 when the repository is not registered', async () => {
+      repositoryManager.getRepository.mockReturnValue(undefined);
+
+      const res = await app.request('/api/repositories/missing/fetch', { method: 'POST' });
+      expect(res.status).toBe(404);
+      expect(mockGit.fetchAllRemote).not.toHaveBeenCalled();
+    });
+
+    it('maps GitError to a 400 response (network failure surfaces as Validation)', async () => {
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      mockGit.fetchAllRemote.mockImplementation(() => {
+        throw new GitError('network error', 128, 'fatal: network error');
+      });
+
+      const res = await app.request('/api/repositories/repo1/fetch', { method: 'POST' });
+      expect(res.status).toBe(400);
+
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain('Failed to fetch remote');
     });
   });
 

--- a/packages/server/src/routes/repositories.ts
+++ b/packages/server/src/routes/repositories.ts
@@ -373,6 +373,7 @@ const repositories = new Hono<AppBindings>()
     const repoId = c.req.param('id');
     const branch = c.req.param('branch');
     const { repositoryManager } = c.get('appContext');
+    const authUser = c.get('authUser');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {
@@ -380,8 +381,10 @@ const repositories = new Hono<AppBindings>()
     }
 
     try {
-      // First fetch the specific branch to get latest remote state
-      await fetchRemote(branch, repo.path);
+      // Thread the authenticated username so multi-user mode runs the network
+      // fetch as the requesting user (picks up their SSH_AUTH_SOCK / gitconfig
+      // via sudo -i); otherwise SSH-URL remotes fail with Permission denied.
+      await fetchRemote(branch, repo.path, authUser.username);
 
       // Then count commits behind and ahead
       const [behind, ahead] = await Promise.all([
@@ -402,6 +405,7 @@ const repositories = new Hono<AppBindings>()
   .post('/:id/fetch', async (c) => {
     const repoId = c.req.param('id');
     const { repositoryManager } = c.get('appContext');
+    const authUser = c.get('authUser');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {
@@ -409,7 +413,9 @@ const repositories = new Hono<AppBindings>()
     }
 
     try {
-      await fetchAllRemote(repo.path);
+      // Same rationale as the per-branch remote-status fetch above — elevate
+      // the network fetch so SSH-URL remotes authenticate as the user.
+      await fetchAllRemote(repo.path, authUser.username);
       return c.json({ success: true });
     } catch (error) {
       // Handle git-specific errors (network issues, no remote, etc.)

--- a/packages/server/src/services/__tests__/worktree-creation-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-creation-service.test.ts
@@ -152,8 +152,10 @@ describe('createWorktreeWithSession', () => {
     expect(result.session).toEqual(MOCK_SESSION);
     expect(result.setupCommandResult).toEqual({ success: true, output: 'setup done' });
 
-    // Verify fetch was called with remote branch
-    expect(mockGit.fetchRemote).toHaveBeenCalledWith('main', '/repos/my-repo');
+    // Verify fetch was called with remote branch. `requestUsername` is
+    // forwarded from `CreateWorktreeParams` -- undefined here because
+    // DEFAULT_PARAMS does not set it (single-user defaults).
+    expect(mockGit.fetchRemote).toHaveBeenCalledWith('main', '/repos/my-repo', undefined);
     // Verify createWorktree used origin/ prefix. `requestUsername` is
     // forwarded from `CreateWorktreeParams` -- undefined here because
     // DEFAULT_PARAMS does not set it (single-user defaults).
@@ -337,6 +339,21 @@ describe('createWorktreeWithSession', () => {
     expect(sessionRequest.templateVars).toEqual({ model: 'opus' });
     // createdBy is passed via the context parameter
     expect(passedContext).toEqual(context);
+  });
+
+  it('threads requestUsername to fetchRemote for SSH-credential elevation (Issue #912)', async () => {
+    // Without this threading, the pre-worktree `git fetch origin <baseBranch>`
+    // runs as the server user (`agentconsole`), which has no SSH credentials
+    // and silently falls back to the local branch -- exactly the symptom
+    // Issue #912 catches for SSH-URL remotes.
+    const sm = createMockSessionManager();
+    await createWorktreeWithSession(
+      { ...DEFAULT_PARAMS, requestUsername: 'alice' },
+      sm,
+      mockWorktreeService,
+    );
+
+    expect(mockGit.fetchRemote).toHaveBeenCalledWith('main', '/repos/my-repo', 'alice');
   });
 
   it('threads requestUsername to WorktreeService.createWorktree (Issue #838)', async () => {

--- a/packages/server/src/services/worktree-creation-service.ts
+++ b/packages/server/src/services/worktree-creation-service.ts
@@ -117,7 +117,10 @@ export async function createWorktreeWithSession(
 
   if (useRemote && baseBranch) {
     try {
-      await fetchRemote(baseBranch, repoPath);
+      // Forward `requestUsername` so multi-user mode runs the network fetch
+      // as the requesting user (picks up their SSH credentials via sudo -i),
+      // matching the elevated `createWorktree` call below.
+      await fetchRemote(baseBranch, repoPath, requestUsername);
       effectiveBaseBranch = `origin/${baseBranch}`;
     } catch (error) {
       logger.warn(


### PR DESCRIPTION
## Summary

Closes #912
Refs #837 (Wave 2 elevation umbrella)

In multi-user mode, `fetchRemote` and `fetchAllRemote` in `packages/server/src/lib/git.ts` ran unconditionally as the server user (`agentconsole`), which lacks GitHub SSH credentials. Every user-initiated fetch path silently failed against private SSH-URL repositories with `Permission denied (publickey)`:

- The UI "Fetch" button (`POST /api/repositories/:id/fetch`).
- The branch remote-status check (`GET /api/repositories/:id/branches/:branch/remote-status`).
- The pre-worktree-create fetch in `createWorktreeWithSession` (silent fallback to local branch).

This PR wires the three call sites to forward the authenticated user through to the existing `git()` helper, which already accepts `requestUser?: string | null` and routes the invocation through `runAsUser` (the elevated login shell picks up the user's PATH / gitconfig / SSH_AUTH_SOCK).

## Production wiring (3 files)

- **`packages/server/src/lib/git.ts`** — `fetchRemote(branch, cwd, requestUser?)` and `fetchAllRemote(cwd, requestUser?)` accept the optional trailing arg and forward it to the inner `git()` call. JSDoc references `{@link git}` per the sibling pattern.
- **`packages/server/src/routes/repositories.ts`** — both routes read `c.get('authUser')` and pass `authUser.username` to the respective git helper.
- **`packages/server/src/services/worktree-creation-service.ts`** — forwards the already-received `requestUsername` to `fetchRemote`, matching the elevated `createWorktree` call below it.

This is purely call-site wiring — no elevation infra refactor, no clone-time auth path changes (out of scope per Issue body). Mirrors the Wave 2 elevation pattern established for `git worktree add` (#843), `listBranches` / `refreshDefaultBranch` (#870), `delegate_to_worktree` (#877), and `executeHookCommand` (#896).

## Tests (+9 new cases)

- **`lib/__tests__/git.test.ts`** — `fetchRemote` and `fetchAllRemote` each get two cases: "uses Bun.spawn directly when requestUser is omitted (default path)" and "routes through runAsUser when requestUser is non-empty (elevated path)". Mirrors the existing `requestUser routing (Issue #869 / #870)` block (argv-shape assertions via `__setRunAsUserForTesting`).
- **`routes/__tests__/repositories.test.ts`** — `GET /:id/branches/:branch/remote-status` and `POST /:id/fetch` each assert the username is forwarded to the corresponding git helper. The POST route had no prior tests; this PR adds a fresh describe block covering happy-path, 404, and 400-GitError cases.
- **`services/__tests__/worktree-creation-service.test.ts`** — `createWorktreeWithSession({ requestUsername: 'alice' })` asserts `fetchRemote` was called with the elevated username.

Pre-existing assertions in `api.test.ts`, `mcp-server.test.ts`, and `worktree-creation-service.test.ts` happy-path test were updated to include the new trailing arg (4 sites total, all asserting the existing single-user path with `undefined` / `null` / `TEST_AUTH_USER.username`).

## Polarity-flip verification

Per workflow.md "No partial polarity", stashed the production diff only (kept tests + mock-helper changes) and re-ran the affected tests. Result:

- **5/5 NEW tests failed without the wiring** — all 5 new cases exercise the elevated path and depend on the production wiring to pass.
- **4/4 UPDATED pre-existing assertions also failed** — they assert the new arity (`toHaveBeenCalledWith('main', '/repo', 'testuser')` etc.).

After `git stash pop`, all 9 changed cases pass. No partial polarity.

## Verification

| Gate | Exit |
|---|---|
| `bun run typecheck` | 0 |
| Full server `bun test src/` | 2941 pass / 1 skip / 6 fail |
| `bun run check:lang` | 0 |
| `node .claude/skills/orchestrator/preflight-check.js` | 0 |
| `bun scripts/check-source-comment-blame-shift.mjs` | 0 (0 new violations; all `Issue #912` mentions are in `__tests__/`, excluded by the lint) |

### Pre-existing test failures (NOT caused by this PR)

Baseline comparison: stashed the entire diff and re-ran `bun test src/` on the unmodified base — got the same **6 failures** (and 9 fewer passes, matching the +9 new test count). The 6 failures are:

- `build output (dist/) shape > bun run build produces a self-contained dist/...` — requires a prior `bun run build`; pre-existing environmental dependency.
- `Issue #800: git-diff base spec re-resolution (real repo)` × 2 — same fixture-state flakes the agent's first run hit; documented Sprint 2026-04-25 lesson.
- `InteractiveProcessManager` × 3 (`runProcess > should detect exit when a stdin-reading script calls process.exit(0)`, `output flush before exit > should call onOutput before onExit when process exits after writeResponse`, `output buffering > should call onOutput exactly once per settled output burst for writeResponse flow`) — timing-sensitive PTY tests.

None of these touch fetch / elevation code paths. Verified clean diff impact via baseline.

## Test plan

- [ ] Owner verifies the UI "Fetch" button works against a private SSH-URL repository in multi-user mode (`Permission denied (publickey)` should no longer appear).
- [ ] Owner verifies branch remote-status check works for the same private repo.
- [ ] Owner verifies pre-worktree-create fetch succeeds (no silent fallback to stale local branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)