### PR TITLE
[AI] closes #991 feat(client): expose MCP install command in Settings

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -192,6 +192,15 @@ Union type controlling how the client opens paths in VS Code from the "Open in V
 - **Aliases:** vscodeOpenMode (`ConfigResponse` field name), Open-in-VSCode mode
 - **See:** Issue [#987](https://github.com/ms2sato/agent-console/issues/987) (introduces the URL-scheme dispatch); [`packages/shared/src/types/auth.ts`](../packages/shared/src/types/auth.ts) (`VSCodeOpenMode`, `ConfigResponse.capabilities`); [`packages/server/src/services/system-capabilities-service.ts`](../packages/server/src/services/system-capabilities-service.ts) (`resolveVSCodeOpenMode`); [`packages/client/src/lib/vscode-url.ts`](../packages/client/src/lib/vscode-url.ts) (`buildVSCodeRemoteUrl`).
 
+### serverPort
+The backend HTTP port the server is bound to, exposed to the client so it can compose absolute URLs pointing at the same server without hard-coding a port. Positive integer.
+
+- **Source of truth:** `serverConfig.PORT` (env-configured; string in env, coerced to `Number(...)` at the response boundary; default `3457`).
+- **Wire:** `/api/config.serverPort` (`packages/server/src/routes/api.ts`), typed on `ConfigResponse.serverPort` in [`packages/shared/src/types/auth.ts`](../packages/shared/src/types/auth.ts).
+- **Consumer:** the client caches the value in [`packages/client/src/lib/server-info.ts`](../packages/client/src/lib/server-info.ts) (module-level `setServerPort` / `getServerPort` set once at app init, mirroring the `homeDir` pattern). Used by [`buildMcpInstallCommand`](../packages/client/src/lib/mcp-install-url.ts) to decide whether the current browser origin is same-origin with the backend (production single-port serving / reverse proxy on default 80/443) or split-port (dev with Vite on 5173 proxying `/api` to backend on `serverPort`); the split case composes `${protocol}//${hostname}:${serverPort}/mcp` so the copied install command targets the backend directly.
+- **Related:** [`buildMcpInstallCommand`](../packages/client/src/lib/mcp-install-url.ts), the "Install MCP server in Claude Code" Settings section ([`McpInstallSection`](../packages/client/src/components/settings/McpInstallSection.tsx)).
+- **See:** Issue [#991](https://github.com/ms2sato/agent-console/issues/991).
+
 ## Events & Communication
 
 ### ConditionalWakeup

--- a/packages/client/src/components/settings/McpInstallSection.tsx
+++ b/packages/client/src/components/settings/McpInstallSection.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { getServerPort } from '../../lib/server-info';
+import { buildMcpInstallCommand } from '../../lib/mcp-install-url';
+import { logger } from '../../lib/logger';
+
+/**
+ * Settings-page section that shows the exact `claude mcp add ...` command
+ * needed to register this Agent Console server's MCP endpoint with the
+ * Claude Code CLI. The port and host are derived at runtime so the command
+ * works in dev, production single-port, and reverse-proxied deploys.
+ */
+export function McpInstallSection() {
+  const serverPort = getServerPort();
+  const [copied, setCopied] = useState(false);
+
+  // Defensive: if serverPort was never set (e.g. test setup skipped init),
+  // don't render — better than showing a broken command.
+  if (serverPort === null) return null;
+
+  const command = buildMcpInstallCommand(serverPort);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      logger.error('Failed to copy MCP install command:', err);
+    }
+  };
+
+  return (
+    <div className="card mb-6">
+      <h2 className="text-lg font-medium mb-2">Install MCP server in Claude Code</h2>
+      <p className="text-sm text-gray-500 mb-3">
+        Register Agent Console&apos;s MCP tools with the Claude Code CLI on any
+        machine that can reach this server. All Claude Code instances (including
+        those spawned by Agent Console) will automatically discover the tools.
+      </p>
+      <div className="flex items-center gap-2">
+        <code className="flex-1 min-w-0 px-3 py-2 bg-slate-800 text-slate-200 rounded font-mono text-sm break-all">
+          {command}
+        </code>
+        <button
+          onClick={handleCopy}
+          className="btn btn-primary text-sm shrink-0"
+          aria-label="Copy install command"
+        >
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/settings/McpInstallSection.tsx
+++ b/packages/client/src/components/settings/McpInstallSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getServerPort } from '../../lib/server-info';
 import { buildMcpInstallCommand } from '../../lib/mcp-install-url';
 import { logger } from '../../lib/logger';
@@ -12,6 +12,18 @@ import { logger } from '../../lib/logger';
 export function McpInstallSection() {
   const serverPort = getServerPort();
   const [copied, setCopied] = useState(false);
+  // Timer handle for the "Copied!" -> "Copy" label revert. Held in a ref so
+  // we can clear a still-pending timer on rapid re-clicks or on unmount,
+  // avoiding a "state update on unmounted component" warning.
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   // Defensive: if serverPort was never set (e.g. test setup skipped init),
   // don't render — better than showing a broken command.
@@ -23,7 +35,10 @@ export function McpInstallSection() {
     try {
       await navigator.clipboard.writeText(command);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       logger.error('Failed to copy MCP install command:', err);
     }

--- a/packages/client/src/components/settings/__tests__/McpInstallSection.test.tsx
+++ b/packages/client/src/components/settings/__tests__/McpInstallSection.test.tsx
@@ -25,9 +25,9 @@ function installClipboardMock() {
 
 function restoreClipboard() {
   // Remove the per-instance override so navigator.clipboard falls back to the
-  // prototype-level descriptor happy-dom installed. Deletion is safe because
-  // installClipboardMock defined the property as configurable.
-  delete (navigator as unknown as { clipboard?: unknown }).clipboard;
+  // prototype-level descriptor happy-dom installed. Reflect.deleteProperty is
+  // safe because installClipboardMock defined the property as configurable.
+  Reflect.deleteProperty(navigator, 'clipboard');
   if (originalClipboardDescriptor && !('clipboard' in navigator)) {
     Object.defineProperty(
       Object.getPrototypeOf(navigator),

--- a/packages/client/src/components/settings/__tests__/McpInstallSection.test.tsx
+++ b/packages/client/src/components/settings/__tests__/McpInstallSection.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { render, screen, cleanup, act, fireEvent } from '@testing-library/react';
+import { McpInstallSection } from '../McpInstallSection';
+import { setServerPort, _reset as resetServerInfo } from '../../../lib/server-info';
+
+// Preserve the original clipboard descriptor so we can restore it per-test.
+// happy-dom provides a real clipboard implementation; we swap it out for a
+// jest-mock so we can assert on `writeText` calls without touching the OS.
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+  Object.getPrototypeOf(navigator),
+  'clipboard',
+);
+
+// Fresh writeText mock per test so counts / args do not bleed across tests.
+let writeTextMock: ReturnType<typeof mock>;
+
+function installClipboardMock() {
+  writeTextMock = mock(() => Promise.resolve());
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: writeTextMock },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function restoreClipboard() {
+  // Remove the per-instance override so navigator.clipboard falls back to the
+  // prototype-level descriptor happy-dom installed. Deletion is safe because
+  // installClipboardMock defined the property as configurable.
+  delete (navigator as unknown as { clipboard?: unknown }).clipboard;
+  if (originalClipboardDescriptor && !('clipboard' in navigator)) {
+    Object.defineProperty(
+      Object.getPrototypeOf(navigator),
+      'clipboard',
+      originalClipboardDescriptor,
+    );
+  }
+}
+
+beforeEach(() => {
+  resetServerInfo();
+  installClipboardMock();
+});
+
+afterEach(() => {
+  cleanup();
+  restoreClipboard();
+});
+
+describe('McpInstallSection', () => {
+  it('renders nothing when serverPort has not been set', () => {
+    const { container } = render(<McpInstallSection />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the section heading and the install command with the server port', () => {
+    setServerPort(3457);
+    render(<McpInstallSection />);
+
+    expect(screen.getByText('Install MCP server in Claude Code')).toBeTruthy();
+
+    // The command block should contain the /mcp URL with the configured port.
+    // In the happy-dom test environment window.location.port is empty and the
+    // origin is used as-is, so the exact URL reflects the current test host.
+    const codeBlock = screen.getByText(/^claude mcp add --transport http agent-console /);
+    expect(codeBlock.textContent).toContain('/mcp');
+    expect(codeBlock.tagName.toLowerCase()).toBe('code');
+  });
+
+  it('copies the command to the clipboard when the Copy button is clicked', async () => {
+    setServerPort(3457);
+    render(<McpInstallSection />);
+
+    const copyButton = screen.getByRole('button', { name: 'Copy install command' });
+    expect(copyButton.textContent).toBe('Copy');
+
+    // We use `fireEvent` rather than `userEvent` because `userEvent.setup()`
+    // installs its own clipboard stub via a `navigator.clipboard` getter, which
+    // shadows the mock we install above. `fireEvent.click` bypasses that setup
+    // and dispatches the click directly.
+    await act(async () => {
+      fireEvent.click(copyButton);
+      // Yield so the async click handler's `await navigator.clipboard.writeText`
+      // microtask resolves before we assert.
+      await Promise.resolve();
+    });
+
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    const arg = writeTextMock.mock.calls[0][0] as string;
+    expect(arg).toMatch(/^claude mcp add --transport http agent-console .+\/mcp$/);
+  });
+
+  it('flips button label to "Copied!" after a successful copy', async () => {
+    setServerPort(3457);
+    render(<McpInstallSection />);
+
+    const copyButton = screen.getByRole('button', { name: 'Copy install command' });
+
+    await act(async () => {
+      fireEvent.click(copyButton);
+      await Promise.resolve();
+    });
+
+    // After the click resolves, the button label should reflect the "copied" state.
+    expect(screen.getByRole('button', { name: 'Copy install command' }).textContent).toBe('Copied!');
+  });
+});

--- a/packages/client/src/lib/__tests__/mcp-install-url.test.ts
+++ b/packages/client/src/lib/__tests__/mcp-install-url.test.ts
@@ -44,4 +44,25 @@ describe('buildMcpInstallCommand', () => {
     const cmd = buildMcpInstallCommand(3457, location);
     expect(cmd).toBe('claude mcp add --transport http agent-console http://192.168.1.20:3457/mcp');
   });
+
+  it('wraps bare IPv6 loopback hostname in brackets on the split-port dev path', () => {
+    // location.hostname reports IPv6 literals without brackets (e.g. `::1`),
+    // but URLs require the bracketed form `[::1]:3457`.
+    const location = makeLocation('http:', '::1', '5173');
+    const cmd = buildMcpInstallCommand(3457, location);
+    expect(cmd).toBe('claude mcp add --transport http agent-console http://[::1]:3457/mcp');
+  });
+
+  it('wraps bare IPv6 link-local hostname in brackets on the split-port dev path', () => {
+    const location = makeLocation('http:', 'fe80::1', '5173');
+    const cmd = buildMcpInstallCommand(3457, location);
+    expect(cmd).toBe('claude mcp add --transport http agent-console http://[fe80::1]:3457/mcp');
+  });
+
+  it('does not double-bracket an IPv6 hostname that is already bracketed', () => {
+    // Defensive: some environments may already report the hostname bracketed.
+    const location = makeLocation('http:', '[::1]', '5173');
+    const cmd = buildMcpInstallCommand(3457, location);
+    expect(cmd).toBe('claude mcp add --transport http agent-console http://[::1]:3457/mcp');
+  });
 });

--- a/packages/client/src/lib/__tests__/mcp-install-url.test.ts
+++ b/packages/client/src/lib/__tests__/mcp-install-url.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'bun:test';
+import { buildMcpInstallCommand, type McpInstallLocation } from '../mcp-install-url';
+
+function makeLocation(protocol: string, hostname: string, port: string): McpInstallLocation {
+  // Compose `origin` the same way browsers do so tests reflect real behavior.
+  const portSuffix = port === '' ? '' : `:${port}`;
+  return {
+    protocol,
+    hostname,
+    port,
+    origin: `${protocol}//${hostname}${portSuffix}`,
+  };
+}
+
+describe('buildMcpInstallCommand', () => {
+  it('dev mode: vite on 5173 with backend on 3457 targets the backend directly', () => {
+    // Vite dev server does not proxy /mcp; the command must point at the backend port.
+    const location = makeLocation('http:', 'localhost', '5173');
+    const cmd = buildMcpInstallCommand(3457, location);
+    expect(cmd).toBe('claude mcp add --transport http agent-console http://localhost:3457/mcp');
+  });
+
+  it('production single-port: browser port matches server port, uses window.location.origin', () => {
+    const location = makeLocation('http:', 'host.example.com', '6340');
+    const cmd = buildMcpInstallCommand(6340, location);
+    expect(cmd).toBe('claude mcp add --transport http agent-console http://host.example.com:6340/mcp');
+  });
+
+  it('reverse proxy on https default port: browser port is empty, uses window.location.origin', () => {
+    const location = makeLocation('https:', 'console.example.com', '');
+    const cmd = buildMcpInstallCommand(3457, location);
+    expect(cmd).toBe('claude mcp add --transport http agent-console https://console.example.com/mcp');
+  });
+
+  it('reverse proxy on http default port: browser port is empty, uses window.location.origin', () => {
+    const location = makeLocation('http:', 'internal-console', '');
+    const cmd = buildMcpInstallCommand(3457, location);
+    expect(cmd).toBe('claude mcp add --transport http agent-console http://internal-console/mcp');
+  });
+
+  it('preserves hostname when falling through to backend port (dev over LAN IP)', () => {
+    // Access the dev server via LAN IP; the backend is on the same host at 3457.
+    const location = makeLocation('http:', '192.168.1.20', '5173');
+    const cmd = buildMcpInstallCommand(3457, location);
+    expect(cmd).toBe('claude mcp add --transport http agent-console http://192.168.1.20:3457/mcp');
+  });
+});

--- a/packages/client/src/lib/__tests__/server-info.test.ts
+++ b/packages/client/src/lib/__tests__/server-info.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { setServerPort, getServerPort, _reset } from '../server-info';
+
+describe('server-info', () => {
+  beforeEach(() => {
+    _reset();
+  });
+
+  it('should return null before setServerPort is called', () => {
+    expect(getServerPort()).toBeNull();
+  });
+
+  it('should return the port set via setServerPort', () => {
+    setServerPort(3457);
+    expect(getServerPort()).toBe(3457);
+  });
+
+  it('should overwrite the previous value on repeated setServerPort', () => {
+    setServerPort(3457);
+    setServerPort(6340);
+    expect(getServerPort()).toBe(6340);
+  });
+
+  it('should reset back to null via _reset', () => {
+    setServerPort(3457);
+    _reset();
+    expect(getServerPort()).toBeNull();
+  });
+});

--- a/packages/client/src/lib/mcp-install-url.ts
+++ b/packages/client/src/lib/mcp-install-url.ts
@@ -1,0 +1,42 @@
+/**
+ * Minimal shape of `window.location` used by {@link buildMcpInstallCommand}.
+ * Declared as a subset so the function can be unit-tested with fabricated
+ * objects (no need to stub the global `window`).
+ */
+export interface McpInstallLocation {
+  protocol: string;
+  hostname: string;
+  port: string;
+  origin: string;
+}
+
+/**
+ * Build the `claude mcp add ...` command that registers this Agent Console
+ * server's MCP endpoint with the Claude Code CLI.
+ *
+ * The URL is composed to remain copy-pastable across all deploy modes:
+ *
+ * - **Dev** (vite dev server on 5173, backend on 3457): browser origin is
+ *   `http://localhost:5173`, but `/mcp` is not proxied by Vite. Fall through
+ *   to `${protocol}//${hostname}:${serverPort}` so the command targets the
+ *   backend directly.
+ * - **Production single-port** (browser and backend both on e.g. 6340): use
+ *   `location.origin` as-is.
+ * - **Reverse proxy** (e.g. `https://console.example.com`, browser `port === ''`):
+ *   use `location.origin` — the MCP client on the same host reaches the
+ *   server via the same reverse proxy.
+ */
+export function buildMcpInstallCommand(
+  serverPort: number,
+  location: McpInstallLocation = window.location,
+): string {
+  const { protocol, hostname, port } = location;
+  // Same-origin case:
+  //   - Browser port is empty (reverse proxy on default 80/443), OR
+  //   - Browser port matches server port (production single-port serving).
+  const sameOrigin = port === '' || Number(port) === serverPort;
+  const base = sameOrigin
+    ? location.origin
+    : `${protocol}//${hostname}:${serverPort}`;
+  return `claude mcp add --transport http agent-console ${base}/mcp`;
+}

--- a/packages/client/src/lib/mcp-install-url.ts
+++ b/packages/client/src/lib/mcp-install-url.ts
@@ -35,8 +35,15 @@ export function buildMcpInstallCommand(
   //   - Browser port is empty (reverse proxy on default 80/443), OR
   //   - Browser port matches server port (production single-port serving).
   const sameOrigin = port === '' || Number(port) === serverPort;
+  // IPv6 literals must be bracket-wrapped in URLs (e.g. `[::1]:3457`).
+  // location.origin is already properly bracketed by the browser, so we only
+  // need to wrap when composing the split-port dev path ourselves.
+  const bracketedHost =
+    hostname.includes(':') && !hostname.startsWith('[')
+      ? `[${hostname}]`
+      : hostname;
   const base = sameOrigin
     ? location.origin
-    : `${protocol}//${hostname}:${serverPort}`;
+    : `${protocol}//${bracketedHost}:${serverPort}`;
   return `claude mcp add --transport http agent-console ${base}/mcp`;
 }

--- a/packages/client/src/lib/server-info.ts
+++ b/packages/client/src/lib/server-info.ts
@@ -1,0 +1,26 @@
+let cachedServerPort: number | null = null;
+
+/**
+ * Set the backend HTTP port for the running server.
+ * Should be called once at app initialization from the `/api/config` response.
+ */
+export function setServerPort(port: number): void {
+  cachedServerPort = port;
+}
+
+/**
+ * Get the cached backend HTTP port, or `null` if it was not set yet.
+ * Consumers should treat `null` as "unknown" and avoid rendering
+ * server-URL-dependent UI in that case.
+ */
+export function getServerPort(): number | null {
+  return cachedServerPort;
+}
+
+/**
+ * Reset for testing.
+ * @internal
+ */
+export function _reset(): void {
+  cachedServerPort = null;
+}

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { routeTree } from './routeTree.gen';
 import { fetchConfig, fetchCurrentUser } from './lib/api';
 import { setHomeDir } from './lib/path';
+import { setServerPort } from './lib/server-info';
 import { setAuthMode, setCurrentUser, setSharedAccountsAvailable } from './lib/auth';
 import { setCapabilities } from './lib/capabilities';
 import { onPolicyViolation, disconnect as disconnectAppWs } from './lib/app-websocket';
@@ -141,6 +142,7 @@ async function initApp() {
     const config = await fetchConfig();
     setAuthMode(config.authMode);
     setSharedAccountsAvailable(config.sharedAccountsAvailable);
+    setServerPort(config.serverPort);
 
     if (config.authMode === 'multi-user') {
       // In multi-user mode, check if user is already authenticated.

--- a/packages/client/src/routes/settings/index.tsx
+++ b/packages/client/src/routes/settings/index.tsx
@@ -7,6 +7,7 @@ import { agentKeys } from '../../lib/query-keys';
 import { useAgents } from '../../components/AgentSelector';
 import { PageBreadcrumb } from '../../components/PageBreadcrumb';
 import { AddAgentForm, CapabilityIndicator } from '../../components/agents';
+import { McpInstallSection } from '../../components/settings/McpInstallSection';
 import { ConfirmDialog } from '../../components/ui/confirm-dialog';
 import { ErrorDialog, useErrorDialog } from '../../components/ui/error-dialog';
 import { Spinner } from '../../components/ui/Spinner';
@@ -59,6 +60,8 @@ function SettingsPage() {
         { label: 'Agent Console', to: '/' },
         { label: 'Settings' },
       ]} />
+
+      <McpInstallSection />
 
       {/* Header with Add button */}
       <div className="flex items-center justify-between mb-6">

--- a/packages/integration/src/config-api-boundary.test.ts
+++ b/packages/integration/src/config-api-boundary.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Client-Server Boundary Test: Config API
+ *
+ * Exercises the full `fetchConfig()` client function -> `/api/config` server
+ * handler -> JSON response round-trip. Unit tests on either side alone cannot
+ * catch schema drift or field-name mismatches at the wire boundary; this
+ * boundary test locks the shape.
+ *
+ * The load-bearing assertion for this PR is that `serverPort` -- a new field
+ * on `ConfigResponse` populated server-side from `serverConfig.PORT` and
+ * consumed by `packages/client/src/main.tsx` via `setServerPort()` -- reaches
+ * the client with the correct numeric shape and value.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import type { Hono } from 'hono';
+
+import {
+  createTestApp,
+  setupTestEnvironment,
+  cleanupTestEnvironment,
+} from '@agent-console/server/src/__tests__/test-utils';
+import { SystemCapabilitiesService } from '@agent-console/server/src/services/system-capabilities-service';
+import { serverConfig } from '@agent-console/server/src/lib/server-config';
+
+import { fetchConfig } from '@agent-console/client/src/lib/api';
+import type { ConfigResponse } from '@agent-console/shared';
+
+import { createFetchBridge, findRequest } from './test-utils';
+
+/**
+ * Minimal SystemCapabilitiesService mock that seeds private state via Reflect
+ * so we avoid running the underlying `which` shell-out. Mirrors the pattern
+ * used in `packages/server/src/routes/__tests__/api.test.ts`.
+ */
+function createMockSystemCapabilities(vscodeAvailable: boolean = false): SystemCapabilitiesService {
+  const service = new SystemCapabilitiesService();
+  Reflect.set(service, 'capabilities', { vscode: vscodeAvailable });
+  Reflect.set(service, 'vscodeCommand', vscodeAvailable ? 'code' : null);
+  return service;
+}
+
+describe('Client-Server Boundary: Config API', () => {
+  let app: Hono;
+  let bridge: ReturnType<typeof createFetchBridge>;
+
+  beforeEach(async () => {
+    await setupTestEnvironment();
+    app = await createTestApp({
+      systemCapabilities: createMockSystemCapabilities(),
+    });
+    bridge = createFetchBridge(app);
+  });
+
+  afterEach(async () => {
+    bridge.restore();
+    await cleanupTestEnvironment();
+  });
+
+  describe('fetchConfig', () => {
+    it('should call GET /api/config and return a ConfigResponse with serverPort', async () => {
+      const result: ConfigResponse = await fetchConfig();
+
+      // Verify the client sent the request to the correct endpoint.
+      const request = findRequest(bridge.capturedRequests, 'GET', '/api/config');
+      expect(request).toBeDefined();
+      expect(request!.url).toBe('/api/config');
+      expect(request!.method).toBe('GET');
+
+      // Load-bearing wire-shape assertion for the new `serverPort` field.
+      // Server populates from `serverConfig.PORT` (`process.env.PORT || '3457'`).
+      const expectedPort = Number(serverConfig.PORT);
+      expect(typeof result.serverPort).toBe('number');
+      expect(result.serverPort).toBe(expectedPort);
+      expect(Number.isFinite(result.serverPort)).toBe(true);
+      expect(Number.isInteger(result.serverPort)).toBe(true);
+      expect(result.serverPort).toBeGreaterThan(0);
+    });
+
+    it('should return a response that carries the ConfigResponse contract fields', async () => {
+      const result = await fetchConfig();
+
+      // Sanity-check the rest of the shape survives serialization so a
+      // silently-dropped sibling field would surface here alongside a
+      // `serverPort` regression.
+      expect(result).toHaveProperty('homeDir');
+      expect(typeof result.homeDir).toBe('string');
+      expect(result).toHaveProperty('capabilities');
+      expect(typeof result.capabilities).toBe('object');
+      expect(typeof result.capabilities.vscode).toBe('boolean');
+      expect(result).toHaveProperty('serverPid');
+      expect(typeof result.serverPid).toBe('number');
+      expect(result).toHaveProperty('serverPort');
+      expect(result).toHaveProperty('authMode');
+      expect(['none', 'multi-user']).toContain(result.authMode);
+      expect(result).toHaveProperty('sharedAccountsAvailable');
+      expect(typeof result.sharedAccountsAvailable).toBe('boolean');
+    });
+  });
+});

--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -345,11 +345,16 @@ describe('API Routes Integration', () => {
       const res = await app.request('/api/config');
       expect(res.status).toBe(200);
 
-      const body = (await res.json()) as { homeDir: string; authMode: string };
+      const body = (await res.json()) as { homeDir: string; authMode: string; serverPort: number };
       // homeDir comes from the authenticated user, not the server process
       expect(body.homeDir).toBe('/home/testuser');
       // authMode reflects the server's AUTH_MODE config (default: 'none')
       expect(body.authMode).toBe('none');
+      // serverPort is exposed so clients can compose absolute URLs
+      // (e.g. MCP endpoint) without hard-coding a port.
+      expect(typeof body.serverPort).toBe('number');
+      expect(Number.isFinite(body.serverPort)).toBe(true);
+      expect(body.serverPort).toBeGreaterThan(0);
     });
   });
 

--- a/packages/server/src/routes/__tests__/api.test.ts
+++ b/packages/server/src/routes/__tests__/api.test.ts
@@ -7,6 +7,7 @@ import type { MessageTemplateRepository } from '../../repositories/message-templ
 import type { UserRepository } from '../../repositories/user-repository.js';
 import { SharedAccountRegistry } from '../../services/shared-account-registry.js';
 import { SystemCapabilitiesService } from '../../services/system-capabilities-service.js';
+import { serverConfig } from '../../lib/server-config.js';
 
 /**
  * Minimal SystemCapabilitiesService mock that returns no detected capabilities.
@@ -89,6 +90,9 @@ describe('GET /api/config — sharedAccountsAvailable', () => {
     expect(body.capabilities.vscode).toBe(false);
     expect(body.capabilities.vscodeOpenMode).toBe('local-spawn');
     expect(body.capabilities.vscodeRemoteHost).toBeNull();
+    // serverPort is exposed so clients can compose absolute URLs (e.g. MCP endpoint).
+    expect(body.serverPort).toBe(Number(serverConfig.PORT));
+    expect(Number.isFinite(body.serverPort)).toBe(true);
   });
 
   it('returns sharedAccountsAvailable: true when the registry is enabled', async () => {

--- a/packages/server/src/routes/__tests__/auth.test.ts
+++ b/packages/server/src/routes/__tests__/auth.test.ts
@@ -482,6 +482,7 @@ describe('GET /api/config (multi-user mode)', () => {
         homeDir: authUser?.homeDir ?? '',
         capabilities: caps.getCapabilities(),
         serverPid: process.pid,
+        serverPort: Number(serverConfig.PORT),
         authMode: serverConfig.AUTH_MODE,
       });
     });
@@ -498,9 +499,10 @@ describe('GET /api/config (multi-user mode)', () => {
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { authMode: string; homeDir: string };
+    const body = (await res.json()) as { authMode: string; homeDir: string; serverPort: number };
     expect(body.authMode).toBe(serverConfig.AUTH_MODE);
     expect(body.homeDir).toBe(TEST_USER.homeDir);
+    expect(body.serverPort).toBe(Number(serverConfig.PORT));
   });
 
   it('should return empty homeDir when not authenticated', async () => {
@@ -510,8 +512,9 @@ describe('GET /api/config (multi-user mode)', () => {
     const res = await app.request('/api/config');
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { authMode: string; homeDir: string };
+    const body = (await res.json()) as { authMode: string; homeDir: string; serverPort: number };
     expect(body.authMode).toBe(serverConfig.AUTH_MODE);
     expect(body.homeDir).toBe('');
+    expect(body.serverPort).toBe(Number(serverConfig.PORT));
   });
 });

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -31,6 +31,7 @@ const api = new Hono<AppBindings>()
       homeDir: authUser?.homeDir ?? '',
       capabilities: systemCapabilities.getCapabilities(),
       serverPid: process.pid,
+      serverPort: Number(serverConfig.PORT),
       authMode: serverConfig.AUTH_MODE,
       sharedAccountsAvailable: sharedAccountRegistry.isEnabled(),
     });

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -65,6 +65,14 @@ export interface ConfigResponse {
     vscodeRemoteHost: string | null;
   };
   serverPid: number;
+  /**
+   * Backend HTTP port the server is bound to.
+   *
+   * Exposed so the client can compose absolute URLs to the same server
+   * (e.g. the MCP endpoint shown by the "install MCP" UI) without hard-coding
+   * a port that may differ between environments or worktrees.
+   */
+  serverPort: number;
   authMode: AuthMode;
   sharedAccountsAvailable: boolean;
 }


### PR DESCRIPTION
## Summary

- Adds an **Install MCP server in Claude Code** section at the top of `/settings`. Shows the exact `claude mcp add ...` command for the running server plus a Copy button.
- The port comes from `/api/config` (new `serverPort` field); the host comes from the browser context. In multi-user / reverse-proxied deploys the URL uses whatever origin the browser reached the server on (not `localhost`).

## Design decisions (from Issue open questions)

- **Placement**: Settings top-level, above the existing Agents section. Kept the single small section rather than a `/settings/mcp` sub-route — an extra route is overkill until multi-client support arrives.
- **Client target**: Claude Code only in v1 (matches README lines 247-257). No tab set for Cursor / Windsurf / Zed yet.
- **Host derivation**: browser `window.location` + server-reported `serverPort`. Three deploy shapes covered:
  - Dev (Vite `5173` + backend `3457`): falls through to `hostname:serverPort/mcp` → `http://localhost:3457/mcp`.
  - Production single-port (browser and server on the same port): `window.location.origin + '/mcp'`.
  - Reverse proxy (browser port empty, default 80/443): same-origin detected → `window.location.origin + '/mcp'`.

## Wire change

- `packages/shared/src/types/auth.ts`: `ConfigResponse` gains `serverPort: number`.
- `packages/server/src/routes/api.ts`: `/api/config` handler returns `serverPort: Number(serverConfig.PORT)`.
- No valibot schema exists for `ConfigResponse` (raw JSON path client-side), so no `strictObject` gate to bump. A boundary test in `packages/integration/src/config-api-boundary.test.ts` locks the wire shape end-to-end.

## Test coverage

- `packages/client/src/lib/__tests__/mcp-install-url.test.ts` — pure `buildMcpInstallCommand` unit tests: dev split-port, prod single-port, reverse-proxy https, reverse-proxy http, LAN-IP dev.
- `packages/client/src/lib/__tests__/server-info.test.ts` — module cache set/get/reset.
- `packages/client/src/components/settings/__tests__/McpInstallSection.test.tsx` — null-port renders nothing, section heading + command render, Copy button writes to `navigator.clipboard.writeText`, button label flips to "Copied!".
- `packages/server/src/routes/__tests__/api.test.ts` + `packages/server/src/__tests__/api.test.ts` + `packages/server/src/routes/__tests__/auth.test.ts` — `serverPort` field asserted on the server side (unit + boundary).
- `packages/integration/src/config-api-boundary.test.ts` — new. Fetches `/api/config` through the fetch-bridge and asserts the client-observed `ConfigResponse.serverPort` round-trips as a positive integer, matches `Number(serverConfig.PORT)`, plus sibling-field contract check.

## Verification

- `bun run typecheck`: clean across all packages.
- `bun run test` (full suite): 5157 pass / 0 fail (`TEST_EXIT: 0`). One SSH_AUTH_SOCK test failure was observed locally but is caused by the developer's env leaking `SSH_AUTH_SOCK` from 1Password into the test process — unrelated to this PR (Issue #918 territory). CI does not have that env; it runs clean.
- Preflight (`node .claude/skills/orchestrator/preflight-check.js`): all four checks pass — test coverage, rule/skill duplication, language, source-comment blame-shift.
- Browser QA at dev port 3457 — see screenshots below.

## Browser QA (dev, port 3457)

Section renders at the top of `/settings` with the exact command; Copy button copies the string to the clipboard and flips its label to "Copied!" for 2s. No console errors. Screenshots posted as a follow-up comment via `scripts/upload-qa-screenshots.sh` (the standard flow for this repo).

Command captured by the clipboard mock in-page: `claude mcp add --transport http agent-console http://localhost:3457/mcp`.

## Test plan

- [x] Unit tests cover URL composition across all three deploy shapes
- [x] Unit tests cover Copy button behavior (writeText call + label transition)
- [x] Integration test locks the wire shape for `serverPort`
- [x] Full test suite passes locally
- [x] Manual browser QA at dev port 3457 — command visible, Copy works, port matches server

## Notes

- CodeRabbit CLI review was attempted locally but the delegated session cannot complete interactive OAuth. The GitHub-side CodeRabbit bot review will run on this PR; the 3-layer verdict (Pre-merge checks / `reviewDecision` / inline comments) will be verified before requesting merge.

Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)