### PR TITLE
feat(client): support VSCode URL scheme for remote-access (closes #987)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -171,6 +171,27 @@ The session-side resolution is encapsulated by one of two sibling helpers in `pa
 - **Contrast:** [Service User](#service-user) (the OS account the server process runs as — what elevation is FROM, not TO).
 - **See:** Issue [#837](https://github.com/ms2sato/agent-console/issues/837) (privilege-elevation umbrella), [`packages/server/src/services/privilege-elevation.ts`](../packages/server/src/services/privilege-elevation.ts) — exposes `runAsUser` / `spawnAsUser` / `rmRecursiveAsUser` (the canonical elevated-recursive-removal helper). The strict-thin-wrapper family also includes domain-level runners that compose `runAsUser` plus caller semantics: [`packages/server/src/services/github-cli.ts`](../packages/server/src/services/github-cli.ts)'s `runGh` (gh-CLI-specific; throws on non-zero exit / timeout — lives in `services/` rather than `privilege-elevation.ts` per [Elevation Helpers rule](../.claude/rules/elevation-helpers.md) because it adds semantic layering). Identity-resolution helpers live alongside in [`packages/server/src/services/resolve-spawn-username.ts`](../packages/server/src/services/resolve-spawn-username.ts) (`resolveSpawnUsername` / `resolveRequestUsername` — see the bullet pair above). Issues [#879](https://github.com/ms2sato/agent-console/issues/879) and [#886](https://github.com/ms2sato/agent-console/issues/886). PRs #843 / #856 / #877 / #880 / #881 / #888 / #889 / #892 for individual consumer migrations and resolver / runner extractions
 
+## Client Capabilities
+
+### VSCodeOpenMode
+Union type controlling how the client opens paths in VS Code from the "Open in VS Code" UI. Determined server-side and delivered to the client via `/api/config.capabilities.vscodeOpenMode`.
+
+- `local-spawn` — the server spawns `code <path>` on its own host via `Bun.spawn`. Suitable for single-machine setups (server and browser run on the same OS). Default when `AUTH_MODE=none`.
+- `remote-url-scheme` — the client navigates to `vscode://vscode-remote/ssh-remote+<host><path>`, letting the browser's local VS Code + Remote-SSH extension open the file over SSH. Suitable for remote-access setups (server on a remote host, browser on the user's local machine). Default when `AUTH_MODE=multi-user`.
+
+**Server env overrides:**
+- `VSCODE_OPEN_MODE` — explicit `local-spawn` / `remote-url-scheme`; wins over the `AUTH_MODE`-derived default. Invalid values throw at server startup.
+- `VSCODE_REMOTE_HOST` — string surfaced on `/api/config.capabilities.vscodeRemoteHost` (null when unset). When null, the client falls back to `window.location.hostname` for host derivation.
+
+**Related capability fields:**
+- `capabilities.vscode: boolean` — the button-visibility gate. Unconditionally `true` in `remote-url-scheme` mode (the client's local VS Code handles the URL scheme, so the server's `code` binary presence is irrelevant); in `local-spawn` mode reflects the `which code` / `which code-insiders` detection.
+- `capabilities.vscodeRemoteHost: string | null` — the host embedded in the SSH-remote URL when the client dispatches the URL scheme.
+
+**Guardrails:** `POST /api/system/open-in-vscode` rejects (400) in `remote-url-scheme` mode so stale clients cannot silently spawn on the wrong host.
+
+- **Aliases:** vscodeOpenMode (`ConfigResponse` field name), Open-in-VSCode mode
+- **See:** Issue [#987](https://github.com/ms2sato/agent-console/issues/987) (introduces the URL-scheme dispatch); [`packages/shared/src/types/auth.ts`](../packages/shared/src/types/auth.ts) (`VSCodeOpenMode`, `ConfigResponse.capabilities`); [`packages/server/src/services/system-capabilities-service.ts`](../packages/server/src/services/system-capabilities-service.ts) (`resolveVSCodeOpenMode`); [`packages/client/src/lib/vscode-url.ts`](../packages/client/src/lib/vscode-url.ts) (`buildVSCodeRemoteUrl`).
+
 ## Events & Communication
 
 ### ConditionalWakeup

--- a/packages/client/src/__tests__/routes/WorktreeRow.test.tsx
+++ b/packages/client/src/__tests__/routes/WorktreeRow.test.tsx
@@ -5,10 +5,12 @@ import { WorktreeDeletionTasksContext } from '../../routes/__root';
 import type { UseWorktreeDeletionTasksReturn } from '../../hooks/useWorktreeDeletionTasks';
 import type { Worktree, WorktreeSession, WorktreeDeletionTask, Session } from '@agent-console/shared';
 
-// Mock hasVSCode - reads from a module-level cache set during app initialization,
+// Mock capabilities - reads from a module-level cache set during app initialization,
 // so module-level mocking is appropriate here (no business logic or fetch involved).
 mock.module('../../lib/capabilities', () => ({
   hasVSCode: () => false,
+  getVSCodeOpenMode: () => 'local-spawn',
+  getVSCodeRemoteHost: () => null,
 }));
 
 // Import WorktreeRow AFTER mock.module calls to ensure mocks are applied

--- a/packages/client/src/lib/__tests__/api.test.ts
+++ b/packages/client/src/lib/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect as bunExpect, mock, beforeEach, afterAll } from 'bun:test';
+import { describe, it, expect as bunExpect, mock, beforeEach, afterAll, afterEach, spyOn } from 'bun:test';
 import {
   fetchConfig,
   createSession,
@@ -15,9 +15,11 @@ import {
   fetchBranches,
   generateRepositoryDescription,
   resumeSession,
+  openInVSCode,
   ServerUnavailableError,
   ApiError,
 } from '../api';
+import * as capabilitiesModule from '../capabilities';
 
 // Bun's expect().toEqual() enforces strict generic matching between actual and expected types.
 // Tests use partial mock data intentionally (verifying passthrough, not shape), so we wrap
@@ -906,6 +908,103 @@ describe('API Client', () => {
         expect(thrown.status).toBe(400);
         expect(thrown.code).toBeUndefined();
       }
+    });
+  });
+
+  /**
+   * openInVSCode() dispatches between two modes based on the server-provided
+   * capabilities cache. These tests exercise both branches: the legacy REST
+   * POST path (local-spawn) and the client-side URL-scheme navigation
+   * (remote-url-scheme).
+   *
+   * `getVSCodeOpenMode` and `getVSCodeRemoteHost` are replaced per-test via
+   * `spyOn` (NOT mock.module, which is process-global in bun:test and would
+   * leak into other test files). This mirrors the pattern used in
+   * `routes/__tests__/index.test.tsx` for `hasVSCode`.
+   */
+  describe('openInVSCode', () => {
+    let windowOpenSpy: ReturnType<typeof spyOn>;
+    let modeSpy: ReturnType<typeof spyOn>;
+    let hostSpy: ReturnType<typeof spyOn>;
+    let originalLocation: Location;
+
+    beforeEach(() => {
+      // window.open is spied to capture the URL-scheme invocation. Provide a
+      // no-op impl so no actual popup / navigation is attempted in jsdom.
+      windowOpenSpy = spyOn(window, 'open').mockImplementation(() => null);
+      originalLocation = window.location;
+    });
+
+    afterEach(() => {
+      windowOpenSpy.mockRestore();
+      modeSpy?.mockRestore();
+      hostSpy?.mockRestore();
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+      });
+    });
+
+    it('mode=local-spawn: POSTs to /api/system/open-in-vscode and does NOT invoke window.open', async () => {
+      modeSpy = spyOn(capabilitiesModule, 'getVSCodeOpenMode').mockImplementation(
+        () => 'local-spawn'
+      );
+      hostSpy = spyOn(capabilitiesModule, 'getVSCodeRemoteHost').mockImplementation(
+        () => null
+      );
+      mockFetch.mockResolvedValue(createMockResponse({ success: true }));
+
+      await openInVSCode('/home/user/foo.ts');
+
+      expect(getLastFetchUrl()).toContain('/api/system/open-in-vscode');
+      expect(getLastFetchMethod()).toBe('POST');
+      const body = await getLastFetchBody();
+      expect(body).toEqual({ path: '/home/user/foo.ts' });
+      // Negative: URL-scheme path MUST NOT fire in local-spawn mode.
+      expect(windowOpenSpy).not.toHaveBeenCalled();
+    });
+
+    it('mode=remote-url-scheme + configured host: navigates via window.open and does NOT hit the REST endpoint', async () => {
+      modeSpy = spyOn(capabilitiesModule, 'getVSCodeOpenMode').mockImplementation(
+        () => 'remote-url-scheme'
+      );
+      hostSpy = spyOn(capabilitiesModule, 'getVSCodeRemoteHost').mockImplementation(
+        () => 'srv.example.com'
+      );
+
+      await openInVSCode('/home/user/foo.ts');
+
+      // Positive: window.open invoked once with the expected URL + target.
+      expect(windowOpenSpy).toHaveBeenCalledTimes(1);
+      const call = windowOpenSpy.mock.calls[0] as [string, string];
+      expect(call[0]).toBe(
+        'vscode://vscode-remote/ssh-remote+srv.example.com/home/user/foo.ts'
+      );
+      expect(call[1]).toBe('_self');
+      // Negative: REST fetch MUST NOT fire in remote-url-scheme mode.
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('mode=remote-url-scheme + vscodeRemoteHost=null: falls back to window.location.hostname', async () => {
+      Object.defineProperty(window, 'location', {
+        value: { hostname: 'fallback.local', protocol: 'http:', host: 'fallback.local' },
+        writable: true,
+      });
+      modeSpy = spyOn(capabilitiesModule, 'getVSCodeOpenMode').mockImplementation(
+        () => 'remote-url-scheme'
+      );
+      hostSpy = spyOn(capabilitiesModule, 'getVSCodeRemoteHost').mockImplementation(
+        () => null
+      );
+
+      await openInVSCode('/tmp/x.ts');
+
+      expect(windowOpenSpy).toHaveBeenCalledTimes(1);
+      const call = windowOpenSpy.mock.calls[0] as [string, string];
+      expect(call[0]).toBe(
+        'vscode://vscode-remote/ssh-remote+fallback.local/tmp/x.ts'
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/client/src/lib/__tests__/vscode-url.test.ts
+++ b/packages/client/src/lib/__tests__/vscode-url.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'bun:test';
+import { buildVSCodeRemoteUrl } from '../vscode-url';
+
+describe('buildVSCodeRemoteUrl', () => {
+  it('encodes a root path', () => {
+    expect(buildVSCodeRemoteUrl('/', 'host')).toBe(
+      'vscode://vscode-remote/ssh-remote+host/'
+    );
+  });
+
+  it('encodes a typical path with no special characters', () => {
+    expect(buildVSCodeRemoteUrl('/home/user/foo.ts', 'host')).toBe(
+      'vscode://vscode-remote/ssh-remote+host/home/user/foo.ts'
+    );
+  });
+
+  it('percent-encodes spaces in path segments (preserves / as separator)', () => {
+    expect(buildVSCodeRemoteUrl('/home/user/foo bar.ts', 'host')).toBe(
+      'vscode://vscode-remote/ssh-remote+host/home/user/foo%20bar.ts'
+    );
+  });
+
+  it('percent-encodes multi-byte Unicode in path segments', () => {
+    // Japanese "日本語" -> UTF-8 %E6%97%A5%E6%9C%AC%E8%AA%9E
+    expect(buildVSCodeRemoteUrl('/home/user/日本語.ts', 'host')).toBe(
+      'vscode://vscode-remote/ssh-remote+host/home/user/%E6%97%A5%E6%9C%AC%E8%AA%9E.ts'
+    );
+  });
+
+  it('percent-encodes URL-reserved special characters (# and ?) in path segments', () => {
+    expect(buildVSCodeRemoteUrl('/home/user/a#b?c.ts', 'host')).toBe(
+      'vscode://vscode-remote/ssh-remote+host/home/user/a%23b%3Fc.ts'
+    );
+  });
+
+  it('preserves a host with dots (dots are unreserved in encodeURIComponent)', () => {
+    expect(buildVSCodeRemoteUrl('/tmp/x', 'srv.example.com')).toBe(
+      'vscode://vscode-remote/ssh-remote+srv.example.com/tmp/x'
+    );
+  });
+
+  it('preserves a numeric IPv4 host', () => {
+    expect(buildVSCodeRemoteUrl('/tmp/x', '192.168.1.10')).toBe(
+      'vscode://vscode-remote/ssh-remote+192.168.1.10/tmp/x'
+    );
+  });
+
+  it('percent-encodes URL-reserved characters in host (colons, etc.)', () => {
+    // IPv6-ish notation; encodeURIComponent encodes ':' -> '%3A'
+    expect(buildVSCodeRemoteUrl('/tmp/x', 'fe80::1')).toBe(
+      'vscode://vscode-remote/ssh-remote+fe80%3A%3A1/tmp/x'
+    );
+  });
+
+  it('throws when the path is empty', () => {
+    expect(() => buildVSCodeRemoteUrl('', 'host')).toThrow(
+      'absolutePath must not be empty'
+    );
+  });
+
+  it('throws when the host is empty', () => {
+    expect(() => buildVSCodeRemoteUrl('/tmp/x', '')).toThrow(
+      'host must not be empty'
+    );
+  });
+});

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -38,6 +38,8 @@ import type {
 
 export type { ConfigResponse } from '@agent-console/shared';
 import { api } from './api-client';
+import { getVSCodeOpenMode, getVSCodeRemoteHost } from './capabilities';
+import { buildVSCodeRemoteUrl } from './vscode-url';
 
 // Base URL kept only for the wildcard worktree delete endpoint which Hono RPC doesn't handle well
 const API_BASE = '/api';
@@ -611,6 +613,12 @@ export async function openPath(path: string): Promise<void> {
 }
 
 export async function openInVSCode(path: string): Promise<void> {
+  if (getVSCodeOpenMode() === 'remote-url-scheme') {
+    const host = getVSCodeRemoteHost() ?? window.location.hostname;
+    const url = buildVSCodeRemoteUrl(path, host);
+    window.open(url, '_self');
+    return;
+  }
   const res = await api.system['open-in-vscode'].$post({ json: { path } });
   if (!res.ok) {
     await handleApiError(res, 'Failed to open in VS Code');

--- a/packages/client/src/lib/capabilities.ts
+++ b/packages/client/src/lib/capabilities.ts
@@ -1,5 +1,9 @@
+import type { VSCodeOpenMode } from '@agent-console/shared';
+
 interface SystemCapabilities {
   vscode: boolean;
+  vscodeOpenMode: VSCodeOpenMode;
+  vscodeRemoteHost: string | null;
 }
 
 let cachedCapabilities: SystemCapabilities | null = null;
@@ -10,4 +14,13 @@ export function setCapabilities(capabilities: SystemCapabilities): void {
 
 export function hasVSCode(): boolean {
   return cachedCapabilities?.vscode ?? false;
+}
+
+export function getVSCodeOpenMode(): VSCodeOpenMode {
+  // Default 'local-spawn' if not yet initialized (defensive; setCapabilities runs before UI).
+  return cachedCapabilities?.vscodeOpenMode ?? 'local-spawn';
+}
+
+export function getVSCodeRemoteHost(): string | null {
+  return cachedCapabilities?.vscodeRemoteHost ?? null;
 }

--- a/packages/client/src/lib/vscode-url.ts
+++ b/packages/client/src/lib/vscode-url.ts
@@ -1,0 +1,20 @@
+/**
+ * Build a `vscode://vscode-remote/ssh-remote+HOST<absolutePath>` URL that opens
+ * the file in the local VS Code via the Remote-SSH extension.
+ *
+ * The absolute path is encoded per-segment (`/` preserved as separator, other
+ * chars %-encoded via encodeURIComponent). The host is encoded whole.
+ */
+export function buildVSCodeRemoteUrl(absolutePath: string, host: string): string {
+  if (!absolutePath) {
+    throw new Error('absolutePath must not be empty');
+  }
+  if (!host) {
+    throw new Error('host must not be empty');
+  }
+  const encodedPath = absolutePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `vscode://vscode-remote/ssh-remote+${encodeURIComponent(host)}${encodedPath}`;
+}

--- a/packages/integration/src/system-api-boundary.test.ts
+++ b/packages/integration/src/system-api-boundary.test.ts
@@ -62,7 +62,11 @@ function setupSpawnMock() {
 function createMockSystemCapabilities(vscodeAvailable: boolean = true): SystemCapabilitiesService {
   const mockCapabilities = new SystemCapabilitiesService();
   // Manually set capabilities to avoid running 'which' command
-  Reflect.set(mockCapabilities, 'capabilities', { vscode: vscodeAvailable });
+  Reflect.set(mockCapabilities, 'capabilities', {
+    vscode: vscodeAvailable,
+    vscodeOpenMode: 'local-spawn',
+    vscodeRemoteHost: null,
+  });
   Reflect.set(mockCapabilities, 'vscodeCommand', vscodeAvailable ? 'code' : null);
   return mockCapabilities;
 }

--- a/packages/server/src/__tests__/system.test.ts
+++ b/packages/server/src/__tests__/system.test.ts
@@ -67,13 +67,21 @@ describe('System API - open-in-vscode', () => {
   });
 
   // Helper to create app with mocked system capabilities
-  async function createApp(vscodeAvailable: boolean, vscodeCommand: 'code' | 'code-insiders' | null = 'code') {
+  async function createApp(
+    vscodeAvailable: boolean,
+    vscodeCommand: 'code' | 'code-insiders' | null = 'code',
+    options: { vscodeOpenMode?: 'local-spawn' | 'remote-url-scheme'; vscodeRemoteHost?: string | null } = {},
+  ) {
     const suffix = `?v=${++importCounter}`;
 
     // Set up mock system capabilities
     const mockCapabilities = new SystemCapabilitiesService();
     // Manually set capabilities to avoid running which command
-    Reflect.set(mockCapabilities, 'capabilities', { vscode: vscodeAvailable });
+    Reflect.set(mockCapabilities, 'capabilities', {
+      vscode: vscodeAvailable,
+      vscodeOpenMode: options.vscodeOpenMode ?? 'local-spawn',
+      vscodeRemoteHost: options.vscodeRemoteHost ?? null,
+    });
     Reflect.set(mockCapabilities, 'vscodeCommand', vscodeAvailable ? vscodeCommand : null);
     const { system } = await import(`../routes/system.js${suffix}`);
     const { onApiError } = await import(`../lib/error-handler.js${suffix}`);
@@ -210,6 +218,26 @@ describe('System API - open-in-vscode', () => {
       });
 
       expect(res.status).toBe(400);
+    });
+
+    it('should return 400 in remote-url-scheme mode and not spawn locally', async () => {
+      // Simulate the multi-user / remote-access deployment: the client is
+      // expected to navigate to a `vscode://vscode-remote/...` URL directly,
+      // so hitting this REST endpoint is a stale-client / bug indicator.
+      const app = await createApp(true, 'code', { vscodeOpenMode: 'remote-url-scheme' });
+
+      const res = await app.request('/api/system/open-in-vscode', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: '/test/existing-dir' }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain('remote-url-scheme mode');
+
+      // The guard must fire before any spawn attempt.
+      expect(spawnCalls.length).toBe(0);
     });
   });
 });

--- a/packages/server/src/lib/server-config.ts
+++ b/packages/server/src/lib/server-config.ts
@@ -138,6 +138,37 @@ export const serverConfig = {
     }
     return value as 'bun-pty' | 'bun-terminal';
   })(),
+  /**
+   * VS Code "Open" mode selector.
+   * - undefined (default): capability service decides based on AUTH_MODE.
+   *   AUTH_MODE=multi-user -> 'remote-url-scheme' (server likely on remote host);
+   *   otherwise 'local-spawn'.
+   * - 'local-spawn': server spawns `code <path>` locally.
+   * - 'remote-url-scheme': client opens `vscode://vscode-remote/...` URL.
+   *
+   * Empty string is treated as unset (operator-friendly).
+   */
+  VSCODE_OPEN_MODE: (() => {
+    const raw = process.env.VSCODE_OPEN_MODE?.trim();
+    if (!raw) return undefined;
+    if (raw !== 'local-spawn' && raw !== 'remote-url-scheme') {
+      throw new Error(
+        `Invalid VSCODE_OPEN_MODE: '${raw}'. Must be 'local-spawn' or 'remote-url-scheme'.`
+      );
+    }
+    return raw as 'local-spawn' | 'remote-url-scheme';
+  })(),
+  /**
+   * Host to embed in `vscode://vscode-remote/ssh-remote+HOST<path>` URLs when
+   * `VSCODE_OPEN_MODE === 'remote-url-scheme'`. When unset, the client uses
+   * `window.location.hostname`.
+   *
+   * Empty string is treated as unset (operator-friendly).
+   */
+  VSCODE_REMOTE_HOST: (() => {
+    const raw = process.env.VSCODE_REMOTE_HOST?.trim();
+    return raw || undefined;
+  })(),
 } as const;
 
 /**

--- a/packages/server/src/routes/__tests__/api.test.ts
+++ b/packages/server/src/routes/__tests__/api.test.ts
@@ -18,7 +18,11 @@ import { SystemCapabilitiesService } from '../../services/system-capabilities-se
  */
 function createMockSystemCapabilities(): SystemCapabilitiesService {
   const service = new SystemCapabilitiesService();
-  Reflect.set(service, 'capabilities', { vscode: false });
+  Reflect.set(service, 'capabilities', {
+    vscode: false,
+    vscodeOpenMode: 'local-spawn',
+    vscodeRemoteHost: null,
+  });
   Reflect.set(service, 'vscodeCommand', null);
   return service;
 }
@@ -80,6 +84,11 @@ describe('GET /api/config — sharedAccountsAvailable', () => {
     // Boundary contract: only the boolean gate is exposed.
     expect(body).not.toHaveProperty('sharedAccountIds');
     expect(body).not.toHaveProperty('sharedAccounts');
+    // VS Code capability fields are always present in the response so the
+    // client can decide how to render the "Open in VS Code" affordance.
+    expect(body.capabilities.vscode).toBe(false);
+    expect(body.capabilities.vscodeOpenMode).toBe('local-spawn');
+    expect(body.capabilities.vscodeRemoteHost).toBeNull();
   });
 
   it('returns sharedAccountsAvailable: true when the registry is enabled', async () => {

--- a/packages/server/src/routes/__tests__/auth.test.ts
+++ b/packages/server/src/routes/__tests__/auth.test.ts
@@ -451,8 +451,14 @@ describe('GET /api/config (multi-user mode)', () => {
   function createMockSystemCapabilities(): SystemCapabilitiesService {
     return {
       detect: async () => {},
-      getCapabilities: () => ({ vscode: false }),
+      getCapabilities: () => ({
+        vscode: false,
+        vscodeOpenMode: 'local-spawn' as const,
+        vscodeRemoteHost: null,
+      }),
       getVSCodeCommand: () => null,
+      getVSCodeOpenMode: () => 'local-spawn' as const,
+      getVSCodeRemoteHost: () => null,
     } as unknown as SystemCapabilitiesService;
   }
 

--- a/packages/server/src/routes/__tests__/auth.test.ts
+++ b/packages/server/src/routes/__tests__/auth.test.ts
@@ -16,7 +16,7 @@ import type { UserMode, LoginResult } from '../../services/user-mode.js';
 import type { AuthUser } from '@agent-console/shared';
 import type { PtyInstance } from '../../lib/pty-provider.js';
 import type { PtySpawnRequest } from '../../services/user-mode.js';
-import type { SystemCapabilitiesService } from '../../services/system-capabilities-service.js';
+import { SystemCapabilitiesService } from '../../services/system-capabilities-service.js';
 
 // ============================================================================
 // Mock UserMode implementations
@@ -449,17 +449,14 @@ describe('GET /api/config (multi-user mode)', () => {
    * Create a mock SystemCapabilitiesService for testing.
    */
   function createMockSystemCapabilities(): SystemCapabilitiesService {
-    return {
-      detect: async () => {},
-      getCapabilities: () => ({
-        vscode: false,
-        vscodeOpenMode: 'local-spawn' as const,
-        vscodeRemoteHost: null,
-      }),
-      getVSCodeCommand: () => null,
-      getVSCodeOpenMode: () => 'local-spawn' as const,
-      getVSCodeRemoteHost: () => null,
-    } as unknown as SystemCapabilitiesService;
+    const service = new SystemCapabilitiesService();
+    Reflect.set(service, 'capabilities', {
+      vscode: false,
+      vscodeOpenMode: 'local-spawn',
+      vscodeRemoteHost: null,
+    });
+    Reflect.set(service, 'vscodeCommand', null);
+    return service;
   }
 
   /**

--- a/packages/server/src/routes/__tests__/system.test.ts
+++ b/packages/server/src/routes/__tests__/system.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { Hono } from 'hono';
-import type { AppBindings } from '../app-context.js';
-import { asAppContext } from './test-utils.js';
+import type { AppBindings } from '../../app-context.js';
+import { asAppContext } from '../../__tests__/test-utils.js';
 
 // Mock open package BEFORE importing mock-fs-helper
 // The open package internally uses fs and needs to be mocked first
@@ -11,8 +11,8 @@ mock.module('open', () => ({
 }));
 
 // Import mock-fs-helper to set up memfs mocks
-import { setupMemfs, cleanupMemfs } from './utils/mock-fs-helper.js';
-import { SystemCapabilitiesService } from '../services/system-capabilities-service.js';
+import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
+import { SystemCapabilitiesService } from '../../services/system-capabilities-service.js';
 
 // Track Bun.spawn calls for VS Code
 const spawnCalls: Array<{ args: string[]; options: Record<string, unknown> }> = [];
@@ -83,8 +83,8 @@ describe('System API - open-in-vscode', () => {
       vscodeRemoteHost: options.vscodeRemoteHost ?? null,
     });
     Reflect.set(mockCapabilities, 'vscodeCommand', vscodeAvailable ? vscodeCommand : null);
-    const { system } = await import(`../routes/system.js${suffix}`);
-    const { onApiError } = await import(`../lib/error-handler.js${suffix}`);
+    const { system } = await import(`../system.js${suffix}`);
+    const { onApiError } = await import(`../../lib/error-handler.js${suffix}`);
 
     const app = new Hono<AppBindings>();
     app.use('*', async (c, next) => {

--- a/packages/server/src/routes/system.ts
+++ b/packages/server/src/routes/system.ts
@@ -52,6 +52,17 @@ const system = new Hono<AppBindings>()
 
     // Check if VS Code is available
     const { systemCapabilities } = c.get('appContext');
+
+    // Guard against stale clients (or bugs) that hit this endpoint in
+    // remote-url-scheme mode. In that mode the client is expected to navigate
+    // to the `vscode://vscode-remote/...` URL directly; spawning a local
+    // `code` process here would be a silent no-op on remote-access setups.
+    if (systemCapabilities.getVSCodeOpenMode() === 'remote-url-scheme') {
+      throw new ValidationError(
+        'open-in-vscode REST endpoint is disabled in remote-url-scheme mode; use the URL scheme instead'
+      );
+    }
+
     const vscodeCommand = systemCapabilities.getVSCodeCommand();
 
     if (!vscodeCommand) {

--- a/packages/server/src/services/__tests__/system-capabilities-service.test.ts
+++ b/packages/server/src/services/__tests__/system-capabilities-service.test.ts
@@ -1,7 +1,24 @@
 import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
+import type { ServerConfig } from '../../lib/server-config.js';
 
 // Store original Bun.spawn to restore after tests
 const originalBunSpawn = Bun.spawn;
+
+/**
+ * Minimal ServerConfig-shaped stub for VS Code capability resolution.
+ * Only fields consumed by SystemCapabilitiesService need to be provided.
+ */
+function makeConfig(overrides: {
+  VSCODE_OPEN_MODE?: 'local-spawn' | 'remote-url-scheme';
+  VSCODE_REMOTE_HOST?: string;
+  AUTH_MODE?: 'none' | 'multi-user';
+}): Pick<ServerConfig, 'VSCODE_OPEN_MODE' | 'VSCODE_REMOTE_HOST' | 'AUTH_MODE'> {
+  return {
+    VSCODE_OPEN_MODE: overrides.VSCODE_OPEN_MODE,
+    VSCODE_REMOTE_HOST: overrides.VSCODE_REMOTE_HOST,
+    AUTH_MODE: overrides.AUTH_MODE ?? 'none',
+  };
+}
 
 // Track which commands should be "available"
 let availableCommands: Set<string> = new Set();
@@ -59,9 +76,9 @@ describe('SystemCapabilitiesService', () => {
     (Bun as { spawn: typeof Bun.spawn }).spawn = originalBunSpawn;
   });
 
-  async function getService() {
+  async function getService(configOverrides: Parameters<typeof makeConfig>[0] = {}) {
     const module = await import(`../system-capabilities-service.js?v=${++importCounter}`);
-    return new module.SystemCapabilitiesService();
+    return new module.SystemCapabilitiesService(makeConfig(configOverrides));
   }
 
   describe('detect()', () => {
@@ -192,6 +209,118 @@ describe('SystemCapabilitiesService', () => {
       const service = await getService();
 
       expect(() => service.getCapabilities()).toThrow(
+        'SystemCapabilitiesService not initialized. Call detect() first.'
+      );
+    });
+  });
+
+  // =========================================================================
+  // vscodeOpenMode resolution
+  // =========================================================================
+
+  describe('vscodeOpenMode', () => {
+    it('honors VSCODE_OPEN_MODE=local-spawn regardless of AUTH_MODE', async () => {
+      const service = await getService({
+        VSCODE_OPEN_MODE: 'local-spawn',
+        AUTH_MODE: 'multi-user',
+      });
+      await service.detect();
+
+      expect(service.getVSCodeOpenMode()).toBe('local-spawn');
+      expect(service.getCapabilities().vscodeOpenMode).toBe('local-spawn');
+    });
+
+    it('honors VSCODE_OPEN_MODE=remote-url-scheme regardless of AUTH_MODE', async () => {
+      const service = await getService({
+        VSCODE_OPEN_MODE: 'remote-url-scheme',
+        AUTH_MODE: 'none',
+      });
+      await service.detect();
+
+      expect(service.getVSCodeOpenMode()).toBe('remote-url-scheme');
+    });
+
+    it('defaults to remote-url-scheme when AUTH_MODE=multi-user and VSCODE_OPEN_MODE unset', async () => {
+      const service = await getService({ AUTH_MODE: 'multi-user' });
+      await service.detect();
+
+      expect(service.getVSCodeOpenMode()).toBe('remote-url-scheme');
+    });
+
+    it('defaults to local-spawn when AUTH_MODE=none and VSCODE_OPEN_MODE unset', async () => {
+      const service = await getService({ AUTH_MODE: 'none' });
+      await service.detect();
+
+      expect(service.getVSCodeOpenMode()).toBe('local-spawn');
+    });
+
+    it('reports vscode=true in remote-url-scheme mode even when no local binary exists', async () => {
+      // No commands available on the server host
+      const service = await getService({ VSCODE_OPEN_MODE: 'remote-url-scheme' });
+      await service.detect();
+
+      expect(service.hasVSCode()).toBe(true);
+      expect(service.getCapabilities().vscode).toBe(true);
+      // vscodeCommand still reflects the local detection result (null here);
+      // the REST guard uses vscodeOpenMode, not vscodeCommand, to reject.
+      expect(service.getVSCodeCommand()).toBe(null);
+    });
+
+    it('reports vscode=false in local-spawn mode when no local binary exists', async () => {
+      const service = await getService({ VSCODE_OPEN_MODE: 'local-spawn' });
+      await service.detect();
+
+      expect(service.hasVSCode()).toBe(false);
+      expect(service.getCapabilities().vscode).toBe(false);
+    });
+
+    it('reports vscode=true in local-spawn mode when a local binary exists', async () => {
+      availableCommands.add('code');
+
+      const service = await getService({ VSCODE_OPEN_MODE: 'local-spawn' });
+      await service.detect();
+
+      expect(service.hasVSCode()).toBe(true);
+      expect(service.getVSCodeCommand()).toBe('code');
+    });
+
+    it('getVSCodeOpenMode() throws before detect()', async () => {
+      const service = await getService();
+
+      expect(() => service.getVSCodeOpenMode()).toThrow(
+        'SystemCapabilitiesService not initialized. Call detect() first.'
+      );
+    });
+  });
+
+  // =========================================================================
+  // vscodeRemoteHost resolution
+  // =========================================================================
+
+  describe('vscodeRemoteHost', () => {
+    it('surfaces VSCODE_REMOTE_HOST when set', async () => {
+      const service = await getService({
+        VSCODE_OPEN_MODE: 'remote-url-scheme',
+        VSCODE_REMOTE_HOST: 'dev.example.com',
+      });
+      await service.detect();
+
+      expect(service.getVSCodeRemoteHost()).toBe('dev.example.com');
+      expect(service.getCapabilities().vscodeRemoteHost).toBe('dev.example.com');
+    });
+
+    it('returns null when VSCODE_REMOTE_HOST is unset', async () => {
+      const service = await getService({ VSCODE_OPEN_MODE: 'remote-url-scheme' });
+      await service.detect();
+
+      expect(service.getVSCodeRemoteHost()).toBe(null);
+      expect(service.getCapabilities().vscodeRemoteHost).toBe(null);
+    });
+
+    it('getVSCodeRemoteHost() throws before detect()', async () => {
+      const service = await getService();
+
+      expect(() => service.getVSCodeRemoteHost()).toThrow(
         'SystemCapabilitiesService not initialized. Call detect() first.'
       );
     });

--- a/packages/server/src/services/system-capabilities-service.ts
+++ b/packages/server/src/services/system-capabilities-service.ts
@@ -1,13 +1,46 @@
+import type { VSCodeOpenMode } from '@agent-console/shared';
 import { createLogger } from '../lib/logger.js';
+import { serverConfig, type ServerConfig } from '../lib/server-config.js';
 
 const logger = createLogger('system-capabilities');
+
+/**
+ * Subset of server configuration consumed by VS Code capability resolution.
+ * Extracted as a Pick so tests can pass a minimal override without going
+ * through module-cache resets.
+ */
+type VSCodeConfig = Pick<ServerConfig, 'VSCODE_OPEN_MODE' | 'VSCODE_REMOTE_HOST' | 'AUTH_MODE'>;
+
+/**
+ * Resolve the effective `VSCodeOpenMode`:
+ * 1. Explicit `VSCODE_OPEN_MODE` env wins.
+ * 2. Otherwise, `AUTH_MODE=multi-user` -> `remote-url-scheme` (server is
+ *    typically on a remote host in that deployment).
+ * 3. Otherwise, `local-spawn` (single-machine dev / default).
+ */
+export function resolveVSCodeOpenMode(
+  config: Pick<VSCodeConfig, 'VSCODE_OPEN_MODE' | 'AUTH_MODE'>,
+): VSCodeOpenMode {
+  if (config.VSCODE_OPEN_MODE) {
+    return config.VSCODE_OPEN_MODE;
+  }
+  return config.AUTH_MODE === 'multi-user' ? 'remote-url-scheme' : 'local-spawn';
+}
 
 /**
  * System capabilities detected at startup.
  */
 export interface SystemCapabilities {
-  /** Whether VS Code (or Insiders) is available */
+  /**
+   * Whether the "Open in VS Code" UI should be surfaced.
+   *
+   * In `remote-url-scheme` mode this is always `true` (the client's VS Code
+   * handles the URL); in `local-spawn` mode it reflects whether a `code`
+   * binary was detected on the server host.
+   */
   vscode: boolean;
+  vscodeOpenMode: VSCodeOpenMode;
+  vscodeRemoteHost: string | null;
 }
 
 /**
@@ -20,20 +53,34 @@ export class SystemCapabilitiesService {
   private capabilities: SystemCapabilities | null = null;
   private vscodeCommand: 'code' | 'code-insiders' | null = null;
 
+  constructor(private readonly config: VSCodeConfig = serverConfig) {}
+
   /**
    * Detect all system capabilities.
    * Should be called once at application startup.
    */
   async detect(): Promise<void> {
     const vscodeResult = await this.detectVSCode();
+    const vscodeOpenMode = resolveVSCodeOpenMode(this.config);
+    const vscodeRemoteHost = this.config.VSCODE_REMOTE_HOST ?? null;
+    const localVscodeAvailable = vscodeResult !== null;
 
     this.vscodeCommand = vscodeResult;
     this.capabilities = {
-      vscode: vscodeResult !== null,
+      // In remote-url-scheme mode the client's VS Code handles the URL, so the
+      // server's binary presence is irrelevant to whether the UI should show.
+      vscode: vscodeOpenMode === 'remote-url-scheme' ? true : localVscodeAvailable,
+      vscodeOpenMode,
+      vscodeRemoteHost,
     };
 
     logger.info(
-      { vscode: this.capabilities.vscode, vscodeCommand: vscodeResult },
+      {
+        vscode: this.capabilities.vscode,
+        vscodeCommand: vscodeResult,
+        vscodeOpenMode,
+        vscodeRemoteHost,
+      },
       'System capabilities detected'
     );
   }
@@ -62,6 +109,29 @@ export class SystemCapabilitiesService {
    */
   getVSCodeCommand(): 'code' | 'code-insiders' | null {
     return this.vscodeCommand;
+  }
+
+  /**
+   * Get the resolved VS Code "Open" mode.
+   * @throws Error if detect() has not been called
+   */
+  getVSCodeOpenMode(): VSCodeOpenMode {
+    if (!this.capabilities) {
+      throw new Error('SystemCapabilitiesService not initialized. Call detect() first.');
+    }
+    return this.capabilities.vscodeOpenMode;
+  }
+
+  /**
+   * Get the remote host embedded in `vscode://vscode-remote/...` URLs. `null`
+   * means the client falls back to `window.location.hostname`.
+   * @throws Error if detect() has not been called
+   */
+  getVSCodeRemoteHost(): string | null {
+    if (!this.capabilities) {
+      throw new Error('SystemCapabilitiesService not initialized. Call detect() first.');
+    }
+    return this.capabilities.vscodeRemoteHost;
   }
 
   /**

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -1,6 +1,17 @@
 export type AuthMode = 'none' | 'multi-user';
 
 /**
+ * Determines how the client opens paths in VS Code.
+ * - `local-spawn`: Server spawns `code <path>` locally. Requires a `code` binary
+ *   on the server host. Suitable for single-machine setups (server and browser
+ *   on the same OS).
+ * - `remote-url-scheme`: Client-side navigates to a `vscode://vscode-remote/ssh-remote+HOST<path>`
+ *   URL, letting the browser's local VS Code open the remote path over SSH.
+ *   Suitable for remote-access setups (server and browser on different machines).
+ */
+export type VSCodeOpenMode = 'local-spawn' | 'remote-url-scheme';
+
+/**
  * Authenticated user identity.
  *
  * Represents the OS user who is currently authenticated.
@@ -36,7 +47,22 @@ export interface CurrentUserResponse {
 export interface ConfigResponse {
   homeDir: string;
   capabilities: {
+    /**
+     * Whether the "Open in VS Code" UI should be surfaced to the user.
+     * Semantics depend on `vscodeOpenMode`:
+     * - `local-spawn`: `true` iff a `code` / `code-insiders` binary exists on
+     *   the server host.
+     * - `remote-url-scheme`: always `true` (the client's local VS Code handles
+     *   the URL scheme, so the server's binary presence is irrelevant).
+     */
     vscode: boolean;
+    vscodeOpenMode: VSCodeOpenMode;
+    /**
+     * Host to embed in the `vscode://vscode-remote/ssh-remote+HOST<path>` URL
+     * when `vscodeOpenMode === 'remote-url-scheme'`. `null` means the client
+     * falls back to `window.location.hostname`.
+     */
+    vscodeRemoteHost: string | null;
   };
   serverPid: number;
   authMode: AuthMode;


### PR DESCRIPTION
## Summary

Opens files in the user's **local VS Code** via `vscode://vscode-remote/ssh-remote+HOST<path>` URL scheme when the server signals a remote-access deployment. Fixes the "silent success failure" where the previous `Bun.spawn(['code', absolutePath])` on the server host either failed on headless remote hosts or opened the file on the wrong machine.

- **Server capability signal**: new `ConfigResponse.capabilities.vscodeOpenMode` + `vscodeRemoteHost` fields, driven by `AUTH_MODE` (multi-user → `remote-url-scheme`, else `local-spawn`), overridable via `VSCODE_OPEN_MODE` / `VSCODE_REMOTE_HOST` env vars.
- **Client dispatch**: `openInVSCode()` branches on the mode — `local-spawn` keeps the legacy REST path, `remote-url-scheme` calls `window.open('vscode://…', '_self')`. Host derivation prefers server-supplied `vscodeRemoteHost`, falling back to `window.location.hostname`.
- **Path encoding**: per-segment `encodeURIComponent` (split/join on `/`) handles spaces, unicode, and URL-reserved chars while preserving `/` as separators.
- **Stale-client guard**: the REST `/api/system/open-in-vscode` endpoint now rejects (400) in `remote-url-scheme` mode instead of silently spawning on the wrong host.
- UI callers (`routes/index.tsx` × 2, `SessionSettingsMenu.tsx`) are unchanged — the signature and `hasVSCode()` semantics are preserved.

Closes #987

## Design decisions

- **Mode = server capability (Option i)** — matches the Issue's tentative direction. Server knows its own deployment shape (single-user local vs multi-user remote-access) via `AUTH_MODE`; client just dispatches on the received capability. Client-side user override is deferred to a future PR.
- **`capabilities.vscode` semantics preserved** — the field now means "should the button render" for both modes. In `remote-url-scheme` mode it's unconditionally `true` because the client's local VS Code handles the URL scheme regardless of the server's `code` binary.
- **Backwards compat** — single-user local deployments hit the default `local-spawn` mode; the REST path is byte-identical to today. Stale clients on a newly-remote server see a clear 400 instead of silent success.

## Verification Matrix

| Item | Verified | How |
|---|---|---|
| ✅ Server capability shape (`vscodeOpenMode` / `vscodeRemoteHost` in `/api/config`) | agent | New `SystemCapabilitiesService` tests × 11 + `/api/config` assertions × 3 |
| ✅ REST endpoint 400 in `remote-url-scheme` mode | agent | New `system.test.ts` case + integration boundary mock |
| ✅ Client `openInVSCode()` dispatch (both branches, negative assertions) | agent | New `api.test.ts` `openInVSCode` describe (3 cases) |
| ✅ URL construction (root, plain, `%20`, unicode UTF-8, `#`/`?`, dot-host, IPv4, IPv6, empty guards) | agent | New `vscode-url.test.ts` (10 cases) |
| ✅ `bun run typecheck` clean | agent | All 3 packages, exit 0 |
| ✅ `bun run test` full suite | agent | 5085 pass / 1 skip / 0 fail (SSH_AUTH_SOCK env leak pre-existing, cleared by `unset`) |
| ✅ `bun run check:lang` clean | agent | 108 files scanned |
| ✅ `preflight-check.js` clean | agent | Coverage, rule-skill, language, blame-shift all green |
| ✅ Local-mode regression (dev browser) | agent | chrome-devtools MCP: `/api/config` returns expected shape; `POST /api/system/open-in-vscode` still returns 200; UI buttons render; no console errors |
| 🔶 Remote-access (owner's Mac + Remote-SSH) actually opens the file in local VS Code | **owner** | Requires a real remote-access setup with VS Code + Remote-SSH extension installed on the browser host |
| 🔶 URL-scheme browser prompt UX / VS Code protocol handler quirks | **owner** | Environment-specific browser behavior when clicking a `vscode://` link (permission prompts, "Open with…" dialogs) |

## Follow-up ideas (out of scope for this PR)

- Client-side user override for `vscodeOpenMode` (localStorage) if the server's default is wrong for a specific user
- Path translation across dissimilar filesystems (SSHFS remap, bind-mount)
- A "Copy path" secondary action as a fallback when Remote-SSH isn't installed

## CodeRabbit findings disposition

- ✅ **Addressed**: `auth.test.ts` `as unknown as SystemCapabilitiesService` cast (Nitpick, coding-guideline violation) — mirrored the real-instance + `Reflect.set` pattern already used in `api.test.ts` in a follow-up commit.
- ⏭ **Deferred**: `createMockSystemCapabilities` duplicated across 4 test files (`system.test.ts` / `system-api-boundary.test.ts` / `auth.test.ts` / `api.test.ts`). Extracting a shared helper is a broader test-infra refactor that would touch four setups in lockstep; deferring keeps this PR focused on the #987 behaviour change. Left for a follow-up alongside the next `SystemCapabilities` field addition.

## Test plan

- [x] Unit — URL construction covers empty guards, root, spaces, unicode, URL-reserved chars, dot / IPv4 / IPv6 hosts
- [x] Unit — mode dispatch: `local-spawn` calls REST + NOT `window.open`; `remote-url-scheme` calls `window.open` + NOT REST; null host falls back to `window.location.hostname`
- [x] Server unit — `SystemCapabilitiesService` resolves mode from env / AUTH_MODE / default; `getVSCodeOpenMode` / `getVSCodeRemoteHost` throw when uninitialized
- [x] Server integration — `/api/config` returns new fields; `/api/system/open-in-vscode` returns 400 in remote mode
- [x] Local dev regression — `/api/config` returns `local-spawn`; REST endpoint still 200; UI unchanged (chrome-devtools MCP)
- [ ] Remote-access manual QA — Owner verifies file opens in local VS Code via Remote-SSH (blocked on real environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)