### PR TITLE
feat(labs): terminal renderer PoC — @xterm/headless + custom React DOM renderer (refs #722)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-serialize": "^0.13.0",
         "@xterm/addon-web-links": "^0.11.0",
+        "@xterm/headless": "^5.5.0",
         "@xterm/xterm": "^5.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -608,6 +609,8 @@
     "@xterm/addon-serialize": ["@xterm/addon-serialize@0.13.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-kGs8o6LWAmN1l2NpMp01/YkpxbmO4UrfWybeGu79Khw5K9+Krp7XhXbBTOTc3GJRRhd6EmILjpR8k5+odY39YQ=="],
 
     "@xterm/addon-web-links": ["@xterm/addon-web-links@0.11.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q=="],
+
+    "@xterm/headless": ["@xterm/headless@5.5.0", "", {}, "sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g=="],
 
     "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -23,6 +23,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-serialize": "^0.13.0",
     "@xterm/addon-web-links": "^0.11.0",
+    "@xterm/headless": "^5.5.0",
     "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/client/src/labs/terminal-poc/PocKeyboardInput.tsx
+++ b/packages/client/src/labs/terminal-poc/PocKeyboardInput.tsx
@@ -1,0 +1,160 @@
+import { forwardRef, useRef, useState } from 'react';
+import type { KeyboardEvent, CompositionEvent, FormEvent } from 'react';
+import type { PocTerminalInstance } from './poc-terminal-store';
+
+interface PocKeyboardInputProps {
+  instance: PocTerminalInstance;
+}
+
+// Special keys -> escape sequences. Arrow keys use the normal (non-application)
+// cursor sequences, which is correct for the PoC.
+const SPECIAL_KEYS: Record<string, string> = {
+  Enter: '\r',
+  Backspace: '\x7f',
+  Tab: '\t',
+  Escape: '\x1b',
+  ArrowUp: '\x1b[A',
+  ArrowDown: '\x1b[B',
+  ArrowRight: '\x1b[C',
+  ArrowLeft: '\x1b[D',
+};
+
+/**
+ * Visually-hidden focusable textarea that captures input, including IME
+ * composition. Tapping the terminal focuses it, which pops the mobile soft
+ * keyboard. A soft-key bar provides keys that are hard to reach on mobile.
+ */
+export const PocKeyboardInput = forwardRef<HTMLTextAreaElement, PocKeyboardInputProps>(
+  function PocKeyboardInput({ instance }, ref) {
+    const composingRef = useRef(false);
+    const [composeText, setComposeText] = useState('');
+
+    const send = (data: string) => instance.sendInput(data);
+
+    const clearTextarea = (el: HTMLTextAreaElement) => {
+      el.value = '';
+    };
+
+    const handleCompositionStart = () => {
+      composingRef.current = true;
+    };
+
+    const handleCompositionUpdate = (e: CompositionEvent<HTMLTextAreaElement>) => {
+      setComposeText(e.data);
+    };
+
+    const handleCompositionEnd = (e: CompositionEvent<HTMLTextAreaElement>) => {
+      composingRef.current = false;
+      setComposeText('');
+      if (e.data) send(e.data);
+      clearTextarea(e.currentTarget);
+    };
+
+    const handleInput = (e: FormEvent<HTMLTextAreaElement>) => {
+      if (composingRef.current) return;
+      const el = e.currentTarget;
+      if (el.value) {
+        send(el.value);
+        clearTextarea(el);
+      }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (composingRef.current || e.nativeEvent.isComposing) return;
+
+      if (e.key === 'Enter' && e.shiftKey) {
+        e.preventDefault();
+        send('\n');
+        return;
+      }
+
+      // Ctrl + single letter -> control character.
+      if (e.ctrlKey && !e.altKey && !e.metaKey && e.key.length === 1) {
+        const code = e.key.toUpperCase().charCodeAt(0);
+        if (code >= 64 && code <= 95) {
+          e.preventDefault();
+          send(String.fromCharCode(code - 64));
+          return;
+        }
+      }
+
+      const seq = SPECIAL_KEYS[e.key];
+      if (seq !== undefined) {
+        e.preventDefault();
+        send(seq);
+      }
+    };
+
+    return (
+      <>
+        {composeText && (
+          <div className="pointer-events-none absolute bottom-16 left-2 z-10 rounded bg-slate-800/90 px-2 py-1 text-sm text-yellow-300 underline">
+            {composeText}
+          </div>
+        )}
+
+        <textarea
+          ref={ref}
+          onCompositionStart={handleCompositionStart}
+          onCompositionUpdate={handleCompositionUpdate}
+          onCompositionEnd={handleCompositionEnd}
+          onInput={handleInput}
+          onKeyDown={handleKeyDown}
+          autoCapitalize="off"
+          autoCorrect="off"
+          autoComplete="off"
+          spellCheck={false}
+          aria-label="Terminal input"
+          className="absolute opacity-0"
+          style={{ width: 1, height: 1, left: 0, top: 0, resize: 'none', border: 'none', padding: 0 }}
+        />
+
+        <SoftKeyBar onKey={send} />
+      </>
+    );
+  },
+);
+
+interface SoftKeyBarProps {
+  onKey: (data: string) => void;
+}
+
+const SOFT_KEYS: { label: string; data: string }[] = [
+  { label: 'Esc', data: '\x1b' },
+  { label: 'Tab', data: '\t' },
+  { label: 'Ctrl+C', data: '\x03' },
+  { label: '↑', data: '\x1b[A' },
+  { label: '↓', data: '\x1b[B' },
+  { label: '←', data: '\x1b[D' },
+  { label: '→', data: '\x1b[C' },
+  { label: 'Enter', data: '\r' },
+];
+
+function SoftKeyBar({ onKey }: SoftKeyBarProps) {
+  return (
+    <div className="flex flex-wrap gap-1 border-t border-slate-700 bg-slate-900 p-1">
+      {SOFT_KEYS.map((key) => (
+        <button
+          key={key.label}
+          type="button"
+          // pointerDown + preventDefault so the button never steals focus from
+          // the hidden textarea (which would dismiss the mobile keyboard).
+          onPointerDown={(e) => {
+            e.preventDefault();
+            onKey(key.data);
+          }}
+          // Keyboard activation (Enter / Space) for physical-keyboard users.
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onKey(key.data);
+            }
+          }}
+          className="min-w-10 rounded bg-slate-700 px-3 py-2 text-sm text-white hover:bg-slate-600 active:bg-slate-500"
+        >
+          {key.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/client/src/labs/terminal-poc/PocScrollIndicator.tsx
+++ b/packages/client/src/labs/terminal-poc/PocScrollIndicator.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import { computeIndicatorGeometry, hasOverflow } from './scroll-indicator-math';
+
+const FADE_OUT_DELAY_MS = 800;
+
+interface PocScrollIndicatorProps {
+  /** The scroll container to track. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Signal that recomputes geometry (scroll count + snapshot version). */
+  tick: number;
+}
+
+/**
+ * iOS-style fade-in scroll indicator: a thin thumb on the right edge that
+ * appears while scrolling and fades out after inactivity. Reads container
+ * metrics directly (never via the store) so it stays cheap and event-driven.
+ */
+export function PocScrollIndicator({ containerRef, tick }: PocScrollIndicatorProps) {
+  const [geometry, setGeometry] = useState<{ height: number; top: number } | null>(null);
+  const [visible, setVisible] = useState(false);
+  const fadeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const metrics = {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    };
+    if (!hasOverflow(metrics)) {
+      setGeometry(null);
+      return;
+    }
+    setGeometry(computeIndicatorGeometry(metrics));
+    setVisible(true);
+    if (fadeTimer.current) clearTimeout(fadeTimer.current);
+    fadeTimer.current = setTimeout(() => setVisible(false), FADE_OUT_DELAY_MS);
+  }, [containerRef, tick]);
+
+  useEffect(() => {
+    return () => {
+      if (fadeTimer.current) clearTimeout(fadeTimer.current);
+    };
+  }, []);
+
+  if (!geometry) return null;
+
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: 'absolute',
+        right: 2,
+        top: geometry.top,
+        height: geometry.height,
+        width: 4,
+        borderRadius: 9999,
+        backgroundColor: 'rgba(148,163,184,0.55)',
+        pointerEvents: 'none',
+        opacity: visible ? 1 : 0,
+        transition: 'opacity 200ms',
+      }}
+    />
+  );
+}

--- a/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
@@ -1,0 +1,164 @@
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react';
+import type { CSSProperties } from 'react';
+import type { PocTerminalInstance } from './poc-terminal-store';
+import type { PocRow, PocSegment, PocStyle } from './buffer-to-rows';
+
+const FONT_FAMILY =
+  "'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace";
+const RESIZE_DEBOUNCE_MS = 150;
+const BOTTOM_THRESHOLD_PX = 4;
+
+interface PocTerminalViewProps {
+  instance: PocTerminalInstance;
+  onRequestFocus?: () => void;
+}
+
+function segmentStyle(style: PocStyle | null): CSSProperties | undefined {
+  if (!style) return undefined;
+  const css: CSSProperties = {};
+  if (style.fg) css.color = style.fg;
+  if (style.bg) css.backgroundColor = style.bg;
+  if (style.bold) css.fontWeight = 'bold';
+  if (style.italic) css.fontStyle = 'italic';
+  if (style.dim) css.opacity = 0.6;
+  if (style.underline && style.strikethrough) css.textDecoration = 'underline line-through';
+  else if (style.underline) css.textDecoration = 'underline';
+  else if (style.strikethrough) css.textDecoration = 'line-through';
+  return css;
+}
+
+const Row = memo(function Row({ row }: { row: PocRow }) {
+  return (
+    <div style={{ whiteSpace: 'pre' }}>
+      {row.segments.map((seg: PocSegment, i) => (
+        <span key={i} style={segmentStyle(seg.style)}>
+          {seg.text}
+        </span>
+      ))}
+    </div>
+  );
+});
+
+export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewProps) {
+  const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLSpanElement>(null);
+  const wasAtBottomRef = useRef(true);
+  const [atBottom, setAtBottom] = useState(true);
+
+  // Record whether the user is pinned to the bottom BEFORE the DOM updates, so
+  // the layout effect below can decide whether to auto-scroll.
+  const container = scrollRef.current;
+  if (container) {
+    const distance = container.scrollHeight - container.scrollTop - container.clientHeight;
+    wasAtBottomRef.current = distance <= BOTTOM_THRESHOLD_PX;
+  }
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    if (wasAtBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [snapshot]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    setAtBottom(distance <= BOTTOM_THRESHOLD_PX);
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    setAtBottom(true);
+  }, []);
+
+  // Measure cell size + observe container size -> derive cols/rows -> resize.
+  useEffect(() => {
+    const el = scrollRef.current;
+    const measure = measureRef.current;
+    if (!el || !measure) return;
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const applyResize = () => {
+      const rect = measure.getBoundingClientRect();
+      const charW = rect.width || 8;
+      const charH = rect.height || 16;
+      // clientWidth/Height include the container's padding; subtract it so the
+      // grid is not overestimated.
+      const computed = getComputedStyle(el);
+      const paddingX = parseFloat(computed.paddingLeft) + parseFloat(computed.paddingRight);
+      const paddingY = parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
+      const cols = Math.max(2, Math.floor((el.clientWidth - paddingX) / charW));
+      const rows = Math.max(1, Math.floor((el.clientHeight - paddingY) / charH));
+      instance.resize(cols, rows);
+    };
+
+    const observer = new ResizeObserver(() => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(applyResize, RESIZE_DEBOUNCE_MS);
+    });
+    observer.observe(el);
+    applyResize();
+
+    return () => {
+      observer.disconnect();
+      if (timer) clearTimeout(timer);
+    };
+  }, [instance]);
+
+  return (
+    <div className="relative flex-1 min-h-0">
+      {/* Hidden single-cell probe for measuring monospace cell metrics. */}
+      <span
+        ref={measureRef}
+        aria-hidden
+        style={{
+          position: 'absolute',
+          visibility: 'hidden',
+          fontFamily: FONT_FAMILY,
+          fontSize: 14,
+          lineHeight: '18px',
+          whiteSpace: 'pre',
+        }}
+      >
+        M
+      </span>
+
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        onPointerDown={onRequestFocus}
+        className="h-full overflow-y-auto bg-[#1a1a2e] text-[#eeeeee] px-2 py-1"
+        style={{
+          fontFamily: FONT_FAMILY,
+          fontSize: 14,
+          lineHeight: '18px',
+          overscrollBehavior: 'contain',
+          fontVariantLigatures: 'none',
+          WebkitOverflowScrolling: 'touch',
+        }}
+      >
+        {snapshot.rows.map((row) => (
+          <Row key={row.key} row={row} />
+        ))}
+      </div>
+
+      {!atBottom && (
+        <button
+          type="button"
+          onPointerDown={(e) => {
+            e.preventDefault();
+            scrollToBottom();
+          }}
+          className="absolute bottom-3 right-3 rounded-full bg-slate-700 hover:bg-slate-600 text-white text-xs px-3 py-2 shadow-lg"
+        >
+          Jump to bottom
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, useSyn
 import type { CSSProperties } from 'react';
 import type { PocTerminalInstance } from './poc-terminal-store';
 import type { PocRow, PocSegment, PocStyle } from './buffer-to-rows';
+import { PocScrollIndicator } from './PocScrollIndicator';
 
 const FONT_FAMILY =
   "'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace";
@@ -62,11 +63,13 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
     }
   }, [snapshot]);
 
+  const [scrollTick, setScrollTick] = useState(0);
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
     const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
     setAtBottom(distance <= BOTTOM_THRESHOLD_PX);
+    setScrollTick((t) => t + 1);
   }, []);
 
   const scrollToBottom = useCallback(() => {
@@ -146,6 +149,10 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
           <Row key={row.key} row={row} />
         ))}
       </div>
+
+      {/* tick = scroll events + snapshot version, so the thumb appears on scroll
+          and on content growth, then fades after inactivity. */}
+      <PocScrollIndicator containerRef={scrollRef} tick={scrollTick + snapshot.version} />
 
       {!atBottom && (
         <button

--- a/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
@@ -47,6 +47,11 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
   const wasAtBottomRef = useRef(true);
   const [atBottom, setAtBottom] = useState(true);
 
+  // Read by the native wheel/touch listeners (attached once, keyed on instance)
+  // so they know whether to forward scroll to the app or let native scroll run.
+  const bufferTypeRef = useRef<'normal' | 'alternate'>('normal');
+  bufferTypeRef.current = snapshot.bufferType;
+
   // Record whether the user is pinned to the bottom BEFORE the DOM updates, so
   // the layout effect below can decide whether to auto-scroll.
   const container = scrollRef.current;
@@ -110,6 +115,79 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
     return () => {
       observer.disconnect();
       if (timer) clearTimeout(timer);
+    };
+  }, [instance]);
+
+  // Alternate-screen scroll forwarding. Native (non-passive) wheel + touch
+  // listeners so preventDefault works; attached once per instance and gated on
+  // bufferTypeRef so we do not re-subscribe on every snapshot.
+  useEffect(() => {
+    const el = scrollRef.current;
+    const measure = measureRef.current;
+    if (!el || !measure) return;
+
+    // Fractional line remainder carried between events for smooth stepping.
+    let remainder = 0;
+    let touchLastY: number | null = null;
+
+    const cellMetrics = () => {
+      const r = measure.getBoundingClientRect();
+      return { charW: r.width || 8, charH: r.height || 16 };
+    };
+    const cellFromPoint = (clientX: number, clientY: number, charW: number, charH: number) => {
+      const rect = el.getBoundingClientRect();
+      return {
+        x: Math.floor((clientX - rect.left) / charW) + 1,
+        y: Math.floor((clientY - rect.top) / charH) + 1,
+      };
+    };
+    const stepFrom = (deltaPx: number, charH: number): number => {
+      const total = remainder + deltaPx;
+      const steps = Math.trunc(total / charH);
+      remainder = total - steps * charH;
+      return steps;
+    };
+
+    const onWheel = (e: WheelEvent) => {
+      if (bufferTypeRef.current !== 'alternate') return; // main screen: native scroll
+      e.preventDefault();
+      const { charW, charH } = cellMetrics();
+      const steps = stepFrom(e.deltaY, charH);
+      if (steps === 0) return;
+      instance.forwardScroll(steps, cellFromPoint(e.clientX, e.clientY, charW, charH));
+    };
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (bufferTypeRef.current !== 'alternate') return;
+      touchLastY = e.touches[0]?.clientY ?? null;
+      remainder = 0;
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      if (bufferTypeRef.current !== 'alternate') return;
+      const touch = e.touches[0];
+      if (!touch || touchLastY === null) return;
+      e.preventDefault(); // suppress rubber-banding
+      const { charW, charH } = cellMetrics();
+      // Finger up (clientY decreases) => content scrolls toward newer (down).
+      const steps = stepFrom(touchLastY - touch.clientY, charH);
+      if (steps === 0) return;
+      touchLastY = touch.clientY;
+      instance.forwardScroll(steps, cellFromPoint(touch.clientX, touch.clientY, charW, charH));
+    };
+    const onTouchEnd = () => {
+      touchLastY = null;
+    };
+
+    el.addEventListener('wheel', onWheel, { passive: false });
+    el.addEventListener('touchstart', onTouchStart, { passive: false });
+    el.addEventListener('touchmove', onTouchMove, { passive: false });
+    el.addEventListener('touchend', onTouchEnd);
+
+    return () => {
+      el.removeEventListener('wheel', onWheel);
+      el.removeEventListener('touchstart', onTouchStart);
+      el.removeEventListener('touchmove', onTouchMove);
+      el.removeEventListener('touchend', onTouchEnd);
     };
   }, [instance]);
 

--- a/packages/client/src/labs/terminal-poc/__tests__/buffer-to-rows.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/buffer-to-rows.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Terminal } from '@xterm/headless';
+import { extractRow, extractRowWithCursor } from '../buffer-to-rows';
+
+function write(term: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => term.write(data, () => resolve()));
+}
+
+/** Extract absolute row 0 of a fresh terminal after writing `data`. */
+async function rowFrom(term: Terminal, data: string) {
+  await write(term, data);
+  const buffer = term.buffer.active;
+  const line = buffer.getLine(0);
+  if (!line) throw new Error('no line 0');
+  return extractRow(line, term.cols, buffer.getNullCell(), 0);
+}
+
+describe('extractRow', () => {
+  let term: Terminal;
+
+  beforeEach(() => {
+    term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true });
+  });
+
+  afterEach(() => {
+    term.dispose();
+  });
+
+  it('plain text -> single default segment', async () => {
+    const row = await rowFrom(term, 'hello');
+    expect(row.segments).toHaveLength(1);
+    expect(row.segments[0].text).toBe('hello');
+    expect(row.segments[0].style).toBeNull();
+  });
+
+  it('16-color palette red fg -> #cd3131', async () => {
+    const row = await rowFrom(term, '\x1b[31mred\x1b[0m');
+    expect(row.segments[0].text).toBe('red');
+    expect(row.segments[0].style?.fg).toBe('#cd3131');
+  });
+
+  it('truecolor -> #ff6b35 (Claude Code orange)', async () => {
+    const row = await rowFrom(term, '\x1b[38;2;255;107;53morange\x1b[0m');
+    expect(row.segments[0].text).toBe('orange');
+    expect(row.segments[0].style?.fg).toBe('#ff6b35');
+  });
+
+  it('256-palette color cube (208 -> #ff8700)', async () => {
+    const row = await rowFrom(term, '\x1b[38;5;208mX\x1b[0m');
+    expect(row.segments[0].style?.fg).toBe('#ff8700');
+  });
+
+  it('256-palette grayscale ramp (240 -> #585858)', async () => {
+    const row = await rowFrom(term, '\x1b[38;5;240mX\x1b[0m');
+    expect(row.segments[0].style?.fg).toBe('#585858');
+  });
+
+  it('bold + underline flags', async () => {
+    const row = await rowFrom(term, '\x1b[1;4mA\x1b[0m');
+    expect(row.segments[0].style?.bold).toBe(true);
+    expect(row.segments[0].style?.underline).toBe(true);
+  });
+
+  it('inverse swaps default fg/bg to concrete colors', async () => {
+    const row = await rowFrom(term, '\x1b[7mZ\x1b[0m');
+    expect(row.segments[0].style?.fg).toBe('#1a1a2e'); // default bg becomes fg
+    expect(row.segments[0].style?.bg).toBe('#eeeeee'); // default fg becomes bg
+  });
+
+  it('groups consecutive same-style cells and splits on style change', async () => {
+    const row = await rowFrom(term, 'ab\x1b[31mcd\x1b[0mef');
+    expect(row.segments.map((s) => s.text)).toEqual(['ab', 'cd', 'ef']);
+    expect(row.segments[0].style).toBeNull();
+    expect(row.segments[1].style?.fg).toBe('#cd3131');
+    expect(row.segments[2].style).toBeNull();
+  });
+
+  it('CJK wide chars: width-0 cells skipped, characters preserved once', async () => {
+    const row = await rowFrom(term, 'こんにちは');
+    const text = row.segments.map((s) => s.text).join('');
+    expect(text).toBe('こんにちは');
+    expect(text).toHaveLength(5);
+  });
+
+  it('empty row keeps one empty segment for line height', async () => {
+    const row = await rowFrom(term, '');
+    expect(row.segments).toHaveLength(1);
+    expect(row.segments[0].text).toBe('');
+  });
+});
+
+describe('extractRowWithCursor', () => {
+  let term: Terminal;
+
+  beforeEach(() => {
+    term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true });
+  });
+
+  afterEach(() => {
+    term.dispose();
+  });
+
+  it('renders the cursor cell as its own styled block at the given column', async () => {
+    await write(term, 'abc');
+    const buffer = term.buffer.active;
+    const line = buffer.getLine(0);
+    if (!line) throw new Error('no line');
+    const row = extractRowWithCursor(line, term.cols, buffer.getNullCell(), 0, 1);
+    // 'b' (column 1) should be an isolated cursor-styled segment.
+    const cursorSeg = row.segments.find((s) => s.text === 'b');
+    expect(cursorSeg?.style?.bg).toBe('#eeeeee');
+    expect(cursorSeg?.style?.fg).toBe('#1a1a2e');
+  });
+
+  it('places the cursor correctly after a CJK glyph (column advances by 2)', async () => {
+    // Write one wide char then a caret target; cursor at column 2 sits on 'X'.
+    await write(term, 'あX');
+    const buffer = term.buffer.active;
+    const line = buffer.getLine(0);
+    if (!line) throw new Error('no line');
+    const row = extractRowWithCursor(line, term.cols, buffer.getNullCell(), 0, 2);
+    const cursorSeg = row.segments.find((s) => s.style?.bg === '#eeeeee');
+    expect(cursorSeg?.text).toBe('X');
+  });
+});

--- a/packages/client/src/labs/terminal-poc/__tests__/buffer-to-rows.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/buffer-to-rows.test.ts
@@ -122,4 +122,48 @@ describe('extractRowWithCursor', () => {
     const cursorSeg = row.segments.find((s) => s.style?.bg === '#eeeeee');
     expect(cursorSeg?.text).toBe('X');
   });
+
+  it('cursor at end of text: trailing blanks after the cursor cell are trimmed, cursor cell remains', async () => {
+    // Cursor sits on the blank cell just after 'abc' (column 3).
+    await write(term, 'abc');
+    const buffer = term.buffer.active;
+    const line = buffer.getLine(0);
+    if (!line) throw new Error('no line');
+    const row = extractRowWithCursor(line, term.cols, buffer.getNullCell(), 0, 3);
+
+    // The cursor cell (a single blank block) is the last segment - no trailing
+    // full-width whitespace segment survives after it.
+    const lastSeg = row.segments[row.segments.length - 1];
+    expect(lastSeg.style?.bg).toBe('#eeeeee');
+    expect(lastSeg.text).toBe(' ');
+    const text = row.segments.map((s) => s.text).join('');
+    expect(text).toBe('abc '); // 'abc' + single cursor blank, no full-width padding
+  });
+
+  it('cursor mid-text: content unchanged except trailing trim', async () => {
+    await write(term, 'abc');
+    const buffer = term.buffer.active;
+    const line = buffer.getLine(0);
+    if (!line) throw new Error('no line');
+    const row = extractRowWithCursor(line, term.cols, buffer.getNullCell(), 0, 1);
+    const text = row.segments.map((s) => s.text).join('');
+    expect(text).toBe('abc'); // no trailing blank cells beyond the text
+  });
+
+  it('parity: cursor row visible text matches extractRow plus cursor styling', async () => {
+    await write(term, 'abc');
+    const buffer = term.buffer.active;
+    const line = buffer.getLine(0);
+    if (!line) throw new Error('no line');
+    const plain = extractRow(line, term.cols, buffer.getNullCell(), 0);
+    const withCursor = extractRowWithCursor(line, term.cols, buffer.getNullCell(), 0, 1);
+
+    const plainText = plain.segments.map((s) => s.text).join('');
+    const cursorText = withCursor.segments.map((s) => s.text).join('');
+    expect(cursorText).toBe(plainText);
+
+    // The 'b' cell carries cursor styling in the cursor row but not the plain row.
+    expect(withCursor.segments.find((s) => s.text === 'b')?.style?.bg).toBe('#eeeeee');
+    expect(plain.segments.find((s) => s.style?.bg === '#eeeeee')).toBeUndefined();
+  });
 });

--- a/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
@@ -12,6 +12,13 @@ function lastSentMessages(ws: MockWebSocket): unknown[] {
   return calls.map((call) => JSON.parse(call[0]));
 }
 
+function allText(instance: ReturnType<typeof getOrCreatePocTerminal>): string {
+  return instance
+    .getSnapshot()
+    .rows.map((r) => r.segments.map((s) => s.text).join(''))
+    .join('\n');
+}
+
 describe('poc-terminal-store', () => {
   let restoreWebSocket: () => void;
   let originalLocation: PropertyDescriptor | undefined;
@@ -83,6 +90,62 @@ describe('poc-terminal-store', () => {
       .rows.map((r) => r.segments.map((s) => s.text).join(''))
       .join('');
     expect(text).toContain('restored line');
+  });
+
+  it('preserves scrollback: CSI 3J in a later output does not erase earlier text', async () => {
+    const instance = getOrCreatePocTerminal('s3j', 'w3j');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    // Push 'first line' above the 24-row screen so it lives in scrollback, which
+    // is exactly what raw CSI 3J erases (and the filter preserves).
+    const filler = Array.from({ length: 40 }, (_, i) => `filler ${i}`).join('\r\n');
+    ws!.simulateMessage(
+      JSON.stringify({ type: 'output', data: `first line\r\n${filler}\r\n`, offset: 0 }),
+    );
+    await flush();
+    // A redraw that would normally wipe scrollback via CSI 3J.
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[3Jsecond line', offset: 500 }));
+    await flush();
+
+    const text = allText(instance);
+    expect(text).toContain('first line');
+    expect(text).toContain('second line');
+  });
+
+  it('CSI 2J is rewritten to cursor-home + erase-below (post-clear write lands at home)', async () => {
+    const instance = getOrCreatePocTerminal('s2j', 'w2j');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    // Move the cursor down to row 2, then clear + write. The filter rewrites 2J
+    // to `\x1b[H\x1b[J`, so the cursor homes and 'after' lands on row 0. Raw 2J
+    // leaves the cursor on row 2, so without the filter this assertion fails.
+    ws!.simulateMessage(
+      JSON.stringify({ type: 'output', data: 'line0\r\nline1\r\nline2', offset: 0 }),
+    );
+    await flush();
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[2Jafter', offset: 17 }));
+    await flush();
+
+    const snap = instance.getSnapshot();
+    expect(snap.cursor.y).toBe(0); // homed by the 2J rewrite
+    expect(snap.rows[0].segments.map((s) => s.text).join('')).toContain('after');
+  });
+
+  it('strips [internal:...] system lines from rendered output', async () => {
+    const instance = getOrCreatePocTerminal('sint', 'wint');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    ws!.simulateMessage(
+      JSON.stringify({ type: 'output', data: 'visible\r\n[internal:timer] hidden', offset: 0 }),
+    );
+    await flush();
+
+    const text = allText(instance);
+    expect(text).toContain('visible');
+    expect(text).not.toContain('internal:timer');
   });
 
   it('sendInput sends a correct input frame', () => {

--- a/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { MockWebSocket, installMockWebSocket } from '../../../test/mock-websocket';
+import { getOrCreatePocTerminal, _resetPocTerminals } from '../poc-terminal-store';
+
+/** Let write callbacks + the rAF/timeout snapshot flush run. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 40));
+}
+
+function lastSentMessages(ws: MockWebSocket): unknown[] {
+  const calls = ws.send.mock.calls as unknown as string[][];
+  return calls.map((call) => JSON.parse(call[0]));
+}
+
+describe('poc-terminal-store', () => {
+  let restoreWebSocket: () => void;
+  let originalLocation: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    restoreWebSocket = installMockWebSocket();
+    originalLocation = Object.getOwnPropertyDescriptor(window, 'location');
+    Object.defineProperty(window, 'location', {
+      value: { protocol: 'http:', host: 'localhost:3000' },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    _resetPocTerminals();
+    restoreWebSocket();
+    if (originalLocation) {
+      Object.defineProperty(window, 'location', originalLocation);
+    }
+  });
+
+  it('requests full history with fromOffset 0 on open', () => {
+    getOrCreatePocTerminal('s1', 'w1');
+    const ws = MockWebSocket.getLastInstance();
+    expect(ws).toBeDefined();
+    ws!.simulateOpen();
+
+    const sent = lastSentMessages(ws!);
+    const history = sent.find((m) => (m as { type: string }).type === 'request-history');
+    expect(history).toEqual({ type: 'request-history', fromOffset: 0 });
+  });
+
+  it('sends initial resize on open', () => {
+    getOrCreatePocTerminal('s2', 'w2');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    const sent = lastSentMessages(ws!);
+    const resize = sent.find((m) => (m as { type: string }).type === 'resize');
+    expect(resize).toMatchObject({ type: 'resize' });
+  });
+
+  it('renders output into snapshot rows and bumps version', async () => {
+    const instance = getOrCreatePocTerminal('s3', 'w3');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    const before = instance.getSnapshot().version;
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: 'hello world', offset: 0 }));
+    await flush();
+
+    const after = instance.getSnapshot();
+    expect(after.version).toBeGreaterThan(before);
+    const text = after.rows.map((r) => r.segments.map((s) => s.text).join('')).join('');
+    expect(text).toContain('hello world');
+  });
+
+  it('renders history message content', async () => {
+    const instance = getOrCreatePocTerminal('s4', 'w4');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    ws!.simulateMessage(JSON.stringify({ type: 'history', data: 'restored line', offset: 0 }));
+    await flush();
+
+    const text = instance
+      .getSnapshot()
+      .rows.map((r) => r.segments.map((s) => s.text).join(''))
+      .join('');
+    expect(text).toContain('restored line');
+  });
+
+  it('sendInput sends a correct input frame', () => {
+    const instance = getOrCreatePocTerminal('s5', 'w5');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    instance.sendInput('ls\r');
+    const sent = lastSentMessages(ws!);
+    expect(sent).toContainEqual({ type: 'input', data: 'ls\r' });
+  });
+
+  it('sets status to exited on exit message', () => {
+    const instance = getOrCreatePocTerminal('s6', 'w6');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    ws!.simulateMessage(JSON.stringify({ type: 'exit', exitCode: 0, signal: null }));
+    const snap = instance.getSnapshot();
+    expect(snap.status).toBe('exited');
+    expect(snap.exitInfo).toEqual({ code: 0, signal: null });
+  });
+
+  it('keeps status exited and does not reconnect when the socket closes after exit', () => {
+    const instance = getOrCreatePocTerminal('s6b', 'w6b');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateMessage(JSON.stringify({ type: 'exit', exitCode: 0, signal: null }));
+
+    const instancesBefore = MockWebSocket.getInstances().length;
+    // A terminated PTY closes the socket right after 'exit'.
+    ws!.simulateClose();
+
+    expect(instance.getSnapshot().status).toBe('exited');
+    // No reconnect socket was created (a live disconnect would schedule one).
+    expect(MockWebSocket.getInstances().length).toBe(instancesBefore);
+  });
+
+  it('sets status to disconnected on an unexpected close (contrast: not exited)', () => {
+    const instance = getOrCreatePocTerminal('s6c', 'w6c');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    ws!.simulateClose();
+    expect(instance.getSnapshot().status).toBe('disconnected');
+  });
+
+  it('reuses the same instance for the same session/worker key', () => {
+    const a = getOrCreatePocTerminal('s7', 'w7');
+    const b = getOrCreatePocTerminal('s7', 'w7');
+    expect(a).toBe(b);
+  });
+
+  it('interface methods survive being destructured (useSyncExternalStore contract)', () => {
+    const instance = getOrCreatePocTerminal('s8', 'w8');
+    // React calls these detached from the instance, so `this` must be bound.
+    const { subscribe, getSnapshot } = instance;
+
+    expect(() => getSnapshot()).not.toThrow();
+    expect(getSnapshot().status).toBe('connecting');
+
+    let notified = 0;
+    const unsubscribe = subscribe(() => {
+      notified += 1;
+    });
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen(); // updateStatus -> notify
+    expect(notified).toBeGreaterThan(0);
+    expect(() => unsubscribe()).not.toThrow();
+  });
+});

--- a/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
@@ -12,6 +12,12 @@ function lastSentMessages(ws: MockWebSocket): unknown[] {
   return calls.map((call) => JSON.parse(call[0]));
 }
 
+function inputFrames(ws: MockWebSocket): string[] {
+  return (lastSentMessages(ws) as { type: string; data?: string }[])
+    .filter((m) => m.type === 'input')
+    .map((m) => m.data ?? '');
+}
+
 function allText(instance: ReturnType<typeof getOrCreatePocTerminal>): string {
   return instance
     .getSnapshot()
@@ -146,6 +152,71 @@ describe('poc-terminal-store', () => {
     const text = allText(instance);
     expect(text).toContain('visible');
     expect(text).not.toContain('internal:timer');
+  });
+
+  it('forwardScroll with mouse tracking active emits SGR wheel reports with clamped coords', async () => {
+    const instance = getOrCreatePocTerminal('smt', 'wmt');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    // Enable mouse tracking (DECSET 1002 = button-event tracking).
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?1002h', offset: 0 }));
+    await flush();
+
+    instance.forwardScroll(-1, { x: 5, y: 3 }); // scroll up -> button 64
+    instance.forwardScroll(2, { x: 5, y: 3 }); // scroll down x2 -> button 65
+    // Coords beyond the grid clamp to [1..cols]/[1..rows].
+    instance.forwardScroll(1, { x: 9999, y: 9999 });
+
+    const frames = inputFrames(ws!);
+    expect(frames).toContain('\x1b[<64;5;3M');
+    expect(frames).toContain('\x1b[<65;5;3M\x1b[<65;5;3M');
+    // Coords clamped to grid (cols 80, rows 24); never emits the raw 9999.
+    expect(frames).toContain('\x1b[<65;80;24M');
+  });
+
+  it('forwardScroll without mouse tracking emits arrow keys (CSI A/B)', () => {
+    const instance = getOrCreatePocTerminal('sar', 'war');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    instance.forwardScroll(-2, { x: 1, y: 1 }); // up x2
+    instance.forwardScroll(1, { x: 1, y: 1 }); // down x1
+
+    const frames = inputFrames(ws!);
+    expect(frames).toContain('\x1b[A\x1b[A');
+    expect(frames).toContain('\x1b[B');
+  });
+
+  it('forwardScroll without tracking + DECCKM on emits SS3 arrows (ESC O A/B)', async () => {
+    const instance = getOrCreatePocTerminal('sck', 'wck');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    // Application Cursor Keys (DECCKM, DECSET 1).
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?1h', offset: 0 }));
+    await flush();
+
+    instance.forwardScroll(-1, { x: 1, y: 1 });
+    instance.forwardScroll(1, { x: 1, y: 1 });
+
+    const frames = inputFrames(ws!);
+    expect(frames).toContain('\x1bOA');
+    expect(frames).toContain('\x1bOB');
+  });
+
+  it('bufferType appears in snapshot and flips on alt-screen enter/exit', async () => {
+    const instance = getOrCreatePocTerminal('sbt', 'wbt');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    expect(instance.getSnapshot().bufferType).toBe('normal');
+
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?1049h', offset: 0 }));
+    await flush();
+    expect(instance.getSnapshot().bufferType).toBe('alternate');
+
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?1049l', offset: 8 }));
+    await flush();
+    expect(instance.getSnapshot().bufferType).toBe('normal');
   });
 
   it('sendInput sends a correct input frame', () => {

--- a/packages/client/src/labs/terminal-poc/__tests__/scroll-indicator-math.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/scroll-indicator-math.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  computeIndicatorGeometry,
+  hasOverflow,
+  MIN_INDICATOR_HEIGHT,
+} from '../scroll-indicator-math';
+
+describe('hasOverflow', () => {
+  it('is false when content fits (with 1px tolerance)', () => {
+    expect(hasOverflow({ scrollTop: 0, scrollHeight: 100, clientHeight: 100 })).toBe(false);
+    expect(hasOverflow({ scrollTop: 0, scrollHeight: 101, clientHeight: 100 })).toBe(false);
+  });
+
+  it('is true when content overflows beyond tolerance', () => {
+    expect(hasOverflow({ scrollTop: 0, scrollHeight: 200, clientHeight: 100 })).toBe(true);
+  });
+});
+
+describe('computeIndicatorGeometry', () => {
+  it('height is proportional to the visible fraction', () => {
+    // clientHeight^2 / scrollHeight = 100*100/400 = 25
+    const { height } = computeIndicatorGeometry({
+      scrollTop: 0,
+      scrollHeight: 400,
+      clientHeight: 100,
+    });
+    expect(height).toBe(25);
+  });
+
+  it('height is floored at MIN_INDICATOR_HEIGHT', () => {
+    // raw = 100*100/2000 = 5 -> floored to 24
+    const { height } = computeIndicatorGeometry({
+      scrollTop: 0,
+      scrollHeight: 2000,
+      clientHeight: 100,
+    });
+    expect(height).toBe(MIN_INDICATOR_HEIGHT);
+  });
+
+  it('top is 0 at the top of the scroll range', () => {
+    const { top } = computeIndicatorGeometry({ scrollTop: 0, scrollHeight: 400, clientHeight: 100 });
+    expect(top).toBe(0);
+  });
+
+  it('top reaches the bottom of the track when fully scrolled', () => {
+    // height 25, track = 100 - 25 = 75; scrollable = 300; scrollTop = 300 -> top = 75
+    const { top, height } = computeIndicatorGeometry({
+      scrollTop: 300,
+      scrollHeight: 400,
+      clientHeight: 100,
+    });
+    expect(height).toBe(25);
+    expect(top).toBe(75);
+  });
+
+  it('top is clamped to the track and never exceeds it', () => {
+    // Over-scrolled scrollTop beyond scrollable -> clamped to track (75)
+    const { top } = computeIndicatorGeometry({
+      scrollTop: 999,
+      scrollHeight: 400,
+      clientHeight: 100,
+    });
+    expect(top).toBe(75);
+  });
+
+  it('top is 0 when there is no scrollable range', () => {
+    const { top } = computeIndicatorGeometry({ scrollTop: 0, scrollHeight: 100, clientHeight: 100 });
+    expect(top).toBe(0);
+  });
+});

--- a/packages/client/src/labs/terminal-poc/buffer-to-rows.ts
+++ b/packages/client/src/labs/terminal-poc/buffer-to-rows.ts
@@ -160,6 +160,12 @@ export function extractRowWithCursor(
   cursorX: number,
 ): PocRow {
   const segments = walkCells(line, cols, nullCell, cursorX);
+  // Trim trailing default-style blanks like extractRow, but protect the cursor
+  // segment (and everything up to it): the cursor commonly sits on a blank cell
+  // just after the text, so only whitespace strictly AFTER the cursor is trimmed.
+  const cursorIndex = segments.findIndex((s) => s.style === CURSOR_STYLE);
+  const protectedCount = cursorIndex === -1 ? 0 : cursorIndex + 1;
+  trimTrailingDefaultWhitespace(segments, protectedCount);
   if (segments.length === 0) {
     segments.push({ text: '', style: null });
   }
@@ -222,10 +228,11 @@ function walkCells(
 /**
  * Trim trailing whitespace from the last segment when that segment has no
  * style (default background), keeping the DOM light without altering visible
- * colored cells.
+ * colored cells. `protectedCount` leading segments are never trimmed or popped
+ * (used to keep the cursor segment on the cursor row).
  */
-function trimTrailingDefaultWhitespace(segments: PocSegment[]): void {
-  while (segments.length > 0) {
+function trimTrailingDefaultWhitespace(segments: PocSegment[], protectedCount = 0): void {
+  while (segments.length > protectedCount) {
     const last = segments[segments.length - 1];
     if (last.style !== null) break;
     const trimmed = last.text.replace(/ +$/, '');

--- a/packages/client/src/labs/terminal-poc/buffer-to-rows.ts
+++ b/packages/client/src/labs/terminal-poc/buffer-to-rows.ts
@@ -1,0 +1,242 @@
+import { Terminal } from '@xterm/headless';
+
+/**
+ * Pure extraction from an xterm headless buffer line into a React-renderable
+ * row model. Kept free of DOM / React so it is unit-testable against a real
+ * headless Terminal instance.
+ */
+
+// @xterm/headless does not export IBufferCell / IBufferLine directly, so we
+// derive them from the exported Terminal's buffer namespace via indexed access.
+type IBufferCell = ReturnType<Terminal['buffer']['active']['getNullCell']>;
+export type IBufferLine = NonNullable<ReturnType<Terminal['buffer']['active']['getLine']>>;
+
+export interface PocStyle {
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+  italic?: boolean;
+  dim?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+}
+
+export interface PocSegment {
+  text: string;
+  style: PocStyle | null; // null = default style (CSS inherits)
+}
+
+export interface PocRow {
+  key: number; // absolute row index in the buffer
+  segments: PocSegment[];
+}
+
+// Standard xterm dark-theme 16-color palette (ANSI 0-15).
+const ANSI_16 = [
+  '#000000', '#cd3131', '#0dbc79', '#e5e510',
+  '#2472c8', '#bc3fc0', '#11a8cd', '#e5e5e5',
+  '#666666', '#f14c4c', '#23d18b', '#f5f543',
+  '#3b8eea', '#d670d6', '#29b8db', '#ffffff',
+] as const;
+
+// Defaults used when inverse video needs a concrete color to swap in.
+const DEFAULT_FG = '#eeeeee';
+const DEFAULT_BG = '#1a1a2e';
+
+function toHex(value: number): string {
+  return `#${value.toString(16).padStart(6, '0')}`;
+}
+
+/** Map an xterm 256-color palette index to a hex string (standard xterm formulas). */
+function paletteToHex(index: number): string {
+  if (index < 16) return ANSI_16[index];
+  if (index < 232) {
+    // 6x6x6 color cube: indices 16-231.
+    const i = index - 16;
+    const r = Math.floor(i / 36);
+    const g = Math.floor((i % 36) / 6);
+    const b = i % 6;
+    const channel = (v: number) => (v === 0 ? 0 : v * 40 + 55);
+    return toHex((channel(r) << 16) | (channel(g) << 8) | channel(b));
+  }
+  // Grayscale ramp: indices 232-255.
+  const level = (index - 232) * 10 + 8;
+  return toHex((level << 16) | (level << 8) | level);
+}
+
+type ColorResolver = 'fg' | 'bg';
+
+function resolveColor(cell: IBufferCell, which: ColorResolver): string | undefined {
+  if (which === 'fg') {
+    if (cell.isFgDefault()) return undefined;
+    if (cell.isFgRGB()) return toHex(cell.getFgColor());
+    if (cell.isFgPalette()) return paletteToHex(cell.getFgColor());
+    return undefined;
+  }
+  if (cell.isBgDefault()) return undefined;
+  if (cell.isBgRGB()) return toHex(cell.getBgColor());
+  if (cell.isBgPalette()) return paletteToHex(cell.getBgColor());
+  return undefined;
+}
+
+function cellStyle(cell: IBufferCell): PocStyle | null {
+  let fg = resolveColor(cell, 'fg');
+  let bg = resolveColor(cell, 'bg');
+
+  if (cell.isInverse()) {
+    // Swap fg/bg; substitute concrete defaults so the swap is visible.
+    const swappedFg = bg ?? DEFAULT_BG;
+    const swappedBg = fg ?? DEFAULT_FG;
+    fg = swappedFg;
+    bg = swappedBg;
+  }
+
+  const style: PocStyle = {};
+  if (fg !== undefined) style.fg = fg;
+  if (bg !== undefined) style.bg = bg;
+  if (cell.isBold()) style.bold = true;
+  if (cell.isItalic()) style.italic = true;
+  if (cell.isDim()) style.dim = true;
+  if (cell.isUnderline()) style.underline = true;
+  if (cell.isStrikethrough()) style.strikethrough = true;
+
+  return Object.keys(style).length === 0 ? null : style;
+}
+
+/**
+ * Comparison key for grouping consecutive cells into one segment. Uses the
+ * color modes + raw color values + attribute flags so two cells only merge
+ * when they render identically.
+ */
+function styleKey(cell: IBufferCell): string {
+  return [
+    cell.getFgColorMode(), cell.getFgColor(),
+    cell.getBgColorMode(), cell.getBgColor(),
+    cell.isBold() ? 1 : 0,
+    cell.isItalic() ? 1 : 0,
+    cell.isDim() ? 1 : 0,
+    cell.isUnderline() ? 1 : 0,
+    cell.isStrikethrough() ? 1 : 0,
+    cell.isInverse() ? 1 : 0,
+  ].join(':');
+}
+
+/**
+ * Extract one buffer line into a PocRow. Consecutive cells with identical
+ * style merge into a single segment. Width-0 cells (the trailing half of a
+ * CJK wide glyph) are skipped so wide characters are not duplicated.
+ */
+export function extractRow(
+  line: IBufferLine,
+  cols: number,
+  nullCell: IBufferCell,
+  key: number,
+): PocRow {
+  const segments = walkCells(line, cols, nullCell, -1);
+  trimTrailingDefaultWhitespace(segments);
+
+  // Keep at least one (empty) segment so the row box renders its line height.
+  if (segments.length === 0) {
+    segments.push({ text: '', style: null });
+  }
+
+  return { key, segments };
+}
+
+// Cursor cell rendering: a solid block (light bg, dark fg) at the cursor cell.
+const CURSOR_STYLE: PocStyle = { fg: DEFAULT_BG, bg: DEFAULT_FG };
+
+/**
+ * Like extractRow but forces the cell at column `cursorX` into its own segment
+ * styled as the cursor block. Computed in the store where cell access is cheap;
+ * this keeps the cursor at the correct visual position even after CJK glyphs
+ * (which advance the column by 2) without any DOM measurement.
+ */
+export function extractRowWithCursor(
+  line: IBufferLine,
+  cols: number,
+  nullCell: IBufferCell,
+  key: number,
+  cursorX: number,
+): PocRow {
+  const segments = walkCells(line, cols, nullCell, cursorX);
+  if (segments.length === 0) {
+    segments.push({ text: '', style: null });
+  }
+  return { key, segments };
+}
+
+/**
+ * Shared cell walk. When `cursorX >= 0`, the cell at that column becomes its
+ * own single-cell segment with the cursor style and never merges with
+ * neighbours. Width-0 cells (trailing half of a wide char) are skipped.
+ */
+function walkCells(
+  line: IBufferLine,
+  cols: number,
+  nullCell: IBufferCell,
+  cursorX: number,
+): PocSegment[] {
+  const segments: PocSegment[] = [];
+  let currentKey: string | null = null;
+  let currentText = '';
+  let currentStyle: PocStyle | null = null;
+
+  const flush = () => {
+    if (currentKey !== null) {
+      segments.push({ text: currentText, style: currentStyle });
+    }
+  };
+
+  for (let x = 0; x < cols; x++) {
+    const cell = line.getCell(x, nullCell);
+    if (!cell) break;
+    if (cell.getWidth() === 0) continue; // trailing half of a wide char
+
+    const chars = cell.getChars() || ' ';
+
+    if (x === cursorX) {
+      flush();
+      segments.push({ text: chars, style: CURSOR_STYLE });
+      currentKey = null;
+      currentText = '';
+      currentStyle = null;
+      continue;
+    }
+
+    const key2 = styleKey(cell);
+    if (key2 !== currentKey) {
+      flush();
+      currentKey = key2;
+      currentText = chars;
+      currentStyle = cellStyle(cell);
+    } else {
+      currentText += chars;
+    }
+  }
+  flush();
+
+  return segments;
+}
+
+/**
+ * Trim trailing whitespace from the last segment when that segment has no
+ * style (default background), keeping the DOM light without altering visible
+ * colored cells.
+ */
+function trimTrailingDefaultWhitespace(segments: PocSegment[]): void {
+  while (segments.length > 0) {
+    const last = segments[segments.length - 1];
+    if (last.style !== null) break;
+    const trimmed = last.text.replace(/ +$/, '');
+    if (trimmed === last.text) break;
+    if (trimmed === '') {
+      segments.pop();
+    } else {
+      segments[segments.length - 1] = { text: trimmed, style: null };
+      break;
+    }
+  }
+}
+
+export { DEFAULT_FG, DEFAULT_BG };

--- a/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
+++ b/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
@@ -40,6 +40,7 @@ export interface PocSnapshot {
   cursor: { x: number; y: number; visible: boolean }; // y = absolute row index
   cols: number;
   terminalRows: number;
+  bufferType: 'normal' | 'alternate'; // 'alternate' = full-screen app (scroll is forwarded)
 }
 
 export interface PocTerminalInstance {
@@ -47,6 +48,8 @@ export interface PocTerminalInstance {
   getSnapshot(): PocSnapshot;
   sendInput(data: string): void;
   resize(cols: number, rows: number): void;
+  /** Forward scroll to the app in alternate-screen mode. positive = toward newer. */
+  forwardScroll(lines: number, cell: { x: number; y: number }): void;
   dispose(): void;
 }
 
@@ -100,10 +103,14 @@ class PocTerminal implements PocTerminalInstance {
       cursor: { x: 0, y: 0, visible: true },
       cols: DEFAULT_COLS,
       terminalRows: DEFAULT_ROWS,
+      bufferType: 'normal',
     };
 
     this.terminal.onScroll(() => this.scheduleNotify());
     this.terminal.onCursorMove(() => this.scheduleNotify());
+    // The alt-screen enter/exit itself must trigger a fresh snapshot.
+    // onBufferChange lives on the buffer namespace, not the Terminal.
+    this.terminal.buffer.onBufferChange(() => this.scheduleNotify());
 
     this.connect();
   }
@@ -132,6 +139,27 @@ class PocTerminal implements PocTerminalInstance {
     this.terminal.resize(cols, rows);
     this.send({ type: 'resize', cols, rows });
     this.scheduleNotify();
+  };
+
+  forwardScroll = (lines: number, cell: { x: number; y: number }): void => {
+    const steps = Math.abs(Math.trunc(lines));
+    if (steps === 0) return;
+    const down = lines > 0; // toward newer content
+    let data: string;
+
+    if (this.terminal.modes.mouseTrackingMode !== 'none') {
+      // SGR mouse wheel report per line. Button 64 = wheel up, 65 = wheel down.
+      const col = clampCell(cell.x, this.terminal.cols);
+      const row = clampCell(cell.y, this.terminal.rows);
+      const button = down ? 65 : 64;
+      data = `\x1b[<${button};${col};${row}M`.repeat(steps);
+    } else {
+      // No mouse tracking: emit arrow keys (SS3 form under DECCKM).
+      const app = this.terminal.modes.applicationCursorKeysMode;
+      const seq = down ? (app ? '\x1bOB' : '\x1b[B') : app ? '\x1bOA' : '\x1b[A';
+      data = seq.repeat(steps);
+    }
+    this.sendInput(data);
   };
 
   dispose = (): void => {
@@ -337,12 +365,18 @@ class PocTerminal implements PocTerminalInstance {
       cursor: { x: cursorX, y: cursorY, visible: true },
       cols,
       terminalRows: this.terminal.rows,
+      bufferType: buffer.type,
     };
   }
 
   private notify(): void {
     for (const listener of this.listeners) listener();
   }
+}
+
+/** Clamp a 1-based cell coordinate into [1, max]. */
+function clampCell(value: number, max: number): number {
+  return Math.min(max, Math.max(1, Math.round(value)));
 }
 
 // --- Module-level registry ---

--- a/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
+++ b/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
@@ -1,0 +1,365 @@
+import { Terminal } from '@xterm/headless';
+import {
+  WORKER_SERVER_MESSAGE_TYPES,
+  type WorkerServerMessage,
+  type WorkerClientMessage,
+} from '@agent-console/shared';
+import { getWorkerWsUrl } from '../../lib/websocket-url.js';
+import { logger } from '../../lib/logger';
+import { extractRow, extractRowWithCursor, type PocRow } from './buffer-to-rows';
+
+/**
+ * Module-level store: the headless Terminal + WebSocket for each worker live
+ * OUTSIDE React, keyed by `${sessionId}:${workerId}`. React only subscribes via
+ * useSyncExternalStore. Because the live instance persists across route
+ * navigation, no serialize/restore of terminal state is ever needed — returning
+ * to the route reuses the same instance and its already-parsed buffer.
+ *
+ * This is the architectural point of the PoC.
+ */
+
+export type PocStatus = 'connecting' | 'connected' | 'disconnected' | 'exited';
+
+export interface PocSnapshot {
+  version: number; // bumped on every batched buffer change
+  status: PocStatus;
+  exitInfo: { code: number; signal: string | null } | null;
+  rows: PocRow[]; // full scrollback + viewport
+  cursor: { x: number; y: number; visible: boolean }; // y = absolute row index
+  cols: number;
+  terminalRows: number;
+}
+
+export interface PocTerminalInstance {
+  subscribe(listener: () => void): () => void;
+  getSnapshot(): PocSnapshot;
+  sendInput(data: string): void;
+  resize(cols: number, rows: number): void;
+  dispose(): void;
+}
+
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+const SCROLLBACK = 5000;
+const RECONNECT_DELAY_MS = 1500;
+const MAX_RECONNECT_ATTEMPTS = 10;
+
+// rAF batching: guard for non-browser (bun test) where requestAnimationFrame
+// may be absent — fall back to a ~1-frame timeout.
+const scheduleFrame: (fn: () => void) => void =
+  typeof requestAnimationFrame === 'function'
+    ? (fn) => requestAnimationFrame(fn)
+    : (fn) => {
+        setTimeout(fn, 16);
+      };
+
+class PocTerminal implements PocTerminalInstance {
+  private terminal: Terminal;
+  private ws: WebSocket | null = null;
+  private listeners = new Set<() => void>();
+  private snapshot: PocSnapshot;
+  private frameScheduled = false;
+  private disposed = false;
+
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private historyRequested = false; // per WS connection
+
+  // Row cache: rows below baseY are immutable scrollback; reuse the same object
+  // reference so React.memo skips re-render. Cleared on shrink / history rewrite.
+  private rowCache = new Map<number, PocRow>();
+  private lastBufferLength = 0;
+
+  constructor(
+    private sessionId: string,
+    private workerId: string,
+  ) {
+    this.terminal = new Terminal({
+      cols: DEFAULT_COLS,
+      rows: DEFAULT_ROWS,
+      scrollback: SCROLLBACK,
+      allowProposedApi: true,
+    });
+    this.snapshot = {
+      version: 0,
+      status: 'connecting',
+      exitInfo: null,
+      rows: [],
+      cursor: { x: 0, y: 0, visible: true },
+      cols: DEFAULT_COLS,
+      terminalRows: DEFAULT_ROWS,
+    };
+
+    this.terminal.onScroll(() => this.scheduleNotify());
+    this.terminal.onCursorMove(() => this.scheduleNotify());
+
+    this.connect();
+  }
+
+  // Interface-facing methods are arrow-function fields so consumers (e.g.
+  // useSyncExternalStore) can destructure / pass them by reference without
+  // losing `this`.
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = (): PocSnapshot => {
+    return this.snapshot;
+  };
+
+  sendInput = (data: string): void => {
+    this.send({ type: 'input', data });
+  };
+
+  resize = (cols: number, rows: number): void => {
+    if (cols <= 0 || rows <= 0) return;
+    if (cols === this.terminal.cols && rows === this.terminal.rows) return;
+    this.terminal.resize(cols, rows);
+    this.send({ type: 'resize', cols, rows });
+    this.scheduleNotify();
+  };
+
+  dispose = (): void => {
+    this.disposed = true;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+    this.closeWs();
+    this.terminal.dispose();
+    this.listeners.clear();
+    removeInstance(this.sessionId, this.workerId);
+  };
+
+  // --- WebSocket ---
+
+  private connect(): void {
+    if (this.disposed) return;
+    const url = getWorkerWsUrl(this.sessionId, this.workerId);
+    this.historyRequested = false;
+    const ws = new WebSocket(url);
+    this.ws = ws;
+
+    ws.onopen = () => {
+      if (this.disposed) return;
+      this.reconnectAttempts = 0;
+      this.updateStatus('connected');
+      // Request full history once per connection; server does not push it.
+      if (!this.historyRequested) {
+        this.historyRequested = true;
+        this.send({ type: 'request-history', fromOffset: 0 });
+      }
+      this.send({ type: 'resize', cols: this.terminal.cols, rows: this.terminal.rows });
+    };
+
+    ws.onmessage = (event) => {
+      if (typeof event.data !== 'string') return;
+      this.handleMessage(event.data);
+    };
+
+    ws.onerror = () => {
+      logger.warn(`[poc-terminal] ws error ${this.sessionId}:${this.workerId}`);
+    };
+
+    ws.onclose = () => {
+      if (this.disposed) return;
+      this.ws = null;
+      // A terminated process closes the socket after the 'exit' message; keep
+      // the 'exited' status and do not reconnect to a dead PTY.
+      if (this.snapshot.status === 'exited') return;
+      this.updateStatus('disconnected');
+      this.scheduleReconnect();
+    };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.disposed) return;
+    if (this.snapshot.status === 'exited') return;
+    if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) return;
+    this.reconnectAttempts += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.updateStatus('connecting');
+      this.connect();
+    }, RECONNECT_DELAY_MS);
+  }
+
+  private closeWs(): void {
+    if (!this.ws) return;
+    this.ws.onopen = null;
+    this.ws.onmessage = null;
+    this.ws.onerror = null;
+    this.ws.onclose = null;
+    try {
+      this.ws.close();
+    } catch {
+      // ignore
+    }
+    this.ws = null;
+  }
+
+  private send(message: WorkerClientMessage): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify(message));
+  }
+
+  private handleMessage(raw: string): void {
+    let message: WorkerServerMessage;
+    try {
+      message = JSON.parse(raw) as WorkerServerMessage;
+    } catch {
+      return;
+    }
+    if (!message || typeof message.type !== 'string') return;
+    if (!(message.type in WORKER_SERVER_MESSAGE_TYPES)) return;
+
+    switch (message.type) {
+      case 'history':
+        // Full ANSI stream. Reset first if the buffer already has content
+        // (e.g. a reconnect re-requested history) to avoid double-write.
+        if (this.terminal.buffer.active.length > 1 || this.lastBufferLength > 0) {
+          this.terminal.reset();
+          this.rowCache.clear();
+        }
+        this.terminal.write(message.data, () => this.scheduleNotify());
+        break;
+      case 'output':
+        this.terminal.write(message.data, () => this.scheduleNotify());
+        break;
+      case 'exit':
+        this.updateStatus('exited', { code: message.exitCode, signal: message.signal });
+        break;
+      case 'output-truncated':
+        // History was truncated server-side; nothing to render, just note it.
+        break;
+      case 'error':
+        logger.warn(`[poc-terminal] server error: ${message.message}`);
+        break;
+      // activity / server-restarted: not rendered in the PoC.
+    }
+  }
+
+  // --- Snapshot building ---
+
+  private updateStatus(
+    status: PocStatus,
+    exitInfo?: { code: number; signal: string | null },
+  ): void {
+    this.snapshot = {
+      ...this.snapshot,
+      status,
+      exitInfo: exitInfo ?? this.snapshot.exitInfo,
+      version: this.snapshot.version + 1,
+    };
+    this.notify();
+  }
+
+  private scheduleNotify(): void {
+    if (this.disposed || this.frameScheduled) return;
+    this.frameScheduled = true;
+    scheduleFrame(() => {
+      this.frameScheduled = false;
+      if (this.disposed) return;
+      this.rebuildSnapshot();
+      this.notify();
+    });
+  }
+
+  private rebuildSnapshot(): void {
+    const buffer = this.terminal.buffer.active;
+    const cols = this.terminal.cols;
+    const length = buffer.length;
+    const baseY = buffer.baseY;
+    const nullCell = buffer.getNullCell();
+
+    // Clear cache when the buffer shrank (reset / alt-buffer switch).
+    if (length < this.lastBufferLength) {
+      this.rowCache.clear();
+    }
+    this.lastBufferLength = length;
+
+    // At the scrollback cap the buffer length is constant while lines shift up,
+    // so absolute index y no longer identifies the same line -> disable caching.
+    if (length >= SCROLLBACK + this.terminal.rows) {
+      this.rowCache.clear();
+    }
+
+    const cursorY = baseY + buffer.cursorY;
+    const cursorX = buffer.cursorX;
+
+    const rows: PocRow[] = [];
+    for (let y = 0; y < length; y++) {
+      const isScrollback = y < baseY;
+      const isCursorRow = y === cursorY;
+
+      if (isScrollback && !isCursorRow) {
+        const cached = this.rowCache.get(y);
+        if (cached) {
+          rows.push(cached);
+          continue;
+        }
+      }
+
+      const line = buffer.getLine(y);
+      if (!line) {
+        rows.push({ key: y, segments: [{ text: '', style: null }] });
+        continue;
+      }
+
+      const row = isCursorRow
+        ? extractRowWithCursor(line, cols, nullCell, y, cursorX)
+        : extractRow(line, cols, nullCell, y);
+
+      // Cache immutable scrollback rows (not the cursor row, which changes).
+      if (isScrollback && !isCursorRow) {
+        this.rowCache.set(y, row);
+      }
+      rows.push(row);
+    }
+
+    this.snapshot = {
+      ...this.snapshot,
+      version: this.snapshot.version + 1,
+      rows,
+      cursor: { x: cursorX, y: cursorY, visible: true },
+      cols,
+      terminalRows: this.terminal.rows,
+    };
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) listener();
+  }
+}
+
+// --- Module-level registry ---
+
+const instances = new Map<string, PocTerminal>();
+
+function keyOf(sessionId: string, workerId: string): string {
+  // JSON-encoded tuple so no separator character can cause a key collision.
+  return JSON.stringify([sessionId, workerId]);
+}
+
+function removeInstance(sessionId: string, workerId: string): void {
+  instances.delete(keyOf(sessionId, workerId));
+}
+
+export function getOrCreatePocTerminal(sessionId: string, workerId: string): PocTerminalInstance {
+  const key = keyOf(sessionId, workerId);
+  let instance = instances.get(key);
+  if (!instance) {
+    instance = new PocTerminal(sessionId, workerId);
+    instances.set(key, instance);
+  }
+  return instance;
+}
+
+/** @internal Test helper: dispose and clear all live instances. */
+export function _resetPocTerminals(): void {
+  for (const instance of Array.from(instances.values())) {
+    instance.dispose();
+  }
+  instances.clear();
+}

--- a/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
+++ b/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
@@ -334,6 +334,16 @@ class PocTerminal implements PocTerminalInstance {
 }
 
 // --- Module-level registry ---
+//
+// INTENTIONAL LIFETIME: instances are deliberately NOT disposed when a React
+// route/component unmounts. Surviving mounts is the architectural point of this
+// PoC — the live headless Terminal + WebSocket replace the serialize/restore
+// cache layer, so navigating away and back reuses the already-parsed buffer with
+// zero rehydration. The trade-off is that instances live until dispose() is
+// called explicitly (only the test helper does so today), which a static
+// analyzer reads as a leak. A production adoption would add reference counting
+// (mount/unmount) + idle eviction (TTL after the last WS activity); both are out
+// of PoC scope.
 
 const instances = new Map<string, PocTerminal>();
 

--- a/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
+++ b/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
@@ -5,8 +5,20 @@ import {
   type WorkerClientMessage,
 } from '@agent-console/shared';
 import { getWorkerWsUrl } from '../../lib/websocket-url.js';
+import { stripSystemMessages, stripScrollbackClear } from '../../lib/terminal-utils.js';
 import { logger } from '../../lib/logger';
 import { extractRow, extractRowWithCursor, type PocRow } from './buffer-to-rows';
+
+/**
+ * Filters applied to every history/output chunk before writing to the buffer.
+ * stripScrollbackClear neutralizes CSI 3J/2J so Claude Code's per-redraw
+ * scrollback wipe does not destroy history. Always-on in the PoC; the
+ * production port makes stripScrollbackClear conditional per agent config
+ * (`stripScrollbackClear` flag; roadmap PR-1 scope).
+ */
+function processOutput(data: string): string {
+  return stripScrollbackClear(stripSystemMessages(data));
+}
 
 /**
  * Module-level store: the headless Terminal + WebSocket for each worker live
@@ -222,10 +234,10 @@ class PocTerminal implements PocTerminalInstance {
           this.terminal.reset();
           this.rowCache.clear();
         }
-        this.terminal.write(message.data, () => this.scheduleNotify());
+        this.terminal.write(processOutput(message.data), () => this.scheduleNotify());
         break;
       case 'output':
-        this.terminal.write(message.data, () => this.scheduleNotify());
+        this.terminal.write(processOutput(message.data), () => this.scheduleNotify());
         break;
       case 'exit':
         this.updateStatus('exited', { code: message.exitCode, signal: message.signal });

--- a/packages/client/src/labs/terminal-poc/scroll-indicator-math.ts
+++ b/packages/client/src/labs/terminal-poc/scroll-indicator-math.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure geometry for the iOS-style scroll indicator. Kept separate from the
+ * component so the height/top/overflow math is unit-testable without a DOM.
+ */
+
+export interface ScrollMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+export interface IndicatorGeometry {
+  height: number;
+  top: number;
+}
+
+export const MIN_INDICATOR_HEIGHT = 24;
+
+/** Whether the content overflows enough to warrant an indicator. */
+export function hasOverflow(m: ScrollMetrics): boolean {
+  return m.scrollHeight > m.clientHeight + 1;
+}
+
+/**
+ * Indicator thumb height + top offset. Height is proportional to the visible
+ * fraction (floored at MIN_INDICATOR_HEIGHT); top maps scroll progress onto the
+ * remaining track, clamped to [0, track].
+ */
+export function computeIndicatorGeometry(m: ScrollMetrics): IndicatorGeometry {
+  const { scrollTop, scrollHeight, clientHeight } = m;
+  const height = Math.max(MIN_INDICATOR_HEIGHT, (clientHeight * clientHeight) / scrollHeight);
+  const scrollable = scrollHeight - clientHeight;
+  const track = clientHeight - height;
+  if (scrollable <= 0 || track <= 0) {
+    return { height, top: 0 };
+  }
+  const progress = scrollTop / scrollable;
+  const top = clamp(progress * track, 0, track);
+  return { height, top };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/packages/client/src/labs/terminal-poc/useVisualViewportHeight.ts
+++ b/packages/client/src/labs/terminal-poc/useVisualViewportHeight.ts
@@ -1,0 +1,38 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Tracks the visual viewport height. On mobile the visual viewport shrinks when
+ * the soft keyboard opens (unlike window.innerHeight / layout viewport), so the
+ * PoC page uses this value as its root height to keep the input bar above the
+ * keyboard instead of hidden behind it.
+ */
+
+function subscribe(listener: () => void): () => void {
+  const vv = typeof window !== 'undefined' ? window.visualViewport : null;
+  if (!vv) {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', listener);
+      return () => window.removeEventListener('resize', listener);
+    }
+    return () => {};
+  }
+  vv.addEventListener('resize', listener);
+  vv.addEventListener('scroll', listener);
+  return () => {
+    vv.removeEventListener('resize', listener);
+    vv.removeEventListener('scroll', listener);
+  };
+}
+
+function getSnapshot(): number {
+  if (typeof window === 'undefined') return 0;
+  return window.visualViewport?.height ?? window.innerHeight;
+}
+
+function getServerSnapshot(): number {
+  return 0;
+}
+
+export function useVisualViewportHeight(): number {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/packages/client/src/routes/labs/terminal-poc.tsx
+++ b/packages/client/src/routes/labs/terminal-poc.tsx
@@ -1,0 +1,165 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { fetchWorkers } from '../../lib/api';
+import { getOrCreatePocTerminal } from '../../labs/terminal-poc/poc-terminal-store';
+import { PocTerminalView } from '../../labs/terminal-poc/PocTerminalView';
+import { PocKeyboardInput } from '../../labs/terminal-poc/PocKeyboardInput';
+import { useVisualViewportHeight } from '../../labs/terminal-poc/useVisualViewportHeight';
+
+interface TerminalPocSearch {
+  sessionId?: string;
+  workerId?: string;
+}
+
+export const Route = createFileRoute('/labs/terminal-poc')({
+  validateSearch: (search: Record<string, unknown>): TerminalPocSearch => ({
+    sessionId: typeof search.sessionId === 'string' ? search.sessionId : undefined,
+    workerId: typeof search.workerId === 'string' ? search.workerId : undefined,
+  }),
+  component: TerminalPocRoute,
+});
+
+function TerminalPocRoute() {
+  const { sessionId, workerId } = Route.useSearch();
+  if (sessionId && workerId) {
+    return <TerminalPocPage sessionId={sessionId} workerId={workerId} />;
+  }
+  return <TerminalPocPicker initialSessionId={sessionId} />;
+}
+
+function TerminalPocPage({ sessionId, workerId }: { sessionId: string; workerId: string }) {
+  const vvh = useVisualViewportHeight();
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  // Instance is keyed by sessionId:workerId and lives in the module store, so
+  // this memo just fetches the live handle (never re-creates on re-render).
+  const instance = useMemo(
+    () => getOrCreatePocTerminal(sessionId, workerId),
+    [sessionId, workerId],
+  );
+
+  const focusInput = () => inputRef.current?.focus();
+
+  // Snapshot-free page: all live-state reads happen in subscribed children.
+  return (
+    <div
+      className="fixed left-0 top-0 flex w-full flex-col bg-[#1a1a2e]"
+      style={{ height: vvh || '100vh' }}
+    >
+      <header className="flex items-center justify-between border-b border-slate-700 bg-slate-900 px-3 py-2 text-white">
+        <span className="text-sm font-medium">Terminal Renderer PoC (labs)</span>
+        <span className="text-xs text-slate-400">{sessionId.slice(0, 8)} / {workerId.slice(0, 8)}</span>
+      </header>
+
+      <StatusLine instance={instance} />
+
+      <PocTerminalView instance={instance} onRequestFocus={focusInput} />
+
+      <PocKeyboardInput ref={inputRef} instance={instance} />
+
+      <ExitBanner instance={instance} />
+    </div>
+  );
+}
+
+function StatusLine({ instance }: { instance: ReturnType<typeof getOrCreatePocTerminal> }) {
+  const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
+  const color =
+    snapshot.status === 'connected'
+      ? 'text-green-400'
+      : snapshot.status === 'exited'
+        ? 'text-red-400'
+        : 'text-yellow-400';
+  return (
+    <div className="flex items-center gap-3 bg-slate-800 px-3 py-1 text-xs text-slate-300">
+      <span className={color}>● {snapshot.status}</span>
+      <span>
+        {snapshot.cols}×{snapshot.terminalRows}
+      </span>
+    </div>
+  );
+}
+
+function ExitBanner({ instance }: { instance: ReturnType<typeof getOrCreatePocTerminal> }) {
+  const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
+  if (snapshot.status !== 'exited' || !snapshot.exitInfo) return null;
+  return (
+    <div className="bg-red-900/60 px-3 py-1 text-center text-xs text-red-200">
+      Process exited (code {snapshot.exitInfo.code}
+      {snapshot.exitInfo.signal ? `, signal ${snapshot.exitInfo.signal}` : ''})
+    </div>
+  );
+}
+
+function TerminalPocPicker({ initialSessionId }: { initialSessionId?: string }) {
+  const navigate = useNavigate();
+  const [sessionInput, setSessionInput] = useState(initialSessionId ?? '');
+  const [activeSessionId, setActiveSessionId] = useState(initialSessionId ?? '');
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['poc-workers', activeSessionId],
+    queryFn: () => fetchWorkers(activeSessionId),
+    enabled: activeSessionId.length > 0,
+  });
+
+  return (
+    <div className="mx-auto max-w-lg px-4 py-8 text-slate-200">
+      <h1 className="mb-1 text-xl font-semibold">Terminal Renderer PoC (labs)</h1>
+      <p className="mb-6 text-sm text-slate-400">
+        Enter a session ID, then pick a worker to open the experimental renderer.
+      </p>
+
+      <form
+        className="mb-4 flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          setActiveSessionId(sessionInput.trim());
+        }}
+      >
+        <input
+          value={sessionInput}
+          onChange={(e) => setSessionInput(e.target.value)}
+          placeholder="sessionId"
+          className="flex-1 rounded border border-slate-600 bg-slate-800 px-3 py-2 text-sm"
+        />
+        <button type="submit" className="rounded bg-slate-700 px-4 py-2 text-sm hover:bg-slate-600">
+          Load
+        </button>
+      </form>
+
+      {isLoading && <div className="text-sm text-slate-400">Loading workers…</div>}
+      {error && (
+        <div className="text-sm text-red-400">
+          {error instanceof Error ? error.message : 'Failed to load workers'}
+        </div>
+      )}
+
+      {data && (
+        <ul className="space-y-2">
+          {data.workers.length === 0 && (
+            <li className="text-sm text-slate-400">No workers in this session.</li>
+          )}
+          {data.workers.map((worker) => (
+            <li key={worker.id}>
+              <button
+                type="button"
+                onClick={() =>
+                  navigate({
+                    to: '/labs/terminal-poc',
+                    search: { sessionId: activeSessionId, workerId: worker.id },
+                  })
+                }
+                className="flex w-full items-center justify-between rounded border border-slate-700 bg-slate-800 px-3 py-2 text-left text-sm hover:bg-slate-700"
+              >
+                <span className="font-mono">{worker.id}</span>
+                <span className="rounded bg-slate-700 px-2 py-0.5 text-xs capitalize">
+                  {worker.type}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
# Terminal Renderer PoC: @xterm/headless + custom React DOM renderer (labs)

Refs #722

**Research spike — working PoC record.** Not a replacement of the existing terminal. The owner decides adoption later. The existing `Terminal.tsx`, WebSocket protocol contract, and all existing routes are untouched (verified: zero-diff outside `labs/`, route file, generated routeTree, and the `@xterm/headless` dependency line).

## Why (Phase 1 findings — what "unreasonable code" actually is)

Two distinct problem classes were confirmed in the current xterm.js integration:

### A. Forced use of xterm.js internals ("unreasonable code")

1. **Private-API monkey-patching for render stall recovery** — `Terminal.tsx:458-523`: overrides `(terminal as any)._core._renderService._renderDebouncer.refresh`, rebinds `terminal.write`, force-writes `renderService._isPaused = false`, and force-refreshes on a 2s watchdog interval.
2. **MutationObserver waiting for `.xterm-viewport`** — `Terminal.tsx:757-782`: the scrollable element appears asynchronously inside xterm's DOM, so scroll listeners are attached via DOM mutation observation; scroll events are triple-sourced (container capture / `terminal.onScroll` / viewport element).
3. **Deferred-dispose ritual** — `Terminal.tsx:832-845`: `setTimeout(0)` + ref-nulling to dodge "Cannot read properties of undefined (reading 'dimensions')" from xterm internals during React Strict Mode double-mounting.

### B. Architecture mismatch (serialize/restore support layer)

4. **788 LOC of cache machinery exists only because xterm's state dies with its DOM**: `terminal-state-cache.ts` (250) + `terminal-state-save-manager.ts` (357) + `terminal-chunk-writer.ts` (181, ANSI-safe chunk splitting), plus 4-fold stale-guards (`mountGeneration` / `currentWorkerId` / `isMounted` / AbortController) duplicated across success and error paths in `Terminal.tsx:558-619`.

### C. Mobile gap

5. **No mobile hooks exist at the source**: zero `visualViewport` handling, zero touch handlers, IME support limited to an `isComposing` short-circuit, and `fit()` wired only to `window.resize` (which iOS Safari does not fire on soft-keyboard open/close).

## Candidate comparison (Phase 2)

| Axis | A: @xterm/headless + own React renderer | B: ghostty-web | C: wterm | D: full custom parser |
|---|---|---|---|---|
| Mobile experience | own DOM = native scroll/visualViewport/IME | xterm-compatible mount model | gaps unresolved | (possible) |
| No serialize needed (state model) | buffer is readable data | getViewport corruption bug open | #35 open | (possible) |
| No private API for render | rendering is our code | black box | black box | (possible) |
| No mount/dispose ritual | no DOM attach at all | `open(container)` model | same | (possible) |
| CJK / truecolor | same battle-tested core as today | grapheme clusters (but WASM corruption #141 open) | #54 open (fatal) | months of work |
| Implementation cost | renderer only (PoC 1-2 days) | drop-in cheapest | — | unrealistic |
| Bundle | 142KB min | ~400KB WASM | 12KB WASM | — |
| Maturity risk | minimal (same parser as current) | born 2025-11, corruption-class bugs open | stalled since 2026-05 | — |

**wterm re-evaluation (the #722 axis)**: all three gaps recorded on 2026-04-29 are still open upstream as of 2026-07-02 — serialize (vercel-labs/wterm#35), CJK wide chars (#54), grid clamp (#56). Last push 2026-05-20. Reject stands.

**Selected: A.** One-line summary: *keep xterm.js's parser/buffer, discard only its renderer.*

## PoC architecture

```
PTY (server) ── WS /ws/session/:id/worker/:id ──> poc-terminal-store (module scope, outside React)
                                                    │  @xterm/headless Terminal = VT state machine
                                                    │  rAF-batched snapshot w/ immutable scrollback row cache
                                                    └─> React: useSyncExternalStore → PocTerminalView (plain divs/spans)
                                                         PocKeyboardInput (hidden textarea + IME + soft key bar)
                                                         useVisualViewportHeight (soft keyboard layout)
```

What this structurally eliminates (each maps to a Phase 1 finding):
- Render forcing / stall watchdogs (1): rendering is React; there is nothing to force.
- Viewport DOM observation (2): scrolling is a plain `overflow-y: auto` div — native touch momentum included.
- Dispose rituals (3): the React component holds no terminal resource; unmount is trivial.
- Serialize/restore + IndexedDB cache (4): the VT instance survives route switches in the module store; state is re-readable at any time.
- Mobile gap (5): visualViewport-driven layout, native touch scroll, IME composition handling, soft key bar — all first-class.

## Out of scope (future sprints)

Full serialize parity, tab cache strategy, complete ANSI coverage (links, selection, search), performance tuning for very large scrollback, replacing `Terminal.tsx`.

Deferred to the production-adoption phase (flagged by CodeRabbit review, deliberately not addressed in the PoC — both match current production behavior): input buffering / soft-blocking while disconnected (production `worker-websocket.sendInput` also drops silently), and a distinct "reconnect attempts exhausted" status (production also gives up silently after its retry cap). Instance lifetime management (reference counting + idle eviction for the module registry) likewise belongs to that phase; the PoC's non-disposal is intentional and documented in the code.

## Verification

**Automated** (after rebase onto latest main): `bun run typecheck` exit 0. Full `bun run test` with `env -u SSH_AUTH_SOCK`: **TEST_EXIT 0** — client 1485 pass / shared 359 pass / integration 30 pass / server 2988 pass (5 skip) / scripts 411 pass; PoC unit tests 22 pass. The `env -u` is needed because a main-side test added in PR #925 (`multi-user-mode.test.ts` "does NOT inject any SSH_AUTH_SOCK") asserts `SSH_AUTH_SOCK` is absent from spawn env, which fails on any macOS GUI login where launchd sets it — environment-sensitive, unrelated to this diff (0 server files changed), passes on Linux CI. Reported separately for follow-up.

**Browser QA (desktop, real Claude Code)**: launched Claude Code v2.1.198 through the PoC renderer against a live dev-server session. Verified: full I/O round trip (prompt sent from the hidden-textarea input path, response received), truecolor orange (`38;2;255;107;53`), CJK both directions (rendered welcome banner CJK + typed CJK input), box-drawing, inverse highlighting, the permission-prompt TUI (1. Yes / 2. No), 120-line scrollback with auto-scroll pinning, scroll-up position retention + "Jump to bottom" button. Two bugs found by this QA (detached-method `this` loss; unsubscribed StatusLine) were fixed with polarity-verified regression tests.

**Browser QA (mobile emulation, 390×844 iPhone-class + touch)**: layout reflows to 46 cols, soft-key bar wraps to two touch-sized rows, native scroll container behaves, CJK + emoji render. Soft-keyboard simulation (visualViewport height 844→480): layout shrinks without breaking, PTY auto-resizes 46×38→46×18, the key bar stays visible — the exact failure mode of the current terminal on iOS Safari does not occur, because the layout is driven by `visualViewport` directly.

**Screenshots** (attached in PR comments): desktop Claude Code round trip / desktop truecolor scrollback / mobile full view / mobile CJK scrolled-up with jump button / mobile soft-keyboard shrink.

**CodeRabbit CLI** (`--base origin/main`): 8 findings; 6 applied (resize padding subtraction, row-cache invalidation at scrollback cap, collision-proof registry key, exited-status preservation on socket close + polarity-verified test pair, test env restoration, soft-key keyboard activation). 2 deliberately skipped: message-validation depth (matches production `worker-websocket.ts`'s validation depth; trusted internal boundary) and Tab focus-trap (a terminal must forward Tab to the PTY — same behavior as xterm.js).

**Not verified here (explicitly)**: real-device touch momentum, real iOS/Android soft-keyboard and IME behavior. Owner real-device verification requested — emulation covers layout and event wiring, not platform quirks.

**Alt-screen note**: while Claude Code runs (alternate screen buffer), there is no scrollback by design — same as any native terminal; scrollback QA used a plain shell worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGB7PwWjbes5ZJBCmMJNMm
