### PR TITLE
fix(client): add Settings link to desktop nav and mobile menu

### DIFF
--- a/packages/client/src/components/header/MobileNavMenu.tsx
+++ b/packages/client/src/components/header/MobileNavMenu.tsx
@@ -6,7 +6,7 @@ interface MobileNavMenuProps {
   onClose: () => void;
 }
 
-/** Mobile navigation dropdown for Jobs, Agents, and Repositories links. */
+/** Mobile navigation dropdown for Jobs, Agents, Repositories, and Settings links. */
 export function MobileNavMenu({ open, onClose }: MobileNavMenuProps) {
   const location = useLocation();
 
@@ -52,6 +52,13 @@ export function MobileNavMenu({ open, onClose }: MobileNavMenuProps) {
           onClick={onClose}
         >
           Repositories
+        </NavMenuItem>
+        <NavMenuItem
+          to="/settings"
+          active={isExact('/settings')}
+          onClick={onClose}
+        >
+          Settings
         </NavMenuItem>
       </nav>
     </>

--- a/packages/client/src/components/header/NavLinks.tsx
+++ b/packages/client/src/components/header/NavLinks.tsx
@@ -58,6 +58,24 @@ export function RepositoriesNavLink() {
   );
 }
 
+export function SettingsNavLink() {
+  const location = useLocation();
+  // Exact match: the Repositories link lives at /settings/repositories, so a
+  // startsWith('/settings') here would double-highlight both links on that path.
+  const isActive = location.pathname === '/settings';
+
+  return (
+    <Link
+      to="/settings"
+      className={`text-sm py-1 px-2 rounded no-underline ${
+        isActive ? 'text-white bg-white/10' : 'text-slate-400'
+      }`}
+    >
+      Settings
+    </Link>
+  );
+}
+
 export function ReviewNavLink() {
   const location = useLocation();
   const queryClient = useQueryClient();

--- a/packages/client/src/components/header/__tests__/MobileNavMenu.test.tsx
+++ b/packages/client/src/components/header/__tests__/MobileNavMenu.test.tsx
@@ -14,6 +14,9 @@ describe('MobileNavMenu', () => {
       expect(screen.getByText('Jobs')).toBeTruthy();
       expect(screen.getByText('Agents')).toBeTruthy();
       expect(screen.getByText('Repositories')).toBeTruthy();
+      const settings = screen.getByText('Settings');
+      expect(settings).toBeTruthy();
+      expect(settings.closest('a')!.getAttribute('href')).toBe('/settings');
     });
 
     it('should not render when closed', async () => {
@@ -21,6 +24,20 @@ describe('MobileNavMenu', () => {
       expect(screen.queryByText('Jobs')).toBeNull();
       expect(screen.queryByText('Agents')).toBeNull();
       expect(screen.queryByText('Repositories')).toBeNull();
+      expect(screen.queryByText('Settings')).toBeNull();
+    });
+
+    it('should mark Settings active only on the exact /settings path, not /settings/repositories', async () => {
+      await renderWithRouter(<MobileNavMenu open={true} onClose={() => {}} />, '/settings/repositories');
+      // On /settings/repositories, Repositories is active and Settings is not
+      // (guards against startsWith double-highlighting both).
+      expect(screen.getByText('Repositories').className).toContain('bg-white/10');
+      expect(screen.getByText('Settings').className).not.toContain('bg-white/10');
+
+      cleanup();
+
+      await renderWithRouter(<MobileNavMenu open={true} onClose={() => {}} />, '/settings');
+      expect(screen.getByText('Settings').className).toContain('bg-white/10');
     });
 
     it('should have Main navigation aria-label', async () => {

--- a/packages/client/src/components/header/__tests__/NavLinks.test.tsx
+++ b/packages/client/src/components/header/__tests__/NavLinks.test.tsx
@@ -7,6 +7,7 @@ import {
   JobsNavLink,
   AgentsNavLink,
   RepositoriesNavLink,
+  SettingsNavLink,
   ReviewNavLink,
   LogoutButton,
   ValidationWarningIndicator,
@@ -128,6 +129,29 @@ describe('RepositoriesNavLink', () => {
     await renderWithRouter(<RepositoriesNavLink />, '/settings/other');
     const link = screen.getByText('Repositories');
     expect(link.className).toContain('text-slate-400');
+  });
+});
+
+describe('SettingsNavLink', () => {
+  it('should render a link with text "Settings"', async () => {
+    await renderWithRouter(<SettingsNavLink />);
+    const link = screen.getByText('Settings');
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBe('/settings');
+  });
+
+  it('should have active styling on exact /settings path', async () => {
+    await renderWithRouter(<SettingsNavLink />, '/settings');
+    const link = screen.getByText('Settings');
+    expect(link.className).toContain('text-white');
+    expect(link.className).toContain('bg-white/10');
+  });
+
+  it('should NOT be active on /settings/repositories (no double-highlight)', async () => {
+    await renderWithRouter(<SettingsNavLink />, '/settings/repositories');
+    const link = screen.getByText('Settings');
+    expect(link.className).toContain('text-slate-400');
+    expect(link.className).not.toContain('bg-white/10');
   });
 });
 

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -4,7 +4,7 @@ import { resumeSession } from '../lib/api';
 import { ChevronRightIcon, PlusIcon } from '../components/Icons';
 import { QuickWorktreeDialog } from '../components/worktrees';
 import { MobileHeaderControls } from '../components/header/MobileHeaderControls';
-import { JobsNavLink, AgentsNavLink, RepositoriesNavLink, ReviewNavLink, LogoutButton, ValidationWarningIndicator } from '../components/header/NavLinks';
+import { JobsNavLink, AgentsNavLink, RepositoriesNavLink, SettingsNavLink, ReviewNavLink, LogoutButton, ValidationWarningIndicator } from '../components/header/NavLinks';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { ConnectionBanner } from '../components/ui/ConnectionBanner';
 import { WebhookConfigBanner } from '../components/ui/WebhookConfigBanner';
@@ -213,6 +213,7 @@ function RootLayout() {
               <JobsNavLink />
               <AgentsNavLink />
               <RepositoriesNavLink />
+              <SettingsNavLink />
               {isMultiUser && <LogoutButton />}
             </nav>
 


### PR DESCRIPTION
Refs #940 (found while enabling the renderer flag).

## What

The settings root page `/settings` (agent registration + the Labs "Terminal renderer" toggle from #956) had no inbound link anywhere in the UI — the header nav linked to `/agents`, `/jobs`, `/review`, `/maintenance`, and `/settings/repositories` only. Owner had to type the URL to reach the renderer toggle.

Adds a **Settings** link to the desktop header nav and the mobile menu, next to Repositories.

## Detail worth reviewing

Active-state uses **exact match** (`pathname === '/settings'` / the menu's `isExact` helper), not `startsWith` — otherwise both Settings and Repositories would highlight on `/settings/repositories`. Regression tests pin exactly this in both `NavLinks.test.tsx` and `MobileNavMenu.test.tsx` (polarity-verified: switching to `startsWith` fails exactly those two tests).

## Verification

- Browser (dev server): on `/settings/repositories` → only Repositories highlighted; on `/settings` → only Settings highlighted; link present in both desktop nav and mobile menu.
- Header tests 33 pass; full suite `env -u SSH_AUTH_SOCK bun run test` → client 1676 / integration 30 / server 2998 / scripts 411, 0 fail; typecheck 0; preflight 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGB7PwWjbes5ZJBCmMJNMm
