### PR TITLE
feat(labs): terminal PoC store production-hardening + memory management (closes #937)

### DIFF
--- a/packages/client/src/labs/terminal-poc/PocKeyboardInput.tsx
+++ b/packages/client/src/labs/terminal-poc/PocKeyboardInput.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useRef, useState } from 'react';
-import type { KeyboardEvent, CompositionEvent, FormEvent } from 'react';
+import type { KeyboardEvent, CompositionEvent, FormEvent, ClipboardEvent } from 'react';
 import type { PocTerminalInstance } from './poc-terminal-store';
 
 interface PocKeyboardInputProps {
@@ -59,6 +59,17 @@ export const PocKeyboardInput = forwardRef<HTMLTextAreaElement, PocKeyboardInput
       }
     };
 
+    const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+      // Paste during IME composition is an edge case; let the default happen.
+      if (composingRef.current) return;
+      const text = e.clipboardData.getData('text/plain');
+      // No text (e.g. image-only clipboard): do nothing for now — image paste
+      // is phase 5.
+      if (!text) return;
+      e.preventDefault();
+      instance.paste(text);
+    };
+
     const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
       if (composingRef.current || e.nativeEvent.isComposing) return;
 
@@ -100,6 +111,7 @@ export const PocKeyboardInput = forwardRef<HTMLTextAreaElement, PocKeyboardInput
           onCompositionEnd={handleCompositionEnd}
           onInput={handleInput}
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
           autoCapitalize="off"
           autoCorrect="off"
           autoComplete="off"

--- a/packages/client/src/labs/terminal-poc/PocKeyboardInput.tsx
+++ b/packages/client/src/labs/terminal-poc/PocKeyboardInput.tsx
@@ -1,9 +1,14 @@
 import { forwardRef, useRef, useState } from 'react';
 import type { KeyboardEvent, CompositionEvent, FormEvent, ClipboardEvent } from 'react';
 import type { PocTerminalInstance } from './poc-terminal-store';
+import { extractImageFiles } from './image-paste';
 
 interface PocKeyboardInputProps {
   instance: PocTerminalInstance;
+  // Called when an image is pasted (image-only or image+text clipboard). The
+  // adapter phase (PR-3) wires this to MessagePanel; the labs route surfaces a
+  // toast so the contract is E2E-visible.
+  onFilesReceived?: (files: File[]) => void;
 }
 
 // Special keys -> escape sequences. Arrow keys use the normal (non-application)
@@ -25,7 +30,7 @@ const SPECIAL_KEYS: Record<string, string> = {
  * keyboard. A soft-key bar provides keys that are hard to reach on mobile.
  */
 export const PocKeyboardInput = forwardRef<HTMLTextAreaElement, PocKeyboardInputProps>(
-  function PocKeyboardInput({ instance }, ref) {
+  function PocKeyboardInput({ instance, onFilesReceived }, ref) {
     const composingRef = useRef(false);
     const [composeText, setComposeText] = useState('');
 
@@ -62,9 +67,17 @@ export const PocKeyboardInput = forwardRef<HTMLTextAreaElement, PocKeyboardInput
     const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
       // Paste during IME composition is an edge case; let the default happen.
       if (composingRef.current) return;
+      // Image precedence matches production (Terminal.tsx): when the clipboard
+      // carries an image, route it to onFilesReceived and swallow the event —
+      // no text is sent, even if text is also present.
+      const imageFiles = extractImageFiles(e.clipboardData.items);
+      if (imageFiles.length > 0 && onFilesReceived) {
+        e.preventDefault();
+        onFilesReceived(imageFiles);
+        return;
+      }
       const text = e.clipboardData.getData('text/plain');
-      // No text (e.g. image-only clipboard): do nothing for now — image paste
-      // is phase 5.
+      // No text (e.g. an image-only clipboard with no handler): let default run.
       if (!text) return;
       e.preventDefault();
       instance.paste(text);

--- a/packages/client/src/labs/terminal-poc/PocTerminalAdapter.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalAdapter.tsx
@@ -36,8 +36,19 @@ export function PocTerminalAdapter({
   // React mounts. stripScrollbackClear is read once at creation (config is fixed
   // per instance lifetime); passing it here again on prop change is a harmless
   // no-op because getOrCreate returns the existing instance.
+  //
+  // When the prop is undefined, OMIT the option so the store default governs —
+  // this keeps an adapter-first instance behaving identically to a labs-route-
+  // first instance for the same worker (a `?? false` here would flip the store
+  // default and diverge intra-labs). Production SessionPage always passes an
+  // explicit boolean, so drop-in parity is unaffected.
   const instance = useMemo(
-    () => getOrCreatePocTerminal(sessionId, workerId, { stripScrollbackClear: stripScrollbackClear ?? false }),
+    () =>
+      getOrCreatePocTerminal(
+        sessionId,
+        workerId,
+        stripScrollbackClear === undefined ? undefined : { stripScrollbackClear },
+      ),
     [sessionId, workerId, stripScrollbackClear],
   );
 
@@ -75,6 +86,7 @@ export function PocTerminalAdapter({
           instance={instance}
           onRequestFocus={focusInput}
           onFilesReceived={onFilesReceived}
+          inputRef={inputRef}
         />
         <AdapterRecoveryOverlay
           instance={instance}

--- a/packages/client/src/labs/terminal-poc/PocTerminalAdapter.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalAdapter.tsx
@@ -1,0 +1,225 @@
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { useMutation } from '@tanstack/react-query';
+import type { TerminalProps } from '../../components/Terminal';
+import { WorkerErrorRecovery } from '../../components/WorkerErrorRecovery';
+import { TerminalLoadingBar } from '../../components/ui/TerminalLoadingBar';
+import { deleteSession } from '../../lib/api';
+import { emitSessionDeleted } from '../../lib/app-websocket';
+import { getOrCreatePocTerminal, type PocStatus, type PocTerminalInstance } from './poc-terminal-store';
+import { PocTerminalView } from './PocTerminalView';
+import { PocKeyboardInput } from './PocKeyboardInput';
+import { toStatusChangeArgs } from './poc-status-mapping';
+
+/**
+ * Drop-in replacement for `components/Terminal.tsx` implementing the exact
+ * `TerminalProps` contract, so the eventual flag swap in `SessionPage.tsx` is a
+ * one-import change. It composes the PoC store + view + keyboard input and
+ * reuses the production `WorkerErrorRecovery` overlay and `TerminalLoadingBar`
+ * as-is (renderer-agnostic).
+ */
+export function PocTerminalAdapter({
+  sessionId,
+  workerId,
+  onStatusChange,
+  onActivityChange,
+  onRequestRestart,
+  onResumeSession,
+  onFilesReceived,
+  hideStatusBar,
+  stripScrollbackClear,
+}: TerminalProps) {
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // The instance is keyed by sessionId:workerId in the module store and outlives
+  // React mounts. stripScrollbackClear is read once at creation (config is fixed
+  // per instance lifetime); passing it here again on prop change is a harmless
+  // no-op because getOrCreate returns the existing instance.
+  const instance = useMemo(
+    () => getOrCreatePocTerminal(sessionId, workerId, { stripScrollbackClear: stripScrollbackClear ?? false }),
+    [sessionId, workerId, stripScrollbackClear],
+  );
+
+  const focusInput = useCallback(() => inputRef.current?.focus(), []);
+
+  // Mirror Terminal.tsx delete-session recovery: delete via API, then broadcast
+  // session-deleted and return to the dashboard.
+  const deleteSessionMutation = useMutation({
+    mutationFn: () => deleteSession(sessionId),
+    onSuccess: () => {
+      emitSessionDeleted(sessionId);
+      navigate({ to: '/' });
+    },
+  });
+
+  const handleRetry = useCallback(() => instance.retry(), [instance]);
+  const handleDeleteSession = useCallback(() => deleteSessionMutation.mutate(), [deleteSessionMutation]);
+  const handleGoToDashboard = useCallback(() => navigate({ to: '/' }), [navigate]);
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col bg-[#1a1a2e]">
+      <StatusCallbackBridge
+        instance={instance}
+        onStatusChange={onStatusChange}
+        onActivityChange={onActivityChange}
+      />
+
+      {!hideStatusBar && <AdapterStatusBar instance={instance} />}
+
+      <AdapterNoticeBanner instance={instance} />
+
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        <AdapterLoadingBar instance={instance} />
+        <PocTerminalView
+          instance={instance}
+          onRequestFocus={focusInput}
+          onFilesReceived={onFilesReceived}
+        />
+        <AdapterRecoveryOverlay
+          instance={instance}
+          onRetry={handleRetry}
+          onDeleteSession={handleDeleteSession}
+          onGoToDashboard={handleGoToDashboard}
+          onRestart={onRequestRestart}
+          onResumeSession={onResumeSession}
+        />
+      </div>
+
+      <PocKeyboardInput ref={inputRef} instance={instance} onFilesReceived={onFilesReceived} />
+
+      <AdapterExitBanner instance={instance} />
+    </div>
+  );
+}
+
+/**
+ * Subscribed, render-null bridge that forwards snapshot changes to the parent
+ * callbacks. Isolated so the outer adapter does not re-render on every frame.
+ */
+function StatusCallbackBridge({
+  instance,
+  onStatusChange,
+  onActivityChange,
+}: {
+  instance: PocTerminalInstance;
+  onStatusChange: TerminalProps['onStatusChange'];
+  onActivityChange: TerminalProps['onActivityChange'];
+}) {
+  const { status, exitInfo, activityState } = useSyncExternalStore(
+    instance.subscribe,
+    instance.getSnapshot,
+  );
+
+  useEffect(() => {
+    const args = toStatusChangeArgs({ status, exitInfo });
+    onStatusChange?.(args.status, args.exitInfo);
+  }, [status, exitInfo, onStatusChange]);
+
+  useEffect(() => {
+    if (activityState) onActivityChange?.(activityState);
+  }, [activityState, onActivityChange]);
+
+  return null;
+}
+
+function AdapterStatusBar({ instance }: { instance: PocTerminalInstance }) {
+  const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
+  const color =
+    snapshot.status === 'connected'
+      ? 'bg-green-500'
+      : snapshot.status === 'exited'
+        ? 'bg-red-500'
+        : snapshot.status === 'disconnected'
+          ? 'bg-gray-500'
+          : 'bg-yellow-500';
+  return (
+    <div className="flex shrink-0 items-center gap-3 border-b border-gray-700 bg-slate-900 px-3 py-2">
+      <span className={`inline-block h-2 w-2 rounded-full ${color}`} />
+      <span className="text-sm text-gray-500">{statusText(snapshot.status, snapshot.exitInfo)}</span>
+    </div>
+  );
+}
+
+function statusText(
+  status: PocStatus,
+  exitInfo: { code: number; signal: string | null } | null,
+): string {
+  switch (status) {
+    case 'connecting':
+      return 'Connecting...';
+    case 'connected':
+      return 'Connected';
+    case 'disconnected':
+      return 'Disconnected';
+    case 'exited':
+      return `Exited (code: ${exitInfo?.code}${exitInfo?.signal ? `, signal: ${exitInfo.signal}` : ''})`;
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+
+function AdapterLoadingBar({ instance }: { instance: PocTerminalInstance }) {
+  const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
+  return <TerminalLoadingBar visible={snapshot.loadingHistory} />;
+}
+
+function AdapterNoticeBanner({ instance }: { instance: PocTerminalInstance }) {
+  const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
+  if (!snapshot.notice) return null;
+  return (
+    <div className="flex items-center justify-between gap-2 bg-amber-900/60 px-3 py-1 text-xs text-amber-200">
+      <span>{snapshot.notice}</span>
+      <button
+        type="button"
+        onClick={() => instance.dismissNotice()}
+        className="rounded bg-amber-700/60 px-2 py-0.5 hover:bg-amber-600/60"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}
+
+function AdapterExitBanner({ instance }: { instance: PocTerminalInstance }) {
+  const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
+  if (snapshot.status !== 'exited' || !snapshot.exitInfo) return null;
+  return (
+    <div className="bg-red-900/60 px-3 py-1 text-center text-xs text-red-200">
+      Process exited (code {snapshot.exitInfo.code}
+      {snapshot.exitInfo.signal ? `, signal ${snapshot.exitInfo.signal}` : ''})
+    </div>
+  );
+}
+
+function AdapterRecoveryOverlay({
+  instance,
+  onRetry,
+  onDeleteSession,
+  onGoToDashboard,
+  onRestart,
+  onResumeSession,
+}: {
+  instance: PocTerminalInstance;
+  onRetry: () => void;
+  onDeleteSession: () => void;
+  onGoToDashboard: () => void;
+  onRestart: TerminalProps['onRequestRestart'];
+  onResumeSession: TerminalProps['onResumeSession'];
+}) {
+  const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
+  if (!snapshot.workerError) return null;
+  return (
+    <WorkerErrorRecovery
+      errorCode={snapshot.workerError.code}
+      errorMessage={snapshot.workerError.message}
+      onRetry={onRetry}
+      onDeleteSession={onDeleteSession}
+      onGoToDashboard={onGoToDashboard}
+      onRestart={onRestart}
+      onResumeSession={onResumeSession}
+    />
+  );
+}

--- a/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
@@ -6,8 +6,16 @@ import { PocScrollIndicator } from './PocScrollIndicator';
 
 const FONT_FAMILY =
   "'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace";
+const FONT_SIZE_PX = 14;
+// Fixed per-row height. Every row div is pinned to this so blank rows still
+// occupy one cell (an empty span collapses to 0), keeping the DOM row grid a
+// 1:1 pixel map of the buffer — required for correct pointer->cell math.
+const LINE_HEIGHT_PX = 18;
 const RESIZE_DEBOUNCE_MS = 150;
 const BOTTOM_THRESHOLD_PX = 4;
+// A touch pointer that moves more than this between down and up is a scroll
+// gesture (forwarded as wheel), not a tap — do not report it as a TUI click.
+const CLICK_MOVE_THRESHOLD_PX = 5;
 
 interface PocTerminalViewProps {
   instance: PocTerminalInstance;
@@ -30,7 +38,7 @@ function segmentStyle(style: PocStyle | null): CSSProperties | undefined {
 
 const Row = memo(function Row({ row }: { row: PocRow }) {
   return (
-    <div style={{ whiteSpace: 'pre' }}>
+    <div style={{ whiteSpace: 'pre', height: LINE_HEIGHT_PX, lineHeight: `${LINE_HEIGHT_PX}px` }}>
       {row.segments.map((seg: PocSegment, i) => (
         <span key={i} style={segmentStyle(seg.style)}>
           {seg.text}
@@ -51,6 +59,8 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
   // so they know whether to forward scroll to the app or let native scroll run.
   const bufferTypeRef = useRef<'normal' | 'alternate'>('normal');
   bufferTypeRef.current = snapshot.bufferType;
+  const mouseTrackingRef = useRef(false);
+  mouseTrackingRef.current = snapshot.mouseTracking;
 
   // Mount reference for memory management: the instance is kept alive while this
   // view is mounted and becomes idle-evictable after unmount. release() is
@@ -138,16 +148,23 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
     let remainder = 0;
     let touchLastY: number | null = null;
 
+    // Container padding is static (Tailwind px-2 py-1); read once.
+    const computedPadding = getComputedStyle(el);
+    const paddingLeft = parseFloat(computedPadding.paddingLeft) || 0;
+    const paddingTop = parseFloat(computedPadding.paddingTop) || 0;
+
     const cellMetrics = () => {
       const r = measure.getBoundingClientRect();
       return { charW: r.width || 8, charH: r.height || 16 };
     };
-    const cellFromPoint = (clientX: number, clientY: number, charW: number, charH: number) => {
+    // 1-based cell coords. Row height is fixed at LINE_HEIGHT_PX (fixed row divs)
+    // so y maps exactly; add scrollTop (normal-buffer scrollback) and subtract
+    // padding. x uses the measured monospace cell width.
+    const cellFromPoint = (clientX: number, clientY: number, charW: number) => {
       const rect = el.getBoundingClientRect();
-      return {
-        x: Math.floor((clientX - rect.left) / charW) + 1,
-        y: Math.floor((clientY - rect.top) / charH) + 1,
-      };
+      const x = Math.floor((clientX - rect.left - paddingLeft) / charW) + 1;
+      const y = Math.floor((clientY - rect.top - paddingTop + el.scrollTop) / LINE_HEIGHT_PX) + 1;
+      return { x: Math.max(1, x), y: Math.max(1, y) };
     };
     const stepFrom = (deltaPx: number, charH: number): number => {
       const total = remainder + deltaPx;
@@ -162,7 +179,7 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
       const { charW, charH } = cellMetrics();
       const steps = stepFrom(e.deltaY, charH);
       if (steps === 0) return;
-      instance.forwardScroll(steps, cellFromPoint(e.clientX, e.clientY, charW, charH));
+      instance.forwardScroll(steps, cellFromPoint(e.clientX, e.clientY, charW));
     };
 
     const onTouchStart = (e: TouchEvent) => {
@@ -180,22 +197,84 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
       const steps = stepFrom(touchLastY - touch.clientY, charH);
       if (steps === 0) return;
       touchLastY = touch.clientY;
-      instance.forwardScroll(steps, cellFromPoint(touch.clientX, touch.clientY, charW, charH));
+      instance.forwardScroll(steps, cellFromPoint(touch.clientX, touch.clientY, charW));
     };
     const onTouchEnd = () => {
       touchLastY = null;
+    };
+
+    // --- Mouse button reporting to the TUI (focus parity) ---
+    // We never preventDefault here, so click-to-focus and native selection keep
+    // working. Under mouse tracking a mouse press+release reaches the TUI as a
+    // click at that cell; a mouse drag reports press(down)+release(up) and the
+    // TUI (e.g. Claude Code) paints its own in-TUI selection — that is expected
+    // parity behavior (#943). Browser text selection is the Shift path (Shift
+    // held -> we do not report, xterm convention). Right-click is never reported
+    // (browser context menu wins). Touch defers to pointerup and only reports a
+    // tap (movement <= threshold) so a scroll drag is not a phantom click.
+    let mousePressActive = false; // a mouse press was emitted, awaiting release
+    let touchDownX = 0;
+    let touchDownY = 0;
+    let touchDownCell: { x: number; y: number } | null = null;
+
+    const reportable = (e: PointerEvent): boolean =>
+      mouseTrackingRef.current && e.button === 0 && e.isPrimary && !e.shiftKey;
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (!reportable(e)) return;
+      const { charW } = cellMetrics();
+      const cell = cellFromPoint(e.clientX, e.clientY, charW);
+      if (e.pointerType === 'touch') {
+        touchDownX = e.clientX;
+        touchDownY = e.clientY;
+        touchDownCell = cell;
+        mousePressActive = false;
+      } else {
+        instance.reportMouseButton('press', cell);
+        mousePressActive = true;
+      }
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      if (e.button !== 0) return; // left-button release only
+      const { charW } = cellMetrics();
+      const cell = cellFromPoint(e.clientX, e.clientY, charW);
+      if (e.pointerType === 'touch') {
+        if (touchDownCell && mouseTrackingRef.current && !e.shiftKey) {
+          const moved = Math.hypot(e.clientX - touchDownX, e.clientY - touchDownY);
+          if (moved <= CLICK_MOVE_THRESHOLD_PX) {
+            instance.reportMouseButton('press', touchDownCell);
+            instance.reportMouseButton('release', cell);
+          }
+        }
+        touchDownCell = null;
+      } else if (mousePressActive) {
+        instance.reportMouseButton('release', cell);
+        mousePressActive = false;
+      }
+    };
+
+    const onPointerCancel = () => {
+      touchDownCell = null;
+      mousePressActive = false;
     };
 
     el.addEventListener('wheel', onWheel, { passive: false });
     el.addEventListener('touchstart', onTouchStart, { passive: false });
     el.addEventListener('touchmove', onTouchMove, { passive: false });
     el.addEventListener('touchend', onTouchEnd);
+    el.addEventListener('pointerdown', onPointerDown);
+    el.addEventListener('pointerup', onPointerUp);
+    el.addEventListener('pointercancel', onPointerCancel);
 
     return () => {
       el.removeEventListener('wheel', onWheel);
       el.removeEventListener('touchstart', onTouchStart);
       el.removeEventListener('touchmove', onTouchMove);
       el.removeEventListener('touchend', onTouchEnd);
+      el.removeEventListener('pointerdown', onPointerDown);
+      el.removeEventListener('pointerup', onPointerUp);
+      el.removeEventListener('pointercancel', onPointerCancel);
     };
   }, [instance]);
 
@@ -209,8 +288,8 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
           position: 'absolute',
           visibility: 'hidden',
           fontFamily: FONT_FAMILY,
-          fontSize: 14,
-          lineHeight: '18px',
+          fontSize: FONT_SIZE_PX,
+          lineHeight: `${LINE_HEIGHT_PX}px`,
           whiteSpace: 'pre',
         }}
       >
@@ -231,8 +310,8 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
         className="h-full overflow-y-auto bg-[#1a1a2e] text-[#eeeeee] px-2 py-1"
         style={{
           fontFamily: FONT_FAMILY,
-          fontSize: 14,
-          lineHeight: '18px',
+          fontSize: FONT_SIZE_PX,
+          lineHeight: `${LINE_HEIGHT_PX}px`,
           overscrollBehavior: 'contain',
           fontVariantLigatures: 'none',
           WebkitOverflowScrolling: 'touch',

--- a/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties, ReactNode } from 'react';
 import type { PocTerminalInstance } from './poc-terminal-store';
 import type { PocRow, PocSegment, PocStyle } from './buffer-to-rows';
 import type { LinkRange } from './link-detection';
+import { joinSelectedRows, collectSelectedRowPieces } from './copy-text';
 import { PocScrollIndicator } from './PocScrollIndicator';
 
 const FONT_FAMILY =
@@ -341,6 +342,43 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
       releaseDangling();
     };
 
+    // Cmd/Ctrl+A while the hidden terminal input is focused selects the TERMINAL
+    // content only (scrollback + viewport = the whole rows container), not the
+    // page. Gated on activeElement being a textarea (our hidden input) so we do
+    // not hijack select-all elsewhere.
+    const onKeyDownSelectAll = (e: KeyboardEvent) => {
+      if (e.key !== 'a' || !(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+      if (!(document.activeElement instanceof HTMLTextAreaElement)) return;
+      const sel = window.getSelection();
+      if (!sel) return;
+      e.preventDefault();
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    };
+
+    // Soft-wrap-aware copy: terminals join wrapped rows into one logical line on
+    // copy (a wrapped URL pastes as one line). We rebuild the clipboard text from
+    // each selected row's exact selected text (so partial first/last-row edges
+    // are preserved) joined per the snapshot's isWrapped flags. Single-row
+    // selections keep the native behavior (already correct).
+    const onCopy = (e: ClipboardEvent) => {
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed || sel.rangeCount === 0) return;
+      const selRange = sel.getRangeAt(0);
+      if (!el.contains(selRange.commonAncestorContainer)) return; // selection outside terminal
+      const snapshotRows = instance.getSnapshot().rows;
+      const pieces = collectSelectedRowPieces(
+        el,
+        selRange,
+        (i) => snapshotRows[i]?.isWrapped ?? false,
+      );
+      if (pieces.length < 2) return; // single row: native copy is already correct
+      e.clipboardData?.setData('text/plain', joinSelectedRows(pieces));
+      e.preventDefault();
+    };
+
     el.addEventListener('wheel', onWheel, { passive: false });
     el.addEventListener('touchstart', onTouchStart, { passive: false });
     el.addEventListener('touchmove', onTouchMove, { passive: false });
@@ -348,8 +386,10 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
     el.addEventListener('pointerdown', onPointerDown);
     el.addEventListener('pointerup', onPointerUp);
     el.addEventListener('pointercancel', onPointerCancel);
+    el.addEventListener('copy', onCopy);
     window.addEventListener('pointerup', onWindowPointerUp);
     window.addEventListener('pointercancel', releaseDangling);
+    window.addEventListener('keydown', onKeyDownSelectAll);
 
     return () => {
       el.removeEventListener('wheel', onWheel);
@@ -359,8 +399,10 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
       el.removeEventListener('pointerdown', onPointerDown);
       el.removeEventListener('pointerup', onPointerUp);
       el.removeEventListener('pointercancel', onPointerCancel);
+      el.removeEventListener('copy', onCopy);
       window.removeEventListener('pointerup', onWindowPointerUp);
       window.removeEventListener('pointercancel', releaseDangling);
+      window.removeEventListener('keydown', onKeyDownSelectAll);
       // Unmount mid-drag: pair the outstanding press so the TUI is not stuck.
       releaseDangling();
     };

--- a/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
@@ -1,9 +1,10 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react';
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, DragEvent as ReactDragEvent, ReactNode } from 'react';
 import type { PocTerminalInstance } from './poc-terminal-store';
 import type { PocRow, PocSegment, PocStyle } from './buffer-to-rows';
 import type { LinkRange } from './link-detection';
 import { joinSelectedRows, collectSelectedRowPieces } from './copy-text';
+import { reduceDragCounter } from './drag-state';
 import { PocScrollIndicator } from './PocScrollIndicator';
 
 const FONT_FAMILY =
@@ -22,6 +23,9 @@ const CLICK_MOVE_THRESHOLD_PX = 5;
 interface PocTerminalViewProps {
   instance: PocTerminalInstance;
   onRequestFocus?: () => void;
+  // Called when files are dropped onto the terminal. Threaded to the same
+  // handler as image paste; the labs route surfaces a toast.
+  onFilesReceived?: (files: File[]) => void;
 }
 
 function segmentStyle(style: PocStyle | null): CSSProperties | undefined {
@@ -109,12 +113,42 @@ const Row = memo(function Row({ row }: { row: PocRow }) {
   );
 });
 
-export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewProps) {
+export function PocTerminalView({ instance, onRequestFocus, onFilesReceived }: PocTerminalViewProps) {
   const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
   const scrollRef = useRef<HTMLDivElement>(null);
   const measureRef = useRef<HTMLSpanElement>(null);
   const wasAtBottomRef = useRef(true);
   const [atBottom, setAtBottom] = useState(true);
+
+  // Drag-and-drop file upload. The depth counter (drag-state.ts) nets out the
+  // enter/leave events that bubble from child rows so the overlay does not
+  // flicker while dragging across cells.
+  const dragCounterRef = useRef(0);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const applyDragAction = (action: 'enter' | 'leave' | 'drop') => {
+    const next = reduceDragCounter(dragCounterRef.current, action);
+    dragCounterRef.current = next.count;
+    setIsDragOver(next.isDragOver);
+  };
+  const onDragEnter = (e: ReactDragEvent) => {
+    e.preventDefault();
+    applyDragAction('enter');
+  };
+  // preventDefault on dragover is mandatory for the drop event to fire.
+  const onDragOver = (e: ReactDragEvent) => {
+    e.preventDefault();
+  };
+  const onDragLeave = (e: ReactDragEvent) => {
+    e.preventDefault();
+    applyDragAction('leave');
+  };
+  const onDrop = (e: ReactDragEvent) => {
+    e.preventDefault();
+    applyDragAction('drop');
+    const files = e.dataTransfer?.files;
+    if (!files || files.length === 0) return;
+    onFilesReceived?.(Array.from(files));
+  };
 
   // Read by the native wheel/touch listeners (attached once, keyed on instance)
   // so they know whether to forward scroll to the app or let native scroll run.
@@ -409,7 +443,20 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
   }, [instance]);
 
   return (
-    <div className="relative flex-1 min-h-0">
+    <div
+      className="relative flex-1 min-h-0"
+      onDragEnter={onDragEnter}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
+      {/* Drag-over overlay for file drop (mirrors production Terminal.tsx). */}
+      {isDragOver && (
+        <div className="absolute inset-0 z-20 flex items-center justify-center border-2 border-dashed border-blue-400 bg-blue-500/20 pointer-events-none">
+          <span className="text-lg font-medium text-blue-300">Drop file here</span>
+        </div>
+      )}
+
       {/* Hidden single-cell probe for measuring monospace cell metrics. */}
       <span
         ref={measureRef}

--- a/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react';
-import type { CSSProperties, DragEvent as ReactDragEvent, ReactNode } from 'react';
+import type { CSSProperties, DragEvent as ReactDragEvent, ReactNode, RefObject } from 'react';
 import type { PocTerminalInstance } from './poc-terminal-store';
 import type { PocRow, PocSegment, PocStyle } from './buffer-to-rows';
 import type { LinkRange } from './link-detection';
@@ -26,6 +26,12 @@ interface PocTerminalViewProps {
   // Called when files are dropped onto the terminal. Threaded to the same
   // handler as image paste; the labs route surfaces a toast.
   onFilesReceived?: (files: File[]) => void;
+  // This view's OWN hidden input (the same ref passed to PocKeyboardInput).
+  // Cmd/Ctrl+A select-all is gated on this element being focused, so on a page
+  // hosting multiple terminals (e.g. /labs/terminal-compare) select-all in one
+  // terminal never selects another's rows. When omitted, select-all is disabled
+  // (safer than matching any focused textarea).
+  inputRef?: RefObject<HTMLTextAreaElement | null>;
 }
 
 function segmentStyle(style: PocStyle | null): CSSProperties | undefined {
@@ -113,7 +119,7 @@ const Row = memo(function Row({ row }: { row: PocRow }) {
   );
 });
 
-export function PocTerminalView({ instance, onRequestFocus, onFilesReceived }: PocTerminalViewProps) {
+export function PocTerminalView({ instance, onRequestFocus, onFilesReceived, inputRef }: PocTerminalViewProps) {
   const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
   const scrollRef = useRef<HTMLDivElement>(null);
   const measureRef = useRef<HTMLSpanElement>(null);
@@ -376,13 +382,14 @@ export function PocTerminalView({ instance, onRequestFocus, onFilesReceived }: P
       releaseDangling();
     };
 
-    // Cmd/Ctrl+A while the hidden terminal input is focused selects the TERMINAL
+    // Cmd/Ctrl+A while THIS view's hidden input is focused selects the TERMINAL
     // content only (scrollback + viewport = the whole rows container), not the
-    // page. Gated on activeElement being a textarea (our hidden input) so we do
-    // not hijack select-all elsewhere.
+    // page. Gated on our OWN input element (not any textarea) so on a page with
+    // multiple terminals, select-all in one never selects another's rows. No
+    // input ref -> select-all disabled (safer than a wrong-instance selection).
     const onKeyDownSelectAll = (e: KeyboardEvent) => {
       if (e.key !== 'a' || !(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
-      if (!(document.activeElement instanceof HTMLTextAreaElement)) return;
+      if (inputRef?.current == null || document.activeElement !== inputRef.current) return;
       const sel = window.getSelection();
       if (!sel) return;
       e.preventDefault();
@@ -440,7 +447,7 @@ export function PocTerminalView({ instance, onRequestFocus, onFilesReceived }: P
       // Unmount mid-drag: pair the outstanding press so the TUI is not stuck.
       releaseDangling();
     };
-  }, [instance]);
+  }, [instance, inputRef]);
 
   return (
     <div

--- a/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
@@ -1,7 +1,8 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react';
-import type { CSSProperties } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import type { PocTerminalInstance } from './poc-terminal-store';
 import type { PocRow, PocSegment, PocStyle } from './buffer-to-rows';
+import type { LinkRange } from './link-detection';
 import { PocScrollIndicator } from './PocScrollIndicator';
 
 const FONT_FAMILY =
@@ -36,14 +37,73 @@ function segmentStyle(style: PocStyle | null): CSSProperties | undefined {
   return css;
 }
 
+// Split a segment's text at link boundaries. `segStart` is the segment's offset
+// into the row's concatenated text; `links` are ranges in that same space.
+function renderSegment(seg: PocSegment, segStart: number, key: number, links: LinkRange[]) {
+  const style = segmentStyle(seg.style);
+  const segEnd = segStart + seg.text.length;
+  const overlapping = links.filter((l) => l.start < segEnd && l.end > segStart);
+  if (overlapping.length === 0) {
+    return (
+      <span key={key} style={style}>
+        {seg.text}
+      </span>
+    );
+  }
+  // Walk the segment, emitting plain spans and <a> for the link portions.
+  const parts: ReactNode[] = [];
+  let cursor = segStart;
+  let pi = 0;
+  for (const link of overlapping) {
+    const linkStart = Math.max(link.start, segStart);
+    const linkEnd = Math.min(link.end, segEnd);
+    if (cursor < linkStart) {
+      parts.push(
+        <span key={pi++} style={style}>
+          {seg.text.slice(cursor - segStart, linkStart - segStart)}
+        </span>,
+      );
+    }
+    parts.push(
+      <a
+        key={pi++}
+        href={link.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        // Link click opens the URL; stop propagation so the container's
+        // click-to-focus / mouse-report paths do not also fire. No
+        // preventDefault so navigation happens.
+        onClick={(e) => e.stopPropagation()}
+        style={{ ...style, textDecoration: 'underline dotted', cursor: 'pointer' }}
+      >
+        {seg.text.slice(linkStart - segStart, linkEnd - segStart)}
+      </a>,
+    );
+    cursor = linkEnd;
+  }
+  if (cursor < segEnd) {
+    parts.push(
+      <span key={pi++} style={style}>
+        {seg.text.slice(cursor - segStart)}
+      </span>,
+    );
+  }
+  return (
+    <span key={key} style={style}>
+      {parts}
+    </span>
+  );
+}
+
 const Row = memo(function Row({ row }: { row: PocRow }) {
+  let offset = 0;
   return (
     <div style={{ whiteSpace: 'pre', height: LINE_HEIGHT_PX, lineHeight: `${LINE_HEIGHT_PX}px` }}>
-      {row.segments.map((seg: PocSegment, i) => (
-        <span key={i} style={segmentStyle(seg.style)}>
-          {seg.text}
-        </span>
-      ))}
+      {row.segments.map((seg: PocSegment, i) => {
+        const node = renderSegment(seg, offset, i, row.links);
+        offset += seg.text.length;
+        return node;
+      })}
     </div>
   );
 });
@@ -223,6 +283,8 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
 
     const onPointerDown = (e: PointerEvent) => {
       if (!reportable(e)) return;
+      // A press on a link should open it, not report a mouse click to the TUI.
+      if ((e.target as Element | null)?.closest?.('a')) return;
       const { charW } = cellMetrics();
       const cell = cellFromPoint(e.clientX, e.clientY, charW);
       if (e.pointerType === 'touch') {

--- a/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
@@ -220,7 +220,14 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        onPointerDown={onRequestFocus}
+        // Focus on click (not pointerdown): click fires after the browser's
+        // default mousedown focus handling, so our focus() sticks. pointerdown
+        // focus is immediately undone by the default handler (focus -> BODY).
+        // Skip when a text selection was just made so native drag-select works.
+        onClick={() => {
+          if (window.getSelection()?.toString()) return;
+          onRequestFocus?.();
+        }}
         className="h-full overflow-y-auto bg-[#1a1a2e] text-[#eeeeee] px-2 py-1"
         style={{
           fontFamily: FONT_FAMILY,

--- a/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
@@ -52,6 +52,14 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
   const bufferTypeRef = useRef<'normal' | 'alternate'>('normal');
   bufferTypeRef.current = snapshot.bufferType;
 
+  // Mount reference for memory management: the instance is kept alive while this
+  // view is mounted and becomes idle-evictable after unmount. release() is
+  // idempotent, so Strict-Mode's double invoke is safe.
+  useEffect(() => {
+    const release = instance.acquire();
+    return release;
+  }, [instance]);
+
   // Record whether the user is pinned to the bottom BEFORE the DOM updates, so
   // the layout effect below can decide whether to auto-scroll.
   const container = scrollRef.current;

--- a/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
+++ b/packages/client/src/labs/terminal-poc/PocTerminalView.tsx
@@ -213,6 +213,7 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
     // (browser context menu wins). Touch defers to pointerup and only reports a
     // tap (movement <= threshold) so a scroll drag is not a phantom click.
     let mousePressActive = false; // a mouse press was emitted, awaiting release
+    let mousePressCell: { x: number; y: number } | null = null; // cell of that press
     let touchDownX = 0;
     let touchDownY = 0;
     let touchDownCell: { x: number; y: number } | null = null;
@@ -232,6 +233,7 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
       } else {
         instance.reportMouseButton('press', cell);
         mousePressActive = true;
+        mousePressCell = cell;
       }
     };
 
@@ -249,14 +251,32 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
         }
         touchDownCell = null;
       } else if (mousePressActive) {
+        // Release inside the container: report at the exact current cell.
         instance.reportMouseButton('release', cell);
         mousePressActive = false;
+        mousePressCell = null;
       }
     };
 
     const onPointerCancel = () => {
-      touchDownCell = null;
+      touchDownCell = null; // touch gesture aborted; mouse cancel handled on window
+    };
+
+    // Emit the release at the last press cell when the pointer is released (or
+    // cancelled) OUTSIDE the container, so a mouse press never goes unpaired and
+    // leaves the TUI in a dragging state. For an in-container up, the container
+    // handler above runs first (bubble order) and clears the flag, so this
+    // guard makes the window path a no-op — no double emission. No
+    // setPointerCapture (it would re-route events and disturb native selection).
+    const releaseDangling = () => {
+      if (!mousePressActive || !mousePressCell) return;
+      instance.reportMouseButton('release', mousePressCell);
       mousePressActive = false;
+      mousePressCell = null;
+    };
+    const onWindowPointerUp = (e: PointerEvent) => {
+      if (e.button !== 0) return;
+      releaseDangling();
     };
 
     el.addEventListener('wheel', onWheel, { passive: false });
@@ -266,6 +286,8 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
     el.addEventListener('pointerdown', onPointerDown);
     el.addEventListener('pointerup', onPointerUp);
     el.addEventListener('pointercancel', onPointerCancel);
+    window.addEventListener('pointerup', onWindowPointerUp);
+    window.addEventListener('pointercancel', releaseDangling);
 
     return () => {
       el.removeEventListener('wheel', onWheel);
@@ -275,6 +297,10 @@ export function PocTerminalView({ instance, onRequestFocus }: PocTerminalViewPro
       el.removeEventListener('pointerdown', onPointerDown);
       el.removeEventListener('pointerup', onPointerUp);
       el.removeEventListener('pointercancel', onPointerCancel);
+      window.removeEventListener('pointerup', onWindowPointerUp);
+      window.removeEventListener('pointercancel', releaseDangling);
+      // Unmount mid-drag: pair the outstanding press so the TUI is not stuck.
+      releaseDangling();
     };
   }, [instance]);
 

--- a/packages/client/src/labs/terminal-poc/__tests__/copy-text.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/copy-text.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { joinSelectedRows, collectSelectedRowPieces } from '../copy-text';
+
+describe('joinSelectedRows', () => {
+  it('returns empty string for no rows', () => {
+    expect(joinSelectedRows([])).toBe('');
+  });
+
+  it('returns a single row verbatim', () => {
+    expect(joinSelectedRows([{ text: 'hello', isWrapped: false }])).toBe('hello');
+  });
+
+  it('joins soft-wrapped continuation rows with no separator', () => {
+    const joined = joinSelectedRows([
+      { text: 'http://example.com/very', isWrapped: false },
+      { text: 'long/path', isWrapped: true },
+    ]);
+    expect(joined).toBe('http://example.com/verylong/path');
+  });
+
+  it('joins a URL wrapped across three rows into one line', () => {
+    const joined = joinSelectedRows([
+      { text: 'https://example.com/', isWrapped: false },
+      { text: 'aaaa', isWrapped: true },
+      { text: 'bbbb', isWrapped: true },
+    ]);
+    expect(joined).toBe('https://example.com/aaaabbbb');
+  });
+
+  it('separates hard (non-wrapped) rows with newlines', () => {
+    const joined = joinSelectedRows([
+      { text: 'line one', isWrapped: false },
+      { text: 'line two', isWrapped: false },
+    ]);
+    expect(joined).toBe('line one\nline two');
+  });
+
+  it('mixes wrapped and hard rows correctly', () => {
+    // logical line 1 (wrapped across 2 rows), then a hard break, then logical line 2.
+    const joined = joinSelectedRows([
+      { text: 'wrapped-', isWrapped: false },
+      { text: 'continuation', isWrapped: true },
+      { text: 'second command', isWrapped: false },
+      { text: 'also-', isWrapped: false },
+      { text: 'wrapped', isWrapped: true },
+    ]);
+    expect(joined).toBe('wrapped-continuation\nsecond command\nalso-wrapped');
+  });
+
+  it('preserves partial edge text (only separators change)', () => {
+    // First and last rows carry already-sliced partial selections.
+    const joined = joinSelectedRows([
+      { text: 'com/very', isWrapped: false }, // partial start
+      { text: 'long/pa', isWrapped: true }, // partial end
+    ]);
+    expect(joined).toBe('com/verylong/pa');
+  });
+});
+
+describe('collectSelectedRowPieces (DOM)', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  function makeContainer(rowTexts: string[]): HTMLDivElement {
+    const container = document.createElement('div');
+    for (const t of rowTexts) {
+      const row = document.createElement('div');
+      row.textContent = t;
+      container.appendChild(row);
+    }
+    document.body.appendChild(container);
+    return container;
+  }
+
+  it('slices partial first/last rows and joins wrapped rows into one line', () => {
+    // Row 1 is a soft-wrap continuation of row 0.
+    const container = makeContainer(['http://example.com/very', 'long/path']);
+    const [r0, r1] = Array.from(container.children);
+    const range = document.createRange();
+    // Select from offset 7 of row 0 ('example...') through offset 4 of row 1 ('long').
+    range.setStart(r0.firstChild!, 7);
+    range.setEnd(r1.firstChild!, 4);
+
+    const pieces = collectSelectedRowPieces(container, range, (i) => i === 1);
+    expect(pieces).toEqual([
+      { text: 'example.com/very', isWrapped: false },
+      { text: 'long', isWrapped: true },
+    ]);
+    expect(joinSelectedRows(pieces)).toBe('example.com/verylong');
+  });
+
+  it('separates hard rows with newline when not wrapped', () => {
+    const container = makeContainer(['line one', 'line two']);
+    const [r0, r1] = Array.from(container.children);
+    const range = document.createRange();
+    range.setStart(r0.firstChild!, 0);
+    range.setEnd(r1.firstChild!, 8);
+
+    const pieces = collectSelectedRowPieces(container, range, () => false);
+    expect(joinSelectedRows(pieces)).toBe('line one\nline two');
+  });
+});

--- a/packages/client/src/labs/terminal-poc/__tests__/drag-state.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/drag-state.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test';
+import { reduceDragCounter } from '../drag-state';
+
+describe('reduceDragCounter', () => {
+  it('turns the overlay on for the first enter', () => {
+    expect(reduceDragCounter(0, 'enter')).toEqual({ count: 1, isDragOver: true });
+  });
+
+  it('stays on across nested (bubbled) enters', () => {
+    expect(reduceDragCounter(1, 'enter')).toEqual({ count: 2, isDragOver: true });
+  });
+
+  it('stays on while inner leaves still leave a positive depth', () => {
+    expect(reduceDragCounter(2, 'leave')).toEqual({ count: 1, isDragOver: true });
+  });
+
+  it('turns off when the last leave returns depth to zero', () => {
+    expect(reduceDragCounter(1, 'leave')).toEqual({ count: 0, isDragOver: false });
+  });
+
+  it('clamps a stray leave at zero (never latches negative)', () => {
+    const once = reduceDragCounter(0, 'leave');
+    expect(once).toEqual({ count: 0, isDragOver: false });
+    // A subsequent enter still turns the overlay on (would stay off if the
+    // counter had gone negative).
+    expect(reduceDragCounter(once.count, 'enter')).toEqual({ count: 1, isDragOver: true });
+  });
+
+  it('drop resets depth and hides the overlay regardless of prior depth', () => {
+    expect(reduceDragCounter(3, 'drop')).toEqual({ count: 0, isDragOver: false });
+    expect(reduceDragCounter(0, 'drop')).toEqual({ count: 0, isDragOver: false });
+  });
+});

--- a/packages/client/src/labs/terminal-poc/__tests__/image-paste.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/image-paste.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test';
+import { extractImageFiles } from '../image-paste';
+import type { ImageItemLike } from '../image-paste';
+
+function item(type: string, file: File | null): ImageItemLike {
+  return { type, getAsFile: () => file };
+}
+
+function list(items: ImageItemLike[]) {
+  // Array-like shape mirroring DataTransferItemList (length + index access).
+  return Object.assign([...items], { length: items.length });
+}
+
+const png = new File(['x'], 'a.png', { type: 'image/png' });
+const jpg = new File(['y'], 'b.jpg', { type: 'image/jpeg' });
+// A non-image item that DOES yield a file — guards that the filter keys on the
+// item TYPE, not merely on getAsFile() returning non-null.
+const textFile = new File(['t'], 'note.txt', { type: 'text/plain' });
+
+describe('extractImageFiles', () => {
+  it('returns [] for null/undefined', () => {
+    expect(extractImageFiles(null)).toEqual([]);
+    expect(extractImageFiles(undefined)).toEqual([]);
+  });
+
+  it('returns [] for an empty list', () => {
+    expect(extractImageFiles(list([]))).toEqual([]);
+  });
+
+  it('returns [] when only non-image items are present', () => {
+    const items = list([item('text/plain', null), item('text/html', null)]);
+    expect(extractImageFiles(items)).toEqual([]);
+  });
+
+  it('excludes non-image items even when they yield a file', () => {
+    const items = list([item('text/plain', textFile), item('image/png', png)]);
+    expect(extractImageFiles(items)).toEqual([png]);
+  });
+
+  it('extracts a single image file', () => {
+    expect(extractImageFiles(list([item('image/png', png)]))).toEqual([png]);
+  });
+
+  it('extracts only the image items from a mixed list, preserving order', () => {
+    const items = list([
+      item('text/plain', null),
+      item('image/png', png),
+      item('text/html', null),
+      item('image/jpeg', jpg),
+    ]);
+    expect(extractImageFiles(items)).toEqual([png, jpg]);
+  });
+
+  it('skips image items whose getAsFile() returns null', () => {
+    const items = list([item('image/png', null), item('image/jpeg', jpg)]);
+    expect(extractImageFiles(items)).toEqual([jpg]);
+  });
+
+  it('matches any image/* subtype prefix', () => {
+    const gif = new File(['z'], 'c.gif', { type: 'image/gif' });
+    expect(extractImageFiles(list([item('image/gif', gif)]))).toEqual([gif]);
+  });
+});

--- a/packages/client/src/labs/terminal-poc/__tests__/link-detection.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/link-detection.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'bun:test';
+import { detectRowLinks, type DetectRow } from '../link-detection';
+
+function row(key: number, text: string, isWrapped = false): DetectRow {
+  return { key, text, isWrapped };
+}
+
+describe('detectRowLinks', () => {
+  it('detects a mid-row URL and reports its column range', () => {
+    const links = detectRowLinks([row(0, 'see http://example.com now')]);
+    expect(links.get(0)).toEqual([{ start: 4, end: 22, href: 'http://example.com' }]);
+  });
+
+  it('trims trailing punctuation from the URL', () => {
+    const links = detectRowLinks([row(0, 'visit https://example.com/path).')]);
+    const [link] = links.get(0)!;
+    expect(link.href).toBe('https://example.com/path');
+    // The trailing ')' and '.' are excluded from the range.
+    expect(row(0, 'visit https://example.com/path).').text.slice(link.start, link.end)).toBe(
+      'https://example.com/path',
+    );
+  });
+
+  it('does not match non-http(s) schemes or dotted plain text', () => {
+    expect(detectRowLinks([row(0, 'foo://bar baz.qux ok')]).size).toBe(0);
+    expect(detectRowLinks([row(0, 'a sentence. with dots.')]).size).toBe(0);
+  });
+
+  it('detects adjacent URLs on one row', () => {
+    const links = detectRowLinks([row(0, 'http://a.com http://b.com')]).get(0)!;
+    expect(links.map((l) => l.href)).toEqual(['http://a.com', 'http://b.com']);
+    expect(links[0]).toMatchObject({ start: 0, end: 12 });
+    expect(links[1]).toMatchObject({ start: 13, end: 25 });
+  });
+
+  it('joins a URL wrapped across two rows and maps ranges per row', () => {
+    // 'http://example.com/very' + 'long/path' joined = full URL.
+    const r0 = 'http://example.com/very';
+    const r1 = 'long/path';
+    const links = detectRowLinks([row(0, r0), row(1, r1, true)]);
+    expect(links.get(0)).toEqual([{ start: 0, end: r0.length, href: r0 + r1 }]);
+    expect(links.get(1)).toEqual([{ start: 0, end: r1.length, href: r0 + r1 }]);
+  });
+
+  it('joins a URL wrapped across three rows', () => {
+    const a = 'https://example.com/aaaa';
+    const b = 'bbbbcccc';
+    const c = 'dddd';
+    const href = a + b + c;
+    const links = detectRowLinks([row(0, a), row(1, b, true), row(2, c, true)]);
+    expect(links.get(0)).toEqual([{ start: 0, end: a.length, href }]);
+    expect(links.get(1)).toEqual([{ start: 0, end: b.length, href }]);
+    expect(links.get(2)).toEqual([{ start: 0, end: c.length, href }]);
+  });
+
+  it('does not join across a non-wrapped (logical) line boundary', () => {
+    // Second row is a NEW logical line (isWrapped=false), so no join.
+    const links = detectRowLinks([row(0, 'http://example.com/a'), row(1, 'b/c', false)]);
+    expect(links.get(0)).toEqual([{ start: 0, end: 20, href: 'http://example.com/a' }]);
+    expect(links.has(1)).toBe(false);
+  });
+
+  it('indexes by code units so CJK text around a URL keeps correct ranges', () => {
+    // Two leading CJK chars (2 code units), then the URL.
+    const text = 'あい http://example.com END';
+    const [link] = detectRowLinks([row(0, text)]).get(0)!;
+    expect(text.slice(link.start, link.end)).toBe('http://example.com');
+    expect(link.start).toBe(3); // 'あ','い',' ' = 3 code units
+  });
+
+  it('returns an empty map for rows with no URLs', () => {
+    expect(detectRowLinks([row(0, ''), row(1, 'plain text')]).size).toBe(0);
+  });
+});

--- a/packages/client/src/labs/terminal-poc/__tests__/poc-status-mapping.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/poc-status-mapping.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import { toStatusChangeArgs } from '../poc-status-mapping';
+
+describe('toStatusChangeArgs', () => {
+  it('passes connecting through with no exitInfo', () => {
+    expect(toStatusChangeArgs({ status: 'connecting', exitInfo: null })).toEqual({
+      status: 'connecting',
+      exitInfo: undefined,
+    });
+  });
+
+  it('passes connected through with no exitInfo', () => {
+    expect(toStatusChangeArgs({ status: 'connected', exitInfo: null })).toEqual({
+      status: 'connected',
+      exitInfo: undefined,
+    });
+  });
+
+  it('passes disconnected through with no exitInfo', () => {
+    expect(toStatusChangeArgs({ status: 'disconnected', exitInfo: null })).toEqual({
+      status: 'disconnected',
+      exitInfo: undefined,
+    });
+  });
+
+  it('forwards exitInfo for the exited status', () => {
+    expect(
+      toStatusChangeArgs({ status: 'exited', exitInfo: { code: 137, signal: 'SIGKILL' } }),
+    ).toEqual({ status: 'exited', exitInfo: { code: 137, signal: 'SIGKILL' } });
+  });
+
+  it('normalizes a null exitInfo to undefined (callback contract, not null)', () => {
+    const args = toStatusChangeArgs({ status: 'exited', exitInfo: null });
+    expect(args.exitInfo).toBeUndefined();
+    expect('exitInfo' in args).toBe(true); // key present, value undefined
+  });
+});

--- a/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
@@ -162,6 +162,90 @@ describe('poc-terminal-store', () => {
     expect(snap.rows[0].segments.map((s) => s.text).join('')).toContain('after');
   });
 
+  it('stripScrollbackClear:false leaves CSI 3J in place, so scrollback IS erased', async () => {
+    // Polarity vs the always-on default (the '...3J does not erase...' test
+    // above): with the filter OFF, raw 3J wipes the scrollback that held the
+    // earlier line.
+    const instance = getOrCreatePocTerminal('sNoStrip', 'wNoStrip', { stripScrollbackClear: false });
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    const filler = Array.from({ length: 40 }, (_, i) => `filler ${i}`).join('\r\n');
+    ws!.simulateMessage(
+      JSON.stringify({ type: 'output', data: `first line\r\n${filler}\r\n`, offset: 0 }),
+    );
+    await flush();
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[3Jsecond line', offset: 500 }));
+    await flush();
+
+    const text = allText(instance);
+    expect(text).not.toContain('first line'); // scrollback erased (filter off)
+    expect(text).toContain('second line');
+  });
+
+  it('stripScrollbackClear:true preserves scrollback across CSI 3J', async () => {
+    const instance = getOrCreatePocTerminal('sStrip', 'wStrip', { stripScrollbackClear: true });
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    const filler = Array.from({ length: 40 }, (_, i) => `filler ${i}`).join('\r\n');
+    ws!.simulateMessage(
+      JSON.stringify({ type: 'output', data: `first line\r\n${filler}\r\n`, offset: 0 }),
+    );
+    await flush();
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[3Jsecond line', offset: 500 }));
+    await flush();
+
+    const text = allText(instance);
+    expect(text).toContain('first line');
+    expect(text).toContain('second line');
+  });
+
+  it('config is fixed per instance lifetime: a later opts value is ignored', async () => {
+    // First creation wins (stripScrollbackClear:false). A second getOrCreate with
+    // a different flag returns the SAME instance and does NOT change behavior.
+    const first = getOrCreatePocTerminal('sFix', 'wFix', { stripScrollbackClear: false });
+    const second = getOrCreatePocTerminal('sFix', 'wFix', { stripScrollbackClear: true });
+    expect(second).toBe(first);
+
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    const filler = Array.from({ length: 40 }, (_, i) => `filler ${i}`).join('\r\n');
+    ws!.simulateMessage(
+      JSON.stringify({ type: 'output', data: `first line\r\n${filler}\r\n`, offset: 0 }),
+    );
+    await flush();
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[3Jsecond line', offset: 500 }));
+    await flush();
+
+    // Behavior follows the FIRST call (false -> not stripped -> scrollback erased).
+    expect(allText(second)).not.toContain('first line');
+  });
+
+  it('retry clears the worker error and opens a fresh connection', async () => {
+    const instance = getOrCreatePocTerminal('sRetry', 'wRetry');
+    const firstWs = MockWebSocket.getLastInstance();
+    firstWs!.simulateOpen();
+
+    // A recoverable error surfaces (server closes deliberately with SESSION_PAUSED,
+    // which also latches noReconnect).
+    firstWs!.simulateMessage(
+      JSON.stringify({ type: 'error', message: 'paused', code: 'SESSION_PAUSED' }),
+    );
+    await flush();
+    expect(instance.getSnapshot().workerError).not.toBeNull();
+
+    instance.retry();
+    await flush();
+
+    // Error cleared and a brand-new WebSocket was opened (reconnect), distinct
+    // from the first — proving retry overrides the noReconnect latch.
+    expect(instance.getSnapshot().workerError).toBeNull();
+    const secondWs = MockWebSocket.getLastInstance();
+    expect(secondWs).not.toBe(firstWs);
+    expect(instance.getSnapshot().status).toBe('connecting');
+  });
+
   it('strips [internal:...] system lines from rendered output', async () => {
     const instance = getOrCreatePocTerminal('sint', 'wint');
     const ws = MockWebSocket.getLastInstance();

--- a/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
@@ -242,6 +242,60 @@ describe('poc-terminal-store', () => {
     expect(instance.getSnapshot().bufferType).toBe('normal');
   });
 
+  it('reportMouseButton emits SGR left-button press/release when tracking is on', async () => {
+    const instance = getOrCreatePocTerminal('mb1', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    // Enable button-event tracking (1002) + SGR encoding (1006).
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?1002h\x1b[?1006h', offset: 0 }));
+    await flush();
+
+    instance.reportMouseButton('press', { x: 5, y: 3 });
+    instance.reportMouseButton('release', { x: 5, y: 3 });
+
+    const frames = inputFrames(ws!);
+    expect(frames).toContain('\x1b[<0;5;3M'); // press
+    expect(frames).toContain('\x1b[<0;5;3m'); // release
+  });
+
+  it('reportMouseButton clamps coordinates to the grid', async () => {
+    const instance = getOrCreatePocTerminal('mb2', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?1002h', offset: 0 }));
+    await flush();
+
+    instance.reportMouseButton('press', { x: 9999, y: 9999 });
+    expect(inputFrames(ws!)).toContain('\x1b[<0;80;24M'); // clamped to cols 80, rows 24
+  });
+
+  it('reportMouseButton is a no-op when mouse tracking is off', () => {
+    const instance = getOrCreatePocTerminal('mb3', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    instance.reportMouseButton('press', { x: 5, y: 3 });
+    instance.reportMouseButton('release', { x: 5, y: 3 });
+
+    // Polarity guard: no SGR mouse frame is sent while tracking is 'none'.
+    expect(inputFrames(ws!).some((f) => f.startsWith('\x1b[<0;'))).toBe(false);
+  });
+
+  it('mouseTracking flips in the snapshot on DECSET enable / disable', async () => {
+    const instance = getOrCreatePocTerminal('mb4', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    expect(instance.getSnapshot().mouseTracking).toBe(false);
+
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?1002h', offset: 0 }));
+    await flush();
+    expect(instance.getSnapshot().mouseTracking).toBe(true);
+
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?1002l', offset: 8 }));
+    await flush();
+    expect(instance.getSnapshot().mouseTracking).toBe(false);
+  });
+
   it('sendInput sends a correct input frame', () => {
     const instance = getOrCreatePocTerminal('s5', 'w5');
     const ws = MockWebSocket.getLastInstance();

--- a/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import type { AppServerMessage } from '@agent-console/shared';
 import { MockWebSocket, installMockWebSocket } from '../../../test/mock-websocket';
-import { getOrCreatePocTerminal, _resetPocTerminals } from '../poc-terminal-store';
+import {
+  getOrCreatePocTerminal,
+  _resetPocTerminals,
+  _setTimings,
+  _setAppSubscribe,
+  _inspect,
+} from '../poc-terminal-store';
+
+/**
+ * Capturable app-WS subscribe seam: records every listener the store registers
+ * so a test can emit AppServerMessages to all live instances.
+ */
+function makeAppBus() {
+  const listeners = new Set<(msg: AppServerMessage) => void>();
+  const subscribe = (listener: (msg: AppServerMessage) => void) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+  const emit = (msg: AppServerMessage) => {
+    for (const l of Array.from(listeners)) l(msg);
+  };
+  return { subscribe, emit };
+}
 
 /** Let write callbacks + the rAF/timeout snapshot flush run. */
 function flush(): Promise<void> {
@@ -286,5 +309,262 @@ describe('poc-terminal-store', () => {
     ws!.simulateOpen(); // updateStatus -> notify
     expect(notified).toBeGreaterThan(0);
     expect(() => unsubscribe()).not.toThrow();
+  });
+
+  // --- PR-1: protocol hardening ---
+
+  it('does not schedule a reconnect for a non-reconnectable close code', () => {
+    const instance = getOrCreatePocTerminal('rc1', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateClose(1000); // NORMAL_CLOSURE -> shouldReconnect === false
+
+    expect(_inspect(instance).reconnectPending).toBe(false);
+    expect(_inspect(instance).reconnectAttempts).toBe(0);
+    expect(instance.getSnapshot().status).toBe('disconnected');
+  });
+
+  it('schedules a reconnect and counts the attempt for a reconnectable close', () => {
+    const instance = getOrCreatePocTerminal('rc2', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateClose(); // ABNORMAL_CLOSURE (default) -> reconnectable
+
+    expect(_inspect(instance).reconnectPending).toBe(true);
+    expect(_inspect(instance).reconnectAttempts).toBe(1);
+  });
+
+  it('re-requests history from lastOffset on reconnect (delta catch-up)', async () => {
+    _setTimings({ reconnectDelayMs: 0 });
+    getOrCreatePocTerminal('off1', 'w');
+    const ws1 = MockWebSocket.getLastInstance();
+    ws1!.simulateOpen();
+    ws1!.simulateMessage(JSON.stringify({ type: 'output', data: 'x', offset: 42 }));
+    await flush();
+
+    ws1!.simulateClose(); // reconnectable, 0ms delay
+    await flush();
+
+    const ws2 = MockWebSocket.getLastInstance();
+    expect(ws2).not.toBe(ws1);
+    ws2!.simulateOpen();
+    const history = lastSentMessages(ws2!).find(
+      (m) => (m as { type: string }).type === 'request-history',
+    );
+    expect(history).toEqual({ type: 'request-history', fromOffset: 42 });
+  });
+
+  it('resets and treats history as full when the response offset regressed (truncation)', async () => {
+    _setTimings({ reconnectDelayMs: 0 });
+    const instance = getOrCreatePocTerminal('trunc', 'w');
+    const ws1 = MockWebSocket.getLastInstance();
+    ws1!.simulateOpen();
+    // First history at a high offset.
+    ws1!.simulateMessage(JSON.stringify({ type: 'history', data: 'OLD', offset: 100 }));
+    await flush();
+    expect(allText(instance)).toContain('OLD');
+
+    ws1!.simulateClose();
+    await flush();
+    const ws2 = MockWebSocket.getLastInstance();
+    ws2!.simulateOpen(); // requests fromOffset=100
+    // Server can only serve from offset 50 -> regression -> reset + full.
+    ws2!.simulateMessage(JSON.stringify({ type: 'history', data: 'FRESH', offset: 50 }));
+    await flush();
+
+    const text = allText(instance);
+    expect(text).toContain('FRESH');
+    expect(text).not.toContain('OLD');
+  });
+
+  it('output-truncated sets a dismissible notice and advances the offset', async () => {
+    _setTimings({ reconnectDelayMs: 0 });
+    const instance = getOrCreatePocTerminal('otr', 'w');
+    const ws1 = MockWebSocket.getLastInstance();
+    ws1!.simulateOpen();
+    ws1!.simulateMessage(
+      JSON.stringify({ type: 'output-truncated', message: 'Output truncated', newOffset: 900 }),
+    );
+    expect(instance.getSnapshot().notice).toBe('Output truncated');
+
+    instance.dismissNotice();
+    expect(instance.getSnapshot().notice).toBeNull();
+
+    // Offset advanced to 900: next reconnect requests from there.
+    ws1!.simulateClose();
+    await flush();
+    const ws2 = MockWebSocket.getLastInstance();
+    ws2!.simulateOpen();
+    const history = lastSentMessages(ws2!).find(
+      (m) => (m as { type: string }).type === 'request-history',
+    );
+    expect(history).toEqual({ type: 'request-history', fromOffset: 900 });
+  });
+
+  it('worker-restarted (app-WS) resets the buffer, reconnects, and shows a notice', async () => {
+    const bus = makeAppBus();
+    _setAppSubscribe(bus.subscribe);
+    const instance = getOrCreatePocTerminal('wr', 'w');
+    const ws1 = MockWebSocket.getLastInstance();
+    ws1!.simulateOpen();
+    ws1!.simulateMessage(JSON.stringify({ type: 'output', data: 'before', offset: 10 }));
+    await flush();
+    expect(allText(instance)).toContain('before');
+
+    bus.emit({ type: 'worker-restarted', sessionId: 'wr', workerId: 'w', activityState: 'idle' });
+
+    expect(instance.getSnapshot().notice).toBe('Terminal restarted');
+    const ws2 = MockWebSocket.getLastInstance();
+    expect(ws2).not.toBe(ws1); // reconnected
+    ws2!.simulateOpen();
+    const history = lastSentMessages(ws2!).find(
+      (m) => (m as { type: string }).type === 'request-history',
+    );
+    expect(history).toEqual({ type: 'request-history', fromOffset: 0 }); // offset reset
+    await flush();
+    expect(allText(instance)).not.toContain('before'); // buffer reset
+  });
+
+  it('worker-restarted for a different worker is ignored', () => {
+    const bus = makeAppBus();
+    _setAppSubscribe(bus.subscribe);
+    const instance = getOrCreatePocTerminal('wr2', 'w');
+    MockWebSocket.getLastInstance()!.simulateOpen();
+    const before = MockWebSocket.getInstances().length;
+
+    bus.emit({ type: 'worker-restarted', sessionId: 'other', workerId: 'w', activityState: 'idle' });
+
+    expect(instance.getSnapshot().notice).toBeNull();
+    expect(MockWebSocket.getInstances().length).toBe(before);
+  });
+
+  it('session-deleted (app-WS) disposes the instance', () => {
+    const bus = makeAppBus();
+    _setAppSubscribe(bus.subscribe);
+    const instance = getOrCreatePocTerminal('sd', 'w');
+    MockWebSocket.getLastInstance()!.simulateOpen();
+
+    bus.emit({ type: 'session-deleted', sessionId: 'sd' });
+
+    expect(_inspect(instance).disposed).toBe(true);
+    // getOrCreate returns a fresh instance after disposal.
+    expect(getOrCreatePocTerminal('sd', 'w')).not.toBe(instance);
+  });
+
+  it('activity message is surfaced in the snapshot', () => {
+    const instance = getOrCreatePocTerminal('act', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateMessage(JSON.stringify({ type: 'activity', state: 'asking' }));
+
+    expect(instance.getSnapshot().activityState).toBe('asking');
+  });
+
+  it('SESSION_PAUSED error prevents reconnect after the subsequent close', () => {
+    const instance = getOrCreatePocTerminal('pause', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateMessage(
+      JSON.stringify({ type: 'error', message: 'Session paused', code: 'SESSION_PAUSED' }),
+    );
+    expect(instance.getSnapshot().workerError).toEqual({
+      message: 'Session paused',
+      code: 'SESSION_PAUSED',
+    });
+
+    ws!.simulateClose(); // reconnectable code, but noReconnect is set
+    expect(_inspect(instance).reconnectPending).toBe(false);
+    expect(_inspect(instance).reconnectAttempts).toBe(0);
+  });
+
+  it('records a history load duration for cold-start instrumentation', async () => {
+    const instance = getOrCreatePocTerminal('perf', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateMessage(JSON.stringify({ type: 'history', data: 'hello', offset: 5 }));
+    await flush();
+
+    expect(_inspect(instance).lastHistoryLoadMs).not.toBeNull();
+    expect(_inspect(instance).lastHistoryLoadMs).toBeGreaterThanOrEqual(0);
+    expect(instance.getSnapshot().loadingHistory).toBe(false);
+  });
+
+  // --- PR-1: memory management ---
+
+  it('acquire/release refcount is idempotent under double release', () => {
+    const instance = getOrCreatePocTerminal('mm1', 'w');
+    const release1 = instance.acquire();
+    const release2 = instance.acquire();
+    expect(_inspect(instance).refCount).toBe(2);
+
+    release1();
+    release1(); // idempotent: no double decrement
+    expect(_inspect(instance).refCount).toBe(1);
+
+    release2();
+    expect(_inspect(instance).refCount).toBe(0);
+  });
+
+  it('disposes after the idle TTL once refCount reaches 0', async () => {
+    _setTimings({ idleTtlMs: 10 });
+    const instance = getOrCreatePocTerminal('mm2', 'w');
+    const release = instance.acquire();
+    release();
+    expect(_inspect(instance).disposed).toBe(false);
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(_inspect(instance).disposed).toBe(true);
+  });
+
+  it('uses the shorter exited TTL for exited instances', async () => {
+    _setTimings({ idleTtlMs: 100000, exitedTtlMs: 10 });
+    const instance = getOrCreatePocTerminal('mm3', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateMessage(JSON.stringify({ type: 'exit', exitCode: 0, signal: null }));
+
+    const release = instance.acquire();
+    release(); // starts timer with exitedTtlMs (10ms), not idleTtlMs
+    await new Promise((r) => setTimeout(r, 30));
+    expect(_inspect(instance).disposed).toBe(true);
+  });
+
+  it('remount cancels a pending idle disposal', async () => {
+    _setTimings({ idleTtlMs: 20 });
+    const instance = getOrCreatePocTerminal('mm4', 'w');
+    const release = instance.acquire();
+    release(); // idle timer armed
+    instance.acquire(); // remount cancels it
+    await new Promise((r) => setTimeout(r, 40));
+    expect(_inspect(instance).disposed).toBe(false);
+  });
+
+  it('LRU-evicts the least-recently-released idle instance over the cap', async () => {
+    _setTimings({ maxInstances: 2 });
+    const a = getOrCreatePocTerminal('lru-a', 'w');
+    a.acquire()(); // refCount 0, released first
+    await new Promise((r) => setTimeout(r, 2));
+    const b = getOrCreatePocTerminal('lru-b', 'w');
+    b.acquire()(); // refCount 0, released later
+    await new Promise((r) => setTimeout(r, 2));
+
+    // Creating a third instance over the cap evicts the oldest idle one (a).
+    const c = getOrCreatePocTerminal('lru-c', 'w');
+    expect(_inspect(a).disposed).toBe(true);
+    expect(_inspect(b).disposed).toBe(false);
+    expect(_inspect(c).disposed).toBe(false);
+  });
+
+  it('never evicts an instance with refCount > 0', () => {
+    _setTimings({ maxInstances: 2 });
+    const a = getOrCreatePocTerminal('busy-a', 'w');
+    a.acquire(); // refCount 1 -> pinned
+    const b = getOrCreatePocTerminal('busy-b', 'w');
+    b.acquire()(); // idle
+
+    // c over the cap: a is pinned, so b (the only idle one) is evicted.
+    getOrCreatePocTerminal('busy-c', 'w');
+    expect(_inspect(a).disposed).toBe(false);
+    expect(_inspect(b).disposed).toBe(true);
   });
 });

--- a/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
@@ -296,6 +296,47 @@ describe('poc-terminal-store', () => {
     expect(instance.getSnapshot().mouseTracking).toBe(false);
   });
 
+  it('paste wraps in bracketed-paste markers and normalizes newlines when DECSET 2004 is on', async () => {
+    const instance = getOrCreatePocTerminal('pst1', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?2004h', offset: 0 }));
+    await flush();
+
+    instance.paste('a\nb\r\nc');
+
+    const frames = inputFrames(ws!);
+    expect(frames).toContain('\x1b[200~a\rb\rc\x1b[201~'); // wrapped + CR-normalized, one frame
+  });
+
+  it('paste sends raw CR-normalized text when bracketed paste is off', () => {
+    const instance = getOrCreatePocTerminal('pst2', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+
+    instance.paste('a\nb\r\nc');
+
+    const frames = inputFrames(ws!);
+    expect(frames).toContain('a\rb\rc');
+    expect(frames.some((f) => f.includes('\x1b[200~'))).toBe(false);
+  });
+
+  it('paste reverts to raw after DECSET 2004 is disabled', async () => {
+    const instance = getOrCreatePocTerminal('pst3', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?2004h', offset: 0 }));
+    await flush();
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?2004l', offset: 8 }));
+    await flush();
+
+    instance.paste('x\ny');
+
+    const frames = inputFrames(ws!);
+    expect(frames).toContain('x\ry');
+    expect(frames.some((f) => f.includes('\x1b[200~'))).toBe(false);
+  });
+
   it('sendInput sends a correct input frame', () => {
     const instance = getOrCreatePocTerminal('s5', 'w5');
     const ws = MockWebSocket.getLastInstance();

--- a/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
@@ -367,6 +367,45 @@ describe('poc-terminal-store', () => {
     }
   });
 
+  it('F1: repeated DECSET mode bursts keep the snapshot stable and touch no selection state', async () => {
+    const instance = getOrCreatePocTerminal('f1', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: 'hello world', offset: 0 }));
+    await flush();
+    const contentBefore = allText(instance);
+
+    // Claude's mode re-send burst, repeated 3x (the #943 F1 pattern).
+    const burst = '\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h';
+    for (let i = 0; i < 3; i++) {
+      ws!.simulateMessage(JSON.stringify({ type: 'output', data: burst, offset: 20 + i }));
+      await flush();
+    }
+
+    expect(instance.getSnapshot().mouseTracking).toBe(true);
+    // No reset thrash: rendered content is unchanged across the bursts.
+    expect(allText(instance)).toBe(contentBefore);
+  });
+
+  it('F2: mouse/scroll reports do not bump the snapshot version (reports are not user input)', async () => {
+    const instance = getOrCreatePocTerminal('f2', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: '\x1b[?1002h', offset: 0 }));
+    await flush();
+
+    const versionBefore = instance.getSnapshot().version;
+    instance.reportMouseButton('press', { x: 2, y: 2 });
+    instance.reportMouseButton('release', { x: 2, y: 2 });
+    instance.forwardScroll(1, { x: 2, y: 2 });
+    // Drain a frame: a scheduled notify would bump the version here if a report
+    // wrongly triggered one.
+    await flush();
+
+    // Reports go out to the PTY only; they must not trigger a React re-render.
+    expect(instance.getSnapshot().version).toBe(versionBefore);
+  });
+
   it('sendInput sends a correct input frame', () => {
     const instance = getOrCreatePocTerminal('s5', 'w5');
     const ws = MockWebSocket.getLastInstance();

--- a/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/poc-terminal-store.test.ts
@@ -337,6 +337,36 @@ describe('poc-terminal-store', () => {
     expect(frames.some((f) => f.includes('\x1b[200~'))).toBe(false);
   });
 
+  it('attaches detected link ranges to snapshot rows', async () => {
+    const instance = getOrCreatePocTerminal('lnk1', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    ws!.simulateMessage(
+      JSON.stringify({ type: 'output', data: 'go http://example.com now', offset: 0 }),
+    );
+    await flush();
+
+    const rowWithLink = instance.getSnapshot().rows.find((r) => r.links.length > 0);
+    expect(rowWithLink).toBeDefined();
+    expect(rowWithLink!.links[0].href).toBe('http://example.com');
+  });
+
+  it('joins a URL wrapped across rows into one href on the snapshot', async () => {
+    const instance = getOrCreatePocTerminal('lnk2', 'w');
+    const ws = MockWebSocket.getLastInstance();
+    ws!.simulateOpen();
+    // Longer than the 80-col default -> the terminal soft-wraps it.
+    const url = 'http://example.com/' + 'a'.repeat(90);
+    ws!.simulateMessage(JSON.stringify({ type: 'output', data: url, offset: 0 }));
+    await flush();
+
+    const linkedRows = instance.getSnapshot().rows.filter((r) => r.links.length > 0);
+    expect(linkedRows.length).toBeGreaterThanOrEqual(2); // wrapped across >= 2 rows
+    for (const r of linkedRows) {
+      expect(r.links[0].href).toBe(url); // every wrapped piece carries the full URL
+    }
+  });
+
   it('sendInput sends a correct input frame', () => {
     const instance = getOrCreatePocTerminal('s5', 'w5');
     const ws = MockWebSocket.getLastInstance();

--- a/packages/client/src/labs/terminal-poc/buffer-to-rows.ts
+++ b/packages/client/src/labs/terminal-poc/buffer-to-rows.ts
@@ -1,4 +1,5 @@
 import { Terminal } from '@xterm/headless';
+import type { LinkRange } from './link-detection';
 
 /**
  * Pure extraction from an xterm headless buffer line into a React-renderable
@@ -29,6 +30,8 @@ export interface PocSegment {
 export interface PocRow {
   key: number; // absolute row index in the buffer
   segments: PocSegment[];
+  isWrapped: boolean; // true = this row is a soft-wrap continuation of the previous
+  links: LinkRange[]; // URL column ranges over the row's concatenated text (empty = none)
 }
 
 // Standard xterm dark-theme 16-color palette (ANSI 0-15).
@@ -140,7 +143,7 @@ export function extractRow(
     segments.push({ text: '', style: null });
   }
 
-  return { key, segments };
+  return { key, segments, isWrapped: line.isWrapped, links: [] };
 }
 
 // Cursor cell rendering: a solid block (light bg, dark fg) at the cursor cell.
@@ -169,7 +172,7 @@ export function extractRowWithCursor(
   if (segments.length === 0) {
     segments.push({ text: '', style: null });
   }
-  return { key, segments };
+  return { key, segments, isWrapped: line.isWrapped, links: [] };
 }
 
 /**

--- a/packages/client/src/labs/terminal-poc/copy-text.ts
+++ b/packages/client/src/labs/terminal-poc/copy-text.ts
@@ -1,0 +1,55 @@
+/**
+ * Copy-text assembly. Terminals join soft-wrapped rows into one logical line on
+ * copy (a wrapped URL/command copies as a single line), while hard line breaks
+ * stay as newlines. `joinSelectedRows` is the pure join rule; `collectSelectedRowPieces`
+ * slices the live selection per row (DOM, but Range-only — no React).
+ */
+
+export interface CopyRow {
+  text: string; // the row's selected text (already sliced to the selection edges)
+  isWrapped: boolean; // true = this row is a soft-wrap continuation of the previous
+}
+
+/**
+ * Join per-row selected text into clipboard text. A row that is a soft-wrap
+ * continuation (`isWrapped`) is appended to the previous row with no separator;
+ * a hard row starts a new line.
+ */
+export function joinSelectedRows(rows: CopyRow[]): string {
+  if (rows.length === 0) return '';
+  let out = rows[0].text;
+  for (let i = 1; i < rows.length; i++) {
+    out += (rows[i].isWrapped ? '' : '\n') + rows[i].text;
+  }
+  return out;
+}
+
+/**
+ * Slice a selection into per-row pieces. For each child row of `container` that
+ * the selection touches, intersect the selection with that row and take its
+ * exact selected text (so partial first/last-row edges are preserved). Rows are
+ * matched to `rowIsWrapped(index)` by their child index (1:1 with the buffer).
+ */
+export function collectSelectedRowPieces(
+  container: Element,
+  selRange: Range,
+  rowIsWrapped: (index: number) => boolean,
+): CopyRow[] {
+  const children = Array.from(container.children);
+  const pieces: CopyRow[] = [];
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    if (!selRange.intersectsNode(child)) continue;
+    const rowRange = document.createRange();
+    rowRange.selectNodeContents(child);
+    // Clamp to the intersection of the selection and this row.
+    if (selRange.compareBoundaryPoints(Range.START_TO_START, rowRange) > 0) {
+      rowRange.setStart(selRange.startContainer, selRange.startOffset);
+    }
+    if (selRange.compareBoundaryPoints(Range.END_TO_END, rowRange) < 0) {
+      rowRange.setEnd(selRange.endContainer, selRange.endOffset);
+    }
+    pieces.push({ text: rowRange.toString(), isWrapped: rowIsWrapped(i) });
+  }
+  return pieces;
+}

--- a/packages/client/src/labs/terminal-poc/drag-state.ts
+++ b/packages/client/src/labs/terminal-poc/drag-state.ts
@@ -1,0 +1,33 @@
+// Drag-enter/leave events bubble from child elements, so a single logical drag
+// over the terminal produces many enter/leave pairs. A depth counter nets them
+// out: `isDragOver` is true whenever the counter is positive. `drop` resets the
+// counter unconditionally (the browser does not emit a matching leave for the
+// element the drop lands on).
+
+export type DragAction = 'enter' | 'leave' | 'drop';
+
+export interface DragState {
+  count: number;
+  isDragOver: boolean;
+}
+
+export function reduceDragCounter(count: number, action: DragAction): DragState {
+  switch (action) {
+    case 'enter': {
+      const next = count + 1;
+      return { count: next, isDragOver: next > 0 };
+    }
+    case 'leave': {
+      // Clamp so a stray leave (e.g. leaving to a child that never entered)
+      // cannot drive the counter negative and latch the overlay open.
+      const next = Math.max(0, count - 1);
+      return { count: next, isDragOver: next > 0 };
+    }
+    case 'drop':
+      return { count: 0, isDragOver: false };
+    default: {
+      const _exhaustive: never = action;
+      return _exhaustive;
+    }
+  }
+}

--- a/packages/client/src/labs/terminal-poc/image-paste.ts
+++ b/packages/client/src/labs/terminal-poc/image-paste.ts
@@ -1,0 +1,34 @@
+// Minimal structural shapes so the extractor is unit-testable with plain mock
+// objects (no need to construct a real DataTransferItemList in happy-dom). A
+// browser `DataTransferItemList` / `DataTransferItem` satisfies these
+// structurally, so the production call site can pass `clipboardData.items`
+// directly.
+export interface ImageItemLike {
+  readonly type: string;
+  getAsFile(): File | null;
+}
+
+export interface ImageItemListLike {
+  readonly length: number;
+  [index: number]: ImageItemLike;
+}
+
+/**
+ * Extract image `File`s from a clipboard/drag item list, mirroring the
+ * production precedence in `Terminal.tsx` (items whose `type` starts with
+ * `image/`, via `getAsFile()`, skipping nulls). Index-based iteration is used
+ * because `DataTransferItemList` is array-like but not declared iterable in the
+ * TS DOM lib.
+ */
+export function extractImageFiles(items: ImageItemListLike | null | undefined): File[] {
+  if (!items) return [];
+  const files: File[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item.type.startsWith('image/')) {
+      const file = item.getAsFile();
+      if (file) files.push(file);
+    }
+  }
+  return files;
+}

--- a/packages/client/src/labs/terminal-poc/link-detection.ts
+++ b/packages/client/src/labs/terminal-poc/link-detection.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure URL detection over terminal rows. Kept free of DOM / React so the range
+ * math (including wrapped-URL joining) is unit-testable in isolation.
+ *
+ * Ranges are offsets into each row's extracted text (JS string code units, the
+ * same units the view splits segment text by) — cell widths are irrelevant here.
+ */
+
+export interface LinkRange {
+  start: number; // inclusive column offset into the row's text
+  end: number; // exclusive
+  href: string; // the full (joined, punctuation-trimmed) URL
+}
+
+export interface DetectRow {
+  key: number;
+  text: string;
+  isWrapped: boolean; // true = continuation of the previous logical line
+}
+
+// Conservative: explicit http(s) schemes only. Bare-domain and mailto matching
+// are deliberately out of scope (future work).
+const URL_RE = /https?:\/\/\S+/g;
+
+// Trailing characters that terminal linkifiers treat as sentence punctuation
+// rather than part of the URL.
+const TRAILING_PUNCTUATION = new Set(['.', ',', ';', ':', '!', '?', ')', ']', '}', "'", '"']);
+
+/**
+ * Detect http(s) links across rows. Consecutive rows whose followers have
+ * `isWrapped === true` form one logical line: their text is joined, matched
+ * once, and each match is mapped back to per-row `[start, end)` column ranges.
+ *
+ * @returns Map of row key -> its link column ranges (only rows with links appear).
+ */
+export function detectRowLinks(rows: DetectRow[]): Map<number, LinkRange[]> {
+  const result = new Map<number, LinkRange[]>();
+  let i = 0;
+  while (i < rows.length) {
+    // A logical line = rows[i] plus following rows flagged isWrapped.
+    let j = i + 1;
+    while (j < rows.length && rows[j].isWrapped) j++;
+    detectInLogicalLine(rows.slice(i, j), result);
+    i = j;
+  }
+  return result;
+}
+
+interface RowSpan {
+  key: number;
+  offset: number; // where this row's text starts in the joined string
+  length: number;
+}
+
+function detectInLogicalLine(group: DetectRow[], result: Map<number, LinkRange[]>): void {
+  let text = '';
+  const spans: RowSpan[] = [];
+  for (const row of group) {
+    spans.push({ key: row.key, offset: text.length, length: row.text.length });
+    text += row.text;
+  }
+
+  for (const match of text.matchAll(URL_RE)) {
+    const start = match.index ?? 0;
+    let end = start + match[0].length;
+    // Trim trailing sentence punctuation from the end of the URL.
+    while (end > start && TRAILING_PUNCTUATION.has(text[end - 1])) end--;
+    if (end <= start) continue;
+    const href = text.slice(start, end);
+
+    // Map the joined-string range back onto each row it overlaps.
+    for (const span of spans) {
+      const rowStart = span.offset;
+      const rowEnd = span.offset + span.length;
+      const s = Math.max(start, rowStart);
+      const e = Math.min(end, rowEnd);
+      if (s >= e) continue;
+      const ranges = result.get(span.key) ?? [];
+      ranges.push({ start: s - rowStart, end: e - rowStart, href });
+      result.set(span.key, ranges);
+    }
+  }
+}

--- a/packages/client/src/labs/terminal-poc/poc-status-mapping.ts
+++ b/packages/client/src/labs/terminal-poc/poc-status-mapping.ts
@@ -1,0 +1,21 @@
+import type { ConnectionStatus } from '../../components/Terminal';
+import type { PocSnapshot } from './poc-terminal-store';
+
+export interface StatusChangeArgs {
+  status: ConnectionStatus;
+  exitInfo?: { code: number; signal: string | null };
+}
+
+/**
+ * Map a store snapshot to the production `onStatusChange(status, exitInfo?)`
+ * argument shape. `PocStatus` is the same union as `ConnectionStatus`, so status
+ * passes through; the only real transform is normalizing `exitInfo: null`
+ * (snapshot representation) to `undefined` (callback contract). Typing the
+ * return `status` as `ConnectionStatus` also structurally pins that the two
+ * unions stay in sync — a divergence would fail to compile here.
+ */
+export function toStatusChangeArgs(
+  snapshot: Pick<PocSnapshot, 'status' | 'exitInfo'>,
+): StatusChangeArgs {
+  return { status: snapshot.status, exitInfo: snapshot.exitInfo ?? undefined };
+}

--- a/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
+++ b/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
@@ -204,6 +204,12 @@ class PocTerminal implements PocTerminalInstance {
     this.scheduleNotify();
   };
 
+  // NOTE (#943 F2): scroll/mouse reports are output TO the app, not user input
+  // to us. They only sendInput — they never mutate the snapshot, bump the
+  // version, or touch any selection state. The store holds NO selection state at
+  // all (native browser selection owns it), so there is nothing here that could
+  // clear a selection on "input". Do not add xterm-style clear-selection-on-key
+  // behavior to these paths.
   forwardScroll = (lines: number, cell: { x: number; y: number }): void => {
     const steps = Math.abs(Math.trunc(lines));
     if (steps === 0) return;

--- a/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
+++ b/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
@@ -62,6 +62,8 @@ export interface PocTerminalInstance {
   forwardScroll(lines: number, cell: { x: number; y: number }): void;
   /** Report a left-button press/release to the TUI (only when mouse tracking is on). */
   reportMouseButton(kind: 'press' | 'release', cell: { x: number; y: number }): void;
+  /** Paste text, honoring the app's bracketed-paste (DECSET 2004) state. */
+  paste(text: string): void;
   dismissNotice(): void;
   /** Mount reference; returns an idempotent release (Strict-Mode safe). */
   acquire(): () => void;
@@ -233,6 +235,18 @@ class PocTerminal implements PocTerminalInstance {
     // PoC (a spurious release is harmless to the TUIs we target).
     const terminator = kind === 'press' ? 'M' : 'm';
     this.sendInput(`\x1b[<0;${col};${row}${terminator}`);
+  };
+
+  paste = (text: string): void => {
+    // The PTY expects CR line endings; normalize \r\n and lone \n to \r (xterm's
+    // IPasteEvent behavior).
+    const normalized = text.replace(/\r\n/g, '\r').replace(/\n/g, '\r');
+    if (this.terminal.modes.bracketedPasteMode) {
+      // One frame so the app sees the paste atomically between the markers.
+      this.sendInput(`\x1b[200~${normalized}\x1b[201~`);
+    } else {
+      this.sendInput(normalized);
+    }
   };
 
   dismissNotice = (): void => {

--- a/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
+++ b/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
@@ -10,21 +10,10 @@ import {
 import { getWorkerWsUrl } from '../../lib/websocket-url.js';
 import { getReconnectDelay, shouldReconnect } from '../../lib/websocket-reconnect.js';
 import { subscribe as subscribeApp } from '../../lib/app-websocket.js';
-import { stripSystemMessages, stripScrollbackClear } from '../../lib/terminal-utils.js';
+import { stripSystemMessages, stripScrollbackClear as applyScrollbackFilter } from '../../lib/terminal-utils.js';
 import { logger } from '../../lib/logger';
 import { extractRow, extractRowWithCursor, type PocRow } from './buffer-to-rows';
 import { detectRowLinks } from './link-detection';
-
-/**
- * Filters applied to every history/output chunk before writing to the buffer.
- * stripScrollbackClear neutralizes CSI 3J/2J so Claude Code's per-redraw
- * scrollback wipe does not destroy history. Always-on in the PoC; the
- * production port makes stripScrollbackClear conditional per agent config
- * (`stripScrollbackClear` flag; roadmap PR-1 scope).
- */
-function processOutput(data: string): string {
-  return stripScrollbackClear(stripSystemMessages(data));
-}
 
 /**
  * Module-level store: the headless Terminal + WebSocket for each worker live
@@ -65,6 +54,8 @@ export interface PocTerminalInstance {
   reportMouseButton(kind: 'press' | 'release', cell: { x: number; y: number }): void;
   /** Paste text, honoring the app's bracketed-paste (DECSET 2004) state. */
   paste(text: string): void;
+  /** Clear the current worker error and force a fresh WS connection (recovery). */
+  retry(): void;
   dismissNotice(): void;
   /** Mount reference; returns an idempotent release (Strict-Mode safe). */
   acquire(): () => void;
@@ -140,6 +131,11 @@ class PocTerminal implements PocTerminalInstance {
   constructor(
     private sessionId: string,
     private workerId: string,
+    // Fixed for the instance's lifetime (see getOrCreatePocTerminal). When true,
+    // CSI 3J/2J scrollback wipes are neutralized so Claude Code's per-redraw
+    // clear does not destroy history; mirrors production's stripScrollbackClear
+    // agent-config flag.
+    private stripScrollbackClear: boolean,
   ) {
     this.terminal = new Terminal({
       cols: DEFAULT_COLS,
@@ -256,10 +252,32 @@ class PocTerminal implements PocTerminalInstance {
     }
   };
 
+  retry = (): void => {
+    if (this.disposed) return;
+    // Recovery: drop the error, re-enable reconnect (a SESSION_* error may have
+    // latched noReconnect), and open a fresh connection to the same worker. The
+    // parsed buffer is preserved (mirrors production's disconnect + retry, which
+    // reconnects rather than recreating the terminal).
+    this.patchMeta({ workerError: null });
+    this.noReconnect = false;
+    this.reconnectAttempts = 0;
+    this.reconnect();
+  };
+
   dismissNotice = (): void => {
     if (this.snapshot.notice === null) return;
     this.patchMeta({ notice: null });
   };
+
+  /**
+   * Filters applied to every history/output chunk before writing to the buffer.
+   * stripSystemMessages is always applied; the CSI 3J/2J scrollback-clear filter
+   * is gated on the per-instance stripScrollbackClear flag.
+   */
+  private processOutput(data: string): string {
+    const stripped = stripSystemMessages(data);
+    return this.stripScrollbackClear ? applyScrollbackFilter(stripped) : stripped;
+  }
 
   acquire = (): (() => void) => {
     this.refCount += 1;
@@ -455,7 +473,7 @@ class PocTerminal implements PocTerminalInstance {
         break;
       case 'output':
         this.lastOffset = message.offset;
-        this.terminal.write(processOutput(message.data), () => this.scheduleNotify());
+        this.terminal.write(this.processOutput(message.data), () => this.scheduleNotify());
         break;
       case 'exit':
         this.updateStatus('exited', { code: message.exitCode, signal: message.signal });
@@ -485,7 +503,7 @@ class PocTerminal implements PocTerminalInstance {
     }
     this.lastOffset = offset;
     const bytes = data.length;
-    this.terminal.write(processOutput(data), () => {
+    this.terminal.write(this.processOutput(data), () => {
       this.lastHistoryLoadMs = nowMs() - this.historyStartMs;
       logger.debug(
         `[poc-terminal] history loaded: ${bytes} bytes in ${Math.round(this.lastHistoryLoadMs)} ms`,
@@ -674,12 +692,29 @@ function evictOverCap(): void {
   victim?.dispose();
 }
 
-export function getOrCreatePocTerminal(sessionId: string, workerId: string): PocTerminalInstance {
+export interface PocTerminalOptions {
+  /**
+   * When true, neutralize CSI 3J/2J scrollback wipes (Claude Code redraw). The
+   * flag is read ONCE, when the instance is first created. Because the registry
+   * returns the existing instance for a repeated key, a differing flag on a
+   * later call is IGNORED — config is fixed per instance lifetime. This is
+   * acceptable because the agent's stripScrollbackClear config is static per
+   * worker. Defaults to true to preserve the always-on labs behavior; the
+   * production-parity adapter passes an explicit value.
+   */
+  stripScrollbackClear?: boolean;
+}
+
+export function getOrCreatePocTerminal(
+  sessionId: string,
+  workerId: string,
+  opts?: PocTerminalOptions,
+): PocTerminalInstance {
   const key = keyOf(sessionId, workerId);
   let instance = instances.get(key);
   if (!instance) {
     evictOverCap();
-    instance = new PocTerminal(sessionId, workerId);
+    instance = new PocTerminal(sessionId, workerId, opts?.stripScrollbackClear ?? true);
     instances.set(key, instance);
   }
   return instance;

--- a/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
+++ b/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
@@ -13,6 +13,7 @@ import { subscribe as subscribeApp } from '../../lib/app-websocket.js';
 import { stripSystemMessages, stripScrollbackClear } from '../../lib/terminal-utils.js';
 import { logger } from '../../lib/logger';
 import { extractRow, extractRowWithCursor, type PocRow } from './buffer-to-rows';
+import { detectRowLinks } from './link-detection';
 
 /**
  * Filters applied to every history/output chunk before writing to the buffer.
@@ -558,6 +559,9 @@ class PocTerminal implements PocTerminalInstance {
     const cursorX = buffer.cursorX;
 
     const rows: PocRow[] = [];
+    const freshYs = new Set<number>(); // rows (re)built this frame
+    const freshScrollbackYs: number[] = []; // fresh scrollback rows to cache after links
+    let minFreshY = -1;
     for (let y = 0; y < length; y++) {
       const isScrollback = y < baseY;
       const isCursorRow = y === cursorY;
@@ -571,20 +575,38 @@ class PocTerminal implements PocTerminalInstance {
       }
 
       const line = buffer.getLine(y);
-      if (!line) {
-        rows.push({ key: y, segments: [{ text: '', style: null }] });
-        continue;
-      }
+      const row: PocRow = line
+        ? isCursorRow
+          ? extractRowWithCursor(line, cols, nullCell, y, cursorX)
+          : extractRow(line, cols, nullCell, y)
+        : { key: y, segments: [{ text: '', style: null }], isWrapped: false, links: [] };
 
-      const row = isCursorRow
-        ? extractRowWithCursor(line, cols, nullCell, y, cursorX)
-        : extractRow(line, cols, nullCell, y);
-
-      // Cache immutable scrollback rows (not the cursor row, which changes).
-      if (isScrollback && !isCursorRow) {
-        this.rowCache.set(y, row);
-      }
       rows.push(row);
+      freshYs.add(y);
+      if (minFreshY === -1) minFreshY = y;
+      // Cache immutable scrollback rows AFTER links are attached (below).
+      if (isScrollback && !isCursorRow) freshScrollbackYs.push(y);
+    }
+
+    // Detect links only for freshly-built rows, expanding left to the head of a
+    // soft-wrapped logical line so a URL that wraps across the cache boundary is
+    // joined. Cached rows keep the links computed when they were built (correct:
+    // a wrapped line's rows scroll into cache together, after the join existed).
+    if (minFreshY !== -1) {
+      let windowStart = minFreshY;
+      while (windowStart > 0 && rows[windowStart].isWrapped) windowStart--;
+      const window = rows.slice(windowStart).map((r) => ({
+        key: r.key,
+        text: rowText(r),
+        isWrapped: r.isWrapped,
+      }));
+      const linkMap = detectRowLinks(window);
+      for (const y of freshYs) {
+        rows[y].links = linkMap.get(rows[y].key) ?? [];
+      }
+    }
+    for (const y of freshScrollbackYs) {
+      this.rowCache.set(y, rows[y]);
     }
 
     this.snapshot = {
@@ -607,6 +629,11 @@ class PocTerminal implements PocTerminalInstance {
 /** Clamp a 1-based cell coordinate into [1, max]. */
 function clampCell(value: number, max: number): number {
   return Math.min(max, Math.max(1, Math.round(value)));
+}
+
+/** Concatenated text of a row's segments (the offset space link ranges use). */
+function rowText(row: PocRow): string {
+  return row.segments.map((s) => s.text).join('');
 }
 
 // --- Module-level registry ---

--- a/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
+++ b/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
@@ -46,6 +46,7 @@ export interface PocSnapshot {
   cols: number;
   terminalRows: number;
   bufferType: 'normal' | 'alternate'; // 'alternate' = full-screen app (scroll is forwarded)
+  mouseTracking: boolean; // app has DECSET mouse tracking on -> report clicks to the TUI
   notice: string | null; // dismissible banner (restart / truncation)
   workerError: { message: string; code?: WorkerErrorCode } | null;
   activityState: AgentActivityState | null;
@@ -59,6 +60,8 @@ export interface PocTerminalInstance {
   resize(cols: number, rows: number): void;
   /** Forward scroll to the app in alternate-screen mode. positive = toward newer. */
   forwardScroll(lines: number, cell: { x: number; y: number }): void;
+  /** Report a left-button press/release to the TUI (only when mouse tracking is on). */
+  reportMouseButton(kind: 'press' | 'release', cell: { x: number; y: number }): void;
   dismissNotice(): void;
   /** Mount reference; returns an idempotent release (Strict-Mode safe). */
   acquire(): () => void;
@@ -150,6 +153,7 @@ class PocTerminal implements PocTerminalInstance {
       cols: DEFAULT_COLS,
       terminalRows: DEFAULT_ROWS,
       bufferType: 'normal',
+      mouseTracking: false,
       notice: null,
       workerError: null,
       activityState: null,
@@ -216,6 +220,19 @@ class PocTerminal implements PocTerminalInstance {
       data = seq.repeat(steps);
     }
     this.sendInput(data);
+  };
+
+  reportMouseButton = (kind: 'press' | 'release', cell: { x: number; y: number }): void => {
+    // Only report when the app enabled DECSET mouse tracking; otherwise a click
+    // is a local focus gesture, not TUI input.
+    if (this.terminal.modes.mouseTrackingMode === 'none') return;
+    const col = clampCell(cell.x, this.terminal.cols);
+    const row = clampCell(cell.y, this.terminal.rows);
+    // SGR encoding, left button (0): press ends with 'M', release with 'm'.
+    // x10 tracking has no release event, but SGR-encoding both is fine for the
+    // PoC (a spurious release is harmless to the TUIs we target).
+    const terminator = kind === 'press' ? 'M' : 'm';
+    this.sendInput(`\x1b[<0;${col};${row}${terminator}`);
   };
 
   dismissNotice = (): void => {
@@ -564,6 +581,7 @@ class PocTerminal implements PocTerminalInstance {
       cols,
       terminalRows: this.terminal.rows,
       bufferType: buffer.type,
+      mouseTracking: this.terminal.modes.mouseTrackingMode !== 'none',
     };
   }
 

--- a/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
+++ b/packages/client/src/labs/terminal-poc/poc-terminal-store.ts
@@ -3,8 +3,13 @@ import {
   WORKER_SERVER_MESSAGE_TYPES,
   type WorkerServerMessage,
   type WorkerClientMessage,
+  type WorkerErrorCode,
+  type AgentActivityState,
+  type AppServerMessage,
 } from '@agent-console/shared';
 import { getWorkerWsUrl } from '../../lib/websocket-url.js';
+import { getReconnectDelay, shouldReconnect } from '../../lib/websocket-reconnect.js';
+import { subscribe as subscribeApp } from '../../lib/app-websocket.js';
 import { stripSystemMessages, stripScrollbackClear } from '../../lib/terminal-utils.js';
 import { logger } from '../../lib/logger';
 import { extractRow, extractRowWithCursor, type PocRow } from './buffer-to-rows';
@@ -41,6 +46,10 @@ export interface PocSnapshot {
   cols: number;
   terminalRows: number;
   bufferType: 'normal' | 'alternate'; // 'alternate' = full-screen app (scroll is forwarded)
+  notice: string | null; // dismissible banner (restart / truncation)
+  workerError: { message: string; code?: WorkerErrorCode } | null;
+  activityState: AgentActivityState | null;
+  loadingHistory: boolean; // a request-history is in flight
 }
 
 export interface PocTerminalInstance {
@@ -50,14 +59,36 @@ export interface PocTerminalInstance {
   resize(cols: number, rows: number): void;
   /** Forward scroll to the app in alternate-screen mode. positive = toward newer. */
   forwardScroll(lines: number, cell: { x: number; y: number }): void;
+  dismissNotice(): void;
+  /** Mount reference; returns an idempotent release (Strict-Mode safe). */
+  acquire(): () => void;
   dispose(): void;
 }
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 const SCROLLBACK = 5000;
-const RECONNECT_DELAY_MS = 1500;
-const MAX_RECONNECT_ATTEMPTS = 10;
+
+// Memory-management + reconnect timings. Mutable so tests can shorten them via
+// _setTimings; production values are the DEFAULT_TIMINGS below.
+const DEFAULT_TIMINGS = {
+  idleTtlMs: 15 * 60 * 1000, // refCount 0 -> evict after 15 min
+  exitedTtlMs: 5 * 60 * 1000, // exited instances evict sooner (no live process)
+  maxInstances: 12, // LRU hard cap
+  maxReconnectAttempts: 100, // production parity
+  reconnectDelayMs: null as number | null, // null -> getReconnectDelay (test override only)
+};
+type Timings = typeof DEFAULT_TIMINGS;
+let timings: Timings = { ...DEFAULT_TIMINGS };
+
+// App-WS subscribe seam: production uses the real module-level subscribe; tests
+// inject a capturable fake to drive worker-restarted / session-deleted.
+let appSubscribeImpl: typeof subscribeApp = subscribeApp;
+
+const nowMs: () => number =
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? () => performance.now()
+    : () => Date.now();
 
 // rAF batching: guard for non-browser (bun test) where requestAnimationFrame
 // may be absent — fall back to a ~1-frame timeout.
@@ -79,6 +110,21 @@ class PocTerminal implements PocTerminalInstance {
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private historyRequested = false; // per WS connection
+  private noReconnect = false; // set on SESSION_DELETED / SESSION_PAUSED
+
+  // Offset tracking for reconnect catch-up and truncation detection.
+  private lastOffset = 0;
+  private requestedFromOffset = 0;
+
+  // Cold-start instrumentation.
+  private historyStartMs = 0;
+  private lastHistoryLoadMs: number | null = null;
+
+  // Memory management.
+  private refCount = 0;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastReleasedAt = 0;
+  private appUnsub: () => void = () => {};
 
   // Row cache: rows below baseY are immutable scrollback; reuse the same object
   // reference so React.memo skips re-render. Cleared on shrink / history rewrite.
@@ -104,6 +150,10 @@ class PocTerminal implements PocTerminalInstance {
       cols: DEFAULT_COLS,
       terminalRows: DEFAULT_ROWS,
       bufferType: 'normal',
+      notice: null,
+      workerError: null,
+      activityState: null,
+      loadingHistory: false,
     };
 
     this.terminal.onScroll(() => this.scheduleNotify());
@@ -112,7 +162,13 @@ class PocTerminal implements PocTerminalInstance {
     // onBufferChange lives on the buffer namespace, not the Terminal.
     this.terminal.buffer.onBufferChange(() => this.scheduleNotify());
 
+    this.appUnsub = appSubscribeImpl((msg) => this.handleAppMessage(msg));
+
     this.connect();
+  }
+
+  get lastHistoryLoadDurationMs(): number | null {
+    return this.lastHistoryLoadMs;
   }
 
   // Interface-facing methods are arrow-function fields so consumers (e.g.
@@ -162,15 +218,91 @@ class PocTerminal implements PocTerminalInstance {
     this.sendInput(data);
   };
 
+  dismissNotice = (): void => {
+    if (this.snapshot.notice === null) return;
+    this.patchMeta({ notice: null });
+  };
+
+  acquire = (): (() => void) => {
+    this.refCount += 1;
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+    let released = false;
+    return () => {
+      if (released) return; // idempotent under Strict-Mode double-invoke
+      released = true;
+      this.refCount = Math.max(0, this.refCount - 1);
+      if (this.refCount === 0) {
+        this.lastReleasedAt = Date.now();
+        this.startIdleTimer();
+      }
+    };
+  };
+
   dispose = (): void => {
+    if (this.disposed) return;
     this.disposed = true;
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     this.reconnectTimer = null;
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    this.idleTimer = null;
+    this.appUnsub();
     this.closeWs();
     this.terminal.dispose();
     this.listeners.clear();
     removeInstance(this.sessionId, this.workerId);
   };
+
+  // --- Memory management ---
+
+  get refCountForTest(): number {
+    return this.refCount;
+  }
+
+  get lastReleasedAtForTest(): number {
+    return this.lastReleasedAt;
+  }
+
+  get reconnectPendingForTest(): boolean {
+    return this.reconnectTimer !== null;
+  }
+
+  get reconnectAttemptsForTest(): number {
+    return this.reconnectAttempts;
+  }
+
+  get disposedForTest(): boolean {
+    return this.disposed;
+  }
+
+  private startIdleTimer(): void {
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    const ttl = this.snapshot.status === 'exited' ? timings.exitedTtlMs : timings.idleTtlMs;
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null;
+      if (this.refCount === 0) this.dispose();
+    }, ttl);
+  }
+
+  // --- App-WS driven events ---
+
+  private handleAppMessage(msg: AppServerMessage): void {
+    if (this.disposed) return;
+    if (msg.type === 'worker-restarted') {
+      if (msg.sessionId !== this.sessionId || msg.workerId !== this.workerId) return;
+      this.terminal.reset();
+      this.rowCache.clear();
+      this.lastBufferLength = 0;
+      this.lastOffset = 0;
+      this.patchMeta({ notice: 'Terminal restarted', workerError: null });
+      this.reconnect();
+    } else if (msg.type === 'session-deleted') {
+      if (msg.sessionId !== this.sessionId) return;
+      this.dispose();
+    }
+  }
 
   // --- WebSocket ---
 
@@ -185,10 +317,11 @@ class PocTerminal implements PocTerminalInstance {
       if (this.disposed) return;
       this.reconnectAttempts = 0;
       this.updateStatus('connected');
-      // Request full history once per connection; server does not push it.
+      // Request history from the last received offset (0 on first connect);
+      // the server returns only the delta and catches us up after a drop.
       if (!this.historyRequested) {
         this.historyRequested = true;
-        this.send({ type: 'request-history', fromOffset: 0 });
+        this.requestHistory();
       }
       this.send({ type: 'resize', cols: this.terminal.cols, rows: this.terminal.rows });
     };
@@ -202,27 +335,51 @@ class PocTerminal implements PocTerminalInstance {
       logger.warn(`[poc-terminal] ws error ${this.sessionId}:${this.workerId}`);
     };
 
-    ws.onclose = () => {
+    ws.onclose = (event) => {
       if (this.disposed) return;
       this.ws = null;
       // A terminated process closes the socket after the 'exit' message; keep
       // the 'exited' status and do not reconnect to a dead PTY.
       if (this.snapshot.status === 'exited') return;
       this.updateStatus('disconnected');
+      // SESSION_DELETED / SESSION_PAUSED: server closes deliberately; do not
+      // reconnect (mirrors worker-websocket.ts error semantics).
+      if (this.noReconnect) return;
+      if (!shouldReconnect(event.code)) return;
       this.scheduleReconnect();
     };
+  }
+
+  private requestHistory(): void {
+    this.requestedFromOffset = this.lastOffset;
+    this.historyStartMs = nowMs();
+    this.patchMeta({ loadingHistory: true });
+    this.send({ type: 'request-history', fromOffset: this.lastOffset });
+  }
+
+  /** Force a fresh WS connection (worker-restarted flow). */
+  private reconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.closeWs();
+    this.updateStatus('connecting');
+    this.connect();
   }
 
   private scheduleReconnect(): void {
     if (this.disposed) return;
     if (this.snapshot.status === 'exited') return;
-    if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) return;
+    if (this.noReconnect) return;
+    if (this.reconnectAttempts >= timings.maxReconnectAttempts) return;
+    const delay = timings.reconnectDelayMs ?? getReconnectDelay(this.reconnectAttempts);
     this.reconnectAttempts += 1;
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       this.updateStatus('connecting');
       this.connect();
-    }, RECONNECT_DELAY_MS);
+    }, delay);
   }
 
   private closeWs(): void {
@@ -256,27 +413,59 @@ class PocTerminal implements PocTerminalInstance {
 
     switch (message.type) {
       case 'history':
-        // Full ANSI stream. Reset first if the buffer already has content
-        // (e.g. a reconnect re-requested history) to avoid double-write.
-        if (this.terminal.buffer.active.length > 1 || this.lastBufferLength > 0) {
-          this.terminal.reset();
-          this.rowCache.clear();
-        }
-        this.terminal.write(processOutput(message.data), () => this.scheduleNotify());
+        this.handleHistory(message.data, message.offset);
         break;
       case 'output':
+        this.lastOffset = message.offset;
         this.terminal.write(processOutput(message.data), () => this.scheduleNotify());
         break;
       case 'exit':
         this.updateStatus('exited', { code: message.exitCode, signal: message.signal });
         break;
       case 'output-truncated':
-        // History was truncated server-side; nothing to render, just note it.
+        // Server dropped older output; advance our offset and surface a banner.
+        this.lastOffset = message.newOffset;
+        this.patchMeta({ notice: message.message });
         break;
       case 'error':
-        logger.warn(`[poc-terminal] server error: ${message.message}`);
+        this.handleError(message.message, message.code);
         break;
-      // activity / server-restarted: not rendered in the PoC.
+      case 'activity':
+        this.patchMeta({ activityState: message.state });
+        break;
+      // server-restarted: no cache to invalidate; ignore.
+    }
+  }
+
+  private handleHistory(data: string, offset: number): void {
+    // Truncation regression: the server's available data starts below what we
+    // asked for (restart / rotation) -> reset and treat the payload as full.
+    if (offset < this.requestedFromOffset) {
+      this.terminal.reset();
+      this.rowCache.clear();
+      this.lastBufferLength = 0;
+    }
+    this.lastOffset = offset;
+    const bytes = data.length;
+    this.terminal.write(processOutput(data), () => {
+      this.lastHistoryLoadMs = nowMs() - this.historyStartMs;
+      logger.debug(
+        `[poc-terminal] history loaded: ${bytes} bytes in ${Math.round(this.lastHistoryLoadMs)} ms`,
+      );
+      this.patchMeta({ loadingHistory: false });
+      this.scheduleNotify();
+    });
+  }
+
+  private handleError(message: string, code?: WorkerErrorCode): void {
+    this.patchMeta({ workerError: { message, code } });
+    if (code === 'SESSION_DELETED' || code === 'SESSION_PAUSED') {
+      // Server will close after this error; ensure we never reconnect.
+      this.noReconnect = true;
+      if (this.reconnectTimer) {
+        clearTimeout(this.reconnectTimer);
+        this.reconnectTimer = null;
+      }
     }
   }
 
@@ -290,6 +479,15 @@ class PocTerminal implements PocTerminalInstance {
       ...this.snapshot,
       status,
       exitInfo: exitInfo ?? this.snapshot.exitInfo,
+      version: this.snapshot.version + 1,
+    };
+    this.notify();
+  }
+
+  private patchMeta(partial: Partial<PocSnapshot>): void {
+    this.snapshot = {
+      ...this.snapshot,
+      ...partial,
       version: this.snapshot.version + 1,
     };
     this.notify();
@@ -381,15 +579,9 @@ function clampCell(value: number, max: number): number {
 
 // --- Module-level registry ---
 //
-// INTENTIONAL LIFETIME: instances are deliberately NOT disposed when a React
-// route/component unmounts. Surviving mounts is the architectural point of this
-// PoC — the live headless Terminal + WebSocket replace the serialize/restore
-// cache layer, so navigating away and back reuses the already-parsed buffer with
-// zero rehydration. The trade-off is that instances live until dispose() is
-// called explicitly (only the test helper does so today), which a static
-// analyzer reads as a leak. A production adoption would add reference counting
-// (mount/unmount) + idle eviction (TTL after the last WS activity); both are out
-// of PoC scope.
+// Instances survive React unmounts (invariant 1) but not forever: reference
+// counting + idle TTL + an LRU hard cap keep memory bounded (roadmap "Memory
+// management design"). refCount>0 instances are never evicted.
 
 const instances = new Map<string, PocTerminal>();
 
@@ -402,20 +594,68 @@ function removeInstance(sessionId: string, workerId: string): void {
   instances.delete(keyOf(sessionId, workerId));
 }
 
+/** Evict the least-recently-released refCount-0 instance to honor the LRU cap. */
+function evictOverCap(): void {
+  if (instances.size < timings.maxInstances) return;
+  let victim: PocTerminal | null = null;
+  for (const instance of instances.values()) {
+    if (instance.refCountForTest > 0) continue;
+    if (victim === null || instance.lastReleasedAtForTest < victim.lastReleasedAtForTest) {
+      victim = instance;
+    }
+  }
+  // No idle instance to evict (all busy) -> allow overflow rather than drop a
+  // mounted terminal.
+  victim?.dispose();
+}
+
 export function getOrCreatePocTerminal(sessionId: string, workerId: string): PocTerminalInstance {
   const key = keyOf(sessionId, workerId);
   let instance = instances.get(key);
   if (!instance) {
+    evictOverCap();
     instance = new PocTerminal(sessionId, workerId);
     instances.set(key, instance);
   }
   return instance;
 }
 
-/** @internal Test helper: dispose and clear all live instances. */
+/** @internal Test helper: dispose and clear all live instances + reset config. */
 export function _resetPocTerminals(): void {
   for (const instance of Array.from(instances.values())) {
     instance.dispose();
   }
   instances.clear();
+  timings = { ...DEFAULT_TIMINGS };
+  appSubscribeImpl = subscribeApp;
+}
+
+/** @internal Test helper: override memory-management / reconnect timings. */
+export function _setTimings(partial: Partial<Timings>): void {
+  timings = { ...timings, ...partial };
+}
+
+/** @internal Test helper: inject a capturable app-WS subscribe seam. */
+export function _setAppSubscribe(impl: typeof subscribeApp): void {
+  appSubscribeImpl = impl;
+}
+
+/** @internal Test helper: read internal state for assertions. */
+export function _inspect(instance: PocTerminalInstance): {
+  refCount: number;
+  lastReleasedAt: number;
+  reconnectPending: boolean;
+  reconnectAttempts: number;
+  disposed: boolean;
+  lastHistoryLoadMs: number | null;
+} {
+  const t = instance as PocTerminal;
+  return {
+    refCount: t.refCountForTest,
+    lastReleasedAt: t.lastReleasedAtForTest,
+    reconnectPending: t.reconnectPendingForTest,
+    reconnectAttempts: t.reconnectAttemptsForTest,
+    disposed: t.disposedForTest,
+    lastHistoryLoadMs: t.lastHistoryLoadDurationMs,
+  };
 }

--- a/packages/client/src/routes/labs/terminal-compare.tsx
+++ b/packages/client/src/routes/labs/terminal-compare.tsx
@@ -1,0 +1,84 @@
+import { createFileRoute } from '@tanstack/react-router';
+import type { ReactNode } from 'react';
+import { MemoizedTerminal } from '../../components/Terminal';
+import { PocTerminalAdapter } from '../../labs/terminal-poc/PocTerminalAdapter';
+
+interface TerminalCompareSearch {
+  sessionId?: string;
+  workerId?: string;
+  stripScrollbackClear?: boolean;
+}
+
+export const Route = createFileRoute('/labs/terminal-compare')({
+  validateSearch: (search: Record<string, unknown>): TerminalCompareSearch => ({
+    sessionId: typeof search.sessionId === 'string' ? search.sessionId : undefined,
+    workerId: typeof search.workerId === 'string' ? search.workerId : undefined,
+    stripScrollbackClear: search.stripScrollbackClear === true || search.stripScrollbackClear === 'true',
+  }),
+  component: TerminalCompareRoute,
+});
+
+/**
+ * Side-by-side parity harness: the production `MemoizedTerminal` (legacy) and the
+ * PoC `PocTerminalAdapter` (next) both attach separate WebSocket connections to
+ * the SAME worker, so a reviewer can compare rendering and recovery behavior on
+ * live output. `stripScrollbackClear` is threaded to both for a fair comparison.
+ */
+function TerminalCompareRoute() {
+  const { sessionId, workerId, stripScrollbackClear } = Route.useSearch();
+
+  if (!sessionId || !workerId) {
+    return (
+      <div className="mx-auto max-w-lg px-4 py-8 text-slate-200">
+        <h1 className="mb-1 text-xl font-semibold">Terminal Comparison (labs)</h1>
+        <p className="text-sm text-slate-400">
+          Provide <code className="rounded bg-slate-800 px-1">sessionId</code> and{' '}
+          <code className="rounded bg-slate-800 px-1">workerId</code> search params, e.g.
+          <code className="mt-2 block break-all rounded bg-slate-800 px-2 py-1 text-xs">
+            /labs/terminal-compare?sessionId=SID&amp;workerId=WID&amp;stripScrollbackClear=true
+          </code>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 flex flex-col bg-black">
+      <div className="shrink-0 border-b border-amber-800/60 bg-amber-950/70 px-3 py-1 text-center text-xs text-amber-200">
+        Both panes share one PTY. The app renders for whichever pane resized last; the other may clip
+        (tmux-style constraint). Use this page for visual parity review; for interaction testing use
+        /labs/terminal-poc.
+      </div>
+      <ComparePane label="legacy (production Terminal.tsx)">
+        <MemoizedTerminal
+          sessionId={sessionId}
+          workerId={workerId}
+          stripScrollbackClear={stripScrollbackClear}
+        />
+      </ComparePane>
+      <div className="h-px shrink-0 bg-slate-600" />
+      <ComparePane label="next (PoC PocTerminalAdapter)">
+        <PocTerminalAdapter
+          sessionId={sessionId}
+          workerId={workerId}
+          stripScrollbackClear={stripScrollbackClear}
+        />
+      </ComparePane>
+    </div>
+  );
+}
+
+function ComparePane({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <div className="shrink-0 bg-slate-800 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-300">
+        {label}
+      </div>
+      {/* Full flex-col chain down to the hosted terminal so xterm's fit sees a
+          resolved height at mount (mirrors how SessionPage hosts Terminal). A
+          bare relative wrapper leaves the production Terminal's flex-1 root with
+          no flex parent -> fit races to rows=1 / 16px. */}
+      <div className="flex min-h-0 flex-1 flex-col">{children}</div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/labs/terminal-poc.tsx
+++ b/packages/client/src/routes/labs/terminal-poc.tsx
@@ -53,11 +53,54 @@ function TerminalPocPage({ sessionId, workerId }: { sessionId: string; workerId:
 
       <StatusLine instance={instance} />
 
+      <LoadingHistoryBar instance={instance} />
+      <NoticeBanner instance={instance} />
+      <WorkerErrorStrip instance={instance} />
+
       <PocTerminalView instance={instance} onRequestFocus={focusInput} />
 
       <PocKeyboardInput ref={inputRef} instance={instance} />
 
       <ExitBanner instance={instance} />
+    </div>
+  );
+}
+
+function LoadingHistoryBar({ instance }: { instance: ReturnType<typeof getOrCreatePocTerminal> }) {
+  const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
+  if (!snapshot.loadingHistory) return null;
+  return (
+    <div className="bg-blue-900/50 px-3 py-1 text-center text-xs text-blue-200 animate-pulse">
+      Loading history…
+    </div>
+  );
+}
+
+function NoticeBanner({ instance }: { instance: ReturnType<typeof getOrCreatePocTerminal> }) {
+  const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
+  if (!snapshot.notice) return null;
+  return (
+    <div className="flex items-center justify-between gap-2 bg-amber-900/60 px-3 py-1 text-xs text-amber-200">
+      <span>{snapshot.notice}</span>
+      <button
+        type="button"
+        onClick={() => instance.dismissNotice()}
+        className="rounded bg-amber-700/60 px-2 py-0.5 hover:bg-amber-600/60"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}
+
+function WorkerErrorStrip({ instance }: { instance: ReturnType<typeof getOrCreatePocTerminal> }) {
+  const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
+  if (!snapshot.workerError) return null;
+  const { message, code } = snapshot.workerError;
+  return (
+    <div className="bg-red-900/70 px-3 py-1 text-xs text-red-200">
+      {message}
+      {code ? ` (${code})` : ''}
     </div>
   );
 }

--- a/packages/client/src/routes/labs/terminal-poc.tsx
+++ b/packages/client/src/routes/labs/terminal-poc.tsx
@@ -103,11 +103,12 @@ interface FileReceipt {
 
 function FileReceiptToast({ files }: { files: FileReceipt['files'] }) {
   return (
-    <div className="pointer-events-none absolute bottom-16 left-1/2 z-30 w-[min(90%,28rem)] -translate-x-1/2 rounded-lg border border-emerald-700 bg-emerald-900/90 px-4 py-3 text-emerald-100 shadow-lg">
+    <div className="pointer-events-none absolute bottom-16 left-1/2 z-30 w-[min(90%,28rem)] -translate-x-1/2 rounded-lg border border-amber-700 bg-amber-950/90 px-4 py-3 text-amber-100 shadow-lg">
       <div className="text-sm font-medium">
-        {files.length} file(s) received (MessagePanel wiring lands with the adapter phase)
+        ⚠ {files.length} file(s) received — NOT yet sent to Claude (delivery activates when
+        integrated into the session screen)
       </div>
-      <ul className="mt-1 space-y-0.5 text-xs text-emerald-200">
+      <ul className="mt-1 space-y-0.5 text-xs text-amber-200/90">
         {files.map((f, i) => (
           <li key={i} className="flex justify-between gap-3">
             <span className="truncate font-mono">{f.name || '(unnamed)'}</span>

--- a/packages/client/src/routes/labs/terminal-poc.tsx
+++ b/packages/client/src/routes/labs/terminal-poc.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { fetchWorkers } from '../../lib/api';
 import { getOrCreatePocTerminal } from '../../labs/terminal-poc/poc-terminal-store';
 import { PocTerminalView } from '../../labs/terminal-poc/PocTerminalView';
@@ -40,6 +40,27 @@ function TerminalPocPage({ sessionId, workerId }: { sessionId: string; workerId:
 
   const focusInput = () => inputRef.current?.focus();
 
+  // Image-paste / file-drop receipt toast. Stands in for the MessagePanel wiring
+  // that lands with the adapter phase (PR-3), so the onFilesReceived contract is
+  // E2E-visible in labs.
+  const [receipt, setReceipt] = useState<FileReceipt | null>(null);
+  const receiptTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleFilesReceived = useCallback((files: File[]) => {
+    if (files.length === 0) return;
+    setReceipt({
+      id: Date.now(),
+      files: files.map((f) => ({ name: f.name, size: f.size })),
+    });
+    if (receiptTimer.current) clearTimeout(receiptTimer.current);
+    receiptTimer.current = setTimeout(() => setReceipt(null), FILE_RECEIPT_TTL_MS);
+  }, []);
+  useEffect(
+    () => () => {
+      if (receiptTimer.current) clearTimeout(receiptTimer.current);
+    },
+    [],
+  );
+
   // Snapshot-free page: all live-state reads happen in subscribed children.
   return (
     <div
@@ -57,11 +78,42 @@ function TerminalPocPage({ sessionId, workerId }: { sessionId: string; workerId:
       <NoticeBanner instance={instance} />
       <WorkerErrorStrip instance={instance} />
 
-      <PocTerminalView instance={instance} onRequestFocus={focusInput} />
+      <PocTerminalView
+        instance={instance}
+        onRequestFocus={focusInput}
+        onFilesReceived={handleFilesReceived}
+      />
 
-      <PocKeyboardInput ref={inputRef} instance={instance} />
+      <PocKeyboardInput ref={inputRef} instance={instance} onFilesReceived={handleFilesReceived} />
 
       <ExitBanner instance={instance} />
+
+      {receipt && <FileReceiptToast key={receipt.id} files={receipt.files} />}
+    </div>
+  );
+}
+
+const FILE_RECEIPT_TTL_MS = 5000;
+
+interface FileReceipt {
+  id: number;
+  files: { name: string; size: number }[];
+}
+
+function FileReceiptToast({ files }: { files: FileReceipt['files'] }) {
+  return (
+    <div className="pointer-events-none absolute bottom-16 left-1/2 z-30 w-[min(90%,28rem)] -translate-x-1/2 rounded-lg border border-emerald-700 bg-emerald-900/90 px-4 py-3 text-emerald-100 shadow-lg">
+      <div className="text-sm font-medium">
+        {files.length} file(s) received (MessagePanel wiring lands with the adapter phase)
+      </div>
+      <ul className="mt-1 space-y-0.5 text-xs text-emerald-200">
+        {files.map((f, i) => (
+          <li key={i} className="flex justify-between gap-3">
+            <span className="truncate font-mono">{f.name || '(unnamed)'}</span>
+            <span className="shrink-0 tabular-nums">{f.size} B</span>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/packages/client/src/routes/labs/terminal-poc.tsx
+++ b/packages/client/src/routes/labs/terminal-poc.tsx
@@ -82,6 +82,7 @@ function TerminalPocPage({ sessionId, workerId }: { sessionId: string; workerId:
         instance={instance}
         onRequestFocus={focusInput}
         onFilesReceived={handleFilesReceived}
+        inputRef={inputRef}
       />
 
       <PocKeyboardInput ref={inputRef} instance={instance} onFilesReceived={handleFilesReceived} />


### PR DESCRIPTION
Closes #937

Roadmap PR-1 of 5 (`docs/design/labs-terminal-poc-roadmap.md`). Refs #722, #934, #942.

All changes stay inside `packages/client/src/labs/terminal-poc/` + its route file. `Terminal.tsx`, `worker-websocket.ts`, `app-websocket.ts` and every shared file are untouched.

## What

**Protocol hardening** (store):
- Reconnect now uses the shared `getReconnectDelay` / `shouldReconnect` (exponential backoff + jitter, close-code classification, cap 100 — production parity).
- Offset tracking: reconnects request `fromOffset=lastOffset` and receive only the delta (no duplicate replay — E2E-verified below). A history response whose offset is lower than requested means server-side truncation: reset + full resync.
- `output-truncated` → dismissible notice + offset bump. `worker-restarted` (app-WS) → buffer reset + reconnect + notice. `session-deleted` (app-WS) → instance disposal. `activity` → snapshot passthrough. Worker errors surface as `{message, code}`; `SESSION_DELETED` / `SESSION_PAUSED` stop reconnection (mirrors production semantics).

**Memory management** (registry — roadmap "Memory management design"): `acquire()`/idempotent-release refcounting (React Strict Mode safe), idle TTL 15 min (5 min once exited), LRU cap 12 never evicting acquired instances, timers cleaned on dispose.

**View wiring** (labs quality): acquire/release effect, loading-history bar, notice banner with dismiss, worker-error strip. Full `WorkerErrorRecovery` reuse is PR-3 scope (#939).

## Invariant 6 gate: cold-start numbers → IndexedDB mirror NOT justified

| Path | Size | Time |
|---|---|---|
| Headless parse (realistic ANSI incl. truecolor/CJK) | 1 MB / 3 MB / 5 MB | 27.5 ms / 39.4 ms / 51.4 ms |
| Live browser full-reload E2E (network + server read + parse) | 275 KB | 200 ms |

The old ~20s pathology (#648) came from painting the replay; parsing into an off-DOM buffer does not paint. The IndexedDB raw-stream mirror permitted by invariant 6 is therefore not implemented (parsed-buffer serialize remains prohibited by invariant 2 regardless).

## Verification

- `bun test src/labs/`: 57 pass, 0 fail (17 new tests). Polarity-verified per flow: offset re-request, truncation reset, SESSION_PAUSED no-reconnect, idle/exited TTL dispose, LRU eviction both branches, worker-restarted reset, session-deleted dispose.
- `bun run typecheck` exit 0; full `bun run test` TEST_EXIT 0 (client 1610 / server 2988 / shared 359 / integration 30; run with `env -u SSH_AUTH_SOCK` due to the known main-side env-sensitive test, #936).
- CodeRabbit CLI (`--base origin/main`): 0 findings.
- **Live E2E on the dev server**: server restart (bun --watch touch) → reconnect with offset delta, pre-restart output appears exactly once (no duplication), post-reconnect input works; cold-start reload with 5038-row history renders instantly with the measured 200 ms load.

Test seams added (`_setAppSubscribe` DI for app-WS, timing overrides, `_inspect` accessor) keep the public `PocTerminalInstance` interface clean — DI over module mocking per testing.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGB7PwWjbes5ZJBCmMJNMm


---

## Rolling-PR update (owner-directed flow change, 2026-07-02)

The owner directed continuing the roadmap phases on this same branch with one commit per phase ("commit per phase, same branch is fine"). This PR therefore also consumes **#938** (full interaction set — see the phase-commit map in the issue comments):

Closes #938

| Phase | Commits | Real-interaction E2E |
|---|---|---|
| Click-to-focus fix (owner-found: typing was impossible for real users) | b49b1a3 | trusted click → focus sticks → typed input reaches the PTY |
| Mouse click reporting + row-height fix | 4ad5055, f63c42e | Claude Code permission-dialog option selected by click; approved command executed |
| Bracketed paste + release pairing (CodeRabbit Major) | 3381281 | #792 scenario: multi-line paste unsent in prompt; asking-state dialog untouched |
| Clickable links (wrapped-URL joining) | cfd18cc | wrapped 170-char URL opens with full href |
| Selection polish + #943 F1/F2 pins | 5cc940f | scoped Cmd+A, wrap-joined copy via pbpaste, Shift-guard under tracking |
| Image paste + DnD (onFilesReceived contract) | 981bc42 | toast shows pasted/dropped files, zero input frames |

## Owner consultation items (standing list — nothing here proceeds without the owner)

1. **Merge timing of this PR** (rolling; every commit CI-green, CodeRabbit APPROVED as of the last review round).
2. **#949 permanent fix** (server-side env filter) — will be prepared as a separate reviewable PR; merge is the owner's call.
3. **PR-4 flag swap** (first shared-file touch: `SessionPage.tsx`) and **PR-5 legacy removal** — always consulted before starting.
4. **Real-device mobile QA** — cannot be performed by the agent; requested when convenient.
