### PR TITLE
fix(client): restore terminal copy while a CLI enables mouse tracking

### DIFF
--- a/packages/client/src/components/Terminal.tsx
+++ b/packages/client/src/components/Terminal.tsx
@@ -20,6 +20,7 @@ import { buildBaseTerminalOptions } from '../lib/terminal-options.js';
 import { createCustomKeyEventHandler } from '../lib/terminal-key-handler.js';
 import { installMouseProtocolGuard } from '../lib/terminal-mouse-protocol-guard.js';
 import { installCopyPrimeCleanup } from '../lib/terminal-copy-prime-cleanup.js';
+import { installCopyOnSelect } from '../lib/terminal-copy-on-select.js';
 import {
   register as registerSaveManager,
   unregister as unregisterSaveManager,
@@ -443,6 +444,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
     let renderStallRecovery: { dispose: () => void } | null = null;
     let mouseProtocolGuard: { dispose: () => void } | null = null;
     let copyPrimeCleanup: { dispose: () => void } | null = null;
+    let copyOnSelect: { dispose: () => void } | null = null;
     let scrollDisposable: { dispose: () => void } | null = null;
     let viewportObserver: MutationObserver | null = null;
     let viewportElement: Element | null = null;
@@ -515,6 +517,14 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
       // gone, so a later Cmd+C without a live selection does not re-copy old
       // text. See lib/terminal-copy-prime-cleanup.ts for the mechanism.
       copyPrimeCleanup = installCopyPrimeCleanup(terminal);
+
+      // Copy the selection to the clipboard at creation time while mouse
+      // tracking is active — under tracking mouse reports clear the selection
+      // synchronously, so select-then-copy cannot work. Normal shells are
+      // unaffected. See lib/terminal-copy-on-select.ts for the mechanism.
+      copyOnSelect = installCopyOnSelect(terminal, undefined, (e) =>
+        logger.debug('[Terminal] copy-on-select clipboard write failed:', e),
+      );
 
       // 3. Write the cached snapshot BEFORE open() per the library's
       //    recommendation. updateScrollButtonVisibility is safe even though
@@ -830,6 +840,9 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
 
       // Dispose the copy-prime cleanup (removes the selection listener)
       copyPrimeCleanup?.dispose();
+
+      // Dispose copy-on-select (removes the selection listener)
+      copyOnSelect?.dispose();
 
       // Dispose render stall auto-recovery before watchdog
       renderStallRecovery?.dispose();

--- a/packages/client/src/components/Terminal.tsx
+++ b/packages/client/src/components/Terminal.tsx
@@ -18,6 +18,7 @@ import {
 } from '../lib/terminal-restore.js';
 import { buildBaseTerminalOptions } from '../lib/terminal-options.js';
 import { createCustomKeyEventHandler } from '../lib/terminal-key-handler.js';
+import { installMouseProtocolGuard } from '../lib/terminal-mouse-protocol-guard.js';
 import {
   register as registerSaveManager,
   unregister as unregisterSaveManager,
@@ -439,6 +440,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
     let serializeAddon: SerializeAddon | null = null;
     let watchdog: RenderWatchdog | null = null;
     let renderStallRecovery: { dispose: () => void } | null = null;
+    let mouseProtocolGuard: { dispose: () => void } | null = null;
     let scrollDisposable: { dispose: () => void } | null = null;
     let viewportObserver: MutationObserver | null = null;
     let viewportElement: Element | null = null;
@@ -501,6 +503,11 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
       // Enable serialization for terminal state caching
       serializeAddon = new SerializeAddon();
       terminal.loadAddon(serializeAddon);
+
+      // Guard against selection-destroying mouse-protocol re-assertion from
+      // CLIs that re-emit their DEC mouse tracking setup on every redraw.
+      // See lib/terminal-mouse-protocol-guard.ts for the mechanism.
+      mouseProtocolGuard = installMouseProtocolGuard(terminal);
 
       // 3. Write the cached snapshot BEFORE open() per the library's
       //    recommendation. updateScrollButtonVisibility is safe even though
@@ -810,6 +817,9 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
 
     return () => {
       cancelled = true;
+
+      // Dispose the mouse-protocol guard (removes the parser handler)
+      mouseProtocolGuard?.dispose();
 
       // Dispose render stall auto-recovery before watchdog
       renderStallRecovery?.dispose();

--- a/packages/client/src/components/Terminal.tsx
+++ b/packages/client/src/components/Terminal.tsx
@@ -19,6 +19,7 @@ import {
 import { buildBaseTerminalOptions } from '../lib/terminal-options.js';
 import { createCustomKeyEventHandler } from '../lib/terminal-key-handler.js';
 import { installMouseProtocolGuard } from '../lib/terminal-mouse-protocol-guard.js';
+import { installCopyPrimeCleanup } from '../lib/terminal-copy-prime-cleanup.js';
 import {
   register as registerSaveManager,
   unregister as unregisterSaveManager,
@@ -441,6 +442,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
     let watchdog: RenderWatchdog | null = null;
     let renderStallRecovery: { dispose: () => void } | null = null;
     let mouseProtocolGuard: { dispose: () => void } | null = null;
+    let copyPrimeCleanup: { dispose: () => void } | null = null;
     let scrollDisposable: { dispose: () => void } | null = null;
     let viewportObserver: MutationObserver | null = null;
     let viewportElement: Element | null = null;
@@ -508,6 +510,11 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
       // CLIs that re-emit their DEC mouse tracking setup on every redraw.
       // See lib/terminal-mouse-protocol-guard.ts for the mechanism.
       mouseProtocolGuard = installMouseProtocolGuard(terminal);
+
+      // Clear xterm's stale right-click copy prime once its selection is
+      // gone, so a later Cmd+C without a live selection does not re-copy old
+      // text. See lib/terminal-copy-prime-cleanup.ts for the mechanism.
+      copyPrimeCleanup = installCopyPrimeCleanup(terminal);
 
       // 3. Write the cached snapshot BEFORE open() per the library's
       //    recommendation. updateScrollButtonVisibility is safe even though
@@ -820,6 +827,9 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
 
       // Dispose the mouse-protocol guard (removes the parser handler)
       mouseProtocolGuard?.dispose();
+
+      // Dispose the copy-prime cleanup (removes the selection listener)
+      copyPrimeCleanup?.dispose();
 
       // Dispose render stall auto-recovery before watchdog
       renderStallRecovery?.dispose();

--- a/packages/client/src/components/Terminal.tsx
+++ b/packages/client/src/components/Terminal.tsx
@@ -16,6 +16,8 @@ import {
   applyCachedSnapshotBeforeOpen,
   buildTerminalOptionsForRestore,
 } from '../lib/terminal-restore.js';
+import { buildBaseTerminalOptions } from '../lib/terminal-options.js';
+import { createCustomKeyEventHandler } from '../lib/terminal-key-handler.js';
 import {
   register as registerSaveManager,
   unregister as unregisterSaveManager,
@@ -483,16 +485,7 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
       // 2. Construct the terminal at the cached cols/rows when available.
       //    Per @xterm/addon-serialize: writing the snapshot into a same-size
       //    terminal is required for scrollback to be correctly repopulated.
-      const baseOptions = {
-        cursorBlink: true,
-        fontSize: 14,
-        fontFamily: '"JetBrains Mono", "Fira Code", "Cascadia Code", "Source Code Pro", "DejaVu Sans Mono", Menlo, Monaco, "Courier New", monospace',
-        theme: {
-          background: '#1a1a2e',
-          foreground: '#eee',
-          cursor: '#eee',
-        },
-      };
+      const baseOptions = buildBaseTerminalOptions();
       terminal = new XTerm(buildTerminalOptionsForRestore(baseOptions, cached));
 
       fitAddon = new FitAddon();
@@ -682,23 +675,10 @@ export function Terminal({ sessionId, workerId, onStatusChange, onActivityChange
       });
 
       // Handle special key events
-      terminal.attachCustomKeyEventHandler((event) => {
-        // Skip IME composition events (Japanese input, etc.)
-        if (event.isComposing) {
-          return true; // Let IME handle it
-        }
-
-        // Handle Shift+Enter for multi-line input
-        if (event.type === 'keydown' && event.key === 'Enter' && event.shiftKey) {
-          event.preventDefault();
-          event.stopPropagation();
-          // Send soft newline for multi-line input
-          sendInput('\x0a');
-          return false; // Prevent terminal from handling
-        }
-
-        return true; // Allow default handling for other keys
-      });
+      const t = terminal;
+      terminal.attachCustomKeyEventHandler(
+        createCustomKeyEventHandler({ sendInput, selectAll: () => t.selectAll() }),
+      );
 
       // Handle resize
       handleResize = () => {

--- a/packages/client/src/components/__tests__/Terminal.test.tsx
+++ b/packages/client/src/components/__tests__/Terminal.test.tsx
@@ -13,6 +13,7 @@ import { restoreScrollPosition, type ScrollableTerminal } from '../Terminal';
 import { render, screen, cleanup } from '@testing-library/react';
 import { TerminalLoadingBar } from '../ui/TerminalLoadingBar';
 import type { CachedState } from '../../lib/terminal-state-cache';
+import { buildBaseTerminalOptions } from '../../lib/terminal-options';
 import {
   register as registerSaveManager,
   unregister as unregisterSaveManager,
@@ -1512,7 +1513,7 @@ describe('Terminal cache save race on rapid unmount/remount', () => {
 });
 
 /**
- * Tests for the xterm.js fontFamily stack configured in Terminal.tsx.
+ * Tests for the xterm.js fontFamily stack configured via buildBaseTerminalOptions.
  *
  * Background (#818): The original fontFamily only named Mac fonts (Menlo, Monaco,
  * Courier New). On Linux and Windows browsers without those fonts installed,
@@ -1522,23 +1523,14 @@ describe('Terminal cache save race on rapid unmount/remount', () => {
  * Source Code Pro, DejaVu Sans Mono) so installed monospace fonts are picked
  * first on each OS.
  *
- * The Terminal component cannot be rendered in unit tests (xterm.js mocking
- * pollutes global state), so we cannot intercept the XTerm constructor options
- * directly. Instead, we pin the contract by reading the production source file
- * and asserting the fontFamily string contains at least one of the prepended
- * Linux-friendly fonts. This fails if someone reverts the widening change.
+ * The base options were previously hard-coded inline at the XTerm constructor
+ * call site, so this test had to introspect the Terminal.tsx source text. The
+ * options now live in `lib/terminal-options.ts` and are directly importable, so
+ * we assert against the builder's return value instead of the source file.
  */
 describe('Terminal fontFamily stack', () => {
-  it('should configure Linux-friendly monospace fonts in the font stack', async () => {
-    // Source-text introspection: the fontFamily value is hard-coded inline at
-    // the XTerm constructor call site, so we cannot import it. Reading the
-    // production source file pins the user-visible contract.
-    const terminalSourcePath = new URL('../Terminal.tsx', import.meta.url);
-    const source = await Bun.file(terminalSourcePath).text();
-
-    const fontFamilyMatch = source.match(/fontFamily:\s*'([^']+)'/);
-    expect(fontFamilyMatch).not.toBeNull();
-    const fontFamily = fontFamilyMatch![1];
+  it('should configure Linux-friendly monospace fonts in the font stack', () => {
+    const fontFamily = buildBaseTerminalOptions().fontFamily;
 
     // The fix (#818) prepends these fonts so Linux/Windows browsers render
     // a readable monospace before falling back to the original Mac fonts.

--- a/packages/client/src/lib/__tests__/terminal-copy-on-select.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-copy-on-select.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for copy-on-select while mouse tracking is active
+ * (packages/client/src/lib/terminal-copy-on-select.ts).
+ *
+ * Under mouse tracking, every reported mouse action counts as user input and
+ * synchronously clears the selection, so select-then-copy is unwinnable. This
+ * module writes the selection to the clipboard the moment it is created, but
+ * ONLY while mouseTrackingMode !== 'none' so normal shells keep standard
+ * selection UX. These tests pin the guard conditions and the clipboard call
+ * via an injected writer (no real clipboard / xterm needed).
+ */
+import { describe, expect, it, mock } from 'bun:test';
+import {
+  installCopyOnSelect,
+  type ClipboardWriter,
+} from '../terminal-copy-on-select';
+
+type MouseMode = 'none' | 'x10' | 'vt200' | 'drag' | 'any';
+
+function makeFakeTerminal(opts: {
+  mouseTrackingMode: MouseMode;
+  hasSelection: boolean;
+  selection: string;
+}) {
+  const dispose = mock(() => {});
+  let captured: (() => void) | undefined;
+  const terminal = {
+    onSelectionChange(cb: () => void) {
+      captured = cb;
+      return { dispose };
+    },
+    hasSelection: () => opts.hasSelection,
+    getSelection: () => opts.selection,
+    modes: { mouseTrackingMode: opts.mouseTrackingMode },
+  };
+  return {
+    terminal,
+    dispose,
+    fire: () => captured?.(),
+  };
+}
+
+function makeWriter(): ClipboardWriter & { writeText: ReturnType<typeof mock> } {
+  return { writeText: mock((_text: string) => Promise.resolve()) };
+}
+
+describe('installCopyOnSelect', () => {
+  it('should write the selection to the clipboard while tracking is active', () => {
+    const fake = makeFakeTerminal({ mouseTrackingMode: 'any', hasSelection: true, selection: 'hello' });
+    const writer = makeWriter();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    installCopyOnSelect(fake.terminal as any, writer);
+
+    fake.fire();
+
+    expect(writer.writeText).toHaveBeenCalledTimes(1);
+    expect(writer.writeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('should NOT write when mouse tracking is off (normal shells unaffected)', () => {
+    const fake = makeFakeTerminal({ mouseTrackingMode: 'none', hasSelection: true, selection: 'hello' });
+    const writer = makeWriter();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    installCopyOnSelect(fake.terminal as any, writer);
+
+    fake.fire();
+
+    expect(writer.writeText).not.toHaveBeenCalled();
+  });
+
+  it('should NOT write when there is no selection', () => {
+    const fake = makeFakeTerminal({ mouseTrackingMode: 'any', hasSelection: false, selection: '' });
+    const writer = makeWriter();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    installCopyOnSelect(fake.terminal as any, writer);
+
+    fake.fire();
+
+    expect(writer.writeText).not.toHaveBeenCalled();
+  });
+
+  it('should NOT write an empty-string selection', () => {
+    const fake = makeFakeTerminal({ mouseTrackingMode: 'any', hasSelection: true, selection: '' });
+    const writer = makeWriter();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    installCopyOnSelect(fake.terminal as any, writer);
+
+    fake.fire();
+
+    expect(writer.writeText).not.toHaveBeenCalled();
+  });
+
+  it('should route a writer rejection to onError without an unhandled rejection', async () => {
+    const fake = makeFakeTerminal({ mouseTrackingMode: 'drag', hasSelection: true, selection: 'boom' });
+    const writer: ClipboardWriter = { writeText: () => Promise.reject(new Error('denied')) };
+    const onError = mock((_e: unknown) => {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    installCopyOnSelect(fake.terminal as any, writer, onError);
+
+    fake.fire();
+    // Let the rejected promise settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toBe('denied');
+  });
+
+  it('should return the disposable from onSelectionChange', () => {
+    const fake = makeFakeTerminal({ mouseTrackingMode: 'any', hasSelection: false, selection: '' });
+    const writer = makeWriter();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const disposable = installCopyOnSelect(fake.terminal as any, writer);
+
+    disposable.dispose();
+
+    expect(fake.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/client/src/lib/__tests__/terminal-copy-prime-cleanup.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-copy-prime-cleanup.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the context-menu copy-prime cleanup
+ * (packages/client/src/lib/terminal-copy-prime-cleanup.ts).
+ *
+ * xterm primes its hidden helper textarea for the native context menu on
+ * right-click (textarea.value = selection; textarea.select()) but never
+ * un-primes it. When no live xterm selection exists, the 'copy' listener
+ * declines and the browser default copies the stale primed value — silently
+ * wrong clipboard data. These tests pin the pure "is-primed" signature and
+ * the installer that clears the prime once the selection it mirrored is gone.
+ */
+import { describe, expect, it, mock } from 'bun:test';
+import {
+  isPrimedForContextMenuCopy,
+  installCopyPrimeCleanup,
+} from '../terminal-copy-prime-cleanup';
+
+describe('isPrimedForContextMenuCopy (pure predicate)', () => {
+  it('should be true for a fully-selected non-empty value', () => {
+    expect(isPrimedForContextMenuCopy({ value: 'abc', selectionStart: 0, selectionEnd: 3 })).toBe(true);
+  });
+
+  it('should be false for an empty value', () => {
+    expect(isPrimedForContextMenuCopy({ value: '', selectionStart: 0, selectionEnd: 0 })).toBe(false);
+  });
+
+  it('should be false for a partially-selected value', () => {
+    expect(isPrimedForContextMenuCopy({ value: 'abc', selectionStart: 0, selectionEnd: 2 })).toBe(false);
+  });
+
+  it('should be false for a caret-only position (IME-composition-like)', () => {
+    expect(isPrimedForContextMenuCopy({ value: 'abc', selectionStart: 3, selectionEnd: 3 })).toBe(false);
+  });
+
+  it('should be false when selection does not start at 0', () => {
+    expect(isPrimedForContextMenuCopy({ value: 'abc', selectionStart: 1, selectionEnd: 3 })).toBe(false);
+  });
+});
+
+interface FakeTextarea {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+/**
+ * Minimal stand-in for the subset of the xterm Terminal surface the installer
+ * touches: onSelectionChange (to capture the callback), hasSelection, and the
+ * textarea. Avoids constructing a real xterm instance.
+ */
+function makeFakeTerminal(opts: {
+  hasSelection: boolean;
+  textarea: FakeTextarea | undefined;
+}) {
+  const dispose = mock(() => {});
+  let captured: (() => void) | undefined;
+  const terminal = {
+    onSelectionChange(cb: () => void) {
+      captured = cb;
+      return { dispose };
+    },
+    hasSelection: () => opts.hasSelection,
+    textarea: opts.textarea,
+  };
+  return {
+    terminal,
+    dispose,
+    fire: () => captured?.(),
+  };
+}
+
+describe('installCopyPrimeCleanup (installer)', () => {
+  it('should clear a primed textarea when the selection is gone', () => {
+    const ta: FakeTextarea = { value: 'stale', selectionStart: 0, selectionEnd: 5 };
+    const fake = makeFakeTerminal({ hasSelection: false, textarea: ta });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    installCopyPrimeCleanup(fake.terminal as any);
+
+    fake.fire();
+
+    expect(ta.value).toBe('');
+  });
+
+  it('should not touch the textarea while a selection is live', () => {
+    const ta: FakeTextarea = { value: 'stale', selectionStart: 0, selectionEnd: 5 };
+    const fake = makeFakeTerminal({ hasSelection: true, textarea: ta });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    installCopyPrimeCleanup(fake.terminal as any);
+
+    fake.fire();
+
+    expect(ta.value).toBe('stale');
+  });
+
+  it('should not touch a caret-only (composition-like) textarea', () => {
+    const ta: FakeTextarea = { value: 'compose', selectionStart: 7, selectionEnd: 7 };
+    const fake = makeFakeTerminal({ hasSelection: false, textarea: ta });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    installCopyPrimeCleanup(fake.terminal as any);
+
+    fake.fire();
+
+    expect(ta.value).toBe('compose');
+  });
+
+  it('should not throw when the textarea is undefined (pre-open event)', () => {
+    const fake = makeFakeTerminal({ hasSelection: false, textarea: undefined });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    installCopyPrimeCleanup(fake.terminal as any);
+
+    expect(() => fake.fire()).not.toThrow();
+  });
+
+  it('should return the disposable from onSelectionChange', () => {
+    const fake = makeFakeTerminal({ hasSelection: false, textarea: undefined });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const disposable = installCopyPrimeCleanup(fake.terminal as any);
+
+    disposable.dispose();
+
+    expect(fake.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/client/src/lib/__tests__/terminal-key-handler.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-key-handler.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for createCustomKeyEventHandler
+ * (packages/client/src/lib/terminal-key-handler.ts).
+ *
+ * The handler is xterm.js's attachCustomKeyEventHandler callback. Returning
+ * false stops xterm from handling the key; true lets it through.
+ *
+ * The "D' package" fix adds a Cmd+A branch: it selects the whole buffer so
+ * Cmd+C can copy it even while a TUI has DEC mouse tracking enabled (which
+ * disables xterm's SelectionService, so drag-copy is dead). Ctrl+A is
+ * deliberately NOT intercepted — it is readline's beginning-of-line and must
+ * keep reaching the PTY.
+ */
+import { describe, expect, it, mock } from 'bun:test';
+import { createCustomKeyEventHandler } from '../terminal-key-handler';
+
+interface FakeKeyEventInit {
+  type?: string;
+  key?: string;
+  isComposing?: boolean;
+  shiftKey?: boolean;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+}
+
+function makeEvent(init: FakeKeyEventInit) {
+  const preventDefault = mock(() => {});
+  const stopPropagation = mock(() => {});
+  const event = {
+    type: init.type ?? 'keydown',
+    key: init.key ?? '',
+    isComposing: init.isComposing ?? false,
+    shiftKey: init.shiftKey ?? false,
+    metaKey: init.metaKey ?? false,
+    ctrlKey: init.ctrlKey ?? false,
+    altKey: init.altKey ?? false,
+    preventDefault,
+    stopPropagation,
+  } as unknown as KeyboardEvent;
+  return { event, preventDefault, stopPropagation };
+}
+
+function makeDeps() {
+  const sendInput = mock((_data: string) => {});
+  const selectAll = mock(() => {});
+  return { sendInput, selectAll };
+}
+
+describe('createCustomKeyEventHandler', () => {
+  it('should let IME composition events through without side effects', () => {
+    const deps = makeDeps();
+    const handler = createCustomKeyEventHandler(deps);
+    const { event } = makeEvent({ type: 'keydown', key: 'a', isComposing: true });
+
+    expect(handler(event)).toBe(true);
+    expect(deps.sendInput).not.toHaveBeenCalled();
+    expect(deps.selectAll).not.toHaveBeenCalled();
+  });
+
+  it('should send a soft newline on Shift+Enter and stop terminal handling', () => {
+    const deps = makeDeps();
+    const handler = createCustomKeyEventHandler(deps);
+    const { event, preventDefault, stopPropagation } = makeEvent({
+      type: 'keydown',
+      key: 'Enter',
+      shiftKey: true,
+    });
+
+    expect(handler(event)).toBe(false);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(deps.sendInput).toHaveBeenCalledWith('\x0a');
+    expect(deps.selectAll).not.toHaveBeenCalled();
+  });
+
+  it('should select all on Cmd+A and stop terminal handling', () => {
+    const deps = makeDeps();
+    const handler = createCustomKeyEventHandler(deps);
+    const { event, preventDefault } = makeEvent({
+      type: 'keydown',
+      key: 'a',
+      metaKey: true,
+    });
+
+    expect(handler(event)).toBe(false);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(deps.selectAll).toHaveBeenCalledTimes(1);
+    expect(deps.sendInput).not.toHaveBeenCalled();
+  });
+
+  it('should intercept Cmd+A even when key is uppercase A (caps lock)', () => {
+    const deps = makeDeps();
+    const handler = createCustomKeyEventHandler(deps);
+    const { event } = makeEvent({ type: 'keydown', key: 'A', metaKey: true });
+
+    expect(handler(event)).toBe(false);
+    expect(deps.selectAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('should NOT intercept Ctrl+A (readline beginning-of-line must reach the PTY)', () => {
+    const deps = makeDeps();
+    const handler = createCustomKeyEventHandler(deps);
+    const { event } = makeEvent({ type: 'keydown', key: 'a', ctrlKey: true });
+
+    expect(handler(event)).toBe(true);
+    expect(deps.selectAll).not.toHaveBeenCalled();
+  });
+
+  it('should NOT intercept Cmd+Shift+A', () => {
+    const deps = makeDeps();
+    const handler = createCustomKeyEventHandler(deps);
+    const { event } = makeEvent({
+      type: 'keydown',
+      key: 'a',
+      metaKey: true,
+      shiftKey: true,
+    });
+
+    expect(handler(event)).toBe(true);
+    expect(deps.selectAll).not.toHaveBeenCalled();
+  });
+
+  it('should NOT intercept Cmd+A on keyup (keydown-only interception)', () => {
+    const deps = makeDeps();
+    const handler = createCustomKeyEventHandler(deps);
+    const { event } = makeEvent({ type: 'keyup', key: 'a', metaKey: true });
+
+    expect(handler(event)).toBe(true);
+    expect(deps.selectAll).not.toHaveBeenCalled();
+  });
+
+  it('should let a plain "a" keydown through without side effects', () => {
+    const deps = makeDeps();
+    const handler = createCustomKeyEventHandler(deps);
+    const { event } = makeEvent({ type: 'keydown', key: 'a' });
+
+    expect(handler(event)).toBe(true);
+    expect(deps.sendInput).not.toHaveBeenCalled();
+    expect(deps.selectAll).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/lib/__tests__/terminal-key-handler.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-key-handler.test.ts
@@ -5,7 +5,7 @@
  * The handler is xterm.js's attachCustomKeyEventHandler callback. Returning
  * false stops xterm from handling the key; true lets it through.
  *
- * The "D' package" fix adds a Cmd+A branch: it selects the whole buffer so
+ * This handler adds a Cmd+A branch: it selects the whole buffer so
  * Cmd+C can copy it even while a TUI has DEC mouse tracking enabled (which
  * disables xterm's SelectionService, so drag-copy is dead). Ctrl+A is
  * deliberately NOT intercepted — it is readline's beginning-of-line and must

--- a/packages/client/src/lib/__tests__/terminal-mouse-protocol-guard.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-mouse-protocol-guard.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the mouse-protocol re-assertion guard
+ * (packages/client/src/lib/terminal-mouse-protocol-guard.ts).
+ *
+ * Two layers:
+ *  1. Pure predicate tests of shouldSwallowMouseProtocolSet — a table over
+ *     (param x currentMode) pinning which DECSET requests are swallowed
+ *     (non-upgrades of the mouse protocol) vs applied (upgrades / non-mouse).
+ *  2. Integration with a real headless xterm Terminal (no open() — write
+ *     works pre-open, same as our cache-restore path). Confirms that a
+ *     steady-state re-assert burst does not churn the protocol while a
+ *     genuine fresh activation still reaches the intended final mode.
+ */
+import { describe, expect, it } from 'bun:test';
+import { Terminal } from '@xterm/xterm';
+import {
+  shouldSwallowMouseProtocolSet,
+  installMouseProtocolGuard,
+} from '../terminal-mouse-protocol-guard';
+
+type MouseMode = 'none' | 'x10' | 'vt200' | 'drag' | 'any';
+
+function write(term: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => {
+    term.write(data, () => resolve());
+  });
+}
+
+describe('shouldSwallowMouseProtocolSet (pure predicate)', () => {
+  // Steady-state re-assert burst: already at 'any', every mouse param is a
+  // downgrade or equal → swallow.
+  const swallowCases: Array<[number, MouseMode]> = [
+    [1003, 'any'], // any -> any (equal)
+    [1000, 'any'], // vt200 <= any (downgrade)
+    [1002, 'any'], // drag  <= any (downgrade)
+    [9, 'x10'],    // x10 -> x10 (equal)
+    [1002, 'drag'],// drag -> drag (equal)
+    [1000, 'vt200'],// vt200 -> vt200 (equal)
+    [1000, 'drag'],// vt200 <= drag (downgrade)
+  ];
+  for (const [param, mode] of swallowCases) {
+    it(`should swallow param ${param} when current mode is ${mode}`, () => {
+      expect(shouldSwallowMouseProtocolSet(param, mode)).toBe(true);
+    });
+  }
+
+  // Genuine upgrades (and fresh activation) → apply.
+  const applyCases: Array<[number, MouseMode]> = [
+    [1000, 'none'], // none -> vt200 (fresh activation)
+    [1002, 'vt200'],// vt200 -> drag (upgrade)
+    [1003, 'drag'], // drag -> any (upgrade)
+    [1003, 'none'], // none -> any (fresh activation, top mode)
+    [9, 'none'],    // none -> x10 (fresh activation)
+  ];
+  for (const [param, mode] of applyCases) {
+    it(`should apply (not swallow) param ${param} when current mode is ${mode}`, () => {
+      expect(shouldSwallowMouseProtocolSet(param, mode)).toBe(false);
+    });
+  }
+
+  // Non-mouse DECSET params are never swallowed, regardless of mode.
+  const nonMouseParams = [25, 1004, 1005, 1006, 1015, 1016, 1049, 2004];
+  const allModes: MouseMode[] = ['none', 'x10', 'vt200', 'drag', 'any'];
+  for (const param of nonMouseParams) {
+    for (const mode of allModes) {
+      it(`should not swallow non-mouse param ${param} (mode ${mode})`, () => {
+        expect(shouldSwallowMouseProtocolSet(param, mode)).toBe(false);
+      });
+    }
+  }
+});
+
+describe('installMouseProtocolGuard (real xterm integration)', () => {
+  it('should let a fresh activation burst upgrade to "any"', async () => {
+    const term = new Terminal();
+    installMouseProtocolGuard(term);
+    await write(term, '\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h');
+    expect(term.modes.mouseTrackingMode).toBe('any');
+    term.dispose();
+  });
+
+  it('should keep "any" across a steady-state re-assert burst', async () => {
+    const term = new Terminal();
+    installMouseProtocolGuard(term);
+    await write(term, '\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h');
+    // Second identical burst (the re-assert on redraw) must not churn.
+    await write(term, '\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h');
+    expect(term.modes.mouseTrackingMode).toBe('any');
+    term.dispose();
+  });
+
+  // Polarity-observable test: a lone downgrade DECSET while at 'any' must be
+  // swallowed. WITHOUT the guard, xterm would set the mode to 'vt200'.
+  it('should swallow a lone downgrade DECSET while at "any" (polarity)', async () => {
+    const term = new Terminal();
+    installMouseProtocolGuard(term);
+    await write(term, '\x1b[?1003h'); // reach 'any'
+    expect(term.modes.mouseTrackingMode).toBe('any');
+    await write(term, '\x1b[?1000h'); // downgrade request — guard swallows it
+    expect(term.modes.mouseTrackingMode).toBe('any');
+    term.dispose();
+  });
+
+  it('should let DECRST turn tracking off and allow re-activation', async () => {
+    const term = new Terminal();
+    installMouseProtocolGuard(term);
+    await write(term, '\x1b[?1003h');
+    expect(term.modes.mouseTrackingMode).toBe('any');
+    await write(term, '\x1b[?1003l'); // DECRST — always passes through
+    expect(term.modes.mouseTrackingMode).toBe('none');
+    await write(term, '\x1b[?1000h'); // re-activation from 'none' — applies
+    expect(term.modes.mouseTrackingMode).toBe('vt200');
+    term.dispose();
+  });
+
+  it('should pass multi-parameter DECSET through to the builtin', async () => {
+    const term = new Terminal();
+    installMouseProtocolGuard(term);
+    await write(term, '\x1b[?1000;1002h');
+    // Multi-param is not intercepted; the builtin applies it. Pin the
+    // observed builtin outcome (last mouse param wins → 'drag').
+    expect(term.modes.mouseTrackingMode).toBe('drag');
+    term.dispose();
+  });
+
+  it('should not affect non-mouse DECSET (bracketed paste)', async () => {
+    const term = new Terminal();
+    installMouseProtocolGuard(term);
+    await write(term, '\x1b[?2004h');
+    expect(term.modes.bracketedPasteMode).toBe(true);
+    term.dispose();
+  });
+
+  it('should stop guarding after dispose', async () => {
+    const term = new Terminal();
+    const guard = installMouseProtocolGuard(term);
+    await write(term, '\x1b[?1003h');
+    expect(term.modes.mouseTrackingMode).toBe('any');
+    guard.dispose();
+    await write(term, '\x1b[?1000h'); // downgrade now applies (guard gone)
+    expect(term.modes.mouseTrackingMode).toBe('vt200');
+    term.dispose();
+  });
+});

--- a/packages/client/src/lib/__tests__/terminal-options.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-options.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for buildBaseTerminalOptions (packages/client/src/lib/terminal-options.ts).
  *
- * The "D' package" fix restores drag-copy in the web terminal while a TUI
+ * These options restore drag-copy in the web terminal while a TUI
  * (e.g. Claude Code's fullscreen UI) has DEC mouse tracking enabled. When
  * mouse tracking is on, xterm.js disables its SelectionService, killing
  * drag-selection. Three xterm.js constructor options are the fix:
@@ -16,7 +16,7 @@
 import { describe, expect, it } from 'bun:test';
 import { buildBaseTerminalOptions } from '../terminal-options';
 
-describe('buildBaseTerminalOptions D\' mouse-tracking copy options', () => {
+describe('buildBaseTerminalOptions mouse-tracking copy options', () => {
   it('should not select a word on right-click (keeps existing selection for Copy)', () => {
     expect(buildBaseTerminalOptions().rightClickSelectsWord).toBe(false);
   });
@@ -33,10 +33,10 @@ describe('buildBaseTerminalOptions D\' mouse-tracking copy options', () => {
 /**
  * Contract pins — regression guards for the pre-existing base options. These
  * pass in BOTH the pre-fix (refactor) and post-fix states, so they are NOT
- * part of the D' polarity set; they only guard against accidental changes to
- * the unrelated base configuration.
+ * part of the copy-fix polarity set; they only guard against accidental
+ * changes to the unrelated base configuration.
  */
-describe('buildBaseTerminalOptions contract pins (not part of the D\' polarity set)', () => {
+describe('buildBaseTerminalOptions contract pins (not part of the copy-fix polarity set)', () => {
   it('should enable cursor blink', () => {
     expect(buildBaseTerminalOptions().cursorBlink).toBe(true);
   });

--- a/packages/client/src/lib/__tests__/terminal-options.test.ts
+++ b/packages/client/src/lib/__tests__/terminal-options.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for buildBaseTerminalOptions (packages/client/src/lib/terminal-options.ts).
+ *
+ * The "D' package" fix restores drag-copy in the web terminal while a TUI
+ * (e.g. Claude Code's fullscreen UI) has DEC mouse tracking enabled. When
+ * mouse tracking is on, xterm.js disables its SelectionService, killing
+ * drag-selection. Three xterm.js constructor options are the fix:
+ *   - macOptionClickForcesSelection: allow Option+drag selection on Mac
+ *     (macOS has no Shift+drag bypass — that only works on non-Mac).
+ *   - rightClickSelectsWord: false so a right-click keeps the current
+ *     selection for the "select -> right-click -> Copy" flow (defaults to
+ *     true on Mac, which would overwrite the selection with one word).
+ *   - altClickMovesCursor: false so a short Option+click does not emit
+ *     cursor-move escape sequences into the PTY.
+ */
+import { describe, expect, it } from 'bun:test';
+import { buildBaseTerminalOptions } from '../terminal-options';
+
+describe('buildBaseTerminalOptions D\' mouse-tracking copy options', () => {
+  it('should not select a word on right-click (keeps existing selection for Copy)', () => {
+    expect(buildBaseTerminalOptions().rightClickSelectsWord).toBe(false);
+  });
+
+  it('should force selection on Option+drag even under mouse tracking', () => {
+    expect(buildBaseTerminalOptions().macOptionClickForcesSelection).toBe(true);
+  });
+
+  it('should not move the cursor on Option+click (avoids stray PTY input)', () => {
+    expect(buildBaseTerminalOptions().altClickMovesCursor).toBe(false);
+  });
+});
+
+/**
+ * Contract pins — regression guards for the pre-existing base options. These
+ * pass in BOTH the pre-fix (refactor) and post-fix states, so they are NOT
+ * part of the D' polarity set; they only guard against accidental changes to
+ * the unrelated base configuration.
+ */
+describe('buildBaseTerminalOptions contract pins (not part of the D\' polarity set)', () => {
+  it('should enable cursor blink', () => {
+    expect(buildBaseTerminalOptions().cursorBlink).toBe(true);
+  });
+
+  it('should use font size 14', () => {
+    expect(buildBaseTerminalOptions().fontSize).toBe(14);
+  });
+
+  it('should include JetBrains Mono in the font stack (#818)', () => {
+    expect(buildBaseTerminalOptions().fontFamily).toContain('"JetBrains Mono"');
+  });
+
+  it('should use the dark theme background', () => {
+    expect(buildBaseTerminalOptions().theme?.background).toBe('#1a1a2e');
+  });
+});

--- a/packages/client/src/lib/terminal-copy-on-select.ts
+++ b/packages/client/src/lib/terminal-copy-on-select.ts
@@ -1,0 +1,79 @@
+/**
+ * Copy the terminal selection to the clipboard at creation time, but only
+ * while mouse tracking is active (iTerm2-style copy-on-select, scoped).
+ *
+ * xterm's SelectionService subscribes to `coreService.onUserInput` and clears
+ * the selection on ANY user input (SelectionService.ts:139-143).
+ * `CoreMouseService.triggerMouseEvent` reports mouse actions via
+ * `triggerDataEvent(report, true)` with `wasUserInput=true`
+ * (CoreMouseService.ts:284). So under mouse tracking every reported mouse
+ * action — plain click, right-click, wheel, and under the `any` protocol even
+ * cell-crossing mouse MOVES — synchronously clears the selection. A selection
+ * is therefore too ephemeral to survive until the user presses Cmd+C; a
+ * select-then-copy flow is unwinnable under `?1003h`.
+ *
+ * Instead we capture the selection the instant it exists and write it to the
+ * clipboard. Scoped to `mouseTrackingMode !== 'none'` so normal shells keep
+ * the standard select-then-copy UX. Under tracking the only selections that
+ * can occur are deliberate Option+drag / Cmd+A gestures, so auto-copy matches
+ * user intent.
+ */
+import type { IDisposable, Terminal } from '@xterm/xterm';
+
+export interface ClipboardWriter {
+  writeText: (text: string) => Promise<void>;
+}
+
+/**
+ * Default clipboard writer: the async Clipboard API when available, with a
+ * legacy `execCommand('copy')` fallback for insecure origins (non-localhost
+ * http) where `navigator.clipboard` is absent.
+ */
+export function createDefaultClipboardWriter(): ClipboardWriter {
+  return {
+    writeText: (text: string) => {
+      const asyncClipboard = navigator.clipboard;
+      if (asyncClipboard?.writeText) {
+        return asyncClipboard.writeText(text);
+      }
+      // Fallback for insecure origins where the async Clipboard API is
+      // unavailable. document.execCommand('copy') is deprecated but remains
+      // the only synchronous option in those contexts.
+      return new Promise<void>((resolve, reject) => {
+        try {
+          const textarea = document.createElement('textarea');
+          textarea.value = text;
+          textarea.style.position = 'fixed';
+          textarea.style.left = '-9999px';
+          document.body.appendChild(textarea);
+          textarea.select();
+          const ok = document.execCommand('copy');
+          document.body.removeChild(textarea);
+          if (ok) resolve();
+          else reject(new Error('execCommand("copy") returned false'));
+        } catch (e) {
+          reject(e);
+        }
+      });
+    },
+  };
+}
+
+/**
+ * Install copy-on-select on a terminal. Returns the IDisposable from
+ * `onSelectionChange`. Clipboard-write failures (e.g. permission denied) are
+ * routed to `onError`; the default swallows them.
+ */
+export function installCopyOnSelect(
+  terminal: Terminal,
+  writer: ClipboardWriter = createDefaultClipboardWriter(),
+  onError: (e: unknown) => void = () => {},
+): IDisposable {
+  return terminal.onSelectionChange(() => {
+    if (terminal.modes.mouseTrackingMode === 'none') return;
+    if (!terminal.hasSelection()) return;
+    const text = terminal.getSelection();
+    if (!text) return;
+    void writer.writeText(text).catch(onError);
+  });
+}

--- a/packages/client/src/lib/terminal-copy-prime-cleanup.ts
+++ b/packages/client/src/lib/terminal-copy-prime-cleanup.ts
@@ -1,0 +1,51 @@
+/**
+ * Clear the stale context-menu copy prime when its selection is lost.
+ *
+ * On right-click, xterm primes its hidden helper textarea for the native
+ * context-menu "Copy": it sets `textarea.value = selectionText` and calls
+ * `textarea.select()` (Clipboard.ts rightClickHandler). xterm never un-primes
+ * it — the value is cleared only on textarea blur or on Enter/^C keydown.
+ *
+ * xterm's own 'copy' listener handles Cmd+C only while `hasSelection()` is
+ * true; otherwise it declines and the BROWSER DEFAULT copy runs, which copies
+ * the textarea's still-fully-selected STALE value from the previous
+ * right-click. Under mouse tracking, plain clicks never create an xterm
+ * selection, so after the first right-click copy every subsequent Cmd+C
+ * without a live selection silently re-copies the FIRST copy's text.
+ *
+ * This cleanup clears the primed value as soon as the selection it mirrored is
+ * gone. `SelectionService.clearSelection()` fires `onSelectionChange`, so the
+ * selection-wipe is observable via the public API. The "primed" state is
+ * identified by its signature: a non-empty value that is fully selected
+ * (`select()` leaves selectionStart 0 / selectionEnd = length). IME
+ * composition text never sits fully selected in the textarea, so composition
+ * is not affected.
+ */
+import type { IDisposable, Terminal } from '@xterm/xterm';
+
+/**
+ * True iff the textarea currently holds the right-click copy prime: a
+ * non-empty value that is fully selected from start to end.
+ */
+export function isPrimedForContextMenuCopy(
+  ta: Pick<HTMLTextAreaElement, 'value' | 'selectionStart' | 'selectionEnd'>,
+): boolean {
+  return ta.value.length > 0 && ta.selectionStart === 0 && ta.selectionEnd === ta.value.length;
+}
+
+/**
+ * Install the cleanup on a terminal. Returns the IDisposable from
+ * `onSelectionChange`.
+ *
+ * `terminal.textarea` is read lazily inside the handler on purpose: it is
+ * undefined until `open()`, but selection events only fire post-open.
+ */
+export function installCopyPrimeCleanup(terminal: Terminal): IDisposable {
+  return terminal.onSelectionChange(() => {
+    if (terminal.hasSelection()) return;
+    const ta = terminal.textarea;
+    if (ta && isPrimedForContextMenuCopy(ta)) {
+      ta.value = '';
+    }
+  });
+}

--- a/packages/client/src/lib/terminal-key-handler.ts
+++ b/packages/client/src/lib/terminal-key-handler.ts
@@ -18,6 +18,20 @@ export function createCustomKeyEventHandler(
       return true; // Let IME handle it
     }
 
+    // Cmd+A: select the whole buffer so Cmd+C can copy it even while a
+    // TUI has mouse tracking enabled (selectAll bypasses the disabled
+    // selection service). Ctrl+A is deliberately NOT intercepted: it is
+    // readline's beginning-of-line and must keep reaching the PTY.
+    if (
+      event.type === 'keydown' &&
+      event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey &&
+      event.key.toLowerCase() === 'a'
+    ) {
+      event.preventDefault();
+      deps.selectAll();
+      return false;
+    }
+
     // Handle Shift+Enter for multi-line input
     if (event.type === 'keydown' && event.key === 'Enter' && event.shiftKey) {
       event.preventDefault();

--- a/packages/client/src/lib/terminal-key-handler.ts
+++ b/packages/client/src/lib/terminal-key-handler.ts
@@ -1,0 +1,32 @@
+/**
+ * Custom key event handler for the xterm.js terminal.
+ *
+ * Extracted from `Terminal.tsx` so the handler logic is directly importable
+ * and unit-testable without rendering the full Terminal component.
+ */
+export interface TerminalKeyHandlerDeps {
+  sendInput: (data: string) => void;
+  selectAll: () => void;
+}
+
+export function createCustomKeyEventHandler(
+  deps: TerminalKeyHandlerDeps,
+): (event: KeyboardEvent) => boolean {
+  return (event: KeyboardEvent) => {
+    // Skip IME composition events (Japanese input, etc.)
+    if (event.isComposing) {
+      return true; // Let IME handle it
+    }
+
+    // Handle Shift+Enter for multi-line input
+    if (event.type === 'keydown' && event.key === 'Enter' && event.shiftKey) {
+      event.preventDefault();
+      event.stopPropagation();
+      // Send soft newline for multi-line input
+      deps.sendInput('\x0a');
+      return false; // Prevent terminal from handling
+    }
+
+    return true; // Allow default handling for other keys
+  };
+}

--- a/packages/client/src/lib/terminal-mouse-protocol-guard.ts
+++ b/packages/client/src/lib/terminal-mouse-protocol-guard.ts
@@ -1,0 +1,80 @@
+/**
+ * Guard against selection-destroying mouse-protocol re-assertion.
+ *
+ * Some TUIs (e.g. Claude Code's fullscreen UI) re-emit their DEC mouse
+ * tracking setup (CSI ? 1000/1002/1003 h) on every redraw. xterm.js fires
+ * onProtocolChange even when the value does not change, and the browser
+ * terminal responds by disabling the selection service, which also CLEARS
+ * the current selection. With such a CLI running, every redraw wipes the
+ * user's selection, making copy effectively impossible.
+ *
+ * The guard intercepts single-parameter mouse-protocol DECSET sequences at
+ * the parser level and swallows the ones that do NOT strictly upgrade the
+ * protocol. The four protocols form a strict event-superset chain
+ * (x10 < vt200 < drag < any), so:
+ *   - a fresh activation (none -> vt200 -> drag -> any) passes through and
+ *     reaches the intended final mode, and
+ *   - a steady-state re-assert burst (already 'any'; each step is a
+ *     downgrade or equal) is swallowed entirely -- no protocol churn, the
+ *     selection survives.
+ *
+ * Deliberately NOT intercepted: DECRST (`l`, turning tracking off), multi-
+ * parameter sequences, non-mouse parameters, and encoding params
+ * (1005/1006/1015/1016 -- encoding changes do not fire onProtocolChange).
+ * Known trade-off: an app that genuinely downgrades (e.g. any -> vt200)
+ * without an intervening DECRST keeps the stronger mode and receives extra
+ * motion reports it no longer wants; real-world TUIs toggle off/on instead.
+ */
+import type { IDisposable, Terminal } from '@xterm/xterm';
+
+type MouseTrackingMode = 'none' | 'x10' | 'vt200' | 'drag' | 'any';
+
+export const MOUSE_PROTOCOL_RANK = {
+  none: 0,
+  x10: 1,
+  vt200: 2,
+  drag: 3,
+  any: 4,
+} as const;
+
+/**
+ * Maps a mouse-protocol DECSET parameter to the tracking mode it requests.
+ * Only the four protocol-selecting params are listed; encoding params
+ * (1005/1006/1015/1016) and non-mouse params are absent by design.
+ */
+const MOUSE_PARAM_TO_MODE: Record<number, MouseTrackingMode> = {
+  9: 'x10',
+  1000: 'vt200',
+  1002: 'drag',
+  1003: 'any',
+};
+
+/**
+ * True iff a `CSI ? <param> h` request should be swallowed instead of applied.
+ *
+ * Swallowed when the param selects a mouse protocol (9/1000/1002/1003) AND
+ * the requested protocol does not strictly upgrade the current mode
+ * (rank(requested) <= rank(current)). All other params pass through.
+ */
+export function shouldSwallowMouseProtocolSet(
+  param: number,
+  currentMode: MouseTrackingMode,
+): boolean {
+  const requestedMode = MOUSE_PARAM_TO_MODE[param];
+  if (requestedMode === undefined) return false;
+  return MOUSE_PROTOCOL_RANK[requestedMode] <= MOUSE_PROTOCOL_RANK[currentMode];
+}
+
+/**
+ * Install the guard on a terminal. Returns an IDisposable that removes the
+ * parser handler (the guard holds no timers or other resources).
+ */
+export function installMouseProtocolGuard(terminal: Terminal): IDisposable {
+  return terminal.parser.registerCsiHandler(
+    { prefix: '?', final: 'h' },
+    (params) => {
+      if (params.length !== 1 || typeof params[0] !== 'number') return false;
+      return shouldSwallowMouseProtocolSet(params[0], terminal.modes.mouseTrackingMode);
+    },
+  );
+}

--- a/packages/client/src/lib/terminal-options.ts
+++ b/packages/client/src/lib/terminal-options.ts
@@ -16,5 +16,21 @@ export function buildBaseTerminalOptions(): ITerminalOptions & ITerminalInitOnly
       foreground: '#eee',
       cursor: '#eee',
     },
+    // Allow Option+drag selection even while a TUI (e.g. Claude Code's
+    // fullscreen UI) has DEC mouse tracking enabled. Without this, macOS
+    // has no bypass at all: xterm.js only honors Shift+drag on non-Mac
+    // platforms (SelectionService.shouldForceSelection).
+    macOptionClickForcesSelection: true,
+    // Off by default only on non-Mac. On Mac this defaults to true and a
+    // right-click outside the current selection replaces it with a
+    // one-word selection, destroying the "select -> right-click -> Copy"
+    // flow. Disabling keeps the existing selection for the context menu.
+    rightClickSelectsWord: false,
+    // With macOptionClickForcesSelection enabled, a short Option+click
+    // would otherwise emit cursor-move escape sequences (arrow keys) into
+    // the PTY (SelectionService alt-click handling) — stray input for the
+    // running CLI. Disable it; the feature only ever worked while mouse
+    // tracking was off.
+    altClickMovesCursor: false,
   };
 }

--- a/packages/client/src/lib/terminal-options.ts
+++ b/packages/client/src/lib/terminal-options.ts
@@ -1,0 +1,20 @@
+/**
+ * Base constructor options for the xterm.js terminal.
+ *
+ * Extracted from `Terminal.tsx` so the option contract is directly importable
+ * (and therefore unit-testable) instead of being introspected from source text.
+ */
+import type { ITerminalInitOnlyOptions, ITerminalOptions } from '@xterm/xterm';
+
+export function buildBaseTerminalOptions(): ITerminalOptions & ITerminalInitOnlyOptions {
+  return {
+    cursorBlink: true,
+    fontSize: 14,
+    fontFamily: '"JetBrains Mono", "Fira Code", "Cascadia Code", "Source Code Pro", "DejaVu Sans Mono", Menlo, Monaco, "Courier New", monospace',
+    theme: {
+      background: '#1a1a2e',
+      foreground: '#eee',
+      cursor: '#eee',
+    },
+  };
+}


### PR DESCRIPTION
## Symptom

With Claude Code CLI's new UI (v2.1.195+ mouse click support), text copy via browser drag-selection stopped working in the AgentConsole terminal. Shift+drag did not recover it. Paste kept working. Additionally, the "drag-select, right-click, Copy" flow copied only a single word instead of the selection.

## Root cause (xterm.js 5.5.0, verified against installed sources)

1. **Mouse tracking disables the selection layer.** When the CLI enables DEC mouse tracking (`CSI ? 1000/1002/1003 h`), `InputHandler` sets `CoreMouseService.activeProtocol`, whose setter fires `onProtocolChange`; the browser `Terminal` responds with `_selectionService.disable()` (`browser/Terminal.ts:721-733`), so drag no longer selects — every mouse event is reported to the PTY instead.
2. **macOS has no Shift+drag bypass.** `SelectionService.shouldForceSelection` (`browser/services/SelectionService.ts:429-435`) returns `event.shiftKey` only on non-Mac. On Mac it requires Option+drag **and** `macOptionClickForcesSelection`, which defaults to `false` (`common/services/OptionsService.ts:40`). Our terminal never set it, so macOS users had no bypass at all.
3. **Right-click word selection is a Mac-only default.** `rightClickSelectsWord` defaults to `isMac` (`common/services/OptionsService.ts:48`). A right-click outside the current selection replaces it with a one-word selection (`SelectionService.rightClickSelect`), which is what broke the context-menu copy flow. This behavior predates the CLI change; the CLI change made it the only copy path and thus visible.

## Fix

Three xterm.js public constructor options (no internal APIs), plus a keyboard shortcut:

| Change | Effect |
|---|---|
| `macOptionClickForcesSelection: true` | Option+drag selects a range even while mouse tracking is active (same UX as iTerm2 under tmux mouse mode) |
| `rightClickSelectsWord: false` | Right-click no longer destroys the selection; the native context menu "Copy" copies the full selection |
| `altClickMovesCursor: false` | Prevents a short Option+click from leaking cursor-move escape sequences (arrow keys) into the running CLI, a path newly reachable once Option+drag is enabled |
| Cmd+A in `attachCustomKeyEventHandler` | Selects the whole buffer via `terminal.selectAll()`, which bypasses the disabled selection service; Cmd+C then works natively (xterm's copy handler only checks `hasSelection()`) |

The base options and the key handler were extracted into `lib/terminal-options.ts` / `lib/terminal-key-handler.ts` so the contract is directly importable and unit-testable (the previous fontFamily test had to introspect the component source text; it now imports the builder).

## Trade-offs (deliberate)

- **Ctrl+A is intentionally NOT intercepted.** It is readline's beginning-of-line (`\x01`) and must keep reaching the PTY. Non-Mac users already have the native Shift+drag bypass; a `Ctrl+Shift+A` select-all for non-Mac is a follow-up candidate.
- Option+drag while mouse tracking is OFF now produces a normal selection instead of a column (rectangular) selection (`shouldColumnSelect` is disabled by `macOptionClickForcesSelection` on Mac).
- Option+click no longer moves the cursor via arrow-key sequences (`altClickMovesCursor: false`). This feature only ever worked while mouse tracking was off.
- Right-clicking a word no longer selects it; right-click now always preserves the current selection.
- A caveat that remains: if the CLI re-asserts its mouse mode (the `activeProtocol` setter re-fires `onProtocolChange` even for the same value), the selection is cleared on that redraw. Copy promptly after selecting.

## Second fix (found during owner verification): mouse-protocol re-assertion guard

Owner dogfood on the dev server surfaced a defect the options alone don't cover: **Claude Code's new UI re-asserts its mouse modes (`CSI ? 1000/1002/1003/1006 h`) on redraws** (15+ bursts in one session's output log, zero DECRST). xterm.js's `CoreMouseService.activeProtocol` setter fires `onProtocolChange` even when the value is unchanged, and the browser Terminal responds with `SelectionService.disable()` → `clearSelection()` — so every CLI redraw wiped the user's selection (~100-300ms after mouseup, triggered by the focus report round trip). The burst is `vt200 → drag → any` while already at `any`, so each step individually changes the mode — a naive same-value check cannot help.

`lib/terminal-mouse-protocol-guard.ts` intercepts single-parameter mouse-protocol DECSET at the parser level (`terminal.parser.registerCsiHandler`, public API) and swallows the ones that do not **strictly upgrade** the protocol (the four protocols form a strict event-superset chain `x10 < vt200 < drag < any`). A fresh activation (`none → vt200 → drag → any`) passes through untouched; a steady-state re-assert burst is swallowed entirely, so the selection survives. DECRST, multi-parameter sequences, encodings, and non-mouse params always pass through. Known trade-off (documented in the module): an app that genuinely downgrades (e.g. `any → vt200`) without an intervening DECRST keeps the stronger mode and receives extra motion reports; real-world TUIs toggle off/on instead. Upstream, the cleaner fix would be idempotent protocol-change handling in xterm.js — a follow-up issue candidate.

Also confirmed during verification: Claude Code's new UI renders **its own in-TUI selection** for plain (unmodified) drags — it looks like a browser selection but xterm has no selection at that point, which is why right-click Copy appeared disabled. That path (Claude's own `ctrl+c to copy`) is a separate follow-up investigation (OSC 52 / `@xterm/addon-clipboard`).

## Third fix (found during owner dogfood): stale context-menu copy prime

Owner's continued dogfood surfaced "copy works once, then a reload is needed". Mechanism (reproduced deterministically): xterm's `rightClickHandler` primes the hidden helper textarea for the native context menu (`textarea.value = selectionText; textarea.select()`) but **never un-primes it** — the value is cleared only on blur or Enter/^C keydown. xterm's `copy` listener handles Cmd+C only when `hasSelection()` is true; with no live selection it declines and the **browser default copy delivers the stale, still-fully-selected primed value** — the previous copy's text, silently wrong clipboard data. Under mouse tracking, plain clicks never create an xterm selection, so this stale path is the norm after the first right-click copy.

`lib/terminal-copy-prime-cleanup.ts` clears the primed value as soon as the selection it mirrored is gone, via public APIs only (`onSelectionChange` + `hasSelection()` + `terminal.textarea`). The primed state is identified by its signature — a non-empty value that is fully selected; IME composition text never sits fully selected in the textarea, so composition is unaffected. (The public-API-only constraint mirrors the renderer-research invariant: render/state control through the published surface, no internal hooks.)

## Fourth fix (the decisive one): copy-on-select while mouse tracking is active

Owner verification revealed the deepest layer: `SelectionService` clears the selection on ANY user input (`onUserInput`, SelectionService.ts:139-143), and mouse REPORTS count as user input (`CoreMouseService.triggerMouseEvent` → `triggerDataEvent(report, true)`, CoreMouseService.ts:284). Under the `any` protocol (`?1003h`, which Claude Code uses), **moving the mouse one cell sends a motion report and synchronously clears the selection** — verified with an instrumented stack trace (`triggerMouseEvent → triggerDataEvent → onUserInput → clearSelection`). A "select, then go copy" flow cannot survive; this is not fixable from the embedding side (upstream candidate #4 in issue #943).

So the selection is captured at creation time instead: `lib/terminal-copy-on-select.ts` writes the selection to the clipboard the moment it exists — **only while `mouseTrackingMode !== 'none'`** (normal shells keep the standard select-then-copy behavior, verified in QA). Under tracking, the only possible selections are deliberate Option+drag / Cmd+A gestures, so auto-copy matches intent (iTerm2-style copy-on-select, scoped). Default writer uses the async Clipboard API with an `execCommand('copy')` fallback for insecure origins; failures are logged at debug level.

The full findings, upstream xterm.js contribution candidates, and requirements for the terminal-renderer replacement research are recorded in issue #943.

## Relation to `CLAUDE_CODE_DISABLE_MOUSE_CLICKS`

Claude Code v2.1.195+ ships an env-side escape hatch (`CLAUDE_CODE_DISABLE_MOUSE_CLICKS`). This fix makes AgentConsole copy work **without** that env var, keeps the CLI's mouse features usable, and is robust against any other CLI that enables DEC mouse tracking.

## Tests

- `lib/__tests__/terminal-options.test.ts` — asserts the three new options plus contract pins (cursorBlink/fontSize/fontFamily/theme).
- `lib/__tests__/terminal-key-handler.test.ts` — Cmd+A intercepts (keydown only, lowercase and caps-lock 'A'), Ctrl+A / Cmd+Shift+A / keyup pass through, IME and Shift+Enter behavior unchanged.
- **Polarity verified**: with the fix stashed (tests kept), the 5 fix-targeting tests fail; with the fix restored, 15/15 pass. Contract pins are isolated in a separate describe block and excluded from the polarity set.
- Full suite: client 1478 pass / 0 fail, shared 359, integration 30, typecheck clean. One pre-existing server failure (`MultiUserMode / Issue #918 sshAuthSockFallback`) is an ambient-environment artifact on the dev machine (`SSH_AUTH_SOCK` set by the local agent); this branch does not touch `packages/server` and the test passes in CI's clean environment.

## Browser QA (Chrome DevTools MCP, real reproduction)

Verified on the dev server against a **real Claude Code v2.1.198 session** with its new UI holding mouse tracking active (`.xterm.enable-mouse-events` present), plus a fresh shell with a `printf` DECSET toggle:

- Tracking ON: plain drag selects nothing (symptom reproduced); Option+drag creates a selection that persists while idle; a synthetic `copy` event yields the dragged text; right-click **inside and outside** the selection preserves it and primes the hidden textarea with the full selection (what the native context-menu Copy copies); Cmd+A selects the entire buffer (1019 chars, banner included) with `defaultPrevented`.
- Tracking OFF (fresh shell): plain drag still selects and copies (no regression); right-click outside the selection preserves it.
- **Guard E2E (deterministic)**: with mouse tracking active, an Option+drag selection was made and a delayed re-assert burst (`sleep 3; printf '\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h'`) was delivered through the real PTY → server → WebSocket → parser path while the selection was live. The selection and its copied text survived the burst unchanged (pre-guard, the first `?1000h` cleared it). Also verified against real Claude Code redraws (keystrokes into its input) — selection and copy intact.
- Guard unit/integration tests: 59 tests including a real headless xterm `Terminal` exercising the parser hook (fresh activation reaches `any`; lone downgrade swallowed — the polarity anchor; DECRST and multi-param pass through; dispose restores default behavior).
- **Copy-on-select E2E (host clipboard)**: with a marker preloaded via `pbcopy`, an Option+drag against the live Claude Code session replaced the macOS clipboard with the dragged text (verified via `pbpaste`) — no further action needed. Regression: in a tracking-off shell, plain drag selected text while the clipboard marker stayed untouched (no auto-copy in normal shells).
- Screenshots posted in a PR comment.

Preflight note: the integration-test advisory (`Terminal.tsx — UI component`) does not apply wire-level checks here — this change is client-only, adds no shared type/schema field, and crosses no server/client boundary; coverage is unit tests + the Browser QA above.

## Follow-up candidates (not in this PR)

- Copy-pane button / AgentConsole-native context menu (mobile + discoverability) — to be weighed together with the terminal renderer/UX research track.
- `Ctrl+Shift+A` select-all for non-Mac.

No pre-existing issue tracks this bug; this PR is the tracking artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ubZz2JXXmXnAtXtJRRp3e

## Note on CodeRabbit

The GitHub-side bot was rate-limited at PR open; after the limit reset it reviewed the full branch and returned **APPROVED with zero inline comments**. The local CodeRabbit CLI was also run against `origin/main` before each push: 1 MINOR finding on the first pass (internal codename in a test doc comment, fixed in `174ed23`), 0 findings on the final pass including the guard commit.
