### PR TITLE
feat(client): terminal renderer flag with settings toggle (refs #940)

### DIFF
--- a/packages/client/src/components/sessions/SessionPage.tsx
+++ b/packages/client/src/components/sessions/SessionPage.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import type { ComponentType } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
-import { MemoizedTerminal as Terminal, type ConnectionStatus } from '../Terminal';
+import { MemoizedTerminal as Terminal, type ConnectionStatus, type TerminalProps } from '../Terminal';
+import { PocTerminalAdapter } from '../../labs/terminal-poc/PocTerminalAdapter';
+import {
+  useTerminalRenderer,
+  type TerminalRenderer,
+} from '../../labs/terminal-poc/renderer-flag';
 import { GitDiffWorkerView } from '../workers/GitDiffWorkerView';
 import { SessionSettings } from '../SessionSettings';
 import { QuickSessionSettings } from '../QuickSessionSettings';
@@ -24,6 +30,16 @@ import { logger } from '../../lib/logger';
 
 export { sessionToPageState } from './hooks/useSessionPageState';
 export type { PageState } from './hooks/useSessionPageState';
+
+/**
+ * Pick the terminal implementation for the active renderer flag. Both accept the
+ * same `TerminalProps`, so the swap is a component-identity switch with no prop
+ * changes. Exported as a pure seam so the flag branch is unit-testable without
+ * rendering the whole SessionPage.
+ */
+export function pickTerminalComponent(renderer: TerminalRenderer): ComponentType<TerminalProps> {
+  return renderer === 'next' ? PocTerminalAdapter : Terminal;
+}
 
 // Get branch name from session (for worktree sessions)
 function getBranchName(session: Session): string {
@@ -88,6 +104,8 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
   const { agents } = useAgents();
   const messagePanelRef = useRef<MessagePanelHandle>(null);
   const navigate = useNavigate();
+  // Feature-flag: legacy production Terminal vs the labs PoC renderer (PR-4).
+  const terminalRenderer = useTerminalRenderer();
   // State for resuming paused session
   const [isResuming, setIsResuming] = useState(false);
   const [resumeError, setResumeError] = useState<string | null>(null);
@@ -436,6 +454,7 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
   const activeAgentId = activeWorker?.type === 'agent' ? activeWorker.agentId : undefined;
   const activeAgent = activeAgentId ? agents.find(a => a.id === activeAgentId) : undefined;
   const shouldStripScrollback = activeAgent?.stripScrollbackClear ?? false;
+  const TerminalComponent = pickTerminalComponent(terminalRenderer);
   const statusWorkerType = activeTab?.workerType ?? 'agent';
   const statusColor = getConnectionStatusColor(connectionStatus, activityState, statusWorkerType);
   const statusText = getConnectionStatusText(connectionStatus, activityState, exitInfo ?? null, statusWorkerType);
@@ -506,7 +525,7 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
             workerId={activeTab.id}
           />
         ) : (
-          <Terminal
+          <TerminalComponent
             sessionId={sessionId}
             workerId={activeTab.id}
             onStatusChange={handleStatusChange}

--- a/packages/client/src/components/sessions/__tests__/SessionPage.test.ts
+++ b/packages/client/src/components/sessions/__tests__/SessionPage.test.ts
@@ -13,7 +13,9 @@ import {
   executeWorkerRestart,
   type WorkerRestartResult,
 } from '../workerRestart';
-import { sessionToPageState } from '../SessionPage';
+import { sessionToPageState, pickTerminalComponent } from '../SessionPage';
+import { MemoizedTerminal } from '../../Terminal';
+import { PocTerminalAdapter } from '../../../labs/terminal-poc/PocTerminalAdapter';
 
 // Test helpers
 
@@ -279,6 +281,16 @@ describe('executeWorkerRestart', () => {
       // Should use the first agent worker (agent-1), not terminal-1 or agent-2
       expect(mockRestartAgentWorker.mock.calls[0][1]).toBe('agent-1');
     });
+  });
+});
+
+describe('pickTerminalComponent', () => {
+  it('returns the production Terminal for the legacy renderer', () => {
+    expect(pickTerminalComponent('legacy')).toBe(MemoizedTerminal);
+  });
+
+  it('returns the PoC adapter for the next renderer', () => {
+    expect(pickTerminalComponent('next')).toBe(PocTerminalAdapter);
   });
 });
 

--- a/packages/client/src/labs/terminal-poc/__tests__/renderer-flag.test.ts
+++ b/packages/client/src/labs/terminal-poc/__tests__/renderer-flag.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  DEFAULT_TERMINAL_RENDERER,
+  getTerminalRenderer,
+  setTerminalRenderer,
+  subscribeTerminalRenderer,
+} from '../renderer-flag';
+
+const STORAGE_KEY = 'terminal-renderer';
+
+describe('renderer-flag', () => {
+  let originalLocalStorage: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    if (originalLocalStorage) {
+      Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
+    }
+    localStorage.clear();
+  });
+
+  it('returns the build-time default when nothing is stored', () => {
+    expect(getTerminalRenderer()).toBe(DEFAULT_TERMINAL_RENDERER);
+    expect(DEFAULT_TERMINAL_RENDERER).toBe('legacy');
+  });
+
+  it('returns the stored value when it is a valid renderer', () => {
+    localStorage.setItem(STORAGE_KEY, 'next');
+    expect(getTerminalRenderer()).toBe('next');
+  });
+
+  it('falls back to the default when the stored value is invalid', () => {
+    localStorage.setItem(STORAGE_KEY, 'bogus');
+    expect(getTerminalRenderer()).toBe(DEFAULT_TERMINAL_RENDERER);
+  });
+
+  it('set persists the value and get reads it back', () => {
+    setTerminalRenderer('next');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('next');
+    expect(getTerminalRenderer()).toBe('next');
+
+    setTerminalRenderer('legacy');
+    expect(getTerminalRenderer()).toBe('legacy');
+  });
+
+  it('notifies subscribers on set and stops after unsubscribe', () => {
+    let notifications = 0;
+    const unsubscribe = subscribeTerminalRenderer(() => {
+      notifications += 1;
+    });
+
+    setTerminalRenderer('next');
+    expect(notifications).toBe(1);
+
+    unsubscribe();
+    setTerminalRenderer('legacy');
+    expect(notifications).toBe(1); // no further notifications after unsubscribe
+  });
+
+  it('falls back to the default when localStorage access throws', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem() {
+          throw new Error('SecurityError: localStorage blocked');
+        },
+        setItem() {
+          throw new Error('SecurityError: localStorage blocked');
+        },
+        clear() {},
+      },
+    });
+
+    // getItem throws -> caught -> default.
+    expect(getTerminalRenderer()).toBe(DEFAULT_TERMINAL_RENDERER);
+
+    // setItem throws -> caught -> subscribers still notified (choice applies to
+    // this tab session even though it cannot persist).
+    let notified = false;
+    const unsubscribe = subscribeTerminalRenderer(() => {
+      notified = true;
+    });
+    expect(() => setTerminalRenderer('next')).not.toThrow();
+    expect(notified).toBe(true);
+    unsubscribe();
+  });
+});

--- a/packages/client/src/labs/terminal-poc/renderer-flag.ts
+++ b/packages/client/src/labs/terminal-poc/renderer-flag.ts
@@ -1,0 +1,65 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Per-browser terminal renderer selection (fallback flag for the labs-terminal
+ * swap, roadmap PR-4). `SessionPage` picks the production `Terminal` or the PoC
+ * `PocTerminalAdapter` from this value.
+ */
+export const TERMINAL_RENDERERS = ['legacy', 'next'] as const;
+export type TerminalRenderer = (typeof TERMINAL_RENDERERS)[number];
+
+/**
+ * Build-time fleet default. This is the ONE-LINE switch for the whole fleet:
+ * flip it to `'next'` to make the labs renderer the default for every browser
+ * that has not explicitly chosen one, and flip it back to `'legacy'` for the
+ * emergency revert (no data loss — the next renderer reconstructs all state from
+ * server history). A browser's explicit Settings choice overrides this default.
+ */
+export const DEFAULT_TERMINAL_RENDERER: TerminalRenderer = 'legacy';
+
+const STORAGE_KEY = 'terminal-renderer';
+
+// localStorage is not reactive within a tab, so the store notifies its own
+// subscribers on every write; useSyncExternalStore then re-reads the snapshot.
+const listeners = new Set<() => void>();
+
+function isTerminalRenderer(value: unknown): value is TerminalRenderer {
+  return value === 'legacy' || value === 'next';
+}
+
+export function getTerminalRenderer(): TerminalRenderer {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (isTerminalRenderer(stored)) return stored;
+  } catch {
+    // localStorage unavailable (privacy mode, sandboxed context): use the default.
+  }
+  return DEFAULT_TERMINAL_RENDERER;
+}
+
+export function setTerminalRenderer(value: TerminalRenderer): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    // Write blocked (privacy mode): still notify so the choice takes effect for
+    // this tab session, even though it will not persist across reloads.
+  }
+  for (const listener of listeners) listener();
+}
+
+export function subscribeTerminalRenderer(callback: () => void): () => void {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+export function useTerminalRenderer(): TerminalRenderer {
+  // getSnapshot returns a primitive string, so useSyncExternalStore's identity
+  // check is by value — no cached-snapshot dance needed.
+  return useSyncExternalStore(
+    subscribeTerminalRenderer,
+    getTerminalRenderer,
+    getTerminalRenderer,
+  );
+}

--- a/packages/client/src/routes/settings/index.tsx
+++ b/packages/client/src/routes/settings/index.tsx
@@ -11,6 +11,12 @@ import { ConfirmDialog } from '../../components/ui/confirm-dialog';
 import { ErrorDialog, useErrorDialog } from '../../components/ui/error-dialog';
 import { Spinner } from '../../components/ui/Spinner';
 import { useAppWsState } from '../../hooks/useAppWs';
+import {
+  TERMINAL_RENDERERS,
+  type TerminalRenderer,
+  useTerminalRenderer,
+  setTerminalRenderer,
+} from '../../labs/terminal-poc/renderer-flag';
 
 export const Route = createFileRoute('/settings/')({
   component: SettingsPage,
@@ -123,6 +129,9 @@ function SettingsPage() {
         </div>
       )}
 
+      {/* Labs */}
+      <LabsSection />
+
       {/* Delete Agent Confirmation */}
       <ConfirmDialog
         open={agentToDelete !== null}
@@ -139,6 +148,55 @@ function SettingsPage() {
         isLoading={unregisterMutation.isPending}
       />
       <ErrorDialog {...errorDialogProps} />
+    </div>
+  );
+}
+
+const RENDERER_LABELS: Record<TerminalRenderer, string> = {
+  legacy: 'legacy',
+  next: 'next (PoC)',
+};
+
+function LabsSection() {
+  const renderer = useTerminalRenderer();
+
+  return (
+    <div className="mt-10">
+      <h2 className="text-lg font-semibold mb-3">Labs</h2>
+      <div className="card">
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <div className="font-medium">Terminal renderer</div>
+            <p className="text-sm text-gray-500">
+              Per-browser setting. 'next' renders sessions with the labs terminal renderer.
+            </p>
+          </div>
+          <div
+            role="group"
+            aria-label="Terminal renderer"
+            className="flex shrink-0 overflow-hidden rounded-md border border-slate-600"
+          >
+            {TERMINAL_RENDERERS.map((value) => {
+              const selected = renderer === value;
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() => setTerminalRenderer(value)}
+                  className={`px-3 py-1.5 text-sm ${
+                    selected
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-slate-800 text-gray-300 hover:bg-slate-700'
+                  }`}
+                >
+                  {RENDERER_LABELS[value]}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Refs #940 (roadmap PR-4). Refs #722, #939.

First PR in the promotion chain that touches shared files — kept surgical: `SessionPage.tsx` gains one hook call + a pure `pickTerminalComponent` seam + one JSX tag change; `settings/index.tsx` gains a compact Labs section. Everything else is a new labs module (`renderer-flag.ts`) + tests.

## What

- **Per-browser renderer flag**: `localStorage['terminal-renderer'] = 'legacy' | 'next'`, exposed through a `useSyncExternalStore` module with a build-time default (`DEFAULT_TERMINAL_RENDERER = 'legacy'` — flipping the fleet default is the documented one-line follow-up; emergency revert is flipping it back, no data loss by design).
- **Settings → Labs → "Terminal renderer"** segmented toggle (legacy / next (PoC)).
- **SessionPage** renders `PocTerminalAdapter` when the flag is `next`; identical props, remount keys, and ErrorBoundary.

## Regression E2E executed (real UI, this dev machine)

| Check | Result |
|---|---|
| Settings toggle switches flag + persists | PASS |
| flag=next: real session page renders PoC renderer, no xterm in DOM, Claude Code visible | PASS |
| Typing in next mode reaches the PTY | PASS |
| **Cmd+V image paste → onFilesReceived → MessagePanel attachment** (first time this full path exists) | PASS — file appears in MessagePanel; labs toast correctly absent |
| Session deleted while next-mode page open | PASS — standard "Session Not Found" screen, no crash |
| flag=legacy: xterm returns | PASS |
| Unit/full suite | labs 115 / client 1670 / server 2998 / 0 fail; typecheck 0; preflight 0 |

## Remaining before the default flip (bake gate — NOT blocking this merge)

- Real-device mobile: touch/IME/soft keyboard, and image paste via the browser path (Ctrl+V is Claude Code's own host-clipboard hotkey and will not work remotely — details in #940 comments).
- Sustained-throughput and multi-hour session profiling (see the objective evaluation posted in #940).
- Worker-level `WorkerErrorRecovery` surfaces during bake (SESSION_DELETED already lands on the page-level screen, same as legacy).

The objective legacy-vs-PoC evaluation requested by the owner is recorded in #940 comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGB7PwWjbes5ZJBCmMJNMm
