### PR TITLE
fix(client): auto-dismiss terminal notice banner after TTL (closes #968)

### DIFF
--- a/packages/client/src/components/terminal/__tests__/terminal-store.test.ts
+++ b/packages/client/src/components/terminal/__tests__/terminal-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import type { AppServerMessage } from '@agent-console/shared';
 import { WS_CLOSE_CODE } from '@agent-console/shared';
 import { MockWebSocket, installMockWebSocket } from '../../../test/mock-websocket';
@@ -704,6 +704,117 @@ describe('terminal-store', () => {
 
     expect(instance.getSnapshot().notice).toBeNull();
     expect(MockWebSocket.getInstances().length).toBe(before);
+  });
+
+  // Notice auto-dismiss (issue #968). The notice producer is worker-restarted
+  // ('Terminal restarted'); its banner must self-clear after a TTL, reset that
+  // clock when replaced, and be canceled by manual dismiss and dispose.
+  // The store's auto-dismiss delay (DEFAULT_NOTICE_TTL_MS in terminal-store.ts).
+  const NOTICE_TTL_MS = 5000;
+
+  function makeRestartedInstance(sessionId: string) {
+    const bus = makeAppBus();
+    _setAppSubscribe(bus.subscribe);
+    const instance = getOrCreateTerminal(sessionId, 'w');
+    MockWebSocket.getLastInstance()!.simulateOpen();
+    const emitRestart = () =>
+      bus.emit({ type: 'worker-restarted', sessionId, workerId: 'w', activityState: 'idle' });
+    return { instance, emitRestart };
+  }
+
+  /** The pending setTimeout call scheduled for the notice auto-dismiss. */
+  function noticeTimeoutCalls(spy: ReturnType<typeof spyOn>) {
+    return spy.mock.calls.filter((call: unknown[]) => call[1] === NOTICE_TTL_MS);
+  }
+
+  describe('notice auto-dismiss (#968)', () => {
+    it('auto-clears the notice after the TTL', () => {
+      const setTimeoutSpy = spyOn(globalThis, 'setTimeout');
+      const { instance, emitRestart } = makeRestartedInstance('n1');
+
+      emitRestart();
+      expect(instance.getSnapshot().notice).toBe('Terminal restarted');
+      expect(_inspect(instance).noticeTimer).not.toBeNull();
+
+      // Deterministically fire the auto-dismiss timer (no real wait).
+      const scheduled = noticeTimeoutCalls(setTimeoutSpy);
+      expect(scheduled.length).toBe(1);
+      (scheduled[0][0] as () => void)();
+
+      expect(instance.getSnapshot().notice).toBeNull();
+      expect(_inspect(instance).noticeTimer).toBeNull();
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('resets the clock when a new notice replaces a pending one', () => {
+      const setTimeoutSpy = spyOn(globalThis, 'setTimeout');
+      const clearTimeoutSpy = spyOn(globalThis, 'clearTimeout');
+      const { instance, emitRestart } = makeRestartedInstance('n2');
+
+      emitRestart();
+      const firstTimer = _inspect(instance).noticeTimer;
+      expect(firstTimer).not.toBeNull();
+      expect(noticeTimeoutCalls(setTimeoutSpy).length).toBe(1);
+
+      emitRestart(); // second notice replaces the first
+      // Old timer canceled, a fresh one scheduled (clock reset).
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(firstTimer);
+      const secondTimer = _inspect(instance).noticeTimer;
+      expect(secondTimer).not.toBeNull();
+      expect(secondTimer).not.toBe(firstTimer);
+      expect(noticeTimeoutCalls(setTimeoutSpy).length).toBe(2);
+      expect(instance.getSnapshot().notice).toBe('Terminal restarted');
+
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    });
+
+    it('cancels the pending auto-dismiss on manual dismiss', () => {
+      const clearTimeoutSpy = spyOn(globalThis, 'clearTimeout');
+      const { instance, emitRestart } = makeRestartedInstance('n3');
+
+      emitRestart();
+      const timer = _inspect(instance).noticeTimer;
+      expect(timer).not.toBeNull();
+      expect(instance.getSnapshot().notice).toBe('Terminal restarted');
+
+      instance.dismissNotice();
+
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timer);
+      expect(_inspect(instance).noticeTimer).toBeNull();
+      expect(instance.getSnapshot().notice).toBeNull();
+      clearTimeoutSpy.mockRestore();
+    });
+
+    it('cancels the pending auto-dismiss on dispose and does not notify afterward', () => {
+      const setTimeoutSpy = spyOn(globalThis, 'setTimeout');
+      const clearTimeoutSpy = spyOn(globalThis, 'clearTimeout');
+      const { instance, emitRestart } = makeRestartedInstance('n4');
+
+      emitRestart();
+      const timer = _inspect(instance).noticeTimer;
+      expect(timer).not.toBeNull();
+      // Capture the auto-dismiss callback to prove it is inert after dispose.
+      const noticeCallback = noticeTimeoutCalls(setTimeoutSpy)[0][0] as () => void;
+
+      let notified = 0;
+      instance.subscribe(() => {
+        notified += 1;
+      });
+
+      instance.dispose();
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timer);
+      expect(_inspect(instance).disposed).toBe(true);
+
+      // Even if the (canceled) timer callback were force-invoked, it must not
+      // patch a disposed instance nor notify listeners.
+      notified = 0;
+      noticeCallback();
+      expect(notified).toBe(0);
+
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    });
   });
 
   it('session-deleted (app-WS) disposes the instance', () => {

--- a/packages/client/src/components/terminal/__tests__/terminal-store.test.ts
+++ b/packages/client/src/components/terminal/__tests__/terminal-store.test.ts
@@ -769,6 +769,33 @@ describe('terminal-store', () => {
       clearTimeoutSpy.mockRestore();
     });
 
+    it('a stale (replaced) timer callback cannot clear the successor notice', () => {
+      const setTimeoutSpy = spyOn(globalThis, 'setTimeout');
+      const { instance, emitRestart } = makeRestartedInstance('n5');
+
+      emitRestart(); // notice #1, timer #1
+      const firstCallback = noticeTimeoutCalls(setTimeoutSpy)[0][0] as () => void;
+      const firstTimer = _inspect(instance).noticeTimer;
+
+      emitRestart(); // notice #2 replaces #1 (timer #1 canceled, timer #2 scheduled)
+      const secondTimer = _inspect(instance).noticeTimer;
+      expect(secondTimer).not.toBe(firstTimer);
+
+      // Force-invoke the STALE first callback: it must be inert — it must NOT
+      // clear the current notice nor null the successor's timer handle.
+      firstCallback();
+      expect(instance.getSnapshot().notice).toBe('Terminal restarted');
+      expect(_inspect(instance).noticeTimer).toBe(secondTimer);
+
+      // The current (second) callback still clears normally.
+      const secondCallback = noticeTimeoutCalls(setTimeoutSpy)[1][0] as () => void;
+      secondCallback();
+      expect(instance.getSnapshot().notice).toBeNull();
+      expect(_inspect(instance).noticeTimer).toBeNull();
+
+      setTimeoutSpy.mockRestore();
+    });
+
     it('cancels the pending auto-dismiss on manual dismiss', () => {
       const clearTimeoutSpy = spyOn(globalThis, 'clearTimeout');
       const { instance, emitRestart } = makeRestartedInstance('n3');

--- a/packages/client/src/components/terminal/terminal-store.ts
+++ b/packages/client/src/components/terminal/terminal-store.ts
@@ -287,11 +287,16 @@ class TerminalController implements TerminalInstance {
   private setNotice(message: string, ttlMs: number = DEFAULT_NOTICE_TTL_MS): void {
     this.clearNoticeTimer();
     this.patchMeta({ notice: message });
-    this.noticeTimer = setTimeout(() => {
+    // Capture this timer's own handle so a stale (replaced) callback is inert: it
+    // must neither null the CURRENT timer reference nor clear a successor notice.
+    // Unreachable at runtime (clearTimeout is synchronous, so a replaced timer's
+    // callback never fires); the guard is state-hygiene, not a live race fix.
+    const handle = setTimeout(() => {
+      if (this.disposed || this.noticeTimer !== handle) return;
       this.noticeTimer = null;
-      if (this.disposed) return;
       this.patchMeta({ notice: null });
     }, ttlMs);
+    this.noticeTimer = handle;
   }
 
   private clearNoticeTimer(): void {

--- a/packages/client/src/components/terminal/terminal-store.ts
+++ b/packages/client/src/components/terminal/terminal-store.ts
@@ -66,6 +66,12 @@ const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 const SCROLLBACK = 5000;
 
+// Default auto-dismiss delay for a store notice banner (issue #968). The legacy
+// renderer auto-dismissed restart-class notices after 5s; this restores that
+// parity. Exposed as a per-call parameter on setNotice so a future notice class
+// can choose a longer/shorter TTL without touching the producer default.
+const DEFAULT_NOTICE_TTL_MS = 5000;
+
 // Memory-management + reconnect timings. Mutable so tests can shorten them via
 // _setTimings; production values are the DEFAULT_TIMINGS below.
 const DEFAULT_TIMINGS = {
@@ -106,6 +112,7 @@ class TerminalController implements TerminalInstance {
 
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private noticeTimer: ReturnType<typeof setTimeout> | null = null; // auto-dismiss (issue #968)
   private historyRequested = false; // per WS connection
   private noReconnect = false; // set on SESSION_DELETED / SESSION_PAUSED
 
@@ -265,9 +272,34 @@ class TerminalController implements TerminalInstance {
   };
 
   dismissNotice = (): void => {
+    // Manual dismiss cancels the pending auto-dismiss (issue #968).
+    this.clearNoticeTimer();
     if (this.snapshot.notice === null) return;
     this.patchMeta({ notice: null });
   };
+
+  /**
+   * Show a notice banner that auto-dismisses after `ttlMs` (issue #968). A new
+   * notice replaces any pending auto-dismiss (the clock resets); manual dismiss
+   * and dispose cancel it. `ttlMs` is a per-call parameter so future notice
+   * classes can opt into a different duration.
+   */
+  private setNotice(message: string, ttlMs: number = DEFAULT_NOTICE_TTL_MS): void {
+    this.clearNoticeTimer();
+    this.patchMeta({ notice: message });
+    this.noticeTimer = setTimeout(() => {
+      this.noticeTimer = null;
+      if (this.disposed) return;
+      this.patchMeta({ notice: null });
+    }, ttlMs);
+  }
+
+  private clearNoticeTimer(): void {
+    if (this.noticeTimer) {
+      clearTimeout(this.noticeTimer);
+      this.noticeTimer = null;
+    }
+  }
 
   /**
    * Filters applied to every history/output chunk before writing to the buffer.
@@ -304,6 +336,7 @@ class TerminalController implements TerminalInstance {
     this.reconnectTimer = null;
     if (this.idleTimer) clearTimeout(this.idleTimer);
     this.idleTimer = null;
+    this.clearNoticeTimer();
     this.appUnsub();
     this.closeWs();
     this.terminal.dispose();
@@ -333,6 +366,10 @@ class TerminalController implements TerminalInstance {
     return this.disposed;
   }
 
+  get noticeTimerForTest(): ReturnType<typeof setTimeout> | null {
+    return this.noticeTimer;
+  }
+
   private startIdleTimer(): void {
     if (this.idleTimer) clearTimeout(this.idleTimer);
     const ttl = this.snapshot.status === 'exited' ? timings.exitedTtlMs : timings.idleTtlMs;
@@ -352,7 +389,9 @@ class TerminalController implements TerminalInstance {
       this.rowCache.clear();
       this.lastBufferLength = 0;
       this.lastOffset = 0;
-      this.patchMeta({ notice: 'Terminal restarted', workerError: null });
+      // Clear any stale error and show an auto-dismissing restart notice (#968).
+      this.patchMeta({ workerError: null });
+      this.setNotice('Terminal restarted');
       this.reconnect();
     } else if (msg.type === 'session-deleted') {
       if (msg.sessionId !== this.sessionId) return;
@@ -743,6 +782,7 @@ export function _inspect(instance: TerminalInstance): {
   reconnectAttempts: number;
   disposed: boolean;
   lastHistoryLoadMs: number | null;
+  noticeTimer: ReturnType<typeof setTimeout> | null;
 } {
   const t = instance as TerminalController;
   return {
@@ -752,5 +792,6 @@ export function _inspect(instance: TerminalInstance): {
     reconnectAttempts: t.reconnectAttemptsForTest,
     disposed: t.disposedForTest,
     lastHistoryLoadMs: t.lastHistoryLoadDurationMs,
+    noticeTimer: t.noticeTimerForTest,
   };
 }


### PR DESCRIPTION
Closes #968.

## What

The terminal notice banner now auto-dismisses after a TTL (default 5s), restoring legacy-renderer parity (it had 5-10s timers; the migration dropped them). Post-#971 the surviving producer is the `'Terminal restarted'` notice — previously it persisted until manually dismissed.

- `setNotice(message, ttlMs = 5000)`: schedules auto-clear; a replacement notice resets the clock; manual dismiss and `dispose()` cancel; the timer callback early-returns on a disposed instance. TTL is per-call for future notice classes.

## Verification

4 new deterministic timer tests (spy-based, no real waits): auto-clear at TTL / replacement resets clock / manual dismiss cancels / dispose cancels with zero post-dispose notifications. **Polarity confirmed** (all 4 fail with the timer wiring removed). typecheck 0 / build 0 / client 1422 pass 0 fail / preflight 0. The 2 pre-existing #800 server real-repo flakes were baseline-verified independent (fail identically with the change stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGB7PwWjbes5ZJBCmMJNMm
