### PR TITLE
fix(server): strip inherited Claude Code session env from PTY workers (closes #949)

### DIFF
--- a/packages/server/src/services/__tests__/env-filter.test.ts
+++ b/packages/server/src/services/__tests__/env-filter.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { getChildProcessEnv, getUnsetEnvPrefix, filterRepositoryEnvVars } from '../env-filter.js';
+import {
+  getChildProcessEnv,
+  getUnsetEnvPrefix,
+  filterRepositoryEnvVars,
+  isInheritedClaudeSessionVar,
+} from '../env-filter.js';
 import { SERVER_ONLY_ENV_VARS } from '../../lib/server-config.js';
 
 describe('env-filter', () => {
@@ -100,6 +105,50 @@ describe('env-filter', () => {
 
       expect(childEnv.TERM).toBe('xterm-256color');
     });
+
+    it('should exclude inherited Claude Code session vars (Issue #949)', () => {
+      process.env.CLAUDECODE = '1';
+      process.env.CLAUDE_CODE_SESSION_ID = 'parent-id';
+      process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+
+      const childEnv = getChildProcessEnv();
+
+      expect('CLAUDECODE' in childEnv).toBe(false);
+      expect('CLAUDE_CODE_SESSION_ID' in childEnv).toBe(false);
+      expect('CLAUDE_CODE_ENTRYPOINT' in childEnv).toBe(false);
+    });
+
+    it('should keep vars that only resemble Claude Code session vars', () => {
+      // Prefix rule is exactly `CLAUDE_CODE_`; `CLAUDE_CODEX` must NOT match,
+      // and the exact name is `CLAUDECODE`, so `MY_CLAUDECODE` must NOT match.
+      process.env.CLAUDE_CODEX = 'keep-me';
+      process.env.MY_CLAUDECODE = 'keep-me-too';
+      process.env.CLAUDE_CODE_X = 'strip-me';
+
+      const childEnv = getChildProcessEnv();
+
+      expect(childEnv.CLAUDE_CODEX).toBe('keep-me');
+      expect(childEnv.MY_CLAUDECODE).toBe('keep-me-too');
+      expect('CLAUDE_CODE_X' in childEnv).toBe(false);
+    });
+  });
+
+  describe('isInheritedClaudeSessionVar', () => {
+    it('should match CLAUDECODE and CLAUDE_CODE_* names', () => {
+      expect(isInheritedClaudeSessionVar('CLAUDECODE')).toBe(true);
+      expect(isInheritedClaudeSessionVar('CLAUDE_CODE_SESSION_ID')).toBe(true);
+      expect(isInheritedClaudeSessionVar('CLAUDE_CODE_ENTRYPOINT')).toBe(true);
+      expect(isInheritedClaudeSessionVar('CLAUDE_CODE_X')).toBe(true);
+    });
+
+    it('should not match near-miss names', () => {
+      // `CLAUDE_CODEX` shares the `CLAUDE_CODE` stem but not the `CLAUDE_CODE_`
+      // prefix; `MY_CLAUDECODE` is not the exact `CLAUDECODE` name.
+      expect(isInheritedClaudeSessionVar('CLAUDE_CODEX')).toBe(false);
+      expect(isInheritedClaudeSessionVar('MY_CLAUDECODE')).toBe(false);
+      expect(isInheritedClaudeSessionVar('CLAUDE_API_KEY')).toBe(false);
+      expect(isInheritedClaudeSessionVar('ANTHROPIC_API_KEY')).toBe(false);
+    });
   });
 
   describe('getUnsetEnvPrefix', () => {
@@ -117,6 +166,15 @@ describe('env-filter', () => {
     });
 
     it('should include all blocked env vars in the unset command', () => {
+      // Remove any inherited Claude Code session vars so this baseline test
+      // asserts exactly the blocked-var set (Issue #949: getUnsetEnvPrefix
+      // also unsets CLAUDE_CODE_* dynamically when present).
+      for (const key of Object.keys(process.env)) {
+        if (key === 'CLAUDECODE' || key.startsWith('CLAUDE_CODE_')) {
+          delete process.env[key];
+        }
+      }
+
       const prefix = getUnsetEnvPrefix();
 
       // Parse the variables from the unset command
@@ -139,6 +197,46 @@ describe('env-filter', () => {
       // This regex validates the format
       const validFormat = /^unset [A-Z_]+( [A-Z_]+)*; $/;
       expect(validFormat.test(prefix)).toBe(true);
+    });
+
+    it('should dynamically unset inherited Claude Code session vars (Issue #949)', () => {
+      process.env.CLAUDECODE = '1';
+      process.env.CLAUDE_CODE_SESSION_ID = 'parent-id';
+
+      const prefix = getUnsetEnvPrefix();
+
+      expect(prefix).toContain('CLAUDECODE');
+      expect(prefix).toContain('CLAUDE_CODE_SESSION_ID');
+    });
+
+    it('should not include a var that only resembles a Claude Code session var', () => {
+      // Remove any real inherited session vars, then add near-miss names.
+      for (const key of Object.keys(process.env)) {
+        if (key === 'CLAUDECODE' || key.startsWith('CLAUDE_CODE_')) {
+          delete process.env[key];
+        }
+      }
+      process.env.CLAUDE_CODEX = 'x';
+      process.env.MY_CLAUDECODE = 'y';
+
+      const prefix = getUnsetEnvPrefix();
+
+      // Whole-word check via the space/boundary-delimited unset list.
+      const unsetVars = prefix.slice('unset '.length, -'; '.length).split(' ');
+      expect(unsetVars).not.toContain('CLAUDE_CODEX');
+      expect(unsetVars).not.toContain('MY_CLAUDECODE');
+    });
+
+    it('should equal blocked-only behavior when no Claude Code session vars are set', () => {
+      for (const key of Object.keys(process.env)) {
+        if (key === 'CLAUDECODE' || key.startsWith('CLAUDE_CODE_')) {
+          delete process.env[key];
+        }
+      }
+
+      const prefix = getUnsetEnvPrefix();
+
+      expect(prefix).toBe(`unset ${SERVER_ONLY_ENV_VARS.join(' ')}; `);
     });
   });
 

--- a/packages/server/src/services/env-filter.ts
+++ b/packages/server/src/services/env-filter.ts
@@ -29,6 +29,20 @@ const PROTECTED_ENV_VARS: readonly string[] = [
 ];
 
 /**
+ * Identify environment variables that carry the PARENT process's Claude Code
+ * session identity (`CLAUDECODE`, `CLAUDE_CODE_*`). These are set when the
+ * server is launched from inside a Claude Code session and are never correct
+ * for child PTY workers — a worker's own `claude` must establish its own
+ * session identity. Leaking them makes a worker adopt the parent's
+ * `CLAUDE_CODE_SESSION_ID`, append its conversation to the parent agent's
+ * transcript file, and break `claude -c` restart-with-continue
+ * ("No conversation found to continue").
+ */
+export function isInheritedClaudeSessionVar(key: string): boolean {
+  return key === 'CLAUDECODE' || key.startsWith('CLAUDE_CODE_');
+}
+
+/**
  * Filter environment variables for child PTY processes.
  * Removes server-specific variables that could interfere with child behavior.
  *
@@ -41,7 +55,7 @@ export function getChildProcessEnv(): Record<string, string> {
   const env: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined && !BLOCKED_ENV_VARS.includes(key)) {
+    if (value !== undefined && !BLOCKED_ENV_VARS.includes(key) && !isInheritedClaudeSessionVar(key)) {
       env[key] = value;
     }
   }
@@ -64,13 +78,22 @@ export function getChildProcessEnv(): Record<string, string> {
  * Simply excluding variables from the env object doesn't work - they still
  * get inherited from the parent process.
  *
+ * The concrete set of inherited Claude Code session vars depends on how the
+ * server was launched, so they are resolved dynamically from process.env at
+ * call time (there is no portable glob for `unset`). The dynamic part is
+ * sorted for deterministic output.
+ *
  * @returns Shell command prefix like "unset VAR1 VAR2; " or empty string if no vars to unset
  */
 export function getUnsetEnvPrefix(): string {
-  if (BLOCKED_ENV_VARS.length === 0) {
+  const inheritedClaudeVars = Object.keys(process.env)
+    .filter(isInheritedClaudeSessionVar)
+    .sort();
+  const varsToUnset = Array.from(new Set([...BLOCKED_ENV_VARS, ...inheritedClaudeVars]));
+  if (varsToUnset.length === 0) {
     return '';
   }
-  return `unset ${BLOCKED_ENV_VARS.join(' ')}; `;
+  return `unset ${varsToUnset.join(' ')}; `;
 }
 
 /**


### PR DESCRIPTION
Closes #949

## Bug

A dev server launched from inside a Claude Code session (the standard workflow for every agent working on this repo) leaks the parent agent's `CLAUDECODE` / `CLAUDE_CODE_*` env vars into every PTY worker, because bun-pty re-merges the parent process env. A spawned `claude` worker adopts the inherited `CLAUDE_CODE_SESSION_ID` as its own identity, with three verified consequences (full forensics in #949):

1. The worker's conversation is appended to the **parent agent's transcript file**.
2. Nothing is saved under the worker's own project dir.
3. Restart with "continue conversation" exits 1 with `No conversation found to continue` (owner-reported symptom).

## Fix

Both layers of the existing env-cleaning mechanism in `services/env-filter.ts`:
- `getChildProcessEnv()` excludes `CLAUDECODE` / `CLAUDE_CODE_*` (new `isInheritedClaudeSessionVar` helper).
- `getUnsetEnvPrefix()` dynamically unsets whichever of those vars exist in the server's env at spawn time — the effective layer, since bun-pty merges the parent env regardless of the env object.

Production deployments (launchd / plain shell) are unaffected — they never had these vars.

## Verification

- Unit tests (extend `env-filter.test.ts`): exclusion at both layers, prefix-boundary negatives (`CLAUDE_CODEX` / `MY_CLAUDECODE` survive, `CLAUDE_CODE_X` stripped), blocked-only baseline unchanged when no Claude vars present. Polarity confirmed: reverting the two consumers fails exactly the three fix-guarding tests.
- Full suite green: server 2995 / client 1593 / shared 359 / integration 30 / scripts 411, 0 fail (`env -u SSH_AUTH_SOCK` for the known #936 macOS env-sensitive test).
- **Shipping-path E2E**: a server launched with five inherited `CLAUDE_CODE_*` vars (verified via `ps -wwE`) spawned a terminal worker; probing the worker shell through a real WebSocket `input` (`env | grep -cE "^CLAUDECODE=|^CLAUDE_CODE_"`) returned **0**. Pre-fix baseline on the identical path (this morning's forensics) showed all five inherited and the transcript cross-write.

Post-merge dogfood check suggested: start a dev server from a Claude session WITHOUT the `env -u` workaround, converse with a spawned agent worker, confirm the conversation lands under the worker's own project dir and restart-with-continue revives it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGB7PwWjbes5ZJBCmMJNMm
