### PR TITLE
fix(client): triple-replay seam correction across all archive chunk boundaries

### DIFF
--- a/packages/client/src/components/terminal/__tests__/history-replay.test.ts
+++ b/packages/client/src/components/terminal/__tests__/history-replay.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, afterEach } from 'bun:test';
-import { replayHistoryChunk, replayHistoryPair, _setReplayScrollbackForTest } from '../history-replay';
+import {
+  replayHistoryChunk,
+  replayHistoryPair,
+  replayHistoryJoint,
+  _setReplayScrollbackForTest,
+} from '../history-replay';
 
 const identity = (d: string) => d;
 
@@ -207,5 +212,108 @@ describe('replayHistoryPair (seam correction §6.2)', () => {
     const pair = await replayHistoryPair(newer, top, 20, 24, (d) => d);
     const hrefs = [...pair.newChunkRows, ...pair.topChunkRows].flatMap((r) => r.links.map((l) => l.href));
     expect(hrefs.some((h) => h.includes('very/long/path/that/continues'))).toBe(true);
+  });
+});
+
+describe('replayHistoryJoint (triple seam correction §6.2, #994)', () => {
+  afterEach(() => {
+    _setReplayScrollbackForTest(null);
+  });
+
+  it('partitions a pure line-flow triple with no duplication or loss at either boundary', async () => {
+    // Stream order (oldest first): A precedes B precedes C.
+    const A = Array.from({ length: 30 }, (_, i) => `A${String(i + 1).padStart(2, '0')}\r\n`).join('');
+    const B = Array.from({ length: 15 }, (_, i) => `B${String(i + 1).padStart(2, '0')}\r\n`).join('');
+    const C = Array.from({ length: 10 }, (_, i) => `C${String(i + 1).padStart(2, '0')}\r\n`).join('');
+    const sa = await replayHistoryChunk(A, 80, 24, (d) => d);
+    const sb = await replayHistoryChunk(B, 80, 24, (d) => d);
+    const sc = await replayHistoryChunk(C, 80, 24, (d) => d);
+    const joint = await replayHistoryJoint([A, B, C], 80, 24, (d) => d);
+    expect(joint.overflow).toBe(false);
+    expect(joint.partitions.length).toBe(3);
+    // The joined partition equals the concatenation of the three standalone
+    // extractions (per-partition split boundaries differ — splitBaseY_i counts
+    // only the scrollback settled BEFORE that partition — but the JOINED set
+    // is loss- and duplication-free).
+    expect(
+      joint.partitions.flatMap((rows) => textOf(rows)),
+    ).toEqual([...textOf(sa.rows), ...textOf(sb.rows), ...textOf(sc.rows)]);
+  });
+
+  it('reports overflow (empty partitions) when the joined triple exceeds the scrollback cap', async () => {
+    _setReplayScrollbackForTest(50);
+    // Each chunk alone stays under the cap; all three together exceed it.
+    const A = Array.from({ length: 10 }, (_, i) => `A${i}\r\n`).join('');
+    const B = Array.from({ length: 10 }, (_, i) => `B${i}\r\n`).join('');
+    const C = Array.from({ length: 40 }, (_, i) => `C${i}\r\n`).join('');
+    const result = await replayHistoryJoint([A, B, C], 80, 24, (d) => d);
+    expect(result.overflow).toBe(true);
+    expect(result.partitions).toEqual([]);
+  });
+
+  it('corrects a wrap-boundary seam: the merge row belongs to the next chunk\'s partition, not the middle chunk\'s', async () => {
+    // A (oldest) is line-flow only.
+    const A = Array.from({ length: 30 }, (_, i) => `A${String(i + 1).padStart(2, '0')}\r\n`).join('');
+    // B (middle) ends WITHOUT a trailing newline — a mid-word partial line
+    // that the byte cut splits into (B.tail = 'hello wor', C.head = 'ld world').
+    const B =
+      Array.from({ length: 20 }, (_, i) => `B${String(i + 1).padStart(2, '0')}\r\n`).join('') +
+      'segment-B-tail-hello wor';
+    // C (newest) starts with the completion of B's partial line, then more.
+    const C =
+      'ld world\r\n' +
+      Array.from({ length: 15 }, (_, i) => `C${String(i + 1).padStart(2, '0')}\r\n`).join('');
+    const joint = await replayHistoryJoint([A, B, C], 80, 24, (d) => d);
+    expect(joint.overflow).toBe(false);
+    const [, bPart, cPart] = joint.partitions;
+    const bText = textOf(bPart);
+    const cText = textOf(cPart);
+    // Under the joint partition, B's own on-screen tail ('hello wor') was
+    // still on-screen at splitBaseYs[1] capture — it did NOT settle into
+    // scrollback during B's writes. So B's partition contains NEITHER the
+    // partial fragment NOR the merged row. (Under the current pair-only
+    // design's Step N+1 pair(new_C, B), B's rows WOULD have contained the
+    // 'hello wor' row — that is the #994 duplicate this triple replay avoids.)
+    expect(bText.some((line) => /hello wor$/.test(line))).toBe(false);
+    expect(bText.some((line) => /hello world/.test(line))).toBe(false);
+    // C's partition contains the merged row exactly once — C's leading
+    // 'ld world' completed B's partial line before the next \r\n scrolled it
+    // into scrollback, so the joint extraction captures the merge.
+    expect(cText.filter((line) => /segment-B-tail-hello world/.test(line)).length).toBe(1);
+    // And the partial fragment is NOT visible anywhere — the completion
+    // covered it before extraction.
+    expect(cText.some((line) => /hello wor$/.test(line) && !/hello world/.test(line))).toBe(false);
+  });
+
+  it('corrects a repaint-frame-boundary seam so chrome does not clamp as a leading settled row', async () => {
+    // Mirrors the existing pair-replay test's polarity assertion, extended to
+    // 3 chunks. C alone (standalone) clamps its leading CUU at the empty
+    // screen top, settling 'CHROME-BAR' as a leading scrollback row. The
+    // joint (A, B, C) gives C's leading repaints the state B established, so
+    // the CUU lands on B's on-screen row and does NOT leak chrome into C's
+    // settled scrollback.
+    const A = Array.from({ length: 25 }, (_, i) => `A${String(i + 1).padStart(2, '0')}\r\n`).join(
+      '',
+    );
+    const B =
+      Array.from({ length: 20 }, (_, i) => `B${String(i + 1).padStart(2, '0')}\r\n`).join('');
+    // C starts mid-repaint: relative CUU + clear + chrome-bar, then a
+    // continuation into fresh committed lines. Started from an EMPTY screen
+    // the CUU clamps at the top -> chrome misplaced (baseline).
+    const C =
+      '\x1b[2A\r\x1b[K' +
+      'CHROME-BAR' +
+      '\r\n\r\n' +
+      Array.from({ length: 15 }, (_, i) => `C${String(i + 1).padStart(2, '0')}\r\n`).join('');
+    // Baseline polarity: standalone C has 'CHROME-BAR' as its first row.
+    const standaloneC = await replayHistoryChunk(C, 80, 24, (d) => d);
+    expect(textOf(standaloneC.rows)[0]).toBe('CHROME-BAR');
+    // Joint (A, B, C) — the chrome row is corrected.
+    const joint = await replayHistoryJoint([A, B, C], 80, 24, (d) => d);
+    expect(joint.overflow).toBe(false);
+    const cPart = textOf(joint.partitions[2]);
+    // C's leading row is NOT the chrome bar — it is real content, because
+    // the CUU landed on B's on-screen row (which existed in the joined state).
+    expect(cPart[0]).not.toBe('CHROME-BAR');
   });
 });

--- a/packages/client/src/components/terminal/__tests__/terminal-store-paging.test.ts
+++ b/packages/client/src/components/terminal/__tests__/terminal-store-paging.test.ts
@@ -807,15 +807,15 @@ describe('terminal-store paging', () => {
     }
   });
 
-  // --- Seam correction: older-neighbor pair re-replay (§6.2, #979) ---
-  describe('seam correction (pair re-replay)', () => {
+  // --- Seam correction: older-neighbor joint re-replay (§6.2, #979, #994) ---
+  describe('seam correction (pair/triple re-replay)', () => {
     const negKeys = (instance: ReturnType<typeof getOrCreateTerminal>) =>
       instance
         .getSnapshot()
         .rows.filter((r) => r.key < 0)
         .map((r) => r.key);
 
-    it('re-replays the top chunk on the next older fetch, retaining raw on the new top only', async () => {
+    it('re-replays the top chunk on the next older fetch, retaining raw on both new [0] and new [1] (#994 invariant)', async () => {
       const { instance, ws } = open('s', 'w');
       await seedHistory(ws, { startOffset: 100 });
 
@@ -834,7 +834,10 @@ describe('terminal-store paging', () => {
       const keysBefore = negKeys(instance);
 
       // Older chunk: pair path (the top chunk has raw). It replaces BOTH chunks'
-      // rows with fresh keys and moves raw retention to the new top.
+      // rows with fresh keys. Under the #994 invariant, raw is retained on BOTH
+      // pagedChunks[0] (the new top, B) AND pagedChunks[1] (the former top, A),
+      // so the NEXT older fetch can do a joint 3-chunk replay across the
+      // interior seam. (Under the pre-#994 rule, A's raw was dropped here.)
       await pageChunk(ws, instance, {
         data: manyLines('B'),
         startOffset: 40,
@@ -846,7 +849,8 @@ describe('terminal-store paging', () => {
       expect(p.pagedChunkCount).toBe(2);
       expect(p.oldestOffset).toBe(40); // advanced to B.startOffset (byte range untouched)
       expect(p.topChunkHasRaw).toBe(true); // B is the new top, retains raw
-      expect(p.pagedRawCount).toBe(1); // only ONE raw held: A's was dropped
+      expect(p.secondChunkHasRaw).toBe(true); // A stays at [1] under the #994 invariant
+      expect(p.pagedRawCount).toBe(2); // TWO raws held: [0] and [1]
 
       // Both replaced chunks got fresh negative keys (§6.3 never reuses keys).
       const keysAfter = negKeys(instance);
@@ -857,7 +861,7 @@ describe('terminal-store paging', () => {
       expect(p.pagedRowCount).toBe(negKeys(instance).length);
     });
 
-    it('eviction after a pair re-replay restores the exact byte offset and leaves the new top raw-less', async () => {
+    it('eviction after a pair re-replay restores the exact byte offset and preserves A raw on the new top (#994 invariant)', async () => {
       const { instance, ws } = open('s', 'w');
       await seedHistory(ws, { startOffset: 100 });
       await pageChunk(ws, instance, {
@@ -882,10 +886,15 @@ describe('terminal-store paging', () => {
       let p = _inspect(instance).paging;
       expect(p.pagedChunkCount).toBe(1);
       expect(p.oldestOffset).toBe(70); // B.endOffset exactly
-      expect(p.topChunkHasRaw).toBe(false); // A's raw was dropped when B took over
-      expect(p.pagedRawCount).toBe(0);
+      // Under the #994 invariant A retained raw at index 1 while B was top; the
+      // evict shift makes A the new [0] and its raw is still valid for the next
+      // fetch's pair replay. (Under the pre-#994 rule A's raw would have been
+      // dropped when B took over, forcing a standalone replay next.)
+      expect(p.topChunkHasRaw).toBe(true);
+      expect(p.pagedRawCount).toBe(1);
 
-      // The next older fetch therefore replays STANDALONE and re-retains raw.
+      // The next older fetch therefore replays PAIR (A holds raw) and after it
+      // both pagedChunks[0]=C and [1]=A hold raw again.
       await pageChunk(ws, instance, {
         data: manyLines('C'),
         startOffset: 50,
@@ -895,7 +904,8 @@ describe('terminal-store paging', () => {
       });
       p = _inspect(instance).paging;
       expect(p.topChunkHasRaw).toBe(true);
-      expect(p.pagedRawCount).toBe(1);
+      expect(p.secondChunkHasRaw).toBe(true);
+      expect(p.pagedRawCount).toBe(2);
     });
 
     it('drops retained raw on a cols resize', async () => {
@@ -991,6 +1001,195 @@ describe('terminal-store paging', () => {
       expect(p.pagedRawCount).toBe(1);
       // The folded content is visible (attributed to the top chunk's rows).
       expect(allText(instance)).toContain('small-older-chunk');
+    });
+
+    // --- Triple re-replay (#994) ---
+
+    it('retains raw on both [0] and [1] after 3 sequential fetches, dropping [2] under the invariant', async () => {
+      const { instance, ws } = open('s', 'w');
+      await seedHistory(ws, { startOffset: 100 });
+      // Step 1: standalone A.
+      await pageChunk(ws, instance, {
+        data: manyLines('A'),
+        startOffset: 70,
+        endOffset: 100,
+        hasMore: true,
+        epoch: 1000,
+      });
+      // Step 2: pair(B, A). Under the #994 invariant, [0]=B and [1]=A both hold raw.
+      await pageChunk(ws, instance, {
+        data: manyLines('B'),
+        startOffset: 40,
+        endOffset: 70,
+        hasMore: true,
+        epoch: 1000,
+      });
+      let p = _inspect(instance).paging;
+      expect(p.pagedRawCount).toBe(2);
+      // Step 3: triple(C, B, A). After it, [0]=C(raw), [1]=B(raw), [2]=A(no raw).
+      await pageChunk(ws, instance, {
+        data: manyLines('C'),
+        startOffset: 10,
+        endOffset: 40,
+        hasMore: true,
+        epoch: 1000,
+      });
+      p = _inspect(instance).paging;
+      expect(p.pagedChunkCount).toBe(3);
+      expect(p.pagedRawCount).toBe(2); // top + second-from-top only
+      expect(p.topChunkHasRaw).toBe(true);
+      expect(p.secondChunkHasRaw).toBe(true);
+      // Row-independent invariant check: after any apply-*, pagedRowCount ===
+      // count of negative-key rows in snapshot.rows.
+      expect(p.pagedRowCount).toBe(negKeys(instance).length);
+    });
+
+    it('wrap-boundary chunk cut mid-line: 3rd fetch removes the pair-chain re-inclusion artifact', async () => {
+      // Fixture: three chunks whose byte cuts fall in mid-line positions, so
+      // the pair-only chain would leave a mid-word wrap-misalignment between
+      // chunks (the #994 owner symptom). Under the triple re-replay, each
+      // seam row belongs to the newer chunk's partition once, and does NOT
+      // duplicate in the older chunk's rows.
+      //
+      // Stream order (bytes flow oldest -> newest): C -> B -> A -> live.
+      // So C's tail merges with B's head, and B's tail merges with A's head.
+      // Fetch order (paging goes newest -> oldest): A first, then B, then C.
+      //
+      // Each chunk must exceed one throwaway viewport (24 rows at default 80x24)
+      // so its replay produces scrollback, otherwise the middle chunk folds
+      // into the top and the triple case is never reached (see the sub-viewport
+      // fold test above).
+      const { instance, ws } = open('s', 'w');
+      await seedHistory(ws, { startOffset: 300 });
+      // Chunk C (oldest, fetched third): 30 line-flow rows + partial mid-line
+      // cut at the byte boundary with B.
+      const C =
+        Array.from({ length: 30 }, (_, i) => `C${String(i + 1).padStart(2, '0')}\r\n`).join('') +
+        'segment-C-tail-good mor';
+      // Chunk B (middle, fetched second): completes C's partial line, own
+      // scroll-sized content, then own partial tail cut with A.
+      const B =
+        'ning\r\n' +
+        Array.from({ length: 30 }, (_, i) => `B${String(i + 1).padStart(2, '0')}\r\n`).join('') +
+        'segment-B-tail-hello wor';
+      // Chunk A (newest, fetched first): completes B's partial line, then
+      // scroll-sized line-flow content.
+      const A =
+        'ld world\r\n' +
+        Array.from({ length: 30 }, (_, i) => `A${String(i + 1).padStart(2, '0')}\r\n`).join('');
+      await pageChunk(ws, instance, {
+        data: A,
+        startOffset: 200,
+        endOffset: 300,
+        hasMore: true,
+        epoch: 1000,
+      });
+      await pageChunk(ws, instance, {
+        data: B,
+        startOffset: 100,
+        endOffset: 200,
+        hasMore: true,
+        epoch: 1000,
+      });
+      await pageChunk(ws, instance, {
+        data: C,
+        startOffset: 50,
+        endOffset: 100,
+        hasMore: true,
+        epoch: 1000,
+      });
+      const text = allText(instance);
+      // Both merged words appear once, un-split, in the joined output.
+      expect(text).toContain('segment-C-tail-good morning');
+      expect(text).toContain('segment-B-tail-hello world');
+      // The mid-line cut fragments are NOT visible as standalone rows on the
+      // right edge (the pair-chain re-inclusion artifact). Under the pair-only
+      // chain, Step N+1 would replace B's rows with a partition that included
+      // 'segment-C-tail-good mor' (from B's own on-screen tail at splitBaseY),
+      // and Step N's already-set A.rows would ALSO hold the merged version —
+      // producing the duplicate. The triple eliminates this.
+      const lines = text.split('\n');
+      const badLinesHello = lines.filter(
+        (line) => /hello wor$/.test(line) && !/hello world/.test(line),
+      );
+      expect(badLinesHello).toEqual([]);
+      const badLinesMor = lines.filter(
+        (line) => /good mor$/.test(line) && !/good morning/.test(line),
+      );
+      expect(badLinesMor).toEqual([]);
+    });
+
+    it('repaint-frame-boundary chunk cut: 3rd fetch corrects the chained B-row duplication', async () => {
+      // Fixture: three chunks where C (oldest) ends mid-repaint-frame (a CUU
+      // + clear-line without the follow-through writes). Stream order:
+      //   C (oldest) -> B (middle) -> A (newest, fetched first).
+      // B begins with the repaint's next writes: a 'CHROME-BAR' line then a
+      // continuation into fresh content.
+      //
+      // The #994 duplication signal for this fixture:
+      //   Under the OLD pair-only chain, Step 2's pair(B, A) captured some of
+      //   B's on-screen tail (B07..B30 or similar) into A's partition. Then
+      //   Step 3's pair(C, B) replaced B's rows with a fresh partition that
+      //   included B01..B30 in full. Result: B07..B30 appeared TWICE in the
+      //   paged view (once in B.rows, once in A.rows) — the #994 duplicate.
+      //
+      //   Under the NEW triple(C, B, A) at Step 3, A.rows is re-partitioned
+      //   with the joint context: A.rows gets B's late tail + A01..A30, and
+      //   B.rows gets B's early scrollback. Each B-line appears EXACTLY once.
+      //
+      //   This is a byte-cut-shape signal (not a CUU positioning signal — the
+      //   old pair(C, B) at Step 3 already gave the CUU C's context; the
+      //   remaining bug is the chained partitioning of the older neighbor).
+      const { instance, ws } = open('s', 'w');
+      await seedHistory(ws, { startOffset: 300 });
+      // Each chunk exceeds one throwaway viewport (24 rows at default 80x24)
+      // so its replay produces scrollback and remains a distinct paged chunk.
+      // Chunk C (oldest, fetched third): 30 line-flow rows + trailing CUU/clear.
+      const C =
+        Array.from({ length: 30 }, (_, i) => `C${String(i + 1).padStart(2, '0')}\r\n`).join('') +
+        '\x1b[2A\r\x1b[K';
+      // Chunk B (middle, fetched second): repaint's continuation + scroll-sized content.
+      const B =
+        'CHROME-BAR\r\n\r\n' +
+        Array.from({ length: 30 }, (_, i) => `B${String(i + 1).padStart(2, '0')}\r\n`).join('');
+      // Chunk A (newest, fetched first): scroll-sized line-flow content.
+      const A = Array.from({ length: 30 }, (_, i) => `A${String(i + 1).padStart(2, '0')}\r\n`).join(
+        '',
+      );
+      await pageChunk(ws, instance, {
+        data: A,
+        startOffset: 200,
+        endOffset: 300,
+        hasMore: true,
+        epoch: 1000,
+      });
+      await pageChunk(ws, instance, {
+        data: B,
+        startOffset: 100,
+        endOffset: 200,
+        hasMore: true,
+        epoch: 1000,
+      });
+      await pageChunk(ws, instance, {
+        data: C,
+        startOffset: 50,
+        endOffset: 100,
+        hasMore: true,
+        epoch: 1000,
+      });
+      const text = allText(instance);
+      // Content rows from both extremes are present.
+      expect(text).toContain('C01');
+      expect(text).toContain('A30');
+      // Each B-line label appears EXACTLY once — no duplication across
+      // B.rows and A.rows (which would be the #994 signal).
+      for (let i = 1; i <= 30; i++) {
+        const label = `B${String(i).padStart(2, '0')}`;
+        const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const regex = new RegExp(`(?:^|\\s)${escaped}(?:\\s|$)`, 'g');
+        const matches = text.match(regex) ?? [];
+        expect({ label, count: matches.length }).toEqual({ label, count: 1 });
+      }
     });
   });
 });

--- a/packages/client/src/components/terminal/history-replay.ts
+++ b/packages/client/src/components/terminal/history-replay.ts
@@ -132,6 +132,106 @@ export async function replayHistoryChunk(
   }
 }
 
+export interface ReplayJointResult {
+  /**
+   * N partitioned row arrays in the same order as the input `chunks` (oldest
+   * first, in stream order). Empty partitions on overflow.
+   * Keys are 0..n-1 per partition; callers re-key.
+   */
+  partitions: TerminalRow[][];
+  /**
+   * True when the joined write overflowed the throwaway scrollback. Partitions
+   * are `[]` in that case; callers fall back per §6.2 Fallback.
+   */
+  overflow: boolean;
+}
+
+/**
+ * Joint N-chunk re-replay for seam correction (§6.2 "Seam correction — older-
+ * neighbor pair re-replay (#979)", generalized to N chunks for #994).
+ *
+ * A range chunk begins at an arbitrary VT midpoint, so its standalone replay
+ * starts without the terminal state the preceding bytes established. When
+ * multiple sequential chunks are replayed TOGETHER — writing them in stream
+ * order into one throwaway terminal and capturing `baseY` BETWEEN each write —
+ * every seam between adjacent chunks is corrected in one pass. The extracted
+ * rows are partitioned at those captured `baseY` values, so each chunk's rows
+ * are the scrollback it produced BEFORE the next chunk's first byte landed —
+ * the "on-screen" cursor row (potentially merged mid-line with the next chunk's
+ * head) belongs to the NEXT chunk's partition.
+ *
+ * This solves the #994 pair-chain re-inclusion bug: in the old two-chunk pair
+ * (`replayHistoryPair` semantics, still supported below), the older chunk's
+ * on-screen tail landed in the newer chunk's partition on THIS fetch, but the
+ * next fetch's pair replay had no way to know the older chunk's rows had
+ * already been split that way — it re-included the same seam row in its own
+ * `topChunkRows` partition. The joint replay of 3+ chunks lets each pair of
+ * boundaries be settled in one context.
+ *
+ * @param chunks   Raw bytes for chunks in stream order (oldest first). The
+ *                 first entry is `C_new` (just fetched); subsequent entries are
+ *                 previously-fetched chunks in stream order (i.e. what the
+ *                 store's `pagedChunks[0]`, `pagedChunks[1]`, … held).
+ * @param cols     Live terminal cols (wrap parity).
+ * @param rows     Live terminal rows (bottom-anchored chrome positioning, #979).
+ * @param processOutput  Same strip pipeline the live store applies.
+ * @returns  N partitions in the same order as `chunks`. Empty on overflow.
+ */
+export async function replayHistoryJoint(
+  chunks: string[],
+  cols: number,
+  rows: number,
+  processOutput: (data: string) => string,
+): Promise<ReplayJointResult> {
+  const terminal = new Terminal({
+    cols: Math.max(1, cols),
+    rows: Math.max(REPLAY_ROWS_MIN, rows),
+    scrollback: replayScrollback,
+    allowProposedApi: true,
+  });
+  try {
+    // Capture baseY BETWEEN each chunk write. splitBaseYs[i] is baseY AFTER
+    // writing chunks[i]; the last one is used as `extracted.length` implicitly
+    // in the partitioning below.
+    const splitBaseYs: number[] = [];
+    for (const chunk of chunks) {
+      await new Promise<void>((resolve) => {
+        terminal.write(processOutput(chunk), () => resolve());
+      });
+      splitBaseYs.push(terminal.buffer.active.baseY);
+    }
+
+    const buffer = terminal.buffer.active;
+    if (buffer.length >= replayScrollback) {
+      return { partitions: [], overflow: true };
+    }
+
+    const extracted = extractSettledRows(buffer, cols);
+    // Link detection over the JOINED extraction (cross-boundary URLs join here).
+    detectAndAssignLinks(extracted);
+
+    // Partition at the captured baseYs. For chunks[i], the partition is
+    // extracted[start_i, end_i), where:
+    //   start_0 = 0, start_i>0 = splitBaseYs[i-1]
+    //   end_last = extracted.length, end_i<last = splitBaseYs[i]
+    // Clamp each boundary to extracted.length: a final erase can pull the buffer
+    // back above where an earlier chunk had settled, in which case that
+    // partition becomes empty rather than negative.
+    const partitions: TerminalRow[][] = [];
+    let cursor = 0;
+    for (let i = 0; i < chunks.length; i++) {
+      const isLast = i === chunks.length - 1;
+      const end = isLast ? extracted.length : Math.min(splitBaseYs[i], extracted.length);
+      const start = Math.min(cursor, end);
+      partitions.push(extracted.slice(start, end));
+      cursor = end;
+    }
+    return { partitions, overflow: false };
+  } finally {
+    terminal.dispose();
+  }
+}
+
 export interface ReplayPairResult {
   /** C_new's settled rows: extraction[0, splitBaseY). Keys 0..n-1; store re-keys. */
   newChunkRows: TerminalRow[];
@@ -146,25 +246,16 @@ export interface ReplayPairResult {
 
 /**
  * Pair re-replay for seam correction (§6.2 "Seam correction — older-neighbor
- * pair re-replay (#979)").
- *
- * A range chunk begins at an arbitrary VT midpoint, so its standalone replay
- * starts without the terminal state the preceding bytes established; a
- * relative-repaint TUI's leading frame-tail then clamps at the top of the empty
- * throwaway screen and settles into scrollback as a chrome artifact. When the
- * next older chunk arrives, replaying it TOGETHER with the current top gives the
- * top's leading repaints the state its predecessor established, erasing the seam.
+ * pair re-replay (#979)"). Delegates to {@link replayHistoryJoint} with two
+ * chunks and returns a pair-shaped result for callers that reason about two
+ * partitions specifically (test coverage for the N=2 degenerate case and
+ * fallback callers that only ever hold one previous chunk's raw).
  *
  * Stream order: `newBytes` is the OLDER range (the just-fetched chunk `C_new`)
  * and `topBytes` is the NEWER range (the current top chunk `C_top`). C_new
  * precedes C_top in the stream, so `newBytes` is written FIRST, then `topBytes`.
  * Parameter names are oriented to the store's perspective (`msg.data` = newBytes
  * = older range; `topChunk.rawData` = topBytes = newer range).
- *
- * @returns newChunkRows (replaces C_new's rows) and topChunkRows (replaces
- *          C_top's rows, now seam-free). Link detection runs over the JOINED
- *          extraction before partitioning (LinkRanges are per-row, so the
- *          partition below is safe) — a wrapped URL crossing the boundary joins.
  */
 export async function replayHistoryPair(
   newBytes: string,
@@ -173,42 +264,13 @@ export async function replayHistoryPair(
   rows: number,
   processOutput: (data: string) => string,
 ): Promise<ReplayPairResult> {
-  const terminal = new Terminal({
-    cols: Math.max(1, cols),
-    rows: Math.max(REPLAY_ROWS_MIN, rows),
-    scrollback: replayScrollback,
-    allowProposedApi: true,
-  });
-  try {
-    await new Promise<void>((resolve) => {
-      terminal.write(processOutput(newBytes), () => resolve());
-    });
-    // Scrollback settled so far belongs to C_new; the still-volatile screen rows
-    // are exactly the state C_top's leading repaints consume (the correction).
-    const splitBaseY = terminal.buffer.active.baseY;
-
-    await new Promise<void>((resolve) => {
-      terminal.write(processOutput(topBytes), () => resolve());
-    });
-
-    const buffer = terminal.buffer.active;
-    if (buffer.length >= replayScrollback) {
-      return { newChunkRows: [], topChunkRows: [], overflow: true };
-    }
-
-    const extracted = extractSettledRows(buffer, cols);
-    // Link detection over the JOINED extraction (cross-boundary URLs join here).
-    detectAndAssignLinks(extracted);
-    // Partition at splitBaseY. Clamp when the final extraction is SHORTER than
-    // splitBaseY (C_top's bytes ended with erases that pulled the buffer back
-    // above where C_new had settled): topChunkRows is then empty, not negative.
-    const split = Math.min(splitBaseY, extracted.length);
-    return {
-      newChunkRows: extracted.slice(0, split),
-      topChunkRows: extracted.slice(split),
-      overflow: false,
-    };
-  } finally {
-    terminal.dispose();
+  const joint = await replayHistoryJoint([newBytes, topBytes], cols, rows, processOutput);
+  if (joint.overflow) {
+    return { newChunkRows: [], topChunkRows: [], overflow: true };
   }
+  return {
+    newChunkRows: joint.partitions[0] ?? [],
+    topChunkRows: joint.partitions[1] ?? [],
+    overflow: false,
+  };
 }

--- a/packages/client/src/components/terminal/terminal-store.ts
+++ b/packages/client/src/components/terminal/terminal-store.ts
@@ -14,7 +14,7 @@ import { stripSystemMessages, stripScrollbackClear as applyScrollbackFilter } fr
 import { logger } from '../../lib/logger';
 import { extractRow, extractRowWithCursor, type TerminalRow } from './buffer-to-rows';
 import { detectRowLinks } from './link-detection';
-import { replayHistoryChunk, replayHistoryPair } from './history-replay';
+import { replayHistoryChunk, replayHistoryPair, replayHistoryJoint } from './history-replay';
 import { rowText } from './row-pipeline';
 
 /**
@@ -185,11 +185,15 @@ class TerminalController implements TerminalInstance {
   private oldestOffset = 0;
   // Paged chunks, oldest first (a deque). Each carries its absolute range so
   // contiguity/eviction can reason about boundaries without re-deriving them.
-  // `rawData` is retained ONLY on the current top (oldest) chunk, for the
-  // older-neighbor pair re-replay seam correction (§6.2); bound: one range
-  // request's maxBytes. It is dropped when the chunk stops being the top (a newer
-  // pair takes over), or when the chunk goes away (eviction / cols-drop / resync
-  // / teardown clear the whole array).
+  // `rawData` is retained on `pagedChunks[0]` (current top) AND `pagedChunks[1]`
+  // (second-from-top) for the joint re-replay seam correction (§6.2, #994).
+  // Chunks at index >= 2 never hold rawData. Bounded memory: at most two range
+  // requests' maxBytes (~512KB). The invariant holds after every apply-* step
+  // and is enforced by `enforceRawInvariant()`. It is dropped when:
+  //   - the chunk goes away (eviction / cols-drop / resync / teardown clears
+  //     the whole array), or
+  //   - a triple joint replay pushes it to index >= 2 (its seam is now stably
+  //     rendered against both neighbors, so its raw is no longer needed).
   private pagedChunks: Array<{
     rows: TerminalRow[];
     startOffset: number;
@@ -511,6 +515,7 @@ class TerminalController implements TerminalInstance {
     historyInFlight: boolean;
     topChunkHasRaw: boolean;
     topChunkRawBytes: number;
+    secondChunkHasRaw: boolean;
     pagedRawCount: number;
   } {
     return {
@@ -530,6 +535,7 @@ class TerminalController implements TerminalInstance {
       historyInFlight: this.historyInFlight,
       topChunkHasRaw: this.pagedChunks[0]?.rawData !== undefined,
       topChunkRawBytes: this.pagedChunks[0]?.rawData?.length ?? 0,
+      secondChunkHasRaw: this.pagedChunks[1]?.rawData !== undefined,
       pagedRawCount: this.pagedChunks.filter((c) => c.rawData !== undefined).length,
     };
   }
@@ -1032,16 +1038,42 @@ class TerminalController implements TerminalInstance {
     // does NOT invalidate already-paged chunks.
     const rows = this.terminal.rows;
 
-    // Seam correction (§6.2): if the current top chunk retained its raw bytes,
-    // replay THIS (older) chunk together with the top so the top's leading
-    // repaints see the state its predecessor established. Otherwise standalone.
+    // Seam correction (§6.2, #994):
+    //   - Both pagedChunks[0] AND [1] retain raw -> joint 3-chunk replay,
+    //     partitioning at both boundaries in one context.
+    //   - Only pagedChunks[0] retains raw -> pair replay (Step 2 of a session
+    //     or fallback from a triple overflow that dropped [1]'s raw).
+    //   - Neither -> standalone (Step 1 of a session, or all-blank/broken
+    //     contiguity).
     const topChunk = this.pagedChunks[0];
+    const secondChunk = this.pagedChunks[1];
     const topRaw = topChunk?.rawData;
+    const secondRaw = secondChunk?.rawData;
     if (topRaw === undefined) {
       await this.applyStandaloneChunk(msg, reqMaxBytes, cols, rows);
       return;
     }
+    if (secondRaw === undefined) {
+      await this.applyPairChunk(msg, reqMaxBytes, cols, rows, topChunk, topRaw);
+      return;
+    }
+    await this.applyTripleChunk(msg, reqMaxBytes, cols, rows, topChunk, topRaw, secondChunk, secondRaw);
+  }
 
+  /**
+   * Pair re-replay of the just-fetched chunk with the current top chunk (§6.2).
+   * Runs when only pagedChunks[0] has raw. Both chunks' rows are replaced with
+   * seam-corrected partitions; both pagedChunks[0] AND (post-unshift)
+   * pagedChunks[1] retain rawData so the NEXT older fetch can do a triple.
+   */
+  private async applyPairChunk(
+    msg: { data: string; startOffset: number; endOffset: number; hasMore: boolean },
+    reqMaxBytes: number,
+    cols: number,
+    rows: number,
+    topChunk: (typeof this.pagedChunks)[number],
+    topRaw: string,
+  ): Promise<void> {
     let pair: Awaited<ReturnType<typeof replayHistoryPair>>;
     try {
       pair = await replayHistoryPair(msg.data, topRaw, cols, rows, (d) => this.processOutput(d));
@@ -1063,10 +1095,10 @@ class TerminalController implements TerminalInstance {
       return;
     }
 
-    // Advance the cursor regardless of renderable content (§6.2). BYTE RANGES are
-    // untouched: each chunk keeps its own start/endOffset exactly as fetched —
-    // row attribution may shift across the boundary but eviction bookkeeping is
-    // byte-range-based.
+    // Advance the cursor regardless of renderable content (§6.2). BYTE RANGES
+    // are untouched: each chunk keeps its own start/endOffset exactly as
+    // fetched — row attribution may shift across the boundary but eviction
+    // bookkeeping is byte-range-based.
     this.oldestOffset = msg.startOffset;
     this.hasMoreHistory = msg.hasMore;
 
@@ -1077,10 +1109,12 @@ class TerminalController implements TerminalInstance {
     topChunk.rows = pair.topChunkRows;
 
     if (pair.newChunkRows.length > 0) {
-      // A real new top takes over: it retains the raw for the NEXT older fetch;
-      // the former top no longer needs its raw (its seam is now corrected).
+      // A real new top takes over. Under the #994 invariant, pagedChunks[1]
+      // (== the former top, `topChunk` here) KEEPS its raw so the next older
+      // fetch can run a joint 3-chunk replay across this seam AND the seam
+      // between the former top and its own newer neighbor. Contrast with the
+      // pre-#994 rule which dropped `topChunk.rawData` at this point.
       this.rekeyDownward(pair.newChunkRows);
-      delete topChunk.rawData;
       this.pagedChunks.unshift({
         rows: pair.newChunkRows,
         startOffset: msg.startOffset,
@@ -1091,17 +1125,108 @@ class TerminalController implements TerminalInstance {
       // Edge: the older range was all-blank -> no new chunk is pushed (advance-
       // only, mirroring the standalone empty-chunk case), but the top-chunk row
       // replacement still applies. KEEP the top's rawData: it stays the top, and
-      // the NEXT older fetch pairs against it again (the next boundary sits below
-      // it, between the next fetch and this chunk).
+      // the NEXT older fetch pairs against it again (the next boundary sits
+      // below it, between the next fetch and this chunk).
     }
 
+    this.enforceRawInvariant();
     this.recomputePagedRowCount();
     this.syncPagingMeta();
     this.scheduleNotify();
   }
 
-  /** Standalone throwaway replay + apply of a single older chunk (the pre-seam-
-   * correction path, and the pair-overflow fallback). */
+  /**
+   * Joint 3-chunk re-replay of the just-fetched chunk with the current top AND
+   * second-from-top chunks (§6.2, #994). Runs when both pagedChunks[0] and [1]
+   * have raw. All three chunks' rows are replaced with seam-corrected
+   * partitions in one throwaway-terminal context, so the seam between the
+   * former top and second-from-top is settled here — solving the pair-chain
+   * re-inclusion of the older-boundary's on-screen tail.
+   */
+  private async applyTripleChunk(
+    msg: { data: string; startOffset: number; endOffset: number; hasMore: boolean },
+    reqMaxBytes: number,
+    cols: number,
+    rows: number,
+    topChunk: (typeof this.pagedChunks)[number],
+    topRaw: string,
+    secondChunk: (typeof this.pagedChunks)[number],
+    secondRaw: string,
+  ): Promise<void> {
+    let joint: Awaited<ReturnType<typeof replayHistoryJoint>>;
+    try {
+      joint = await replayHistoryJoint(
+        [msg.data, topRaw, secondRaw],
+        cols,
+        rows,
+        (d) => this.processOutput(d),
+      );
+    } catch {
+      return;
+    }
+    if (this.disposed) return;
+    if (msg.endOffset !== this.oldestOffset) return;
+
+    if (joint.overflow) {
+      // The joined 3-chunk replay overflowed. Fall back to pair(new, top),
+      // leaving the top↔second seam uncorrected for THIS fetch. Drop
+      // secondChunk's raw so the invariant "no raw at index >= 2 after
+      // unshift" holds after the pair fallback (secondChunk is at index 1 now
+      // but will be at index 2 after unshift). One interior seam stays
+      // uncorrected; the fetch loop is not perturbed (§6.2 Fallback).
+      logger.debug(
+        `[terminal] triple replay overflow at endOffset ${msg.endOffset}; falling back to pair`,
+      );
+      delete secondChunk.rawData;
+      await this.applyPairChunk(msg, reqMaxBytes, cols, rows, topChunk, topRaw);
+      return;
+    }
+
+    // Advance the cursor regardless of renderable content. BYTE RANGES are
+    // untouched (see applyPairChunk).
+    this.oldestOffset = msg.startOffset;
+    this.hasMoreHistory = msg.hasMore;
+
+    const [newChunkRows, topChunkRowsNew, secondChunkRowsNew] = joint.partitions;
+    // The seam-corrected rows always replace both existing chunks' rows
+    // (strictly better). Fresh negative keys for all rows of every replaced
+    // chunk (§6.3 never reuses keys).
+    this.rekeyDownward(topChunkRowsNew);
+    topChunk.rows = topChunkRowsNew;
+    this.rekeyDownward(secondChunkRowsNew);
+    secondChunk.rows = secondChunkRowsNew;
+
+    if (newChunkRows.length > 0) {
+      // A real new top takes over. Under the #994 invariant:
+      //   - new chunk (at post-unshift index 0) retains raw.
+      //   - topChunk (post-unshift index 1) KEEPS raw for the next triple.
+      //   - secondChunk (post-unshift index 2) DROPS raw — its seams against
+      //     both neighbors are now stably rendered; it will never re-participate
+      //     in a joint replay.
+      this.rekeyDownward(newChunkRows);
+      delete secondChunk.rawData;
+      this.pagedChunks.unshift({
+        rows: newChunkRows,
+        startOffset: msg.startOffset,
+        endOffset: msg.endOffset,
+        rawData: msg.data,
+      });
+    } else {
+      // Edge: the older range was all-blank -> no new chunk is pushed. The row
+      // replacements for BOTH top and secondChunk still apply. KEEP both raws:
+      // topChunk stays at index 0, secondChunk stays at index 1; the invariant
+      // permits raw at both slots and the next older fetch will pair against
+      // this window again (or triple, if by then it fits).
+    }
+
+    this.enforceRawInvariant();
+    this.recomputePagedRowCount();
+    this.syncPagingMeta();
+    this.scheduleNotify();
+  }
+
+  /** Standalone throwaway replay + apply of a single older chunk. Runs at Step
+   * 1 of a session (no previous chunk) and as the pair-overflow fallback. */
   private async applyStandaloneChunk(
     msg: { data: string; startOffset: number; endOffset: number; hasMore: boolean },
     reqMaxBytes: number,
@@ -1131,9 +1256,11 @@ class TerminalController implements TerminalInstance {
     if (result.rows.length > 0) {
       // Fresh negative keys, allocated downward, never reused (§6.3).
       this.rekeyDownward(result.rows);
-      // Raw is retained on the current top only: the arriving chunk becomes the
-      // new top, so drop the previous top's raw (no-op when it had none).
-      if (this.pagedChunks[0]) delete this.pagedChunks[0].rawData;
+      // Under the #994 invariant: raw is retained on pagedChunks[0] and [1].
+      // The arriving chunk becomes the new [0] via unshift. The former [0]
+      // (if any) becomes [1] and KEEPS its raw. Any chunk that will land at
+      // post-unshift index >= 2 must drop raw — enforced below via
+      // enforceRawInvariant() rather than open-coded here.
       // Each new chunk is older than all prior paged chunks -> front of the deque.
       this.pagedChunks.unshift({
         rows: result.rows,
@@ -1142,16 +1269,34 @@ class TerminalController implements TerminalInstance {
         rawData: msg.data,
       });
     } else {
-      // All-blank chunk: advance-only (no chunk pushed). Drop any retained top
-      // raw — this consumed range now sits between the top and the next fetch, so
-      // a pair replay across it would be non-contiguous. The next fetch replays
-      // standalone (an accepted, rare seam).
-      if (this.pagedChunks[0]) delete this.pagedChunks[0].rawData;
+      // All-blank chunk: advance-only (no chunk pushed). The consumed range
+      // now sits between the top and the next fetch, so ANY joint replay
+      // across it (pair or triple) would be non-contiguous. Drop every
+      // retained raw — the next fetch must be standalone. This is an
+      // accepted, rare seam.
+      for (const chunk of this.pagedChunks) {
+        if (chunk.rawData !== undefined) delete chunk.rawData;
+      }
     }
 
+    this.enforceRawInvariant();
     this.recomputePagedRowCount();
     this.syncPagingMeta();
     this.scheduleNotify();
+  }
+
+  /**
+   * Enforce the #994 raw-retention invariant: `pagedChunks[0]` and
+   * `pagedChunks[1]` may hold `rawData`; every chunk at index >= 2 must not.
+   * Safe idempotent operation — running it after any pagedChunks mutation
+   * keeps the invariant even when a caller forgot the explicit drop.
+   */
+  private enforceRawInvariant(): void {
+    for (let i = 2; i < this.pagedChunks.length; i++) {
+      if (this.pagedChunks[i].rawData !== undefined) {
+        delete this.pagedChunks[i].rawData;
+      }
+    }
   }
 
   /** Assign fresh downward negative keys to a batch of rows (§6.3). */


### PR DESCRIPTION
## Summary

Extends the existing pair re-replay (§6.2, PR #976) to a joint N-chunk replay so every seam between adjacent paged chunks is settled in one throwaway-terminal context. Retains raw bytes on both `pagedChunks[0]` and `pagedChunks[1]` (bounded to 2 raws max, ~512 KB) so the third and subsequent fetches can do a joint 3-chunk replay across TWO interior seams instead of one.

Closes #994
Progresses #979 SEAM class (Candidate direction C-A). C-B server-side option remains as a possible follow-up.

## Root cause correction

The Issue text describes the root cause as "interior seams use standalone parser via `applyStandaloneChunk`". This is inaccurate — trace and code review show the actual bug is subtler.

Every fetch except the first goes through `applyRangeChunk`'s pair path (not the standalone path). The chained pair replays over N steps do NOT leave interior seams uncorrected in the standalone sense; each interior seam DOES get a pair replay. The real bug is that the pair-replay chain **re-includes** the seam row.

Concrete trace (owner symptom scenario, 80 cols, Japanese-heavy dense mid-line cuts):

1. Chunk N-1 stream tail: content ending with partial `hello wor` at columns 60-68 (no trailing newline).
2. Chunk N stream head: `ld world\n...` continuing from N-1's mid-line position.
3. **Step N** (user pages back, fetches N-1 with N as top): `replayHistoryPair(newBytes=N-1, topBytes=N)`. N-1 written first — cursor lands at (row R, col 9) with `hello wor` on row R on-screen. `splitBaseY` captured here excludes row R from N-1's partition. Then N is written — `ld` extends row R to `hello world...`. Partition assigns row R to N's rows (correctly seam-corrected for THIS step).
4. **Step N+1** (fetches N-2): `replayHistoryPair(newBytes=N-2, topBytes=N-1)`. N-1's own last bytes settle on row R' on-screen. This time N-1's partition ends before row R', and row R' (with the un-merged partial `hello wor`) is attributed to N-1's rows partition — **re-including a row conceptually owned by the N/(N-1) seam**.

Result: `pagedChunks[1].rows` ends with `hello wor` (from Step N+1) and `pagedChunks[2].rows` starts with `hello world...` (from Step N, still stored). Visible: `hello wor` on one row + `hello world...` on the next — the reported symptom, density-scaled by Japanese content because multi-byte cuts fall mid-word more often.

## Fix design (Approach C-A)

- **New helper `replayHistoryJoint(chunks[], ...)`** in `history-replay.ts`: generalized N-chunk joint replay, capturing `baseY` between each chunk write and partitioning the extraction at those boundaries. `replayHistoryPair` now delegates to it (N=2 degenerate case).
- **Retention invariant** in `terminal-store.ts`: `pagedChunks[0]` AND `pagedChunks[1]` (if exists) hold `rawData`. Chunks at index >= 2 never do. Bounded memory O(2 x maxBytes) = ~512 KB. Enforced by `enforceRawInvariant()`.
- **Dispatch in `applyRangeChunk`**:
  - Both `[0]` and `[1]` have raw -> `applyTripleChunk` (joint 3-chunk replay, three-way partition).
  - Only `[0]` has raw -> `applyPairChunk` (existing pair path, but under the new rule KEEPS the former top's raw so the NEXT fetch can do a triple).
  - Neither has raw -> `applyStandaloneChunk` (Step 1 of a session or all-blank contiguity break).
- **Fallback chain**: triple overflow -> pair (dropping second-from-top's raw), pair overflow -> standalone, standalone overflow -> re-request at quartered `maxBytes` (existing terminal safety net).

The triple partition attributes the on-screen tail of chunk `k` (which the joint replay merges with chunk `k+1`'s head) to chunk `k+1`'s partition — the same seam-correction rule as pair, applied at both interior boundaries in one pass.

## Test plan

- [x] `replayHistoryJoint`: line-flow triple partition equality, overflow, wrap-boundary seam, repaint-frame-boundary seam (`packages/client/src/components/terminal/__tests__/history-replay.test.ts`, 4 new tests).
- [x] Terminal-store paging: triple retention state (`pagedRawCount === 2` with `secondChunkHasRaw`), wrap-boundary mid-line cut (owner symptom's byte shape) verified duplicate-free, repaint-frame-boundary chained B-row duplication corrected (`packages/client/src/components/terminal/__tests__/terminal-store-paging.test.ts`, 3 new tests + 2 existing pair tests updated to reflect the new retention invariant).
- [x] Polarity verified: stashed the production fix, re-ran the tests, confirmed all 5 modified/new tests fail on the un-fixed code (`pagedRawCount === 1` where the new invariant requires 2, wrap-boundary shows duplicate rows, chained B-rows appear more than once). All 29 unchanged tests continue to pass.
- [x] Full suite green: 1606 client + 3116 server + 408 shared + 46 integration + 420 scripts/hooks = 5596 tests, 0 fail, `TEST_EXIT: 0`.
- [x] Typecheck green.
- [ ] CodeRabbit review (CLI auth blocked in this env — GitHub-side bot review will run on PR).
- [~] Browser QA screenshots — partial. See "Browser QA note" below.

## Notes on preserved behavior

- Existing pair-replay tests for the N=2 degenerate case continue to pass unchanged in row content / attribution — only the retention-count assertions were updated (`pagedRawCount` was 1, is now 2 under the new invariant). Two existing tests renamed / re-explained accordingly.
- The `#959` "never publishes paged row counts ahead of the prepended rows" invariant is preserved.
- Alt-screen paged row suppression (`#959`) is untouched.
- Overflow-fallback `sendRangeRequest` with quartered `maxBytes` is preserved as the terminal safety net.
- Cols-resize / worker-restart / epoch-resync teardown paths clear all paged state including all retained raws (existing behavior).

## Browser QA note (2026-07-09, orchestrator-led session)

The orchestrator ran an isolated dev server on this PR's branch (scratch `AGENT_CONSOLE_HOME`, ports 3557/5273, no impact on the owner's primary instance) and generated 300K rows of Japanese-heavy output via `seq 1 300000 | awk '...'`. Live viewport rendering was fully correct — no word-split symptom on any of the 4 screenshots posted at [PR #997 issuecomment-4920258411](https://github.com/ms2sato/agent-console/pull/997#issuecomment-4920258411). The 300K-row live rendering exercises the Triple-replay's N=2 degenerate case in the live-window path and confirms it does not regress live wrap semantics.

Paged history (interior seam of the archive) could NOT be programmatically triggered from the QA harness. `element.scrollTop = 0` plus repeated `WheelEvent` dispatch (×20) did not fire `terminal-store`'s paged fetch — the archive fetch requires a real user gesture that `Chrome DevTools MCP evaluate_script` cannot synthesize into xterm.js's gesture-scoped scroll path. A REST-level `request-history-range` probe would exercise the server route but skip the production render path this PR modifies, so it was not treated as a substitute.

Joint decision (orchestrator + delegated agent): given that (a) unit tests polarity-verify the interior-seam byte shapes (wrap-boundary mid-line cut + chained B-row duplication under repaint-frame-boundary), (b) the owner's 2026-07-07 symptom describes precisely the wrap-boundary chunk cut mid-line case that the new unit tests cover, and (c) live viewport rendering on 300K rows is clean, the joint judgment is that real-gesture paged-fetch verification is best done by the owner during dogfood after merge. If dogfood shows the symptom persists on paged content, we reopen against this PR's approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
