### PR TITLE
feat(labs): show terminal soft-key bar only on mobile viewports

### DIFF
--- a/packages/client/src/labs/terminal-poc/PocKeyboardInput.tsx
+++ b/packages/client/src/labs/terminal-poc/PocKeyboardInput.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useRef, useState } from 'react';
 import type { KeyboardEvent, CompositionEvent, FormEvent, ClipboardEvent } from 'react';
 import type { PocTerminalInstance } from './poc-terminal-store';
 import { extractImageFiles } from './image-paste';
+import { useIsMobile } from '../../hooks/useIsMobile';
 
 interface PocKeyboardInputProps {
   instance: PocTerminalInstance;
@@ -33,6 +34,10 @@ export const PocKeyboardInput = forwardRef<HTMLTextAreaElement, PocKeyboardInput
   function PocKeyboardInput({ instance, onFilesReceived }, ref) {
     const composingRef = useRef(false);
     const [composeText, setComposeText] = useState('');
+    // The soft-key bar only helps on touch devices without a physical keyboard;
+    // on desktop it wastes space. The hidden textarea + IME + key handling below
+    // stay active on both — desktop still needs the input path.
+    const isMobile = useIsMobile();
 
     const send = (data: string) => instance.sendInput(data);
 
@@ -134,7 +139,9 @@ export const PocKeyboardInput = forwardRef<HTMLTextAreaElement, PocKeyboardInput
           style={{ width: 1, height: 1, left: 0, top: 0, resize: 'none', border: 'none', padding: 0 }}
         />
 
-        <SoftKeyBar onKey={send} />
+        {/* Mobile only. The border/padding live on the bar itself, so omitting
+            it on desktop leaves no stray divider. */}
+        {isMobile && <SoftKeyBar onKey={send} />}
       </>
     );
   },

--- a/packages/client/src/labs/terminal-poc/__tests__/PocKeyboardInput.test.tsx
+++ b/packages/client/src/labs/terminal-poc/__tests__/PocKeyboardInput.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { render, screen, cleanup } from '@testing-library/react';
+import { PocKeyboardInput } from '../PocKeyboardInput';
+import type { PocTerminalInstance, PocSnapshot } from '../poc-terminal-store';
+
+// matchMedia mock following src/hooks/__tests__/useIsMobile.test.ts.
+function installMatchMedia(matches: boolean): void {
+  const mql = {
+    matches,
+    addEventListener: mock(() => {}),
+    removeEventListener: mock(() => {}),
+  };
+  window.matchMedia = mock(() => mql as unknown as MediaQueryList);
+}
+
+const SNAPSHOT_STUB: PocSnapshot = {
+  version: 0,
+  status: 'connecting',
+  exitInfo: null,
+  rows: [],
+  cursor: { x: 0, y: 0, visible: true },
+  cols: 80,
+  terminalRows: 24,
+  bufferType: 'normal',
+  mouseTracking: false,
+  notice: null,
+  workerError: null,
+  activityState: null,
+  loadingHistory: false,
+};
+
+// Render-only stub: PocKeyboardInput never subscribes or reads the snapshot
+// during render; the methods exist only to satisfy the interface.
+function makeMockInstance(): PocTerminalInstance {
+  return {
+    subscribe: () => () => {},
+    getSnapshot: () => SNAPSHOT_STUB,
+    sendInput: () => {},
+    resize: () => {},
+    forwardScroll: () => {},
+    reportMouseButton: () => {},
+    paste: () => {},
+    retry: () => {},
+    dismissNotice: () => {},
+    acquire: () => () => {},
+    dispose: () => {},
+  };
+}
+
+describe('PocKeyboardInput soft-key bar visibility', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    cleanup();
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('renders the soft-key bar on mobile', () => {
+    installMatchMedia(true);
+    render(<PocKeyboardInput instance={makeMockInstance()} />);
+
+    expect(screen.getByText('Esc')).toBeTruthy();
+    expect(screen.getByText('Ctrl+C')).toBeTruthy();
+    // The hidden input path is present on mobile too.
+    expect(screen.getByLabelText('Terminal input')).toBeTruthy();
+  });
+
+  it('hides the soft-key bar on desktop but keeps the hidden input', () => {
+    installMatchMedia(false);
+    render(<PocKeyboardInput instance={makeMockInstance()} />);
+
+    // No soft keys on desktop.
+    expect(screen.queryByText('Esc')).toBeNull();
+    expect(screen.queryByText('Ctrl+C')).toBeNull();
+    // Input path must remain active so a physical keyboard still works.
+    expect(screen.getByLabelText('Terminal input')).toBeTruthy();
+  });
+});

--- a/packages/client/src/labs/terminal-poc/__tests__/PocKeyboardInput.test.tsx
+++ b/packages/client/src/labs/terminal-poc/__tests__/PocKeyboardInput.test.tsx
@@ -3,14 +3,24 @@ import { render, screen, cleanup } from '@testing-library/react';
 import { PocKeyboardInput } from '../PocKeyboardInput';
 import type { PocTerminalInstance, PocSnapshot } from '../poc-terminal-store';
 
-// matchMedia mock following src/hooks/__tests__/useIsMobile.test.ts.
-function installMatchMedia(matches: boolean): void {
-  const mql = {
+// Fully-typed MediaQueryList stub (no double-cast). The soft-key gate only reads
+// `.matches`; the rest of the interface is inert so useIsMobile's subscribe path
+// is a no-op under test.
+function createMatchMediaList(matches: boolean): MediaQueryList {
+  return {
     matches,
-    addEventListener: mock(() => {}),
-    removeEventListener: mock(() => {}),
+    media: '(max-width: 767px)',
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
   };
-  window.matchMedia = mock(() => mql as unknown as MediaQueryList);
+}
+
+function installMatchMedia(matches: boolean): void {
+  window.matchMedia = mock((_query: string) => createMatchMediaList(matches));
 }
 
 const SNAPSHOT_STUB: PocSnapshot = {


### PR DESCRIPTION
Refs #940 (bake-period dogfood feedback).

## What

The next renderer's soft-key bar (Esc / Tab / Ctrl+C / arrows / Enter) now renders **only on mobile viewports** (`useIsMobile()`, the app-convention matchMedia `< 768px` hook). On desktop it wasted vertical space — a physical keyboard covers all those keys.

- Single gate inside `PocKeyboardInput`, so the labs route and the production adapter both inherit it.
- The hidden-textarea input path (typing, IME composition, key→escape-sequence handling) is untouched and stays active on all viewports.
- matchMedia subscription = the bar appears/disappears live on window resize, no reload.
- No leftover border/padding when absent (the bar owns its own border/padding).

## Verification

- Browser QA (dev server): desktop 1200px → 0 soft-key buttons, typing echoes to the shell; mobile emulate 390px → bar present; transition happens live on viewport change.
- New regression tests (2): bar on mobile / hidden on desktop with input still present. Polarity-verified (removing the gate fails the desktop test).
- Full suite `env -u SSH_AUTH_SOCK bun run test`: client 1678 / integration 30 / server 2998 / scripts 411 — 0 fail. typecheck 0, preflight 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGB7PwWjbes5ZJBCmMJNMm
