### PR TITLE
[AI] closes #948 feat(docker): dev compose stack for AI-autonomous multi-user debugging

### DIFF
--- a/.claude/skills/dev-environment-quirks/SKILL.md
+++ b/.claude/skills/dev-environment-quirks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-environment-quirks
-description: Non-obvious operational details of the local dev environments (single-user `dev.sh`, multi-user `dev-multiuser.sh`) — port layout, source-code propagation, sudo boundaries, multi-repo coexistence. Read when a delegated agent or the Orchestrator first needs to interact with the running dev instance, especially for Browser QA, log inspection, or restart workflows.
+description: Non-obvious operational details of the local dev environments (single-user `dev.sh`, multi-user `dev-multiuser.sh`, Docker dev stack `docker/docker-compose.yml`) — port layout, source-code propagation, sudo boundaries, multi-repo coexistence. Read when a delegated agent or the Orchestrator first needs to interact with the running dev instance, especially for Browser QA, log inspection, or restart workflows.
 ---
 
 # Dev Environment Quirks
@@ -13,6 +13,19 @@ This skill captures the operational reality of the dev environments that is not 
 - `scripts/dev-multiuser.sh` — multi-user instance under `/var/lib/agent-console-dev`. Runs the server as the production service user (`agentconsole`) with production-mirrored ownership (`agentconsole:agent-console-users 2775`, setgid). The developer accesses the data via group membership + `core.sharedRepository=group`.
 
 **Only one can run at a time** — both use port 3457 for the backend and port 5173 for vite (client), and both write to `/var/lib/agent-console-dev` (multi-user) or `$HOME/.agent-console-dev` (single-user). Concurrent runs collide on ports and corrupt each other's session DB.
+
+## Docker dev stack: the AI-drivable multi-user environment
+
+`docker/docker-compose.yml` is a third dev environment: a **multi-user dev server inside a container**, launchable with `docker` group membership alone — no privilege elevation, no password prompt. This is the default choice when a delegated agent needs to start / restart / debug a multi-user instance autonomously. Full guide: `docker/README.md`.
+
+Operational facts that differ from the host-side scripts:
+
+- **No rsync step.** The repo is bind-mounted; the server's `bun --watch` and vite HMR both react to host-side edits live. The `dev-multiuser.sh` "server code is a frozen snapshot" trap does not exist here.
+- **Ports are env-mapped.** Container-internal ports are fixed (vite `5173`, server `3457`); host mapping is set at `up` time via `DEV_CLIENT_PORT` / `DEV_SERVER_PORT`. Because host `5173`/`3457` are often taken by `dev.sh`, `dev-multiuser.sh`, or another repo's vite, prefer explicit overrides (e.g. `DEV_CLIENT_PORT=15173 DEV_SERVER_PORT=13457 docker compose -f docker/docker-compose.yml up -d`). Changing the mapping requires `up -d` (recreate), not `restart`.
+- **Login uses baked test users** (`alice` / `bob`, passwords in `docker/README.md`), not host OS accounts. The elevation path (`shouldElevateForUser` → PTY as the target user) is genuinely exercised in-container.
+- **It does NOT exercise host OS quirks.** sudoers drift, PAM config, PATH/login-shell issues on the real host still need `dev-multiuser.sh` or the production instance.
+- **Coexists with the verification stack** (`docker/docker-compose.verification.yml`, host port 8080 — which on the dogfood host is also the production port, so give the verification stack a different `PORT` when production is running).
+- Logs / restart / shell: `docker compose -f docker/docker-compose.yml logs --tail 100 -f`, `... restart agent-console-dev`, `... exec -u agentconsole agent-console-dev sh`.
 
 ## Multi-user dev: source propagation is rsync, not live
 
@@ -66,6 +79,7 @@ Sequence the owner usually wants after applying a server-side fix:
 ## Cross-references
 
 - `scripts/dev.sh` and `scripts/dev-multiuser.sh` — canonical scripts (the prologues are required reading).
+- `docker/README.md` — the Docker dev stack (AI-drivable multi-user environment) and the verification stack.
 - `docs/multi-user-setup-guide.md` — operator-side setup, including the multi-repo-coexistence note.
 - `.claude/skills/development-workflow-standards/development-workflow-standards.md` "Diagnostic Command Error Suppression" — the discipline that prevents misinterpreting permission denied as not-found inside this environment.
 - `.claude/skills/orchestrator/core-responsibilities.md` "Delegation Prompt Mandatory Checklist" item 4 — environment constraint pre-disclosure for delegated agents.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,29 +1,146 @@
-# Multi-User Mode Verification on Docker
+# Multi-User Mode on Docker (dev + verification)
 
-This directory contains a **verification environment** for Agent Console's
-multi-user mode (`AUTH_MODE=multi-user`). It runs the already-implemented
-multi-user feature on real Debian Linux so we can confirm two things that cannot
-be exercised on macOS dev machines:
+This directory contains two Docker Compose stacks built from the **same
+image** (`docker/Dockerfile`). The image provides the OS layer that
+multi-user mode needs — `pamtester`, `sudo`, the non-root `agentconsole`
+service user, the `agent-console-users` shared group, and two test users
+(`alice`, `bob`) with known passwords. The stacks differ only in how the
+application runs:
 
-1. **OS authentication** via `pamtester` (the Linux credential path).
-2. **Per-user PTY identity isolation** via `sudo -u <user> -i` — each logged-in
-   user's terminals and agents run under their own OS identity, not the service
-   user.
+| Stack | Compose file | What runs | When to use |
+|------|---------------|-----------|-------------|
+| **Dev** (default) | `docker-compose.yml` | vite + `bun --watch` against the **bind-mounted repo** (HMR, live server reload) | Daily multi-user development and debugging. AI agents can drive it end to end — `docker` group membership is enough, no privilege elevation. |
+| **Verification** | `docker-compose.verification.yml` | The **built `dist/` bundle**, baked into the image, production-like | CI E2E (`scripts/verify-multiuser-docker.sh`) and pre-release verification of the standalone bundle. |
 
-> This is **not** a production deployment recipe. Production should run under
+Both stacks use distinct project names, container names, volumes, and host
+ports, so they can run **side by side**.
+
+> Neither stack is a production deployment recipe. Production runs under
 > systemd behind TLS — see [`../docs/multi-user-setup-guide.md`](../docs/multi-user-setup-guide.md).
 
 ## What's in here
 
 | File | Purpose |
 |------|---------|
-| `Dockerfile` | Two-stage build: build the `dist/` bundle, then a runtime image with `pamtester`, `sudo`, a non-root `agentconsole` service user, and two test users (`alice`, `bob`). |
-| `docker-compose.yml` | Starts the server in `AUTH_MODE=multi-user` on host port `8080`. |
+| `Dockerfile` | Two-stage build: build the `dist/` bundle, then a runtime image with `pamtester`, `sudo`, the `agentconsole` service user, and test users. Shared by both stacks. |
+| `docker-compose.yml` | **Dev stack**: repo bind mount + dev servers, host ports `5173`/`3457` (env-configurable). |
+| `docker-compose.verification.yml` | **Verification stack**: runs the baked bundle in `AUTH_MODE=multi-user` on host port `8080`. |
+| `dev-entrypoint.sh` | Dev-stack entrypoint: fixes volume-mountpoint ownership as root, drops to `agentconsole`, runs `bun install`, starts vite + server. |
 | `sudoers-agentconsole` | Grants the service user permission to launch login shells as any non-root user. |
 | `verify-client.ts` | Drives the real shipping path (login → session → terminal worker → WS) and asserts `whoami` inside the PTY. |
-| `../scripts/verify-multiuser-docker.sh` | One-command orchestrator: build, start, run all checks, report. |
+| `../scripts/verify-multiuser-docker.sh` | One-command verification orchestrator: build, start, run all checks, report. |
 
-## Running the verification
+## Dev stack
+
+### Quick start
+
+From the repository root:
+
+```bash
+docker compose -f docker/docker-compose.yml up --build -d
+```
+
+First start builds the image (minutes) and runs a full `bun install` inside
+the container; subsequent starts reuse both. Wait for the health check:
+
+```bash
+docker compose -f docker/docker-compose.yml ps          # healthy?
+curl -s http://localhost:3457/api/config                # {"authMode":"multi-user",...}
+```
+
+Then open `http://localhost:5173` and log in as a test user (see
+[Test credentials](#test-credentials-verification-only) below).
+
+### Host ports
+
+Container-internal ports are fixed (vite `5173`, API server `3457`); the
+host-side mapping is env-configurable so the stack coexists with other
+repos' dev servers:
+
+| Env var | Default | Maps to |
+|---------|---------|---------|
+| `DEV_CLIENT_PORT` | `5173` | vite dev server (open this in the browser) |
+| `DEV_SERVER_PORT` | `3457` | API server (direct `curl` debugging) |
+
+```bash
+DEV_CLIENT_PORT=15173 DEV_SERVER_PORT=13457 \
+  docker compose -f docker/docker-compose.yml up -d
+```
+
+Both ports bind to loopback only — the image ships known test credentials
+and must never be reachable from the LAN.
+
+### How it works
+
+- The repo is bind-mounted at `/app`, so **vite HMR and the server's
+  `bun --watch` pick up host-side edits immediately** — no rsync step, no
+  image rebuild (contrast with `scripts/dev-multiuser.sh`, where server code
+  is a frozen rsync snapshot).
+- `node_modules` are **container-side named volumes** (host installs are not
+  binary-compatible: bun-pty is a native module). The container runs its own
+  `bun install --frozen-lockfile` on every start — a no-op when nothing
+  changed.
+- The server runs as the `agentconsole` service user with real in-container
+  privilege elevation, so logging in as `alice`/`bob` genuinely exercises
+  the `shouldElevateForUser` path (PTYs spawn under the test user's own OS
+  identity).
+- Dev data (DB, jwt-secret, worktrees) lives in the `dev-data` volume at
+  `/var/lib/agent-console` and persists across `down`/`up`.
+
+Named volumes (all under the `agent-console-dev` compose project):
+`root-node-modules`, `client-node-modules`, `server-node-modules`,
+`shared-node-modules`, `integration-node-modules`, `dev-data`. Remove them
+with `docker compose -f docker/docker-compose.yml down -v` for a from-scratch
+start.
+
+### Driving the stack as an AI agent
+
+Everything below needs only `docker` group membership — no elevation, no
+password prompt:
+
+```bash
+COMPOSE="docker compose -f docker/docker-compose.yml"
+
+$COMPOSE up -d                        # start (or apply compose changes)
+$COMPOSE restart agent-console-dev    # restart both dev servers
+$COMPOSE logs --tail 100 -f           # tail vite + server logs
+$COMPOSE exec agent-console-dev sh    # shell inside the container (agentconsole)
+$COMPOSE exec -T agent-console-dev id # one-off command
+$COMPOSE down                         # stop (dev data volume survives)
+```
+
+Notes:
+
+- Server code changes are picked up live by `bun --watch`; client changes by
+  vite HMR. A restart is only needed when dependencies or env/compose config
+  change.
+- `exec` lands as the container's initial user (root); use
+  `$COMPOSE exec -u agentconsole agent-console-dev sh` to inspect as the
+  service user, or `-u alice` for a test user's view.
+- If the checkout had no `node_modules` directories when the stack first
+  started, Docker creates empty root-owned placeholder dirs on the host at
+  the volume mountpoints (`node_modules`, `packages/*/node_modules`). They
+  are harmless shadows; a later host-side `bun install` replaces them.
+- Files the container writes into the repo bind mount (in practice only
+  `packages/client/src/routeTree.gen.ts`, which is gitignored) appear on the
+  host owned by the container's uid but group-writable via the repo group,
+  so host-side work is unaffected.
+
+### Dev stack vs `scripts/dev-multiuser.sh`
+
+| | Docker dev stack | `dev-multiuser.sh` |
+|---|---|---|
+| Needs host privilege elevation | No (docker group only) | Yes (interactive password) |
+| Server code propagation | Live (`bun --watch` on bind mount) | Frozen rsync snapshot; re-run to re-sync |
+| Login accounts | Baked test users (`alice`/`bob`) | Real host OS accounts |
+| Data root | `dev-data` volume (container) | `/var/lib/agent-console-dev` (host) |
+| Exercises host-specific quirks (sudoers, PAM config, PATH) | No — container OS only | Yes |
+
+Use the Docker stack for autonomous debugging and multi-user flow QA; use
+`dev-multiuser.sh` when the behavior under test depends on the real host's
+OS configuration.
+
+## Verification stack
 
 From the repository root (requires `docker` and `bun` on the host):
 
@@ -38,6 +155,12 @@ pass/fail summary, and tears the container down. Useful flags:
 - `--no-build` — reuse the already-built image.
 - `PORT=9090 scripts/verify-multiuser-docker.sh` — map a different host port.
 
+Manual start:
+
+```bash
+docker compose -f docker/docker-compose.verification.yml up --build -d
+```
+
 ### What it checks
 
 1. `GET /api/config` reports `"authMode":"multi-user"`.
@@ -46,6 +169,8 @@ pass/fail summary, and tears the container down. Useful flags:
 4. `alice` / `bob` log in successfully (`200`).
 5. **Identity isolation**: `alice`'s terminal `whoami` prints `alice`, `bob`'s
    prints `bob` — never the `agentconsole` service user.
+6. File upload creates the upload dir with mode `2750` (setgid regression, #830).
+7. Worktree creation runs as the requesting user (#838).
 
 ## Test credentials (verification only)
 
@@ -55,8 +180,8 @@ pass/fail summary, and tears the container down. Useful flags:
 | `alice` | `alice-password` | test end user |
 | `bob` | `bob-password` | test end user |
 
-These passwords are intentionally well-known. **Never expose this image**; it
-exists solely for local verification.
+These passwords are intentionally well-known. **Never expose either stack
+beyond loopback**; they exist solely for local development and verification.
 
 ## Why these OS pieces are required
 
@@ -118,9 +243,10 @@ goes through Docker Hub.
   plain-HTTP deployment therefore needs TLS; a localhost / SSH-port-forward
   deployment does not. See the guide's
   [TLS, `NODE_ENV`, and secure contexts](../docs/multi-user-setup-guide.md#tls-node_env-and-secure-contexts).
-- **No static UI in this image.** The bundled login UI is only served when
-  `NODE_ENV=production` (the same flag that makes the cookie `Secure`);
-  verification here is API/WebSocket-driven. To click through the browser UI you
-  need `NODE_ENV=production` plus a secure context (HTTPS, or `http://localhost`).
+- **No static UI in the verification image.** The bundled login UI is only
+  served when `NODE_ENV=production` (the same flag that makes the cookie
+  `Secure`); verification is API/WebSocket-driven. The **dev stack does not
+  have this limitation** — vite serves the full UI, so browser login QA
+  belongs there.
 - **arm64/amd64**: the image builds natively for the host architecture; the
   `bun-pty` native module is installed inside the runtime stage to match.

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# Entrypoint for the dev stack (docker/docker-compose.yml).
+#
+# Stage 1 runs as root and only fixes mount ownership, then drops to the
+# `agentconsole` service user via setpriv and re-executes itself (stage 2)
+# to install dependencies and start the dev servers.
+#
+# Why a root stage is needed at all:
+#   - Named volumes mounted over paths that do not exist in the image
+#     (the node_modules mountpoints) are created root-owned; the service
+#     user could not write to them otherwise.
+#   - The repo bind mount at /app is owned by a HOST uid/gid. Its files are
+#     group-writable (setgid dirs + the host's agent-console-users group),
+#     but that group's NUMERIC gid on the host generally differs from the
+#     gid the image assigned to its own agent-console-users group — so the
+#     dropped process must additionally join the bind mount's numeric gid.
+set -eu
+
+APP_DIR=/app
+SERVICE_USER=agentconsole
+SERVICE_GROUP=agent-console-users
+
+if [ "${1:-}" != "stage2" ]; then
+  # ---- Stage 1 (root): mount fixups, then drop privileges ----------------
+  for dir in \
+    "$APP_DIR/node_modules" \
+    "$APP_DIR/packages/client/node_modules" \
+    "$APP_DIR/packages/server/node_modules" \
+    "$APP_DIR/packages/shared/node_modules" \
+    "$APP_DIR/packages/integration/node_modules" \
+    /var/lib/agent-console; do
+    chown "$SERVICE_USER:$SERVICE_GROUP" "$dir"
+    chmod 2775 "$dir"
+  done
+
+  # Supplementary groups: everything the service user normally gets from
+  # initgroups (most importantly `shadow`, required by pam_unix for OS
+  # authentication) plus the bind mount's numeric gid for repo write access
+  # (vite regenerates routeTree.gen.ts in the repo tree). sort -u dedupes
+  # the repo gid when it happens to match a container group.
+  REPO_GID="$(stat -c %g "$APP_DIR")"
+  GROUP_LIST="$( { id -G "$SERVICE_USER" | tr ' ' '\n'; echo "$REPO_GID"; } | sort -un | paste -sd, -)"
+
+  HOME="$(getent passwd "$SERVICE_USER" | cut -d: -f6)"
+  export HOME
+  export USER="$SERVICE_USER" LOGNAME="$SERVICE_USER"
+  # The image bakes BUN_INSTALL=/usr/local (bun's own install prefix at build
+  # time, root-owned). bun install / bun x place their cache and temp dirs
+  # under $BUN_INSTALL, which fails with AccessDenied for a non-root user —
+  # point it at the service user's home instead.
+  export BUN_INSTALL="$HOME/.bun"
+
+  exec setpriv \
+    --reuid "$SERVICE_USER" \
+    --regid "$SERVICE_GROUP" \
+    --groups "$GROUP_LIST" \
+    sh "$APP_DIR/docker/dev-entrypoint.sh" stage2
+fi
+
+# ---- Stage 2 (agentconsole): install deps, run the dev servers -----------
+# umask 0002 mirrors the production systemd unit and the verification CMD:
+# server-created dirs under the shared data root must stay group-writable
+# so per-user PTYs (alice / bob) can traverse into worktrees.
+umask 0002
+cd "$APP_DIR"
+
+# The container's bun/glibc, not the host's, populates the node_modules
+# volumes. Cheap no-op when the volumes are already in sync with bun.lock.
+bun install --frozen-lockfile
+
+# Same two processes as scripts/dev.sh, with one difference: vite must bind
+# 0.0.0.0 so Docker's port mapping can reach it from the host browser.
+# concurrently is a root devDependency; `bun x` runs its bin under bun (the
+# image has no node).
+exec bun x concurrently -n client,server -c cyan,yellow \
+  "cd packages/client && bun run dev --port ${CLIENT_PORT:-5173} --host 0.0.0.0" \
+  "cd packages/server && bun run dev"

--- a/docker/docker-compose.verification.yml
+++ b/docker/docker-compose.verification.yml
@@ -1,0 +1,34 @@
+# Multi-user verification stack for Agent Console.
+#
+# Usage (from repo root):
+#   scripts/verify-multiuser-docker.sh           # build, start, verify, report
+#   docker compose -f docker/docker-compose.verification.yml up --build -d   # manual start
+#
+# The server runs in AUTH_MODE=multi-user as the non-root `agentconsole` user
+# and exposes the API/WS on host port 8080. For day-to-day development use the
+# sibling dev stack (docker/docker-compose.yml); both stacks share the same
+# image and can run side by side. See docker/README.md.
+#
+# Explicit project name so this stack's resources never collide with the dev
+# stack's (both compose files live in the same directory, whose basename would
+# otherwise be the shared default compose project name).
+name: agent-console-verify
+services:
+  agent-console:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: agent-console-multiuser-verify
+    container_name: agent-console-multiuser-verify
+    # Bind to loopback only: this stack ships intentionally known test
+    # credentials and must never be reachable from the LAN. ${PORT:-8080} keeps
+    # the host port in sync with scripts/verify-multiuser-docker.sh's PORT env.
+    ports:
+      - "127.0.0.1:${PORT:-8080}:8080"
+    # Health: /api/config is reachable without auth and reports authMode.
+    healthcheck:
+      test: ["CMD", "bun", "-e", "fetch('http://localhost:8080/api/config').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 5s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,7 +72,9 @@ services:
       # `docker compose down` / `up` cycles.
       - dev-data:/var/lib/agent-console
     healthcheck:
-      test: ["CMD", "bun", "-e", "fetch('http://localhost:3457/api/config').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      # Healthy only when BOTH dev servers answer: the API server and the
+      # vite client (either alone can be down while the other runs).
+      test: ["CMD", "bun", "-e", "Promise.all([fetch('http://localhost:3457/api/config'),fetch('http://localhost:5173')]).then(rs=>process.exit(rs.every(r=>r.ok)?0:1)).catch(()=>process.exit(1))"]
       interval: 5s
       timeout: 5s
       retries: 60

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,27 +1,88 @@
-# Multi-user verification stack for Agent Console.
+# Multi-user DEV stack for Agent Console.
+#
+# Runs the same image as the verification stack (docker/Dockerfile) but with
+# the repository bind-mounted and the dev servers (vite + `bun --watch`)
+# running inside the container. Because launching it only needs `docker`
+# group membership on the host, an AI agent can start / restart / inspect a
+# multi-user dev server autonomously — no privilege elevation, no password
+# prompt. See docker/README.md for the full guide (including how this differs
+# from scripts/dev-multiuser.sh).
 #
 # Usage (from repo root):
-#   scripts/verify-multiuser-docker.sh           # build, start, verify, report
-#   docker compose -f docker/docker-compose.yml up --build -d   # manual start
+#   docker compose -f docker/docker-compose.yml up --build -d
+#   # host ports are env-configurable to coexist with other vite/dev servers:
+#   DEV_CLIENT_PORT=15173 DEV_SERVER_PORT=13457 \
+#     docker compose -f docker/docker-compose.yml up -d
 #
-# The server runs in AUTH_MODE=multi-user as the non-root `agentconsole` user
-# and exposes the API/WS on host port 8080.
+# Both stacks can run side by side: distinct project names, container names,
+# volumes, and host ports (this stack: 5173/3457 by default; verification:
+# 8080).
+name: agent-console-dev
 services:
-  agent-console:
+  agent-console-dev:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+    # Intentionally the same image tag as the verification stack: one build
+    # serves both; only the runtime wiring (mounts / command) differs.
     image: agent-console-multiuser-verify
-    container_name: agent-console-multiuser-verify
-    # Bind to loopback only: this stack ships intentionally known test
-    # credentials and must never be reachable from the LAN. ${PORT:-8080} keeps
-    # the host port in sync with scripts/verify-multiuser-docker.sh's PORT env.
+    container_name: agent-console-dev
+    # Root is needed only for the entrypoint's mountpoint-ownership fixup;
+    # dev-entrypoint.sh drops to the `agentconsole` service user (setpriv)
+    # before installing dependencies or starting the dev servers.
+    user: root
+    # The image's WORKDIR is /app/dist (the baked bundle). With the repo
+    # bind-mounted, letting that stand would make Docker create a root-owned
+    # empty dist/ INSIDE the host checkout at container start. Point cwd at
+    # the repo root instead.
+    working_dir: /app
+    entrypoint: ["sh", "/app/docker/dev-entrypoint.sh"]
+    environment:
+      # The image bakes AUTH_MODE=multi-user and AGENT_CONSOLE_HOME; here we
+      # only override the dev-server wiring. PORT/CLIENT_PORT are the
+      # CONTAINER-INTERNAL ports (fixed; host mapping is what varies).
+      PORT: 3457
+      CLIENT_PORT: 5173
+      HOST: 0.0.0.0
+      # Links the server generates must point at the HOST-side vite URL.
+      APP_URL: http://localhost:${DEV_CLIENT_PORT:-5173}
+      # Dev runs over plain HTTP on localhost; never mark the auth cookie
+      # Secure (mirrors scripts/dev-multiuser.sh).
+      AUTH_COOKIE_SECURE: "false"
+    # Loopback only: the image ships intentionally known test credentials
+    # (alice / bob) and must never be reachable from the LAN.
     ports:
-      - "127.0.0.1:${PORT:-8080}:8080"
-    # Health: /api/config is reachable without auth and reports authMode.
+      - "127.0.0.1:${DEV_CLIENT_PORT:-5173}:5173"
+      - "127.0.0.1:${DEV_SERVER_PORT:-3457}:3457"
+    volumes:
+      # The whole repo, live: vite HMR and `bun --watch` react to host-side
+      # edits immediately (this also hides the image's baked /app/dist, which
+      # the dev stack does not use).
+      - ..:/app
+      # node_modules stay container-side: the host's install (macOS or a
+      # different bun/glibc) is not binary-compatible with the container
+      # (bun-pty native module in particular). One volume per workspace
+      # package because bun creates per-package node_modules dirs.
+      - root-node-modules:/app/node_modules
+      - client-node-modules:/app/packages/client/node_modules
+      - server-node-modules:/app/packages/server/node_modules
+      - shared-node-modules:/app/packages/shared/node_modules
+      - integration-node-modules:/app/packages/integration/node_modules
+      # Dev data root (DB, jwt-secret, worktrees) persists across
+      # `docker compose down` / `up` cycles.
+      - dev-data:/var/lib/agent-console
     healthcheck:
-      test: ["CMD", "bun", "-e", "fetch('http://localhost:8080/api/config').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
-      interval: 3s
+      test: ["CMD", "bun", "-e", "fetch('http://localhost:3457/api/config').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 5s
       timeout: 5s
-      retries: 20
-      start_period: 5s
+      retries: 60
+      # First start runs a full `bun install` inside the container.
+      start_period: 120s
+
+volumes:
+  root-node-modules:
+  client-node-modules:
+  server-node-modules:
+  shared-node-modules:
+  integration-node-modules:
+  dev-data:

--- a/scripts/verify-multiuser-docker.sh
+++ b/scripts/verify-multiuser-docker.sh
@@ -24,7 +24,7 @@
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.yml"
+COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.verification.yml"
 PORT="${PORT:-8080}"
 BASE_URL="http://localhost:${PORT}"
 KEEP=0


### PR DESCRIPTION
> [!NOTE]
> The `main` regression (Issue #951, from PR #931) that initially reddened the `docker-multiuser-e2e` check is now fixed in merged PR #953. This branch was rebased onto current `main` (which includes #953), and the E2E is green — see the fully-green verify-script capture in section 6.

## Summary

Closes #948

One Dockerfile, two compose files (owner-approved design in the Issue):

- `docker/docker-compose.verification.yml` — **renamed** from `docker/docker-compose.yml`; unchanged behavior (verification stack, baked dist, host port 8080).
- `docker/docker-compose.yml` — **new meaning: dev stack**. Same image, but the repo is bind-mounted and the container runs the dev servers (vite + `bun --watch`) as the `agentconsole` service user. Launchable / restartable / inspectable with `docker` group membership alone — no privilege elevation, no password prompt — so AI agents can drive multi-user debugging autonomously.
- `docker/dev-entrypoint.sh` — dev-stack entrypoint. Root stage only fixes volume-mountpoint ownership, then drops to `agentconsole` via `setpriv` (joining the bind mount's numeric gid so vite can regenerate `routeTree.gen.ts`), repoints `BUN_INSTALL` away from the image's root-owned `/usr/local` prefix, runs `bun install --frozen-lockfile`, and starts both dev servers via `concurrently`.
- Rename fallout: `scripts/verify-multiuser-docker.sh` `COMPOSE_FILE`, `docker/README.md` (now documents both stacks + AI-agent operations), `.claude/skills/dev-environment-quirks/SKILL.md` (new Docker dev stack section). The `docker-multiuser-e2e.yml` `paths` filter already uses `docker/**`, which covers both compose files — dev-stack changes deliberately keep gating on the E2E; no workflow change needed.

Implementation notes (non-obvious):

- `working_dir: /app` is pinned in the dev compose because the image's `WORKDIR /app/dist` would otherwise make Docker materialize a root-owned empty `dist/` inside the host checkout at container start (observed during verification; it broke a host-side `bun run build`).
- Both compose files now carry explicit top-level `name:` (`agent-console-dev` / `agent-console-verify`) — they live in the same directory, whose basename would otherwise be the shared default project name, causing cross-stack orphan-container warnings and volume-prefix collisions.
- Named volumes (project `agent-console-dev`): `root-node-modules`, `client-node-modules`, `server-node-modules`, `shared-node-modules`, `integration-node-modules`, `dev-data`. Lifecycle documented in `docker/README.md` (`down -v` for a from-scratch start).

## AC verification (all executed on the dogfood host by this session)

Host port 5173 is occupied by another repo's vite and 8080 by the production instance, so the dev stack ran with `DEV_CLIENT_PORT=15173 DEV_SERVER_PORT=13457` and the verification stack with `PORT=18080` — which is itself the demonstration of the env-configurable-ports AC.

### 1. Dev stack starts without privilege elevation; authMode=multi-user

```
$ docker compose -f docker/docker-compose.yml ps
NAME                IMAGE                            COMMAND                   SERVICE             CREATED         STATUS                    PORTS
agent-console-dev   agent-console-multiuser-verify   "sh /app/docker/dev-…"   agent-console-dev   5 minutes ago   Up 52 seconds (healthy)   8080/tcp, 127.0.0.1:13457->3457/tcp, 127.0.0.1:15173->5173/tcp

$ curl -s http://localhost:13457/api/config   # DEV_SERVER_PORT=13457 (direct API)
{"homeDir":"","capabilities":{"vscode":false},"serverPid":81,"authMode":"multi-user","sharedAccountsAvailable":false}

$ curl -s http://localhost:15173/api/config   # DEV_CLIENT_PORT=15173 (via vite proxy)
{"homeDir":"","capabilities":{"vscode":false},"serverPid":81,"authMode":"multi-user","sharedAccountsAvailable":false}

$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:15173/   # vite serves the UI
200
```

### 2. Vite reachable from host; HMR works (host edit → reflected, no rebuild)

```
$ curl -s http://localhost:15173/src/main.tsx | grep -c HMR_PROBE   # before edit: marker absent
0

$ echo "console.log(\"HMR_PROBE_LIVE_EDIT\");" >> packages/client/src/main.tsx   # host-side edit
$ curl -s http://localhost:15173/src/main.tsx | grep HMR_PROBE   # after edit: served live, no rebuild
console.log("HMR_PROBE_LIVE_EDIT");

$ docker compose -f docker/docker-compose.yml logs --since 30s | grep -E "hmr|reload"
agent-console-dev  | [client] 12:50:50 PM [vite] (client) page reload src/main.tsx
```

`bun --watch` server-side live reload (bonus, same mechanism):

```
$ echo "// SERVER_WATCH_PROBE" >> packages/server/src/index.ts   # host-side server edit
$ docker compose ... logs --since 20s | grep -E "server.*(restarted|Server URL|listening)"
agent-console-dev  | [server] [12:51:22.056] INFO: JobQueue started
agent-console-dev  | [server] [12:51:22.056] INFO: JobQueue initialized and started
agent-console-dev  | [server] [12:51:22.094] INFO: Server listening
agent-console-dev  | [server]       "url": "/api/config",

$ curl -s http://localhost:13457/api/config | grep -o "serverPid...."   # still serving after auto-reload (bun --watch reloads in-process, same OS pid)
{"homeDir":"","capabilities":{"vscode":false},"serverPid":81,"authMode":"multi-user","sharedAccountsAvailable":false}
```

### 3. Env-configurable host ports + conflict-free co-run with the verification stack

```
$ docker ps --filter name=agent-console --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
NAMES                            STATUS                    PORTS
agent-console-multiuser-verify   Up 15 seconds (healthy)   127.0.0.1:18080->8080/tcp
agent-console-dev                Up 3 minutes (healthy)    8080/tcp, 127.0.0.1:13457->3457/tcp, 127.0.0.1:15173->5173/tcp

$ curl -s http://localhost:18080/api/config   # verification stack (PORT=18080)
{"homeDir":"","capabilities":{"vscode":false},"serverPid":1,"authMode":"multi-user","sharedAccountsAvailable":false}

$ curl -s http://localhost:13457/api/config   # dev stack still healthy alongside
{"homeDir":"","capabilities":{"vscode":false},"serverPid":81,"authMode":"multi-user","sharedAccountsAvailable":false}
```

### 4. Multi-user login with a baked test user (curl-based session check per AC)

```
$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:15173/api/sessions   # unauthenticated -> 401
401

$ curl -s -X POST .../api/auth/login -d {alice, wrong password} -> expect 401 (PAM live)
401

$ curl -s -c jar -X POST .../api/auth/login -d {alice, alice-password}   # baked test user login
{"user":{"id":"3afcd8d1-8825-4bb0-9ac9-1299a699634c","username":"alice","homeDir":"/home/alice"}}

$ curl -s -b jar http://localhost:15173/api/auth/me   # authenticated session check
{"user":{"id":"3afcd8d1-8825-4bb0-9ac9-1299a699634c","username":"alice","homeDir":"/home/alice"}}

$ curl -s -b jar -o /dev/null -w "%{http_code}\n" http://localhost:15173/api/sessions   # 404: auth passed; GET list route does not exist (sessions list flows over /ws/app)
404
$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:15173/api/repositories   # unauthenticated -> 401
401

$ curl -s -b jar http://localhost:15173/api/repositories   # with alice session cookie -> 200
200 {"repositories":[]}
```

### 5. AI-drivable restart cycle

```
$ docker compose -f docker/docker-compose.yml restart agent-console-dev   # AI-drivable restart, no elevation
 Container agent-console-dev Restarting 
 Container agent-console-dev Started 
$ curl -s http://localhost:13457/api/config   # healthy again after restart
{"homeDir":"","capabilities":{"vscode":false},"serverPid":78,"authMode":"multi-user","sharedAccountsAvailable":false}
```

### 6. `scripts/verify-multiuser-docker.sh` after the rename

Rerun locally (`PORT=18080`) after rebasing onto current `main` (with #953). Full green — the previously-failing `#951` check now passes, and the `#838` `dubious ownership` E2E is green:

```
  [PASS] multipart message with file upload returns 201
  [PASS] upload dir is mode 2750 owned by agent-console-users (#830 setgid regression)
  [PASS] source repo bootstrapped inside container (shared=group)
  [PASS] alice can register source repo
  [PASS] worktree creation accepted (202)
  [PASS] worktree appears in repo's worktree list
  [PASS] new worktree dir is owned by alice (Issue #838 root fix)
  [PASS] git status as alice does NOT report dubious ownership (#838 E2E)
  RESULT: 17 passed, 0 failed
```

## Test plan

- Full suite: `bun run typecheck && bun run test` → exit 0 (paste below).
- `node .claude/skills/orchestrator/preflight-check.js` → all sections green ("No production files matching coverage patterns were changed" — this PR is infra/docs only).
- `bun run check:lang` → exit 0.
- CI `docker-multiuser-e2e.yml` runs on this PR via the `docker/**` paths filter and is the real E2E gate.

```
# Rebased onto current main HEAD d6d9611 (includes #953/#954/#982) — full suite:
$ bun run typecheck   -> EXIT 0
$ bun run test:only   (all packages + scripts)
server:      3104 pass / 1 skip / 0 fail (3105 tests, 139 files)
client:      1502 pass / 0 fail (1502 tests, 109 files)
shared:       408 pass / 0 fail
integration:   46 pass / 0 fail  +  411 pass / 0 fail (scripts)
TEST_EXIT: 0
```

## Pre-existing issues surfaced while verifying (not caused by this PR)

- **Main regression from #931 (now fixed)**: `WorktreeService.ensureRepoHasCommits` ran `git rev-parse` as the requesting user *before* `bootstrapSafeDirectoryForUser`, so a first-time multi-user worktree creation failed with `dubious ownership` misclassified as an empty repo. Found because this PR re-triggers the docker E2E, whose paths filter did not cover #931's files. Fixed in merged PR #953 and rebased into this branch; the docker E2E is now green.
- **Client test-order pollution on main HEAD (post-#962/#967)**: the full client suite fails 48 tests with `window is not defined` (happy-dom global lost mid-run) under bun 1.3.8 and 1.3.10, while CI (bun 1.3.5) is green and every failing file passes in isolation. This PR's client code is identical to `origin/main` (diff is docker/scripts/docs only), so this is main-side order-dependence surfaced by newer bun versions, reported to the Orchestrator for a follow-up Issue. Verified both on the host (bun 1.3.10) and inside this PR's dev container (bun 1.3.8) — the container run is incidentally the first practical use of the new stack.
- **Environment-sensitive test**: `multi-user-mode.test.ts` "Issue #918 … does NOT inject any SSH_AUTH_SOCK" asserts `opts.env.SSH_AUTH_SOCK` is undefined, but the direct path inherits `process.env` — it fails on any host where `SSH_AUTH_SOCK` is set (e.g. delegated sessions post-#925). CI is unaffected. Reported to the Orchestrator for a separate Issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
