### PR TITLE
docs(readme): add multi-user systemd webhook setup recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,38 @@ Agent Console can receive GitHub webhooks and route them to active sessions. Whe
    - **Secret**: Same value as `GITHUB_WEBHOOK_SECRET`
    - **Events**: Select individual events: `Workflow runs`, `Issues`, `Pull requests`
 
+### Multi-user mode (Ubuntu / systemd) recipe
+
+Place the secret in a file **outside the deploy target** so that the rsync `--delete` in `scripts/update-and-deploy-for-multiuser-ubuntu.sh` does not wipe it on the next redeploy. The recommended path is `/home/<service-user>/.config/agent-console/secrets.env`, owned by the service user with mode `0600`. Then point the systemd unit at it via `EnvironmentFile=-`.
+
+```bash
+# 1. Secret file outside the deploy target
+sudo mkdir -p /home/agentconsole/.config/agent-console
+echo "GITHUB_WEBHOOK_SECRET=$(openssl rand -hex 32)" | \
+  sudo tee /home/agentconsole/.config/agent-console/secrets.env
+sudo chown -R agentconsole:agentconsole /home/agentconsole/.config/agent-console
+sudo chmod 600 /home/agentconsole/.config/agent-console/secrets.env
+
+# 2. Reference from the systemd unit
+sudo systemctl edit --full agent-console.service
+# In [Service], add:
+#   EnvironmentFile=-/home/agentconsole/.config/agent-console/secrets.env
+# The leading `-` makes the unit start even if the file is absent.
+
+# 3. Reload + restart
+sudo systemctl daemon-reload
+sudo systemctl restart agent-console.service
+
+# 4. Verify (see "Verifying webhook configuration" below for the auth-cookie variant)
+# From a logged-in browser DevTools console:
+#   fetch('/api/system/health').then(r => r.json()).then(console.log)
+# → { webhookSecretConfigured: true, ... }
+```
+
+**Why outside the deploy target.** `scripts/update-and-deploy-for-multiuser-ubuntu.sh` syncs the source-repo into the deploy target with `rsync -a --delete`, excluding only `node_modules` and `.git`. A secret file placed at `<deploy-target>/.env` would work on the first deploy (Bun auto-loads env files at `WorkingDirectory`) but would be deleted on the next `update-and-deploy-for-multiuser-ubuntu.sh` invocation, because env files are excluded from the source-repo by `.gitignore`. Placing the secret under `/home/<service-user>/.config/agent-console/` and referencing it via `EnvironmentFile=-` keeps deploys and secret management on independent lifecycles.
+
+**Tunneling for inbound webhooks** (Cloudflare Tunnel, ngrok, etc.) works the same as in the single-user instructions above — point the public URL at the server's `HOST:PORT` (e.g. `127.0.0.1:8080` for the bootstrap default).
+
 ### Supported Events
 
 | GitHub Event | Condition | Inbound Event | Actions |

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -439,6 +439,18 @@ The script does not perform `git pull` itself — sync the source-repo to the
 intended commit before invoking, and confirm via the printed HEAD line in the
 script's `==> Pre-check` step before the build proceeds.
 
+## GitHub Webhook Setup (multi-user)
+
+For inbound GitHub webhook configuration on the systemd instance — including the
+`EnvironmentFile=-` pattern that survives the deploy script's `rsync --delete` —
+see the README's
+[GitHub Webhook Integration → Multi-user mode (Ubuntu / systemd) recipe](../README.md#multi-user-mode-ubuntu--systemd-recipe).
+
+The short version: place the secret under
+`/home/<service-user>/.config/agent-console/secrets.env` (outside the deploy
+target), reference it from the systemd unit with `EnvironmentFile=-`, then
+`systemctl daemon-reload && systemctl restart agent-console.service`.
+
 ## Environment Variables
 
 | Variable | Default | Description |


### PR DESCRIPTION
## Summary

Document the multi-user / systemd GitHub webhook setup recipe (`EnvironmentFile=-` pattern outside the deploy target) in `README.md`, and cross-reference it from `docs/multi-user-setup-guide.md`. The recipe was discovered and dogfood-verified on 2026-06-29; this PR records the canonical instructions so future operators do not have to reverse-engineer it from `scripts/update-and-deploy-for-multiuser-ubuntu.sh` and the systemd unit.

Closes #916

## Why outside the deploy target

`scripts/update-and-deploy-for-multiuser-ubuntu.sh` uses `rsync -a --delete --exclude=node_modules --exclude='.git'`. A secret placed at `<deploy-target>/.env` would work on the first deploy (Bun auto-loads env files at `WorkingDirectory`) but is deleted on the next deploy because env files are excluded from the source-repo by `.gitignore`. Placing the secret at `/home/<service-user>/.config/agent-console/secrets.env` and referencing it via `EnvironmentFile=-` decouples secret management from the deploy lifecycle.

## Changes

- `README.md`: new "Multi-user mode (Ubuntu / systemd) recipe" subsection under "GitHub Webhook Integration → Setup", with secret file placement, ownership/mode, systemd `EnvironmentFile=-` pattern, daemon-reload/restart, and a verification pointer.
- `docs/multi-user-setup-guide.md`: short "GitHub Webhook Setup (multi-user)" subsection after "Iterative Updates", linking to the README recipe.

## Out of scope

- Modifying `scripts/update-and-deploy-for-multiuser-ubuntu.sh` to exclude env files (Issue #916 "Optional follow-up" — separate concern).
- Documenting `dev-multiuser.sh` webhook secret placement (no systemd; needs its own short note).
- Generalizing for other secrets — could unify later under an "Operator secrets management" section.

## Test plan

- [x] `bun run check:lang` exit 0 (language policy enforcement).
- [ ] Reviewer: confirm the new README anchor link from `docs/multi-user-setup-guide.md` resolves on GitHub once merged (rendered Markdown uses kebab-cased headings).
- [ ] Reviewer: confirm code blocks render correctly in the README's existing "GitHub Webhook Integration" section flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
