### PR TITLE
fix(client): route MessagePanel Escape through the terminal store (closes #961)

### DIFF
--- a/packages/client/src/components/sessions/MessagePanel.tsx
+++ b/packages/client/src/components/sessions/MessagePanel.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { WorkerMessage, SkillDefinition } from '@agent-console/shared';
 import { MAX_MESSAGE_FILES, MAX_TOTAL_FILE_SIZE } from '@agent-console/shared';
 import { sendWorkerMessage, fetchSkills } from '../../lib/api';
-import { sendInput as sendPtyInput } from '../../lib/worker-websocket';
+import { getOrCreatePocTerminal } from '../../labs/terminal-poc/poc-terminal-store';
 import { useDraftMessage } from '../../hooks/useDraftMessage';
 import { useMessageTemplates } from '../../hooks/useMessageTemplates';
 import { skillKeys } from '../../lib/query-keys';
@@ -189,7 +189,11 @@ export const MessagePanel = forwardRef<MessagePanelHandle, MessagePanelProps>(
 
     if (e.key === 'Escape') {
       e.preventDefault();
-      sendPtyInput(sessionId, targetWorkerId, '\x1b');
+      // Route ESC through the next renderer's terminal store (issue #961). The
+      // legacy worker-websocket transport was orphaned by #941, so its sendInput
+      // was a silent no-op. MessagePanel only renders inside an open session
+      // page where the instance already exists; getOrCreatePocTerminal returns it.
+      getOrCreatePocTerminal(sessionId, targetWorkerId).sendInput('\x1b');
     }
   }, [handleSend, sessionId, targetWorkerId, showCompletion, templateSelectorOpen, filteredCommands, clampedIndex, selectCommand]);
 

--- a/packages/client/src/components/sessions/__tests__/MessagePanel.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/MessagePanel.test.tsx
@@ -38,9 +38,15 @@ mock.module('../../../lib/api', () => ({
   reorderMessageTemplates: mockReorderMessageTemplates,
 }));
 
-const mockSendInput = mock(() => true);
-mock.module('../../../lib/worker-websocket', () => ({
+// ESC routes through the next renderer's terminal store (issue #961). Mock the
+// store's factory so the Escape handler resolves to a spyable instance without
+// opening a real WebSocket.
+const mockSendInput = mock((_data: string) => {});
+const mockGetOrCreatePocTerminal = mock((_sessionId: string, _workerId: string) => ({
   sendInput: mockSendInput,
+}));
+mock.module('../../../labs/terminal-poc/poc-terminal-store', () => ({
+  getOrCreatePocTerminal: mockGetOrCreatePocTerminal,
 }));
 
 import { fireEvent, cleanup, act, within } from '@testing-library/react';
@@ -150,6 +156,7 @@ describe('MessagePanel', () => {
     mockSendWorkerMessage.mockClear();
     mockFetchSkills.mockClear();
     mockSendInput.mockClear();
+    mockGetOrCreatePocTerminal.mockClear();
     mockFetchMessageTemplates.mockClear();
     mockCreateMessageTemplate.mockClear();
     mockUpdateMessageTemplate.mockClear();
@@ -379,7 +386,7 @@ describe('MessagePanel', () => {
     expect((textarea3 as HTMLTextAreaElement).value).toBe('draft for agent-1');
   });
 
-  it('ESC key sends escape character to PTY via WebSocket', async () => {
+  it('ESC key sends escape through the terminal store for this session/worker', async () => {
     const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
     const view = within(container);
 
@@ -388,7 +395,11 @@ describe('MessagePanel', () => {
       fireEvent.keyDown(textarea, { key: 'Escape' });
     });
 
-    expect(mockSendInput).toHaveBeenCalledWith('session-1', 'agent-1', '\x1b');
+    // Resolves the store instance for THIS session/worker, then sends the ESC
+    // byte through it. Polarity: reverting to worker-websocket.sendInput leaves
+    // both spies untouched (the real transport is a no-op with no connection).
+    expect(mockGetOrCreatePocTerminal).toHaveBeenCalledWith('session-1', 'agent-1');
+    expect(mockSendInput).toHaveBeenCalledWith('\x1b');
   });
 
   it('ESC key preserves draft content in textarea', async () => {
@@ -404,7 +415,7 @@ describe('MessagePanel', () => {
     });
 
     expect((textarea as HTMLTextAreaElement).value).toBe('my draft');
-    expect(mockSendInput).toHaveBeenCalledWith('session-1', 'agent-1', '\x1b');
+    expect(mockSendInput).toHaveBeenCalledWith('\x1b');
   });
 
   it('ESC key does not trigger HTTP message send', async () => {

--- a/packages/client/src/lib/__tests__/worker-websocket.test.ts
+++ b/packages/client/src/lib/__tests__/worker-websocket.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
-import { WS_CLOSE_CODE } from '@agent-console/shared';
+import { WS_CLOSE_CODE, type GitDiffData } from '@agent-console/shared';
 import { MockWebSocket, installMockWebSocket } from '../../test/mock-websocket';
 import {
   connect,
@@ -8,7 +8,7 @@ import {
   getState,
   subscribeState,
   _reset,
-  type TerminalWorkerCallbacks,
+  type GitDiffWorkerCallbacks,
 } from '../worker-websocket';
 
 describe('worker-websocket', () => {
@@ -45,103 +45,17 @@ describe('worker-websocket', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  const createTerminalCallbacks = (): TerminalWorkerCallbacks => ({
-    type: 'terminal',
-    onOutput: mock(() => {}),
-    onHistory: mock(() => {}),
-    onExit: mock(() => {}),
-    onActivity: mock(() => {}),
-    onError: mock(() => {}),
-  });
-
-  // DISABLED: Visibility-based reconnection is currently disabled to avoid performance overhead.
-  // The event listener registration in worker-websocket.ts is commented out.
-  // These tests are skipped until the feature is re-enabled.
-  describe.skip('visibility-based reconnection', () => {
-    let originalVisibilityState: PropertyDescriptor | undefined;
-
-    beforeEach(() => {
-      // Store original visibilityState descriptor
-      originalVisibilityState = Object.getOwnPropertyDescriptor(document, 'visibilityState');
-    });
-
-    afterEach(() => {
-      // Restore original visibilityState
-      if (originalVisibilityState) {
-        Object.defineProperty(document, 'visibilityState', originalVisibilityState);
-      } else {
-        // If there was no original descriptor, delete it to restore default behavior
-        // We need to reset to 'visible' state
-        Object.defineProperty(document, 'visibilityState', {
-          configurable: true,
-          get: () => 'visible',
-        });
-      }
-    });
-
-    function setVisibilityState(state: 'visible' | 'hidden') {
-      Object.defineProperty(document, 'visibilityState', {
-        configurable: true,
-        get: () => state,
-      });
-    }
-
-    function dispatchVisibilityChange() {
-      document.dispatchEvent(new Event('visibilitychange'));
-    }
-
-    it('should disconnect when page becomes hidden', () => {
-      const callbacks = createTerminalCallbacks();
-      connect('session-1', 'worker-1', callbacks);
-
-      const ws = MockWebSocket.getLastInstance();
-      ws?.simulateOpen();
-
-      // Verify connected
-      expect(ws?.readyState).toBe(MockWebSocket.OPEN);
-
-      // Simulate page becoming hidden
-      setVisibilityState('hidden');
-      dispatchVisibilityChange();
-
-      // Verify WebSocket was closed
-      expect(ws?.close).toHaveBeenCalled();
-    });
-
-    it('should reconnect without fromOffset when page becomes visible (always fetch full history)', () => {
-      const callbacks = createTerminalCallbacks();
-      connect('session-1', 'worker-1', callbacks);
-
-      const ws1 = MockWebSocket.getLastInstance();
-      ws1?.simulateOpen();
-
-      // Receive history with offset
-      ws1?.simulateMessage(JSON.stringify({ type: 'history', data: 'terminal history', offset: 5678 }));
-
-      // Simulate page becoming hidden
-      setVisibilityState('hidden');
-      dispatchVisibilityChange();
-
-      // Clear instances to track new WebSocket creation
-      const instanceCountBeforeVisible = MockWebSocket.getInstances().length;
-
-      // Simulate page becoming visible
-      setVisibilityState('visible');
-      dispatchVisibilityChange();
-
-      // Verify new WebSocket was created
-      const instances = MockWebSocket.getInstances();
-      expect(instances.length).toBe(instanceCountBeforeVisible + 1);
-
-      // Verify new WebSocket URL does NOT contain fromOffset (always fetch full history)
-      const ws2 = MockWebSocket.getLastInstance();
-      expect(ws2?.url).not.toContain('fromOffset');
-    });
+  // git-diff is the only worker type routed through this module (terminal/agent
+  // PTY transport moved to poc-terminal-store; see issues #941 / #961).
+  const createGitDiffCallbacks = (): GitDiffWorkerCallbacks => ({
+    type: 'git-diff',
+    onDiffData: mock(() => {}),
+    onDiffError: mock(() => {}),
   });
 
   describe('disconnectSession', () => {
     it('should disconnect all workers in the session', () => {
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
 
       // Connect two workers in the same session
       connect('session-1', 'worker-1', callbacks);
@@ -161,7 +75,7 @@ describe('worker-websocket', () => {
     });
 
     it('should not affect workers in other sessions', () => {
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
 
       // Connect workers in different sessions
       connect('session-1', 'worker-1', callbacks);
@@ -182,190 +96,56 @@ describe('worker-websocket', () => {
     });
   });
 
-  describe('history message handling', () => {
-    it('should call onHistory callback with data and offset', () => {
-      const callbacks = createTerminalCallbacks();
+  describe('git-diff message handling', () => {
+    it('updates state and calls onDiffError for a diff-error message', () => {
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
 
       const ws = MockWebSocket.getLastInstance();
       ws?.simulateOpen();
 
-      // Send history message with offset
-      ws?.simulateMessage(JSON.stringify({ type: 'history', data: 'terminal history', offset: 5678 }));
+      ws?.simulateMessage(JSON.stringify({ type: 'diff-error', error: 'bad diff' }));
 
-      expect(callbacks.onHistory).toHaveBeenCalledWith('terminal history', 5678);
-    });
-  });
-
-  describe('output message handling', () => {
-    it('should call onOutput callback with data and offset', () => {
-      const callbacks = createTerminalCallbacks();
-      connect('session-1', 'worker-1', callbacks);
-
-      const ws = MockWebSocket.getLastInstance();
-      ws?.simulateOpen();
-
-      // Send output message with offset
-      ws?.simulateMessage(JSON.stringify({ type: 'output', data: 'terminal output', offset: 1234 }));
-
-      expect(callbacks.onOutput).toHaveBeenCalledWith('terminal output', 1234);
-    });
-  });
-
-  describe('error message handling', () => {
-    it('should call onError callback with HISTORY_LOAD_FAILED code', () => {
-      const callbacks = createTerminalCallbacks();
-      connect('session-1', 'worker-1', callbacks);
-
-      const ws = MockWebSocket.getLastInstance();
-      ws?.simulateOpen();
-
-      // Send error message with HISTORY_LOAD_FAILED code
-      ws?.simulateMessage(JSON.stringify({
-        type: 'error',
-        message: 'Loading terminal history timed out. Try refreshing the page.',
-        code: 'HISTORY_LOAD_FAILED'
-      }));
-
-      expect(callbacks.onError).toHaveBeenCalledWith(
-        'Loading terminal history timed out. Try refreshing the page.',
-        'HISTORY_LOAD_FAILED'
-      );
+      expect(getState('session-1', 'worker-1').diffError).toBe('bad diff');
+      expect(callbacks.onDiffError).toHaveBeenCalledWith('bad diff');
     });
 
-    it('should call onError callback without code when code is missing', () => {
-      const callbacks = createTerminalCallbacks();
+    it('updates state and calls onDiffData for a diff-data message', () => {
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
 
       const ws = MockWebSocket.getLastInstance();
       ws?.simulateOpen();
 
-      // Send error message without code
-      ws?.simulateMessage(JSON.stringify({
-        type: 'error',
-        message: 'Some error occurred'
-      }));
+      const diffData: GitDiffData = {
+        summary: {
+          baseCommit: 'abc123',
+          targetRef: 'working-dir',
+          files: [],
+          totalAdditions: 0,
+          totalDeletions: 0,
+          updatedAt: '2026-07-03T00:00:00.000Z',
+        },
+        rawDiff: '',
+      };
+      ws?.simulateMessage(JSON.stringify({ type: 'diff-data', data: diffData }));
 
-      expect(callbacks.onError).toHaveBeenCalledWith(
-        'Some error occurred',
-        undefined
-      );
+      expect(getState('session-1', 'worker-1').diffData).toEqual(diffData);
+      expect(getState('session-1', 'worker-1').diffLoading).toBe(false);
+      expect(callbacks.onDiffData).toHaveBeenCalledWith(diffData);
     });
 
-    it('should call onError callback with other error codes', () => {
-      const callbacks = createTerminalCallbacks();
+    it('sets an error state for an unrecognized message type', () => {
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
 
       const ws = MockWebSocket.getLastInstance();
       ws?.simulateOpen();
 
-      // Send error message with WORKER_NOT_FOUND code
-      ws?.simulateMessage(JSON.stringify({
-        type: 'error',
-        message: 'Worker not found',
-        code: 'WORKER_NOT_FOUND'
-      }));
+      ws?.simulateMessage(JSON.stringify({ type: 'not-a-real-type' }));
 
-      expect(callbacks.onError).toHaveBeenCalledWith(
-        'Worker not found',
-        'WORKER_NOT_FOUND'
-      );
-    });
-
-    it('should remove connection from map on SESSION_PAUSED error to prevent reconnection', () => {
-      const callbacks = createTerminalCallbacks();
-      connect('session-1', 'worker-1', callbacks);
-
-      const ws = MockWebSocket.getLastInstance();
-      ws?.simulateOpen();
-
-      // Verify connection exists
-      expect(getState('session-1', 'worker-1').connected).toBe(true);
-
-      // Send SESSION_PAUSED error
-      ws?.simulateMessage(JSON.stringify({
-        type: 'error',
-        message: 'Session was paused',
-        code: 'SESSION_PAUSED'
-      }));
-
-      // Connection should be removed from the map
-      // (getState returns the default disconnected state when no connection exists)
-      const state = getState('session-1', 'worker-1');
-      expect(state.connected).toBe(false);
-
-      // Subsequent close event should NOT trigger reconnection
-      ws?.simulateClose(WS_CLOSE_CODE.ABNORMAL_CLOSURE);
-
-      // Verify no reconnection was scheduled
-      const reconnectLogged = consoleLogSpy.mock.calls.some((call: unknown[]) =>
-        call.some((arg: unknown) => typeof arg === 'string' && arg.includes('Reconnecting session-'))
-      );
-      expect(reconnectLogged).toBe(false);
-    });
-
-    it('should remove connection from map on SESSION_DELETED error to prevent reconnection', () => {
-      const callbacks = createTerminalCallbacks();
-      connect('session-1', 'worker-1', callbacks);
-
-      const ws = MockWebSocket.getLastInstance();
-      ws?.simulateOpen();
-
-      // Send SESSION_DELETED error
-      ws?.simulateMessage(JSON.stringify({
-        type: 'error',
-        message: 'Session was deleted',
-        code: 'SESSION_DELETED'
-      }));
-
-      // Connection should be removed from the map
-      const state = getState('session-1', 'worker-1');
-      expect(state.connected).toBe(false);
-
-      // Subsequent close event should NOT trigger reconnection
-      ws?.simulateClose(WS_CLOSE_CODE.ABNORMAL_CLOSURE);
-
-      const reconnectLogged = consoleLogSpy.mock.calls.some((call: unknown[]) =>
-        call.some((arg: unknown) => typeof arg === 'string' && arg.includes('Reconnecting session-'))
-      );
-      expect(reconnectLogged).toBe(false);
-    });
-
-    it('should not remove connection from map for non-lifecycle error codes', () => {
-      const callbacks = createTerminalCallbacks();
-      connect('session-1', 'worker-1', callbacks);
-
-      const ws = MockWebSocket.getLastInstance();
-      ws?.simulateOpen();
-
-      // Send a non-lifecycle error (e.g., HISTORY_LOAD_FAILED)
-      ws?.simulateMessage(JSON.stringify({
-        type: 'error',
-        message: 'History load failed',
-        code: 'HISTORY_LOAD_FAILED'
-      }));
-
-      // Connection should still exist
-      expect(getState('session-1', 'worker-1').connected).toBe(true);
-    });
-  });
-
-  describe('server-restarted message handling', () => {
-    it('should handle server-restarted message without errors', () => {
-      const callbacks = createTerminalCallbacks();
-      connect('session-1', 'worker-1', callbacks);
-
-      const ws = MockWebSocket.getLastInstance();
-      ws?.simulateOpen();
-
-      // Send server-restarted message - should not throw
-      ws?.simulateMessage(JSON.stringify({ type: 'server-restarted', serverPid: 12345 }));
-
-      // Verify the message was logged (debug level)
-      const serverRestartLogged = consoleLogSpy.mock.calls.some((call: unknown[]) =>
-        call.some((arg: unknown) => typeof arg === 'string' && arg.includes('Server restarted notification received'))
-      );
-      expect(serverRestartLogged).toBe(true);
+      expect(getState('session-1', 'worker-1').diffError).toBe('Invalid server message');
+      expect(getState('session-1', 'worker-1').diffLoading).toBe(false);
     });
   });
 
@@ -378,7 +158,7 @@ describe('worker-websocket', () => {
     }
 
     it('should not reconnect on NORMAL_CLOSURE (1000)', () => {
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
 
       const ws = MockWebSocket.getLastInstance();
@@ -390,7 +170,7 @@ describe('worker-websocket', () => {
     });
 
     it('should not reconnect on GOING_AWAY (1001)', () => {
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
 
       const ws = MockWebSocket.getLastInstance();
@@ -402,7 +182,7 @@ describe('worker-websocket', () => {
     });
 
     it('should not reconnect on POLICY_VIOLATION (1008)', () => {
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
 
       const ws = MockWebSocket.getLastInstance();
@@ -414,7 +194,7 @@ describe('worker-websocket', () => {
     });
 
     it('should reconnect on ABNORMAL_CLOSURE (1006)', () => {
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
 
       const ws = MockWebSocket.getLastInstance();
@@ -426,7 +206,7 @@ describe('worker-websocket', () => {
     });
 
     it('should reconnect on INTERNAL_ERROR (1011)', () => {
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
 
       const ws = MockWebSocket.getLastInstance();
@@ -441,7 +221,7 @@ describe('worker-websocket', () => {
   describe('exponential backoff', () => {
     it('should use exponential backoff delays', () => {
       const setTimeoutSpy = spyOn(globalThis, 'setTimeout');
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
 
       connect('session-1', 'worker-1', callbacks);
       const ws = MockWebSocket.getLastInstance();
@@ -482,7 +262,7 @@ describe('worker-websocket', () => {
       // With random=0.5, jitter=0, so delay = baseDelay exactly
       const mathRandomSpy = spyOn(Math, 'random').mockReturnValue(0.5);
 
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
       const ws = MockWebSocket.getLastInstance();
       ws?.simulateOpen();
@@ -514,7 +294,7 @@ describe('worker-websocket', () => {
 
     it('should add jitter to prevent thundering herd', () => {
       const setTimeoutSpy = spyOn(globalThis, 'setTimeout');
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
 
       // Test with random=0 (minimum jitter: baseDelay * 0.3 * (0*2 - 1) = -0.3 * baseDelay)
       const mathRandomSpy = spyOn(Math, 'random').mockReturnValue(0);
@@ -558,7 +338,7 @@ describe('worker-websocket', () => {
     it('should reset retry count on successful reconnection', () => {
       const setTimeoutSpy = spyOn(globalThis, 'setTimeout');
       const mathRandomSpy = spyOn(Math, 'random').mockReturnValue(0.5);
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
 
       connect('session-1', 'worker-1', callbacks);
       const ws1 = MockWebSocket.getLastInstance();
@@ -602,7 +382,7 @@ describe('worker-websocket', () => {
       );
       const mathRandomSpy = spyOn(Math, 'random').mockReturnValue(0.5);
 
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
       const ws = MockWebSocket.getLastInstance();
       ws?.simulateOpen();
@@ -646,7 +426,7 @@ describe('worker-websocket', () => {
       );
       const mathRandomSpy = spyOn(Math, 'random').mockReturnValue(0.5);
 
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
       const ws = MockWebSocket.getLastInstance();
       ws?.simulateOpen();
@@ -680,7 +460,7 @@ describe('worker-websocket', () => {
 
     it('should cancel pending reconnection on explicit disconnect', () => {
       const clearTimeoutSpy = spyOn(globalThis, 'clearTimeout');
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
 
       connect('session-1', 'worker-1', callbacks);
       const ws = MockWebSocket.getLastInstance();
@@ -695,7 +475,7 @@ describe('worker-websocket', () => {
     });
 
     it('should not create duplicate connections on concurrent connect calls', () => {
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
 
       // Call connect multiple times with the same sessionId/workerId
       connect('session-1', 'worker-1', callbacks);
@@ -707,7 +487,7 @@ describe('worker-websocket', () => {
     });
 
     it('should not create duplicate connections when already connected', () => {
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
 
       connect('session-1', 'worker-1', callbacks);
       const ws = MockWebSocket.getLastInstance();
@@ -725,7 +505,7 @@ describe('worker-websocket', () => {
     it('should preserve retryCount during reconnection', () => {
       const setTimeoutSpy = spyOn(globalThis, 'setTimeout');
       const mathRandomSpy = spyOn(Math, 'random').mockReturnValue(0.5);
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
 
       connect('session-1', 'worker-1', callbacks);
       const ws1 = MockWebSocket.getLastInstance();
@@ -756,7 +536,7 @@ describe('worker-websocket', () => {
     });
 
     it('should not reconnect when connection was explicitly disconnected before close fires', () => {
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
       connect('session-1', 'worker-1', callbacks);
 
       const ws = MockWebSocket.getLastInstance();
@@ -777,7 +557,7 @@ describe('worker-websocket', () => {
     });
 
     it('should update connection state to disconnected on close', () => {
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
       const listener = mock(() => {});
       subscribeState(listener);
 
@@ -795,7 +575,7 @@ describe('worker-websocket', () => {
 
     it('should cancel pending reconnection when disconnectSession is called', () => {
       const clearTimeoutSpy = spyOn(globalThis, 'clearTimeout');
-      const callbacks = createTerminalCallbacks();
+      const callbacks = createGitDiffCallbacks();
 
       connect('session-1', 'worker-1', callbacks);
       connect('session-1', 'worker-2', callbacks);
@@ -817,76 +597,24 @@ describe('worker-websocket', () => {
     });
   });
 
-  describe('request-history message behavior', () => {
-    it('should NOT send request-history automatically on WebSocket connection', async () => {
-      // This test verifies that worker-websocket does NOT automatically send request-history.
-      // History requests are now the responsibility of Terminal.tsx, which decides
-      // the appropriate fromOffset based on cache state.
-      const callbacks = createTerminalCallbacks();
+  describe('connection open behavior', () => {
+    it('should NOT auto-send any client message on WebSocket open', async () => {
+      // git-diff connections request data on demand (refresh / set-base-commit),
+      // never automatically on open. Guards against a spurious auto-send regression.
+      const callbacks = createGitDiffCallbacks();
 
-      // Create a new connection
       connect('session-1', 'worker-1', callbacks);
 
       const ws = MockWebSocket.getLastInstance();
       expect(ws).toBeDefined();
 
-      // Simulate WebSocket connection opening
       ws?.simulateOpen();
 
       // Wait a bit to ensure no delayed request is sent
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
-      // request-history should NOT be sent automatically
       const calls = ws?.send.mock.calls as unknown as unknown[][];
-      const requestHistoryCalls = calls?.filter(
-        (call) => {
-          try {
-            const msg = JSON.parse(call[0] as string);
-            return msg.type === 'request-history';
-          } catch {
-            return false;
-          }
-        }
-      );
-      expect(requestHistoryCalls?.length ?? 0).toBe(0);
-    });
-
-    it('should NOT send request-history automatically on tab switch (remount with existing OPEN connection)', async () => {
-      // This test verifies that connect() does NOT automatically send request-history
-      // even when called with an existing OPEN connection (tab switch scenario).
-      const callbacks = createTerminalCallbacks();
-
-      // Create initial connection and establish it
-      connect('session-1', 'worker-1', callbacks);
-      const ws = MockWebSocket.getLastInstance();
-      ws?.simulateOpen();
-
-      // Wait for initial setup
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Clear the mock to track subsequent calls
-      ws?.send.mockClear();
-
-      // Simulate tab switch: connect() is called again with the existing OPEN connection
-      const newCallbacks = createTerminalCallbacks();
-      connect('session-1', 'worker-1', newCallbacks);
-
-      // Wait a bit to ensure no delayed request is sent
-      await new Promise((resolve) => setTimeout(resolve, 300));
-
-      // request-history should NOT be sent automatically
-      const calls = ws?.send.mock.calls as unknown as unknown[][];
-      const requestHistoryCalls = calls?.filter(
-        (call) => {
-          try {
-            const msg = JSON.parse(call[0] as string);
-            return msg.type === 'request-history';
-          } catch {
-            return false;
-          }
-        }
-      );
-      expect(requestHistoryCalls?.length ?? 0).toBe(0);
+      expect(calls?.length ?? 0).toBe(0);
     });
   });
 });

--- a/packages/client/src/lib/worker-websocket.ts
+++ b/packages/client/src/lib/worker-websocket.ts
@@ -1,7 +1,12 @@
 /**
  * Worker WebSocket manager module.
- * Manages WebSocket connections for individual workers (terminal, agent, git-diff).
+ * Manages WebSocket connections for git-diff workers.
  * Follows the same singleton pattern as app-websocket.ts.
+ *
+ * Terminal/agent PTY transport used to live here too, but the next renderer's
+ * poc-terminal-store owns its own WebSocket (issue #941 removed the legacy
+ * renderer; #961 removed the orphaned terminal transport). git-diff is the only
+ * worker type routed through this module now.
  *
  * Key design decisions:
  * - Each worker has its own WebSocket connection (different from app-websocket which is single)
@@ -10,17 +15,12 @@
  * - Automatically handles wss:// vs ws:// based on page protocol
  */
 import {
-  WORKER_SERVER_MESSAGE_TYPES,
   GIT_DIFF_SERVER_MESSAGE_TYPES,
   WS_CLOSE_CODE,
-  type WorkerServerMessage,
-  type WorkerClientMessage,
   type GitDiffServerMessage,
   type GitDiffClientMessage,
-  type AgentActivityState,
   type GitDiffData,
   type GitDiffTarget,
-  type WorkerErrorCode,
   type ExpandedLineChunk,
   type ReviewAnnotationSet,
 } from '@agent-console/shared';
@@ -29,17 +29,6 @@ import { getReconnectDelay, shouldReconnect } from './websocket-reconnect.js';
 import { logger } from './logger.js';
 
 const MAX_RETRY_COUNT = 100;
-
-/**
- * Validate that a parsed message is a valid WorkerServerMessage.
- */
-function isValidWorkerMessage(msg: unknown): msg is WorkerServerMessage {
-  if (typeof msg !== 'object' || msg === null) {
-    return false;
-  }
-  const { type } = msg as { type?: unknown };
-  return typeof type === 'string' && type in WORKER_SERVER_MESSAGE_TYPES;
-}
 
 /**
  * Validate that a parsed message is a valid GitDiffServerMessage.
@@ -75,25 +64,14 @@ interface WorkerConnection {
   workerId: string;
 }
 
-// Callbacks for terminal/agent workers
-export interface TerminalWorkerCallbacks {
-  type: 'terminal' | 'agent';
-  onOutput: (data: string, offset: number) => void;
-  onHistory: (data: string, offset: number) => void;
-  onExit: (exitCode: number, signal: string | null) => void;
-  onActivity?: (state: AgentActivityState) => void;
-  onError?: (message: string, code?: WorkerErrorCode) => void;
-  onOutputTruncated?: (message: string, newOffset: number) => void;
-}
-
-// Callbacks for git-diff workers
+// Callbacks for git-diff workers (the only worker type routed through this module).
 export interface GitDiffWorkerCallbacks {
   type: 'git-diff';
   onDiffData?: (data: GitDiffData) => void;
   onDiffError?: (error: string) => void;
 }
 
-type WorkerCallbacks = TerminalWorkerCallbacks | GitDiffWorkerCallbacks;
+type WorkerCallbacks = GitDiffWorkerCallbacks;
 
 // Connection storage
 const connections = new Map<string, WorkerConnection>();
@@ -188,7 +166,9 @@ function reconnect(sessionId: string, workerId: string, callbacks: WorkerCallbac
 
   const initialState: WorkerConnectionState = {
     connected: false,
-    ...(callbacks.type === 'git-diff' ? { diffData: null, diffError: null, diffLoading: true } : {}),
+    diffData: null,
+    diffError: null,
+    diffLoading: true,
   };
 
   const conn: WorkerConnection = {
@@ -204,71 +184,7 @@ function reconnect(sessionId: string, workerId: string, callbacks: WorkerCallbac
   // Notify subscribers that the connection state is now available.
   updateState(key, {});
 
-  setupWebSocketHandlers(key, ws, callbacks);
-}
-
-/**
- * Handle incoming WebSocket message for terminal/agent workers.
- */
-function handleTerminalMessage(
-  msg: WorkerServerMessage,
-  callbacks: TerminalWorkerCallbacks,
-  sessionId: string,
-  workerId: string
-): void {
-  const key = getConnectionKey(sessionId, workerId);
-
-  switch (msg.type) {
-    case 'output':
-      callbacks.onOutput(msg.data, msg.offset);
-      break;
-    case 'history':
-      callbacks.onHistory(msg.data, msg.offset);
-      break;
-    case 'exit':
-      callbacks.onExit(msg.exitCode, msg.signal);
-      break;
-    case 'activity':
-      callbacks.onActivity?.(msg.state);
-      break;
-    case 'error':
-      callbacks.onError?.(msg.message, msg.code);
-      // Prevent reconnection for terminal lifecycle errors.
-      // When a session is paused or deleted, the server sends an error message
-      // followed by a close frame. Remove the connection from the map BEFORE
-      // the close event fires so that the onclose handler sees no entry and
-      // skips reconnection scheduling.
-      if (msg.code === 'SESSION_DELETED' || msg.code === 'SESSION_PAUSED') {
-        const conn = connections.get(key);
-        if (conn) {
-          if (conn.retryTimeout) {
-            clearTimeout(conn.retryTimeout);
-            conn.retryTimeout = null;
-          }
-          connections.delete(key);
-        }
-      }
-      break;
-    case 'output-truncated':
-      // Notify the terminal renderer about the truncation; it resyncs from the
-      // new offset. (The old IndexedDB cache clear was removed with the legacy
-      // renderer — the next renderer holds no persistent cache.)
-      callbacks.onOutputTruncated?.(msg.message, msg.newOffset);
-      break;
-    case 'server-restarted':
-      // Server restart notification received on an active worker WebSocket.
-      // The next renderer reconstructs state from server history on reconnect;
-      // server-side offset-based truncation detection triggers a full-history
-      // resync if the offset is beyond the server's current range.
-      logger.debug('[WorkerWS] Server restarted notification received, serverPid:', msg.serverPid);
-      break;
-    default: {
-      // Exhaustive check: TypeScript will error if a new message type is added
-      // but not handled in this switch statement
-      const _exhaustive: never = msg;
-      logger.error('[WorkerWS] Unknown terminal message type:', _exhaustive);
-    }
-  }
+  setupWebSocketHandlers(key, ws);
 }
 
 /**
@@ -315,23 +231,18 @@ function handleGitDiffMessage(key: string, msg: GitDiffServerMessage, callbacks:
 }
 
 /**
- * Set up WebSocket event handlers.
+ * Set up WebSocket event handlers. The handlers read the current callbacks from
+ * the connection map (they may be swapped via connect() on remount), so no
+ * callbacks argument is threaded here.
  */
-function setupWebSocketHandlers(key: string, ws: WebSocket, callbacks: WorkerCallbacks): void {
+function setupWebSocketHandlers(key: string, ws: WebSocket): void {
   ws.onopen = () => {
     const conn = connections.get(key);
 
     if (conn) {
       conn.retryCount = 0; // Reset retry count on successful connection
     }
-    updateState(key, { connected: true });
-    if (callbacks.type === 'git-diff') {
-      updateState(key, { diffLoading: true });
-    }
-
-    // Note: History request is NOT sent automatically here.
-    // Terminal.tsx is responsible for requesting history with the appropriate fromOffset
-    // (either 0 for fresh load, or cached.offset for incremental sync after cache restoration).
+    updateState(key, { connected: true, diffLoading: true });
   };
 
   ws.onmessage = (event) => {
@@ -343,25 +254,15 @@ function setupWebSocketHandlers(key: string, ws: WebSocket, callbacks: WorkerCal
     try {
       const parsed: unknown = JSON.parse(event.data);
 
-      if (currentCallbacks.type === 'git-diff') {
-        if (!isValidGitDiffMessage(parsed)) {
-          logger.error('[WorkerWS] Invalid git-diff message type:', parsed);
-          updateState(key, { diffError: 'Invalid server message', diffLoading: false });
-          return;
-        }
-        handleGitDiffMessage(key, parsed, currentCallbacks);
-      } else {
-        if (!isValidWorkerMessage(parsed)) {
-          logger.error('[WorkerWS] Invalid worker message type:', parsed);
-          return;
-        }
-        handleTerminalMessage(parsed, currentCallbacks, currentConn.sessionId, currentConn.workerId);
+      if (!isValidGitDiffMessage(parsed)) {
+        logger.error('[WorkerWS] Invalid git-diff message type:', parsed);
+        updateState(key, { diffError: 'Invalid server message', diffLoading: false });
+        return;
       }
+      handleGitDiffMessage(key, parsed, currentCallbacks);
     } catch (e) {
       logger.error('[WorkerWS] Failed to parse message:', e);
-      if (currentCallbacks.type === 'git-diff') {
-        updateState(key, { diffError: 'Failed to parse server message', diffLoading: false });
-      }
+      updateState(key, { diffError: 'Failed to parse server message', diffLoading: false });
     }
   };
 
@@ -385,9 +286,8 @@ function setupWebSocketHandlers(key: string, ws: WebSocket, callbacks: WorkerCal
 
   ws.onerror = (error) => {
     logger.error('[WorkerWS] Error:', error);
-    // Get current callbacks from connection
     const currentConn = connections.get(key);
-    if (currentConn?.callbacks.type === 'git-diff') {
+    if (currentConn) {
       updateState(key, { diffError: 'WebSocket connection error', diffLoading: false });
     }
   };
@@ -417,9 +317,7 @@ export function connect(
     }
 
     // If connection is open, update callbacks and return
-    // This avoids unnecessary connection churn when component remounts
-    // Note: History request is NOT sent automatically here.
-    // Terminal.tsx is responsible for requesting history with the appropriate fromOffset.
+    // This avoids unnecessary connection churn when component remounts.
     if (existing.ws.readyState === WebSocket.OPEN) {
       // Update callbacks for the new component instance
       existing.callbacks = callbacks;
@@ -440,7 +338,9 @@ export function connect(
 
   const initialState: WorkerConnectionState = {
     connected: false,
-    ...(callbacks.type === 'git-diff' ? { diffData: null, diffError: null, diffLoading: true } : {}),
+    diffData: null,
+    diffError: null,
+    diffLoading: true,
   };
 
   const conn: WorkerConnection = {
@@ -456,7 +356,7 @@ export function connect(
   // Notify subscribers that the connection state is now available.
   updateState(key, {});
 
-  setupWebSocketHandlers(key, ws, callbacks);
+  setupWebSocketHandlers(key, ws);
 
   return true;
 }
@@ -495,21 +395,6 @@ export function updateCallbacks(sessionId: string, workerId: string, callbacks: 
 }
 
 /**
- * Send a message to a terminal/agent worker.
- * @returns true if sent, false if not connected
- */
-export function sendTerminalMessage(sessionId: string, workerId: string, msg: WorkerClientMessage): boolean {
-  const key = getConnectionKey(sessionId, workerId);
-  const conn = connections.get(key);
-
-  if (conn && conn.ws.readyState === WebSocket.OPEN) {
-    conn.ws.send(JSON.stringify(msg));
-    return true;
-  }
-  return false;
-}
-
-/**
  * Send a message to a git-diff worker.
  * @returns true if sent, false if not connected
  */
@@ -530,28 +415,6 @@ export function sendGitDiffMessage(sessionId: string, workerId: string, msg: Git
     updateState(key, { diffError: 'Connection lost. Please try again.', diffLoading: false });
   }
   return false;
-}
-
-// Convenience methods for terminal workers
-export function sendInput(sessionId: string, workerId: string, data: string): boolean {
-  return sendTerminalMessage(sessionId, workerId, { type: 'input', data });
-}
-
-export function sendResize(sessionId: string, workerId: string, cols: number, rows: number): boolean {
-  return sendTerminalMessage(sessionId, workerId, { type: 'resize', cols, rows });
-}
-
-/**
- * Request history data from the server.
- * Used when a previously invisible tab becomes visible for the first time.
- * @param fromOffset If specified, request only data after this offset (incremental sync)
- * @returns true if sent, false if not connected
- */
-export function requestHistory(sessionId: string, workerId: string, fromOffset?: number): boolean {
-  return sendTerminalMessage(sessionId, workerId, {
-    type: 'request-history',
-    fromOffset: fromOffset ?? 0
-  });
 }
 
 // Convenience methods for git-diff workers


### PR DESCRIPTION
Closes #961.

## What

`MessagePanel`'s Escape key (interrupt-the-agent) was a **silent no-op** since the renderer migration: it sent ESC through `worker-websocket`'s terminal transport, but nothing establishes a terminal-type connection there anymore (the next renderer's store opens its own WebSocket). The owner confirmed not having used the feature recently, which is why it survived the bake unnoticed.

- `MessagePanel` Escape now routes through `getOrCreatePocTerminal(...).sendInput('\x1b')` — the same transport the terminal itself uses.
- `worker-websocket.ts` loses its entire now-orphaned terminal transport (deliberately retained by #962 as MessagePanel's compile-time dependency, tracked for removal here): callbacks union collapses to git-diff, −508 lines total. git-diff behavior unchanged.

## Verification

**Unit + polarity**: ESC tests assert the store receives `'\x1b'`; neutralizing the fix fails them, and the old path cannot be reintroduced without a compile error (the transport is gone).

**Shipping-path E2E (dev server, real Claude Code, both #961 cases)**:
- *Asking state*: permission prompt on screen → Escape in MessagePanel → prompt cancelled.
- *Processing state*: bash counting loop running → Escape in MessagePanel → "Interrupted" marker, output frozen.

**Battery**: typecheck 0 / full test 0 fail (client 1385, server 2998, shared 359, integration 30, scripts 411) / build 0 / preflight 0 (one advisory integration-test warning: client-transport rewire, no wire-schema change — Q10 N/A; covered by unit polarity + the E2E above).

## Note

`worker-websocket`'s `updateCallbacks`/`isConnected` exports now have zero callers (orphaned by #962, not this PR) — flagged for a future sweep rather than widening this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGB7PwWjbes5ZJBCmMJNMm
