### PR TITLE
[AI] closes #929 fix(client): resolve Terminal cache save race on unmount

### DIFF
--- a/packages/client/src/components/__tests__/Terminal.test.tsx
+++ b/packages/client/src/components/__tests__/Terminal.test.tsx
@@ -1392,6 +1392,116 @@ describe('Terminal cache-save payload contract', () => {
 });
 
 /**
+ * Repro-level test for the Terminal cache save race on rapid unmount/remount
+ * (Issue #929).
+ *
+ * Terminal.tsx's cleanup calls `unregisterSaveManager(...)` fire-and-forget
+ * (React does not await sync return values from useEffect cleanup, see
+ * Terminal.tsx around line 846). When the user rapidly switches to another
+ * session tab and back, a new Terminal mounts with the same sessionId:workerId
+ * BEFORE the previous unregister has finished (its `await pendingSave` is
+ * still in-flight). Without an identity guard, the trailing
+ * `registry.delete(key)` inside the stale unregister wipes the newly-mounted
+ * Terminal's registry entry, and the second unmount's save is silently lost.
+ *
+ * The Terminal component cannot be rendered in unit tests (xterm.js mocking
+ * pollutes global state) so this test drives the save-manager via the same
+ * public API Terminal.tsx uses and asserts the observable end state: the
+ * second mount's `unregister` must save its dirty state.
+ */
+describe('Terminal cache save race on rapid unmount/remount (Issue #929)', () => {
+  const TEST_IDLE_DELAY_MS = 20;
+  const capturedSaves: Array<{
+    sessionId: string;
+    workerId: string;
+    state: CachedState;
+  }> = [];
+
+  beforeEach(() => {
+    clearSaveManagerRegistry();
+    capturedSaves.length = 0;
+    setIdleSaveDelay(TEST_IDLE_DELAY_MS);
+  });
+
+  afterEach(() => {
+    clearSaveManagerRegistry();
+    capturedSaves.length = 0;
+    resetIdleSaveDelay();
+    resetSaveFunction();
+  });
+
+  it('saves the second-mount state after fire-and-forget unmount + immediate remount', async () => {
+    // The first save (Mount A's idle save) is deliberately slow so that
+    // Mount A's `unregister` is still suspended on `await pendingSave` when
+    // Mount B registers. Subsequent saves resolve immediately.
+    let saveCallCount = 0;
+    let resolveSlowSave: (() => void) | null = null;
+    const slowSavePromise = new Promise<void>((resolve) => {
+      resolveSlowSave = resolve;
+    });
+
+    setSaveFunction(async (sessionId, workerId, state) => {
+      saveCallCount++;
+      capturedSaves.push({ sessionId, workerId, state });
+      if (saveCallCount === 1) {
+        await slowSavePromise;
+      }
+    });
+
+    const stateA: CachedState = {
+      data: 'mount-A-data',
+      savedAt: 1,
+      cols: 80,
+      rows: 24,
+      offset: 100,
+    };
+    const stateB: CachedState = {
+      data: 'mount-B-data',
+      savedAt: 2,
+      cols: 80,
+      rows: 24,
+      offset: 200,
+    };
+
+    // === Mount A ===
+    registerSaveManager('session-1', 'worker-1', () => stateA);
+    markSaveManagerDirty('session-1', 'worker-1');
+    // Idle timer fires -> executeIdleSave sets pendingSave to the slow save
+    await new Promise((resolve) =>
+      setTimeout(resolve, TEST_IDLE_DELAY_MS + 20)
+    );
+    expect(capturedSaves).toHaveLength(1);
+
+    // === Mount A unmounts (fire-and-forget, mirrors Terminal.tsx cleanup) ===
+    const unregisterPromiseA = unregisterSaveManager('session-1', 'worker-1');
+    // Yield so unregisterA enters `await workerState.pendingSave`
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // === Mount B (same sessionId:workerId) mounts before A's cleanup finishes ===
+    registerSaveManager('session-1', 'worker-1', () => stateB);
+    markSaveManagerDirty('session-1', 'worker-1');
+
+    // === Release Mount A's slow save so its cleanup can finish ===
+    resolveSlowSave!();
+    await unregisterPromiseA;
+
+    // === Mount B unmounts ===
+    await unregisterSaveManager('session-1', 'worker-1');
+
+    // Expected observable behavior:
+    //   - Mount A saved stateA during its idle timer (before unmount).
+    //   - Mount B saved stateB during its unmount.
+    //
+    // Without the fix, Mount A's trailing `registry.delete(key)` wipes
+    // Mount B's registry entry, so Mount B's unregister sees no entry and
+    // silently skips the save. `capturedSaves` then only contains stateA.
+    expect(capturedSaves).toHaveLength(2);
+    expect(capturedSaves[0].state.data).toBe('mount-A-data');
+    expect(capturedSaves[1].state.data).toBe('mount-B-data');
+  });
+});
+
+/**
  * Tests for the xterm.js fontFamily stack configured in Terminal.tsx.
  *
  * Background (#818): The original fontFamily only named Mac fonts (Menlo, Monaco,

--- a/packages/client/src/components/__tests__/Terminal.test.tsx
+++ b/packages/client/src/components/__tests__/Terminal.test.tsx
@@ -1478,12 +1478,23 @@ describe('Terminal cache save race on rapid unmount/remount (Issue #929)', () =>
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     // === Mount B (same sessionId:workerId) mounts before A's cleanup finishes ===
+    // Raise the idle delay to something far larger than the test can wall-clock,
+    // so Mount B's idle timer CANNOT fire before we manually unregister below.
+    // This isolates the assertion to the unregister-path save specifically —
+    // otherwise the test could green-light via the idle-timer path if scheduling
+    // stalls under load, masking the bug the fix targets.
+    setIdleSaveDelay(60_000);
     registerSaveManager('session-1', 'worker-1', () => stateB);
     markSaveManagerDirty('session-1', 'worker-1');
 
     // === Release Mount A's slow save so its cleanup can finish ===
     resolveSlowSave!();
     await unregisterPromiseA;
+
+    // Sanity check: only Mount A's save has been captured so far. If Mount B's
+    // idle timer had somehow fired, this assertion would catch it before the
+    // final assertion becomes ambiguous.
+    expect(capturedSaves).toHaveLength(1);
 
     // === Mount B unmounts ===
     await unregisterSaveManager('session-1', 'worker-1');

--- a/packages/client/src/components/__tests__/Terminal.test.tsx
+++ b/packages/client/src/components/__tests__/Terminal.test.tsx
@@ -1392,8 +1392,7 @@ describe('Terminal cache-save payload contract', () => {
 });
 
 /**
- * Repro-level test for the Terminal cache save race on rapid unmount/remount
- * (Issue #929).
+ * Repro-level test for the Terminal cache save race on rapid unmount/remount.
  *
  * Terminal.tsx's cleanup calls `unregisterSaveManager(...)` fire-and-forget
  * (React does not await sync return values from useEffect cleanup, see
@@ -1409,7 +1408,7 @@ describe('Terminal cache-save payload contract', () => {
  * public API Terminal.tsx uses and asserts the observable end state: the
  * second mount's `unregister` must save its dirty state.
  */
-describe('Terminal cache save race on rapid unmount/remount (Issue #929)', () => {
+describe('Terminal cache save race on rapid unmount/remount', () => {
   const TEST_IDLE_DELAY_MS = 20;
   const capturedSaves: Array<{
     sessionId: string;

--- a/packages/client/src/lib/__tests__/terminal-state-save-manager.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-state-save-manager.test.ts
@@ -380,7 +380,7 @@ describe('terminal-state-save-manager', () => {
     });
   });
 
-  describe('unregister race with concurrent re-register (Issue #929)', () => {
+  describe('unregister race with concurrent re-register', () => {
     // These tests reproduce the following race:
     // 1. Terminal A unmounts -> React cleanup fires `unregister(...)` fire-and-forget.
     // 2. Inside unregister, execution suspends on `await workerState.pendingSave`.

--- a/packages/client/src/lib/__tests__/terminal-state-save-manager.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-state-save-manager.test.ts
@@ -13,6 +13,8 @@ import {
   getIdleSaveDelay,
   setSaveFunction,
   resetSaveFunction,
+  setTruncationCheckFunction,
+  resetTruncationCheckFunction,
   DEFAULT_IDLE_SAVE_DELAY_MS,
 } from '../terminal-state-save-manager';
 
@@ -371,6 +373,108 @@ describe('terminal-state-save-manager', () => {
 
       // Should not have saved (registry was cleared)
       expect(saveTerminalStateCalls.length).toBe(0);
+    });
+  });
+
+  describe('unregister race with concurrent re-register (Issue #929)', () => {
+    // These tests reproduce the following race:
+    // 1. Terminal A unmounts -> React cleanup fires `unregister(...)` fire-and-forget.
+    // 2. Inside unregister, execution suspends on `await workerState.pendingSave`.
+    // 3. A new Terminal (same sessionId:workerId, e.g. a fast tab switch back)
+    //    mounts and calls `register(...)`, which OVERWRITES the registry slot.
+    // 4. Suspended unregister resumes and unconditionally calls
+    //    `registry.delete(key)`, wiping the newly-registered entry.
+    // 5. On the next unmount, `unregister` sees no entry and the second
+    //    Terminal's cache save is silently lost.
+    //
+    // The fix guards `registry.delete(key)` with an object-identity check
+    // (`registry.get(key) === workerState`) so an in-flight unregister for
+    // a stale entry never touches a replacement entry.
+
+    it('should not delete a re-registered entry after the in-flight save completes', async () => {
+      let resolveSlowSave: (() => void) | null = null;
+      const slowSavePromise = new Promise<void>((resolve) => {
+        resolveSlowSave = resolve;
+      });
+      setSaveFunction(async (sessionId, workerId, state) => {
+        saveTerminalStateCalls.push({ sessionId, workerId, state });
+        await slowSavePromise;
+      });
+
+      const stateA = createValidState({ data: 'state-A' });
+      const stateB = createValidState({ data: 'state-B' });
+
+      // Mount A: register + markDirty. Wait for the idle timer to fire so the
+      // executeIdleSave path assigns `workerState.pendingSave` to the slow save.
+      register('session-1', 'worker-1', () => stateA);
+      markDirty('session-1', 'worker-1');
+      await new Promise((resolve) =>
+        setTimeout(resolve, TEST_IDLE_DELAY_MS + 20)
+      );
+      expect(saveTerminalStateCalls.length).toBe(1);
+
+      // Fire-and-forget unregister — suspends on `await workerState.pendingSave`.
+      const unregisterPromise = unregister('session-1', 'worker-1');
+      // Yield a microtask so unregister enters the await state.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Concurrent re-register (simulating a fast Terminal re-mount).
+      register('session-1', 'worker-1', () => stateB);
+      expect(getRegistrySize()).toBe(1);
+
+      // Release the slow save so the in-flight unregister resumes and runs its
+      // trailing `registry.delete(key)`.
+      resolveSlowSave!();
+      await unregisterPromise;
+
+      // With the fix: identity guard skips the delete because the entry was
+      // replaced. Without the fix: entry B is deleted here.
+      expect(getRegistrySize()).toBe(1);
+
+      // Additionally, markDirty must still target entry B — proving the
+      // surviving entry is entry B, not a resurrected entry A.
+      markDirty('session-1', 'worker-1');
+      expect(hasPendingSaves()).toBe(true);
+    });
+
+    it('should not delete a re-registered entry when unregister exits via truncation branch', async () => {
+      let resolveSlowSave: (() => void) | null = null;
+      const slowSavePromise = new Promise<void>((resolve) => {
+        resolveSlowSave = resolve;
+      });
+      setSaveFunction(async (sessionId, workerId, state) => {
+        saveTerminalStateCalls.push({ sessionId, workerId, state });
+        await slowSavePromise;
+      });
+
+      const stateA = createValidState({ data: 'state-A' });
+      const stateB = createValidState({ data: 'state-B' });
+
+      register('session-1', 'worker-1', () => stateA);
+      markDirty('session-1', 'worker-1');
+      await new Promise((resolve) =>
+        setTimeout(resolve, TEST_IDLE_DELAY_MS + 20)
+      );
+
+      const unregisterPromise = unregister('session-1', 'worker-1');
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      register('session-1', 'worker-1', () => stateB);
+      expect(getRegistrySize()).toBe(1);
+
+      // Force the unregister to take the truncation branch when it resumes.
+      // The truncation branch has its own `registry.delete(key)` at the top of
+      // the else path — it must also be identity-guarded.
+      setTruncationCheckFunction(() => true);
+
+      resolveSlowSave!();
+      await unregisterPromise;
+
+      // With the fix: identity guard also protects the truncation-branch delete.
+      // Without the fix: entry B is deleted from the truncation branch.
+      expect(getRegistrySize()).toBe(1);
+
+      resetTruncationCheckFunction();
     });
   });
 

--- a/packages/client/src/lib/__tests__/terminal-state-save-manager.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-state-save-manager.test.ts
@@ -50,6 +50,10 @@ describe('terminal-state-save-manager', () => {
     saveTerminalStateCalls.length = 0;
     resetIdleSaveDelay();
     resetSaveFunction();
+    // Reset truncation-check unconditionally so an assertion failure in a
+    // test that overrode it does not leak the forced-true behavior into
+    // subsequent tests.
+    resetTruncationCheckFunction();
   });
 
   const createValidState = (
@@ -473,8 +477,7 @@ describe('terminal-state-save-manager', () => {
       // With the fix: identity guard also protects the truncation-branch delete.
       // Without the fix: entry B is deleted from the truncation branch.
       expect(getRegistrySize()).toBe(1);
-
-      resetTruncationCheckFunction();
+      // afterEach resets the truncation-check function; no need to reset here.
     });
   });
 

--- a/packages/client/src/lib/terminal-state-save-manager.ts
+++ b/packages/client/src/lib/terminal-state-save-manager.ts
@@ -138,7 +138,7 @@ export async function unregister(
   // This prevents saving stale state while the cache is being cleared
   if (truncationCheckFunction(sessionId, workerId)) {
     logger.debug('[SaveManager] Skipping save during truncation recovery');
-    // Identity guard (Issue #929): only delete if the entry is still ours.
+    // Identity guard: only delete if the entry is still ours.
     // A concurrent register() during the await above may have overwritten
     // the slot with a fresh entry for the next mount; deleting it would
     // silently drop the next Terminal's cache-save registration.
@@ -153,7 +153,7 @@ export async function unregister(
     await saveWorkerState(sessionId, workerId, workerState);
   }
 
-  // Identity guard (Issue #929): see note above.
+  // Identity guard: see note above.
   if (registry.get(key) === workerState) {
     registry.delete(key);
   }

--- a/packages/client/src/lib/terminal-state-save-manager.ts
+++ b/packages/client/src/lib/terminal-state-save-manager.ts
@@ -138,7 +138,13 @@ export async function unregister(
   // This prevents saving stale state while the cache is being cleared
   if (truncationCheckFunction(sessionId, workerId)) {
     logger.debug('[SaveManager] Skipping save during truncation recovery');
-    registry.delete(key);
+    // Identity guard (Issue #929): only delete if the entry is still ours.
+    // A concurrent register() during the await above may have overwritten
+    // the slot with a fresh entry for the next mount; deleting it would
+    // silently drop the next Terminal's cache-save registration.
+    if (registry.get(key) === workerState) {
+      registry.delete(key);
+    }
     return;
   }
 
@@ -147,7 +153,10 @@ export async function unregister(
     await saveWorkerState(sessionId, workerId, workerState);
   }
 
-  registry.delete(key);
+  // Identity guard (Issue #929): see note above.
+  if (registry.get(key) === workerState) {
+    registry.delete(key);
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #929

## Root cause

`packages/client/src/lib/terminal-state-save-manager.ts::unregister` awaits an in-flight `workerState.pendingSave` before running its trailing `registry.delete(key)`. Meanwhile, `Terminal.tsx`'s React cleanup calls `unregisterSaveManager(...).catch(...)` fire-and-forget (line ~846) — React does not await sync returns from `useEffect` cleanup. When a user rapidly switches to another session tab and quickly switches back, a new `<Terminal>` mounts and calls `register(...)` with the same `sessionId:workerId`, overwriting the registry slot with a fresh entry (call it **entry B**). The suspended `unregister` for the previous entry (**entry A**) then resumes and unconditionally calls `registry.delete(key)`, which deletes **entry B**. On the next unmount, `unregister` sees no entry for the key and silently no-ops — the second Terminal's cache save is dropped.

## Fix

Guard both `registry.delete(key)` sites (the normal path and the truncation-recovery branch) with an object-identity check (`registry.get(key) === workerState`). The captured `workerState` reference is stable across the `await`, so identity comparison is sufficient — no token/Symbol needed.

`flush()` is unaffected: it only reads from the registry and does not delete.

`Terminal.tsx`'s cleanup shape is unchanged (fire-and-forget is the correct callsite contract for React sync-return cleanup).

## Files touched
- `packages/client/src/lib/terminal-state-save-manager.ts` — identity guard on both delete sites (~11 lines including comments)
- `packages/client/src/lib/__tests__/terminal-state-save-manager.test.ts` — two unit-level race tests (normal path + truncation branch)
- `packages/client/src/components/__tests__/Terminal.test.tsx` — one repro-level test mirroring the fire-and-forget unmount + immediate remount pattern

## Polarity flip proof (workflow.md TDD gate)

**Without the fix** (`git checkout origin/main -- packages/client/src/lib/terminal-state-save-manager.ts`, tests kept in place):

```
src/lib/__tests__/terminal-state-save-manager.test.ts:
✗ terminal-state-save-manager > unregister race with concurrent re-register (Issue #929)
    > should not delete a re-registered entry after the in-flight save completes
      expect(getRegistrySize()).toBe(1) — Expected: 1, Received: 0
✗ terminal-state-save-manager > unregister race with concurrent re-register (Issue #929)
    > should not delete a re-registered entry when unregister exits via truncation branch
      expect(getRegistrySize()).toBe(1) — Expected: 1, Received: 0

src/components/__tests__/Terminal.test.tsx:
✗ Terminal cache save race on rapid unmount/remount (Issue #929)
    > saves the second-mount state after fire-and-forget unmount + immediate remount
      expect(capturedSaves).toHaveLength(2) — Expected length: 2, Received length: 1

 93 pass
 3 fail
Ran 96 tests across 2 files.
TEST_EXIT: 1
```

**With the fix**:

```
src/lib/__tests__/terminal-state-save-manager.test.ts:
src/components/__tests__/Terminal.test.tsx:

 96 pass
 0 fail
Ran 96 tests across 2 files.
TEST_EXIT: 0
```

All three new tests flip. No partial polarity.

## Verification

- `bun run typecheck` — exit 0
- `bun run test` — 4835 pass / 3 skip / **1 fail** (pre-existing `multi-user-mode.test.ts:1012` — `SSH_AUTH_SOCK=/home/ms2sato/.1password/agent.sock` leaks into a specific server-side test on this dev host; verified to fail identically on unmodified `origin/main` via `git stash` baseline; unrelated to this client-only change).
- CodeRabbit CLI local review — 2 MINOR findings addressed inline (truncation-check leak protection via `afterEach`, Mount B idle-timer isolation + intermediate assertion). One MINOR finding on `.claude/skills/development-workflow-standards/development-workflow-standards.md` was outside this PR's diff scope (my local base was out of date at review time).

## Skip justifications

- **Integration test skipped**: client-internal registry lifecycle, no WebSocket / REST contract change. The two unit-level race tests exercise the save-manager directly and the Terminal-level test mirrors the fire-and-forget cleanup pattern the component uses.
- **Browser QA requested from owner** (delegated env has no Chrome DevTools MCP). Repro steps below.

## Browser QA (owner, please dogfood)

1. Open Session A. Type or run something in an agent worker terminal so scrollback accumulates.
2. Rapidly switch to Session B, then quickly (within ~1s) switch back to Session A.
3. Reload the page.
4. **Expected (with fix)**: Session A's terminal scrollback is restored from cache.
5. **Without fix**: Session A's terminal is empty on reload — the save on the second (Session A re-mount) cleanup silently no-ops because the first (Session A original mount) fire-and-forget cleanup wiped the registry entry belonging to the re-mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)