### PR TITLE
feat(server): use login shell with sentinel for agent worker PTY spawn

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -72,6 +72,15 @@ A worker that shows the git diff between a base commit and a target ref for its 
 - **Aliases:** DiffWorker, git-diff worker
 - **See:** [GitDiffWorker in worker.ts](../packages/shared/src/types/worker.ts)
 
+### Login-Shell Sentinel
+The spawn → gate → inject protocol used to launch an [AgentWorker](#agentworker) PTY through the user's login shell. Instead of running the agent command directly (which skips `.bashrc` / `.profile` and yields an incomplete PATH), the PTY spawns a login shell whose inner command echoes a per-activation random marker (`__AGENT_CONSOLE_READY_<id>`) and then execs an interactive shell. The worker-manager's onData handler **gates** on the marker: all output before it (login-shell init noise) is dropped and never reaches the output buffer, the persisted output file, clients, or the ActivityDetector; detection is chunk-boundary-safe via a bounded carry of the pre-sentinel tail. On detection, the pending agent command is **injected** with `pty.write(command + '\r')`, avoiding shell-quoting double-escapes.
+
+Both spawn routes honor the same protocol: the direct path (`spawnDirectPty`, single-user mode and the multi-user elevation-skip case) wraps the marker in `$SHELL -l -c`, and the elevated path (`MultiUserMode.spawnSudoPty`) emits it from the inner command of the elevation argv (the elevated login shell provides the login init). A route that spawned without emitting the marker would leave the gate closed forever and silently drop all agent worker output.
+
+- **Key code:** `AgentPtySpawnRequest.sentinel` ([user-mode.ts](../packages/server/src/services/user-mode.ts)); `InternalAgentWorker.loginShellSentinel` / `pendingCommand` ([worker-types.ts](../packages/server/src/services/worker-types.ts)); gate + inject in `WorkerManager.setupWorkerEventHandlers` ([worker-manager.ts](../packages/server/src/services/worker-manager.ts))
+- **Aliases:** sentinel protocol, login-shell sentinel protocol, readiness sentinel
+- **See:** Issue [#999](https://github.com/ms2sato/agent-console/issues/999) (structural enforcement follow-up: sentinel protocol single-writer + spawn-contract conformance suite)
+
 ### Base Spec
 The persisted comparison base of a [GitDiffWorker](#gitdiffworker), stored in `workers.base_commit`. Unlike a frozen commit hash, a base spec records the user's *intent* and is **re-resolved on every diff computation**, so the diff stays aligned with GitHub's merge-base (three-dot) view as the branch absorbs upstream commits. Forms:
 - `merge-base:<ref>` — fork point via `git merge-base <ref> HEAD` (e.g. `merge-base:origin/main`); re-resolves each diff.

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -869,6 +869,52 @@ user's `PATH` leaked into the elevated session and broke `claude` resolution
 with `sh: 1: claude: Permission denied`. Future smoke checks land as sibling
 scripts under `scripts/smoke/`.
 
+### Login-shell sentinel protocol check
+
+Agent workers launch through a login shell that first echoes a one-shot
+sentinel line, then execs an interactive shell into which the worker-manager
+injects the agent command. This smoke spawns a **real** PTY running a real
+login shell, waits for the sentinel, injects a probe command, and asserts the
+observable end state.
+
+Direct mode (runs as the current user -- no elevation):
+
+```bash
+bun scripts/smoke/check-login-shell-sentinel.ts
+```
+
+Elevated mode (runs the target user's login shell through the elevation chain):
+
+```bash
+sudo -u agentconsole bun scripts/smoke/check-login-shell-sentinel.ts --elevated <target-user>
+```
+
+What it verifies (against the **real** login shell):
+
+- The sentinel line is emitted exactly once, before the interactive shell.
+- Command injection after the sentinel gate runs as the expected user
+  (`whoami` matches the current user in direct mode, `<target-user>` under
+  elevation).
+- `PATH` is populated by login-shell init and (WARN-only) includes the user's
+  own home tree.
+- Negative: no probe output leaks before the gate, and the sentinel string
+  never reappears after the gate.
+
+Exit codes:
+
+- `0` -- all assertions passed
+- `1` -- the protocol ran but an assertion failed (the system is wrong)
+- `2` -- bad usage, or the probe could not run at all. In `--elevated` mode
+  this is how an unmet precondition surfaces (elevation not permitted, a
+  password is required, or the target user cannot log in) -- distinct from `1`
+  so operators can tell apart "found a real problem" vs "could not run".
+
+Like the PTY env check, this script imports the production command builders
+(`buildDirectSentinelShellCommand` / `buildElevatedSentinelCommand` from
+`packages/server/src/services/sentinel-spawn-command.ts`) and the production
+`bunPtyProvider`, so the spawn shape it exercises cannot drift from what
+`SingleUserMode` / `MultiUserMode` actually spawn.
+
 ## Local Multi-User Dev Mode
 
 `scripts/dev-multiuser.sh` (also runnable as `bun run dev:multiuser`) starts

--- a/packages/server/src/__tests__/utils/mock-pty.ts
+++ b/packages/server/src/__tests__/utils/mock-pty.ts
@@ -23,13 +23,20 @@ export class MockPty {
   writtenData: string[] = [];
   currentCols = 120;
   currentRows = 30;
+  loginShellSentinel?: string;
+  private sentinelEmitted = false;
 
-  constructor(pid: number) {
+  constructor(pid: number, loginShellSentinel?: string) {
     this.pid = pid;
+    this.loginShellSentinel = loginShellSentinel;
   }
 
   onData(callback: (data: string) => void): MockDisposable {
     this.dataCallback = callback;
+    if (this.loginShellSentinel && !this.sentinelEmitted) {
+      this.sentinelEmitted = true;
+      callback(this.loginShellSentinel + '\n');
+    }
     return {
       dispose: () => {
         if (this.dataCallback === callback) this.dataCallback = null;
@@ -71,8 +78,20 @@ export class MockPty {
 
   // Test helpers - simulate PTY events
   simulateData(data: string) {
+    if (this.loginShellSentinel && !this.sentinelEmitted) {
+      this.sentinelEmitted = true;
+      if (this.dataCallback) {
+        this.dataCallback(this.loginShellSentinel + '\n');
+      }
+    }
     if (this.dataCallback) {
       this.dataCallback(data);
+    }
+  }
+
+  simulateLoginShellReady() {
+    if (this.loginShellSentinel) {
+      this.simulateData(this.loginShellSentinel + '\n');
     }
   }
 
@@ -93,8 +112,14 @@ export function createMockPtyFactory(startPid = 10000) {
   const instances: MockPty[] = [];
   let nextPid = startPid;
 
-  const spawn = mock(() => {
-    const pty = new MockPty(nextPid++);
+  const spawn = mock((...args: unknown[]) => {
+    const spawnArgs = args[1] as string[] | undefined;
+    const shellCmd = spawnArgs?.[1] ?? '';
+    const sentinelMatch = typeof shellCmd === 'string'
+      ? shellCmd.match(/__AGENT_CONSOLE_READY_[a-f0-9]+/)
+      : null;
+    const sentinel = sentinelMatch?.[0];
+    const pty = new MockPty(nextPid++, sentinel);
     instances.push(pty);
     return pty;
   });

--- a/packages/server/src/__tests__/utils/mock-pty.ts
+++ b/packages/server/src/__tests__/utils/mock-pty.ts
@@ -25,15 +25,17 @@ export class MockPty {
   currentRows = 30;
   loginShellSentinel?: string;
   private sentinelEmitted = false;
+  private autoEmitSentinel: boolean;
 
-  constructor(pid: number, loginShellSentinel?: string) {
+  constructor(pid: number, loginShellSentinel?: string, autoEmitSentinel = true) {
     this.pid = pid;
     this.loginShellSentinel = loginShellSentinel;
+    this.autoEmitSentinel = autoEmitSentinel;
   }
 
   onData(callback: (data: string) => void): MockDisposable {
     this.dataCallback = callback;
-    if (this.loginShellSentinel && !this.sentinelEmitted) {
+    if (this.autoEmitSentinel && this.loginShellSentinel && !this.sentinelEmitted) {
       this.sentinelEmitted = true;
       callback(this.loginShellSentinel + '\n');
     }
@@ -78,20 +80,39 @@ export class MockPty {
 
   // Test helpers - simulate PTY events
   simulateData(data: string) {
-    if (this.loginShellSentinel && !this.sentinelEmitted) {
+    // Only mark the sentinel as emitted once a callback actually receives it;
+    // flipping the flag with no listener would suppress the real emit later.
+    if (this.autoEmitSentinel && this.loginShellSentinel && !this.sentinelEmitted && this.dataCallback) {
       this.sentinelEmitted = true;
-      if (this.dataCallback) {
-        this.dataCallback(this.loginShellSentinel + '\n');
-      }
+      this.dataCallback(this.loginShellSentinel + '\n');
     }
     if (this.dataCallback) {
       this.dataCallback(data);
     }
   }
 
+  /**
+   * Emit the login-shell sentinel exactly once, only when a callback is
+   * registered and the sentinel has not already been emitted. Does not route
+   * through simulateData (which would append a spurious duplicate when the
+   * onData auto-emit already fired) and never flips the flag without a
+   * listener present.
+   */
   simulateLoginShellReady() {
-    if (this.loginShellSentinel) {
-      this.simulateData(this.loginShellSentinel + '\n');
+    if (this.loginShellSentinel && !this.sentinelEmitted && this.dataCallback) {
+      this.sentinelEmitted = true;
+      this.dataCallback(this.loginShellSentinel + '\n');
+    }
+  }
+
+  /**
+   * Directly emit raw bytes to the onData callback, bypassing all sentinel
+   * auto-emit. Lets tests feed a login-shell sentinel across arbitrary chunk
+   * boundaries (pair with the factory's autoEmitSentinel=false option).
+   */
+  emitRaw(data: string) {
+    if (this.dataCallback) {
+      this.dataCallback(data);
     }
   }
 
@@ -111,15 +132,17 @@ export class MockPty {
 export function createMockPtyFactory(startPid = 10000) {
   const instances: MockPty[] = [];
   let nextPid = startPid;
+  let autoEmitSentinel = true;
 
   const spawn = mock((...args: unknown[]) => {
     const spawnArgs = args[1] as string[] | undefined;
-    const shellCmd = spawnArgs?.[1] ?? '';
-    const sentinelMatch = typeof shellCmd === 'string'
-      ? shellCmd.match(/__AGENT_CONSOLE_READY_[a-f0-9]+/)
-      : null;
+    // Scan the full argv, not just argv[1]: direct spawns are `sh -c <cmd>`
+    // (sentinel at index 1) but elevated spawns are `sudo -u ... sh -c <cmd>`
+    // (sentinel deep in the array). Joining covers both shapes.
+    const joinedArgs = Array.isArray(spawnArgs) ? spawnArgs.join(' ') : '';
+    const sentinelMatch = joinedArgs.match(/__AGENT_CONSOLE_READY_[a-f0-9]+/);
     const sentinel = sentinelMatch?.[0];
-    const pty = new MockPty(nextPid++, sentinel);
+    const pty = new MockPty(nextPid++, sentinel, autoEmitSentinel);
     instances.push(pty);
     return pty;
   });
@@ -127,7 +150,17 @@ export function createMockPtyFactory(startPid = 10000) {
   const reset = () => {
     instances.length = 0;
     nextPid = startPid;
+    autoEmitSentinel = true;
     spawn.mockClear();
+  };
+
+  /**
+   * Toggle whether ptys spawned afterwards auto-emit their login-shell sentinel
+   * when onData is registered. Disable to drive the sentinel manually via
+   * MockPty.emitRaw (e.g. to feed it across chunk boundaries).
+   */
+  const setAutoEmitSentinel = (enabled: boolean) => {
+    autoEmitSentinel = enabled;
   };
 
   // Create a PtyProvider that uses the mock spawn
@@ -135,5 +168,5 @@ export function createMockPtyFactory(startPid = 10000) {
     spawn: spawn as unknown as PtyProvider['spawn'],
   };
 
-  return { instances, spawn, reset, provider };
+  return { instances, spawn, reset, provider, setAutoEmitSentinel };
 }

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -1052,8 +1052,9 @@ describe('MCP Server Tools', () => {
         fromSessionId: senderSession.id,
       }, nextId++);
 
-      // Reply instructions are the second write (index 1), after the notification (index 0)
-      const replyInstructions = mockPty.writtenData[1];
+      // With login shell sentinel: writtenData[0] = agent command,
+      // [1] = notification, [2] = reply instructions.
+      const replyInstructions = mockPty.writtenData[2];
       expect(replyInstructions).toContain('[Reply Instructions]');
       expect(replyInstructions).toContain(`toSessionId: "${senderSession.id}"`);
       expect(replyInstructions).toContain('AGENT_CONSOLE_SESSION_ID');
@@ -1330,10 +1331,19 @@ describe('MCP Server Tools', () => {
      */
     function findSpawnCallByCommand(commandSubstring: string): unknown[] | undefined {
       const calls = ptyFactory.spawn.mock.calls as unknown as Array<[string, string[], unknown]>;
-      return calls.find((call) => {
+      const spawnMatch = calls.find((call) => {
         const cmd = call[1]?.join(' ') ?? '';
         return cmd.includes(commandSubstring);
       });
+      if (spawnMatch) return spawnMatch;
+      const ptyMatch = ptyFactory.instances.find((pty) =>
+        pty.writtenData.some((d) => d.includes(commandSubstring)),
+      );
+      if (ptyMatch) {
+        const idx = ptyFactory.instances.indexOf(ptyMatch);
+        return calls[idx];
+      }
+      return undefined;
     }
 
     it('should return error when repository not found', async () => {
@@ -1836,24 +1846,17 @@ describe('MCP Server Tools', () => {
      * instead of being indirected through env.__AGENT_PROMPT__.
      */
     function getAgentPromptForSession(sessionId: string): string {
-      // `bun:test`'s `mock(() => ...)` (see __tests__/utils/mock-pty.ts)
-      // infers `mock.calls` as `[][]` because the factory has no declared
-      // parameters; a direct tuple cast fails with TS2352 ("Source has 0
-      // element(s) but target requires 3 — convert the expression to 'unknown'
-      // first"). The `as unknown as ...` step is therefore required, and
-      // matches the pre-existing shape used by `findSpawnCallByCommand` and
-      // the activity-detector probe in this file.
       const calls = ptyFactory.spawn.mock.calls as unknown as Array<[string, string[], PtySpawnOptions]>;
-      const matchingCall = calls.find((call) =>
+      const callIndex = calls.findIndex((call) =>
         call[2]?.env?.AGENT_CONSOLE_SESSION_ID === sessionId,
       );
-      expect(matchingCall).toBeDefined();
-      // PTY spawn shape: ('sh', ['-c', '<unsetPrefix><command>'], options).
-      // The shell-escaped prompt is the trailing single-quoted segment of
-      // the second arg.
-      const shellCommand = matchingCall![1][1];
-      expect(shellCommand).toBeDefined();
-      return extractPromptFromSpawnCommand(shellCommand);
+      expect(callIndex).toBeGreaterThanOrEqual(0);
+      const pty = ptyFactory.instances[callIndex];
+      expect(pty).toBeDefined();
+      const commandWithCR = pty.writtenData.find((d) => d.endsWith('\r'));
+      expect(commandWithCR).toBeDefined();
+      const command = commandWithCR!.slice(0, -1);
+      return extractPromptFromSpawnCommand(command);
     }
 
     it('should append callback instructions to prompt when parent IDs are provided', async () => {

--- a/packages/server/src/services/__tests__/multi-user-mode.test.ts
+++ b/packages/server/src/services/__tests__/multi-user-mode.test.ts
@@ -622,6 +622,71 @@ describe('MultiUserMode', () => {
       expect(opts.rows).toBe(30);
     });
 
+    it('should echo the sentinel and exec a login shell (not the agent command) when sentinel is set', async () => {
+      // Elevated path parity with the direct (sudo-skip) spawn: when the agent
+      // request carries a sentinel, the inner command must echo the sentinel
+      // then exec an interactive login shell instead of running the agent
+      // command directly. The worker-manager gates on the sentinel line and
+      // injects the real command afterwards. Without this, sudo -i runs the
+      // agent command immediately, no sentinel is ever emitted, and the agent
+      // worker's output is dropped forever by the sentinel gate.
+      const mode = await createMode();
+
+      const request: AgentPtySpawnRequest = {
+        type: 'agent',
+        username: 'other-user',
+        cwd: '/workspace/project',
+        additionalEnvVars: {},
+        cols: 80,
+        rows: 24,
+        command: 'claude --prompt "build feature"',
+        agentConsoleContext: {
+          baseUrl: 'http://localhost:3457',
+          sessionId: 'sess-1',
+          workerId: 'wkr-1',
+        },
+        sentinel: '__AGENT_CONSOLE_READY_abc123',
+      };
+
+      mode.spawnPty(request);
+
+      const [cmd, args] = getLastSpawnCall();
+      expect(cmd).toBe('sudo');
+      const innerCommand = args[6];
+      expect(innerCommand).toContain('echo __AGENT_CONSOLE_READY_abc123; exec $SHELL');
+      // The agent command must NOT be spawned directly; the worker-manager
+      // injects it after detecting the sentinel line.
+      expect(innerCommand).not.toContain('claude --prompt "build feature"');
+      // AGENT_CONSOLE_* env is still exported so the injected command inherits it.
+      expect(innerCommand).toContain('AGENT_CONSOLE_BASE_URL');
+    });
+
+    it('should run the agent command directly when no sentinel is set', async () => {
+      const mode = await createMode();
+
+      const request: AgentPtySpawnRequest = {
+        type: 'agent',
+        username: 'other-user',
+        cwd: '/workspace/project',
+        additionalEnvVars: {},
+        cols: 80,
+        rows: 24,
+        command: 'claude --prompt "build feature"',
+        agentConsoleContext: {
+          baseUrl: 'http://localhost:3457',
+          sessionId: 'sess-1',
+          workerId: 'wkr-1',
+        },
+      };
+
+      mode.spawnPty(request);
+
+      const [, args] = getLastSpawnCall();
+      const innerCommand = args[6];
+      expect(innerCommand).toContain('claude --prompt "build feature"');
+      expect(innerCommand).not.toContain('exec $SHELL');
+    });
+
     it('should pass --preserve-env=FORCE_COLOR to sudo so truecolor flag survives sudo -i', async () => {
       // Model B (multi-user) bug: sudo -i resets the env to the sudoers env_keep
       // defaults, which strips FORCE_COLOR. Node-based agents then fall back to

--- a/packages/server/src/services/__tests__/multi-user-mode.test.ts
+++ b/packages/server/src/services/__tests__/multi-user-mode.test.ts
@@ -444,6 +444,36 @@ describe('MultiUserMode', () => {
       expect(opts.cwd).toBe('/workspace/project');
     });
 
+    it('should use login shell with sentinel when sentinel is provided (agent)', async () => {
+      const mode = await createMode();
+      const serverUsername = getServerUsername();
+
+      const request: AgentPtySpawnRequest = {
+        type: 'agent',
+        username: serverUsername,
+        cwd: '/workspace/project',
+        additionalEnvVars: {},
+        cols: 120,
+        rows: 30,
+        command: 'claude --prompt "hello"',
+        agentConsoleContext: {
+          baseUrl: 'http://localhost:3457',
+          sessionId: 'sess-1',
+          workerId: 'wkr-1',
+        },
+        sentinel: '__AGENT_CONSOLE_READY_abc123',
+      };
+
+      mode.spawnPty(request);
+
+      const [cmd, args] = getLastSpawnCall();
+      expect(cmd).toBe('sh');
+      expect(args[0]).toBe('-c');
+      expect(args[1]).toContain('exec $SHELL -l');
+      expect(args[1]).toContain('echo __AGENT_CONSOLE_READY_abc123');
+      expect(args[1]).not.toContain('claude --prompt "hello"');
+    });
+
     it('should spawn directly when username matches server process user (terminal)', async () => {
       const mode = await createMode();
       const serverUsername = getServerUsername();

--- a/packages/server/src/services/__tests__/sentinel-spawn-command.test.ts
+++ b/packages/server/src/services/__tests__/sentinel-spawn-command.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  buildDirectSentinelShellCommand,
+  buildElevatedSentinelCommand,
+} from '../sentinel-spawn-command.js';
+
+const SENTINEL = '__AGENT_CONSOLE_READY_abc123';
+
+describe('buildDirectSentinelShellCommand', () => {
+  it('prepends the unset prefix ahead of the login-shell exec', () => {
+    const cmd = buildDirectSentinelShellCommand(SENTINEL, 'unset FOO BAR; ');
+    expect(cmd.startsWith('unset FOO BAR; ')).toBe(true);
+  });
+
+  it('execs a login shell that echoes the sentinel then execs an interactive shell', () => {
+    const cmd = buildDirectSentinelShellCommand(SENTINEL, '');
+    expect(cmd).toContain('exec $SHELL -l -c');
+    expect(cmd).toContain(`echo ${SENTINEL}; exec $SHELL`);
+    // Byte-exact shape the worker-manager sentinel gate relies on.
+    expect(cmd).toBe(`exec $SHELL -l -c 'echo ${SENTINEL}; exec $SHELL'`);
+  });
+
+  it('does not export env vars across the boundary (unset prefix only, no export/PATH)', () => {
+    const cmd = buildDirectSentinelShellCommand(SENTINEL, 'unset FOO; ');
+    // The direct path relies on the inherited process env, never re-exporting;
+    // an `export`/`PATH=` in this command would signal an accidental leak.
+    expect(cmd).not.toContain('export');
+    expect(cmd).not.toContain('PATH=');
+  });
+
+  it('emits no unset text when the prefix is empty', () => {
+    const cmd = buildDirectSentinelShellCommand(SENTINEL, '');
+    expect(cmd).not.toContain('unset');
+    expect(cmd.startsWith('exec $SHELL -l -c')).toBe(true);
+  });
+});
+
+describe('buildElevatedSentinelCommand', () => {
+  it('is exactly "echo <sentinel>; exec $SHELL"', () => {
+    const cmd = buildElevatedSentinelCommand(SENTINEL);
+    expect(cmd).toBe(`echo ${SENTINEL}; exec $SHELL`);
+  });
+
+  it('does not add the -l login flag (login init is the elevation chain\'s responsibility)', () => {
+    const cmd = buildElevatedSentinelCommand(SENTINEL);
+    expect(cmd).not.toContain('-l');
+  });
+});

--- a/packages/server/src/services/__tests__/user-mode.test.ts
+++ b/packages/server/src/services/__tests__/user-mode.test.ts
@@ -19,7 +19,8 @@ import type { Kysely } from 'kysely';
 import { createDatabaseForTest } from '../../database/connection.js';
 import { SqliteUserRepository } from '../../repositories/sqlite-user-repository.js';
 import { SingleUserMode, MultiUserMode } from '../user-mode.js';
-import type { TerminalPtySpawnRequest } from '../user-mode.js';
+import type { TerminalPtySpawnRequest, AgentPtySpawnRequest } from '../user-mode.js';
+import { getUnsetEnvPrefix } from '../env-filter.js';
 import type { PtyProvider, PtySpawnOptions, PtyInstance } from '../../lib/pty-provider.js';
 
 const mockPtyProvider: PtyProvider = {
@@ -157,6 +158,63 @@ describe('SingleUserMode', () => {
 
       const [, , opts] = lastCall();
       expect(opts.cwd).toBe('/home/cached/project');
+    });
+  });
+
+  describe('spawnPty() - agent login-shell sentinel branch', () => {
+    // Agent workers can request a login-shell + sentinel launch: instead of
+    // running the agent command directly, the PTY execs the user's login
+    // shell, echoes the sentinel line, then execs an interactive login shell.
+    // This lets the worker-manager detect shell readiness before injecting the
+    // agent command. When request.sentinel is unset the direct command path is used.
+    function makeAgentRequest(sentinel?: string): AgentPtySpawnRequest {
+      return {
+        type: 'agent',
+        username: 'cached',
+        cwd: '/home/cached/project',
+        additionalEnvVars: {},
+        cols: 80,
+        rows: 24,
+        command: 'claude --resume',
+        agentConsoleContext: {
+          baseUrl: 'http://localhost:3457',
+          sessionId: 's1',
+          workerId: 'w1',
+        },
+        ...(sentinel !== undefined && { sentinel }),
+      };
+    }
+
+    it('execs a login shell that echoes the sentinel and does NOT run the agent command directly', () => {
+      const { provider, lastCall } = createCapturingPtyProvider();
+      const cachedUser = { id: 'cached-id', username: 'cached', homeDir: '/home/cached' };
+      const userMode = new SingleUserMode(provider, cachedUser);
+
+      userMode.spawnPty(makeAgentRequest('ACX_READY_abc123'));
+
+      const [cmd, args] = lastCall();
+      expect(cmd).toBe('sh');
+      expect(args[0]).toBe('-c');
+      const shellCommand = args[1];
+      expect(shellCommand).toContain("exec $SHELL -l -c 'echo ACX_READY_abc123; exec $SHELL'");
+      // The agent command must not be spawned directly in the sentinel branch;
+      // the worker-manager injects it after detecting the sentinel line.
+      expect(shellCommand).not.toContain('claude --resume');
+      // The unset prefix (if any) is preserved ahead of the exec.
+      expect(shellCommand.startsWith(getUnsetEnvPrefix())).toBe(true);
+    });
+
+    it('runs the agent command directly when no sentinel is provided', () => {
+      const { provider, lastCall } = createCapturingPtyProvider();
+      const cachedUser = { id: 'cached-id', username: 'cached', homeDir: '/home/cached' };
+      const userMode = new SingleUserMode(provider, cachedUser);
+
+      userMode.spawnPty(makeAgentRequest());
+
+      const [, args] = lastCall();
+      const shellCommand = args[1];
+      expect(shellCommand).toContain('claude --resume');
+      expect(shellCommand).not.toContain('exec $SHELL -l -c');
     });
   });
 });

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -478,6 +478,33 @@ describe('WorkerManager', () => {
       expect(worker.outputBuffer).toBe('agent output here');
     });
 
+    it('should detect a sentinel split across two PTY read chunks', async () => {
+      // Suppress the mock's onData auto-emit so we can feed the sentinel
+      // manually straddling a chunk boundary. Without the carry buffer the
+      // per-chunk indexOf never matches and all output is dropped forever.
+      ptyFactory.setAutoEmitSentinel(false);
+
+      const worker = createTestAgentWorker();
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+      const mockPty = ptyFactory.instances[0];
+      const sentinel = mockPty.loginShellSentinel;
+      expect(sentinel).toBeDefined();
+      const mid = Math.floor(sentinel!.length / 2);
+
+      // First chunk carries only the sentinel's first half (plus preamble).
+      mockPty.emitRaw('login banner ' + sentinel!.slice(0, mid));
+      // Not yet detected: pre-sentinel output is dropped, no command written.
+      expect(worker.outputBuffer).toBe('');
+      expect(mockPty.writtenData.some((d) => d.endsWith('\r'))).toBe(false);
+
+      // Second chunk completes the sentinel across the boundary.
+      mockPty.emitRaw(sentinel!.slice(mid) + '\r\npost-sentinel output');
+
+      expect(worker.outputBuffer).toBe('post-sentinel output');
+      expect(mockPty.writtenData.some((d) => d.endsWith('\r'))).toBe(true);
+    });
+
     it('should not feed pre-sentinel output to activity detector', async () => {
       const worker = createTestAgentWorker();
       await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
@@ -488,6 +515,14 @@ describe('WorkerManager', () => {
     it('should clean up sentinel fields on worker exit', async () => {
       const worker = createTestAgentWorker();
       await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+      const mockPty = ptyFactory.instances[0];
+      // Simulate a PTY that dies before its sentinel is ever seen: re-populate
+      // the gating fields, then drive the actual onExit cleanup branch.
+      worker.loginShellSentinel = 'lingering-sentinel';
+      worker.pendingCommand = 'lingering command';
+
+      mockPty.simulateExit(1);
 
       expect(worker.loginShellSentinel).toBeUndefined();
       expect(worker.pendingCommand).toBeUndefined();

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -452,6 +452,48 @@ describe('WorkerManager', () => {
     });
   });
 
+  // ========== Login Shell Sentinel ==========
+
+  describe('login shell sentinel detection', () => {
+    it('should skip pre-sentinel output and write command on sentinel detection', async () => {
+      const worker = createTestAgentWorker();
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+      const mockPty = ptyFactory.instances[0];
+      expect(mockPty.loginShellSentinel).toBeDefined();
+
+      expect(worker.outputBuffer).toBe('');
+      expect(mockPty.writtenData.length).toBeGreaterThan(0);
+      const commandWrite = mockPty.writtenData.find((d) => d.endsWith('\r'));
+      expect(commandWrite).toBeDefined();
+    });
+
+    it('should process post-sentinel output normally', async () => {
+      const worker = createTestAgentWorker();
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+      const mockPty = ptyFactory.instances[0];
+      mockPty.simulateData('agent output here');
+
+      expect(worker.outputBuffer).toBe('agent output here');
+    });
+
+    it('should not feed pre-sentinel output to activity detector', async () => {
+      const worker = createTestAgentWorker();
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+      expect(worker.activityState).toBe('idle');
+    });
+
+    it('should clean up sentinel fields on worker exit', async () => {
+      const worker = createTestAgentWorker();
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+      expect(worker.loginShellSentinel).toBeUndefined();
+      expect(worker.pendingCommand).toBeUndefined();
+    });
+  });
+
   describe('resize', () => {
     it('should resize the PTY', async () => {
       const worker = createTestTerminalWorker();

--- a/packages/server/src/services/sentinel-spawn-command.ts
+++ b/packages/server/src/services/sentinel-spawn-command.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure builders for the login-shell sentinel spawn commands. Extracted so
+ * production (`user-mode.ts`) and the post-deploy smoke script
+ * (`scripts/smoke/check-login-shell-sentinel.ts`) share a single source of
+ * truth for the command shape -- drift between what production spawns and
+ * what smoke verifies is impossible by construction. No I/O, no side effects.
+ */
+
+/**
+ * Direct path (SingleUserMode / MultiUserMode elevation-skip): wraps the
+ * sentinel echo in a login shell; the interactive shell that follows is the
+ * one the worker-manager injects the agent command into.
+ */
+export function buildDirectSentinelShellCommand(sentinel: string, unsetPrefix: string): string {
+  return `${unsetPrefix}exec $SHELL -l -c 'echo ${sentinel}; exec $SHELL'`;
+}
+
+/**
+ * Elevated path (MultiUserMode.spawnSudoPty): the elevation chain's login
+ * shell provides login init, so the inner command only echoes the sentinel
+ * and execs the interactive shell.
+ */
+export function buildElevatedSentinelCommand(sentinel: string): string {
+  return `echo ${sentinel}; exec $SHELL`;
+}

--- a/packages/server/src/services/user-mode.ts
+++ b/packages/server/src/services/user-mode.ts
@@ -78,6 +78,7 @@ export interface AgentPtySpawnRequest extends PtySpawnRequestBase {
   type: 'agent';
   command: string;
   agentConsoleContext: AgentConsoleContext;
+  sentinel?: string;
 }
 
 export interface TerminalPtySpawnRequest extends PtySpawnRequestBase {
@@ -134,7 +135,10 @@ function spawnDirectPty(ptyProvider: PtyProvider, request: PtySpawnRequest): Pty
       };
 
       const unsetPrefix = getUnsetEnvPrefix();
-      return ptyProvider.spawn('sh', ['-c', unsetPrefix + request.command], {
+      const shellCommand = request.sentinel
+        ? `${unsetPrefix}exec $SHELL -l -c 'echo ${request.sentinel}; exec $SHELL'`
+        : unsetPrefix + request.command;
+      return ptyProvider.spawn('sh', ['-c', shellCommand], {
         name: 'xterm-256color',
         cols: request.cols,
         rows: request.rows,

--- a/packages/server/src/services/user-mode.ts
+++ b/packages/server/src/services/user-mode.ts
@@ -21,6 +21,7 @@ import type { PtyProvider, PtyInstance } from '../lib/pty-provider.js';
 import type { UserRepository } from '../repositories/user-repository.js';
 import { getCleanChildProcessEnv, getUnsetEnvPrefix } from './env-filter.js';
 import { buildElevationArgs } from './elevation-args.js';
+import { buildDirectSentinelShellCommand, buildElevatedSentinelCommand } from './sentinel-spawn-command.js';
 import { lookupOsUser } from './os-user-lookup.js';
 import { getConfigDir } from '../lib/config.js';
 import { createLogger } from '../lib/logger.js';
@@ -136,7 +137,7 @@ function spawnDirectPty(ptyProvider: PtyProvider, request: PtySpawnRequest): Pty
 
       const unsetPrefix = getUnsetEnvPrefix();
       const shellCommand = request.sentinel
-        ? `${unsetPrefix}exec $SHELL -l -c 'echo ${request.sentinel}; exec $SHELL'`
+        ? buildDirectSentinelShellCommand(request.sentinel, unsetPrefix)
         : unsetPrefix + request.command;
       return ptyProvider.spawn('sh', ['-c', shellCommand], {
         name: 'xterm-256color',
@@ -499,7 +500,7 @@ export class MultiUserMode implements UserMode {
           ...(ctx.parentWorkerId && { AGENT_CONSOLE_PARENT_WORKER_ID: ctx.parentWorkerId }),
         };
         command = request.sentinel
-          ? `echo ${request.sentinel}; exec $SHELL`
+          ? buildElevatedSentinelCommand(request.sentinel)
           : request.command;
         break;
       }

--- a/packages/server/src/services/user-mode.ts
+++ b/packages/server/src/services/user-mode.ts
@@ -470,6 +470,12 @@ export class MultiUserMode implements UserMode {
    * Creates a full login shell as the target user.
    * Environment variables are embedded in the command since sudo -i
    * does not inherit the parent's process environment.
+   *
+   * When an agent request carries a `sentinel`, the inner command echoes the
+   * sentinel then execs an interactive login shell instead of running the
+   * agent command directly. The worker-manager gates on the sentinel line and
+   * injects the real command afterwards, mirroring the direct (sudo-skip)
+   * spawn path so both routes share identical launch semantics.
    */
   private spawnSudoPty(request: PtySpawnRequest): PtyInstance {
     // Build the sudo argv via the pure helper in `elevation-args.ts`. The
@@ -492,7 +498,9 @@ export class MultiUserMode implements UserMode {
           ...(ctx.parentSessionId && { AGENT_CONSOLE_PARENT_SESSION_ID: ctx.parentSessionId }),
           ...(ctx.parentWorkerId && { AGENT_CONSOLE_PARENT_WORKER_ID: ctx.parentWorkerId }),
         };
-        command = request.command;
+        command = request.sentinel
+          ? `echo ${request.sentinel}; exec $SHELL`
+          : request.command;
         break;
       }
       case 'terminal': {

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -494,22 +494,29 @@ export class WorkerManager {
     const disposables: Disposable[] = [];
 
     let sentinelDetected = worker.type !== 'agent' || !worker.loginShellSentinel;
+    // Carries the tail of the pre-sentinel stream across PTY read boundaries so a
+    // sentinel split between two chunks is still detected. Bounded to
+    // sentinel.length - 1 characters (the largest partial match possible).
+    let preSentinelCarry = '';
 
     const onDataDisposable = worker.pty.onData((rawData) => {
       let data = rawData;
 
       if (!sentinelDetected && worker.type === 'agent' && worker.loginShellSentinel) {
         const sentinel = worker.loginShellSentinel;
-        const idx = data.indexOf(sentinel);
+        const haystack = preSentinelCarry + data;
+        const idx = haystack.indexOf(sentinel);
         if (idx === -1) {
+          preSentinelCarry = haystack.slice(-(sentinel.length - 1));
           return;
         }
         sentinelDetected = true;
+        preSentinelCarry = '';
         if (worker.pendingCommand && worker.pty) {
           worker.pty.write(worker.pendingCommand + '\r');
           worker.pendingCommand = undefined;
         }
-        const afterSentinel = data.slice(idx + sentinel.length).replace(/^[\r\n]+/, '');
+        const afterSentinel = haystack.slice(idx + sentinel.length).replace(/^[\r\n]+/, '');
         worker.loginShellSentinel = undefined;
         if (afterSentinel.length === 0) return;
         data = afterSentinel;

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -378,6 +378,8 @@ export class WorkerManager {
       ...templateEnv,
     };
 
+    const sentinel = `__AGENT_CONSOLE_READY_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+
     const ptyProcess = this.userMode.spawnPty({
       type: 'agent',
       username: params.username,
@@ -387,6 +389,7 @@ export class WorkerManager {
       rows: 30,
       command,
       agentConsoleContext,
+      sentinel,
       // Forward the optional SSH_AUTH_SOCK fallback from the session
       // creation context. Populated only by the MCP delegate path;
       // undefined for every other path so existing behavior is preserved.
@@ -408,6 +411,8 @@ export class WorkerManager {
     worker.pty = ptyProcess;
     worker.activityDetector = activityDetector;
     worker.agentId = agent.id;
+    worker.loginShellSentinel = sentinel;
+    worker.pendingCommand = command;
 
     // Set initial activity state to match ActivityDetector's initial state ('idle').
     // The onStateChange callback only fires on state *changes*, not on initialization,
@@ -488,7 +493,28 @@ export class WorkerManager {
 
     const disposables: Disposable[] = [];
 
-    const onDataDisposable = worker.pty.onData((data) => {
+    let sentinelDetected = worker.type !== 'agent' || !worker.loginShellSentinel;
+
+    const onDataDisposable = worker.pty.onData((rawData) => {
+      let data = rawData;
+
+      if (!sentinelDetected && worker.type === 'agent' && worker.loginShellSentinel) {
+        const sentinel = worker.loginShellSentinel;
+        const idx = data.indexOf(sentinel);
+        if (idx === -1) {
+          return;
+        }
+        sentinelDetected = true;
+        if (worker.pendingCommand && worker.pty) {
+          worker.pty.write(worker.pendingCommand + '\r');
+          worker.pendingCommand = undefined;
+        }
+        const afterSentinel = data.slice(idx + sentinel.length).replace(/^[\r\n]+/, '');
+        worker.loginShellSentinel = undefined;
+        if (afterSentinel.length === 0) return;
+        data = afterSentinel;
+      }
+
       worker.outputBuffer += data;
       const maxBufferSize = serverConfig.WORKER_OUTPUT_BUFFER_SIZE;
       if (worker.outputBuffer.length > maxBufferSize) {
@@ -523,6 +549,11 @@ export class WorkerManager {
       if (worker.type === 'agent' && worker.activityDetector) {
         worker.activityDetector.dispose();
         worker.activityDetector = null;
+      }
+
+      if (worker.type === 'agent') {
+        worker.loginShellSentinel = undefined;
+        worker.pendingCommand = undefined;
       }
 
       const callbacksSnapshot = Array.from(worker.connectionCallbacks.values());

--- a/packages/server/src/services/worker-types.ts
+++ b/packages/server/src/services/worker-types.ts
@@ -69,6 +69,8 @@ export interface InternalAgentWorker extends InternalPtyWorkerBase {
   agentId: string;
   activityState: AgentActivityState;
   activityDetector: ActivityDetector | null;  // null when pty is null
+  loginShellSentinel?: string;
+  pendingCommand?: string;
 }
 
 /**

--- a/scripts/check-source-comment-blame-shift.mjs
+++ b/scripts/check-source-comment-blame-shift.mjs
@@ -669,7 +669,7 @@ export const KNOWN_VIOLATIONS = new Set([
   'packages/server/src/services/worker-manager.ts:123:53:issue-ref',
   'packages/server/src/services/worker-manager.ts:276:15:issue-ref',
   'packages/server/src/services/worker-manager.ts:318:8:issue-ref',
-  'packages/server/src/services/worker-manager.ts:440:8:issue-ref',
+  'packages/server/src/services/worker-manager.ts:445:8:issue-ref',
   'packages/server/src/services/worktree-creation-service.ts:31:25:issue-ref',
   'packages/server/src/services/worktree-creation-service.ts:32:8:bare-ref',
   'packages/server/src/services/worktree-creation-service.ts:32:15:pr-ref',

--- a/scripts/smoke/check-login-shell-sentinel.ts
+++ b/scripts/smoke/check-login-shell-sentinel.ts
@@ -1,0 +1,287 @@
+#!/usr/bin/env bun
+/**
+ * Post-deploy smoke test for the login-shell sentinel PTY protocol.
+ *
+ * Spawns a REAL PTY running a REAL login shell using the same production
+ * PtyProvider (`bunPtyProvider`) and the same shared command builders
+ * (`buildDirectSentinelShellCommand` / `buildElevatedSentinelCommand`) that
+ * `MultiUserMode` / `SingleUserMode` use. It then drives the full protocol:
+ * wait for the sentinel line, inject a probe command into the interactive
+ * shell that follows, and assert the observable end state.
+ *
+ * What this smoke exercises:
+ *   - The production command builders (via direct import -- no hand copy).
+ *   - The real login shell init (PATH / HOME / USER / SHELL) delivered by the
+ *     login shell the sentinel command execs.
+ *   - The one-shot sentinel contract: the sentinel is emitted exactly once,
+ *     before the interactive shell, and command injection after the gate runs
+ *     as the expected user.
+ *   - (--elevated) the real OS elevation chain: real elevation binary, real
+ *     sudoers config, target user's login shell init.
+ *
+ * What this smoke does NOT exercise:
+ *   - The worker-manager's chunk-boundary sentinel gate (covered by the
+ *     worker-manager unit tests). Here the raw PTY stream is inspected
+ *     directly.
+ *   - bun-pty's internal PTY allocation. That is a library concern.
+ *   - The agent-console server. The builders are pure; no server runs here.
+ *
+ * Usage:
+ *   bun scripts/smoke/check-login-shell-sentinel.ts               # direct mode
+ *   bun scripts/smoke/check-login-shell-sentinel.ts --elevated <target-user>
+ *
+ * Requirements:
+ *   - direct mode: a login shell resolvable via $SHELL for the current user.
+ *   - --elevated mode: run as a user with elevation privilege for
+ *     <target-user> (on the dogfood host, the agentconsole service user with
+ *     the sudoers rules installed by scripts/setup-multiuser-for-ubuntu.sh).
+ *     <target-user> must be a real OS user with a login shell.
+ *
+ * Exit codes:
+ *   0  all assertions passed
+ *   1  the protocol ran but an assertion failed (the system is wrong)
+ *   2  bad usage, or the probe could not run at all (e.g. --elevated
+ *      precondition not met: elevation not permitted / password required /
+ *      target user absent). Distinct from 1 so operators can tell apart
+ *      "the smoke ran and found a real problem" vs "the smoke could not run".
+ *
+ * Sync contract: NONE -- the production command builders and PtyProvider are
+ * imported directly. Changing the spawn command shape in production updates
+ * this smoke automatically because both paths call the same builders.
+ */
+
+import * as os from 'os';
+import * as crypto from 'crypto';
+import { existsSync, readFileSync } from 'fs';
+import type { PtyInstance } from '../../packages/server/src/lib/pty-provider.js';
+import { bunPtyProvider } from '../../packages/server/src/lib/pty-provider.js';
+import { getUnsetEnvPrefix } from '../../packages/server/src/services/env-filter.js';
+import {
+  buildDirectSentinelShellCommand,
+  buildElevatedSentinelCommand,
+} from '../../packages/server/src/services/sentinel-spawn-command.js';
+import { buildElevationArgs } from '../../packages/server/src/services/elevation-args.js';
+
+// Neutralize any unreadable inherited cwd (see check-multiuser-pty-env.ts):
+// when invoked via an elevation wrapper the caller's cwd may be untraversable
+// by the spawning user, producing EACCES at posix_spawn time. "/" is always
+// world-traversable.
+process.chdir('/');
+
+const PHASE_TIMEOUT_MS = 15000;
+const POLL_MS = 50;
+
+// ---------- arg parsing ----------
+const args = process.argv.slice(2);
+let mode: 'direct' | 'elevated';
+let targetUser = '';
+if (args.length === 0) {
+  mode = 'direct';
+} else if (args[0] === '--elevated' && args[1]) {
+  mode = 'elevated';
+  targetUser = args[1];
+} else {
+  console.error('usage: bun scripts/smoke/check-login-shell-sentinel.ts [--elevated <target-user>]');
+  process.exit(2);
+}
+
+// ---------- helpers ----------
+function resolveBin(name: string, candidates: string[]): string {
+  for (const path of candidates) {
+    if (existsSync(path)) return path;
+  }
+  console.error(`could not find ${name} in any of: ${candidates.join(', ')}`);
+  process.exit(2);
+}
+
+/** Best-effort target-user home lookup from /etc/passwd (WARN check only). */
+function passwdHome(user: string): string {
+  try {
+    const entry = readFileSync('/etc/passwd', 'utf-8')
+      .split('\n')
+      .find((line) => {
+        const idx = line.indexOf(':');
+        return idx > 0 && line.slice(0, idx) === user;
+      });
+    return entry ? (entry.split(':')[5] ?? '') : '';
+  } catch {
+    return '';
+  }
+}
+
+function cleanEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) env[k] = v;
+  }
+  return env;
+}
+
+const sentinel = '__AGENT_CONSOLE_READY_SMOKE_' + crypto.randomUUID().replace(/-/g, '').slice(0, 12);
+
+// ---------- spawn per mode ----------
+let pty: PtyInstance;
+let expectedUser: string;
+let expectedHome: string;
+
+if (mode === 'direct') {
+  const shellCommand = buildDirectSentinelShellCommand(sentinel, getUnsetEnvPrefix());
+  pty = bunPtyProvider.spawn('sh', ['-c', shellCommand], {
+    name: 'xterm-256color',
+    cols: 120,
+    rows: 30,
+    cwd: '/',
+    env: cleanEnv(),
+  });
+  expectedUser = os.userInfo().username;
+  expectedHome = os.homedir();
+} else {
+  const SUDO_BIN = resolveBin('elevation binary', ['/usr/bin/sudo', '/bin/sudo']);
+  const { argv } = buildElevationArgs({
+    username: targetUser,
+    cwd: '/',
+    additionalEnvVars: {},
+    command: buildElevatedSentinelCommand(sentinel),
+  });
+  pty = bunPtyProvider.spawn(SUDO_BIN, argv, {
+    name: 'xterm-256color',
+    cols: 120,
+    rows: 30,
+    cwd: '/',
+  });
+  expectedUser = targetUser;
+  expectedHome = passwdHome(targetUser);
+}
+
+// ---------- drive the protocol ----------
+let output = '';
+let exited = false;
+let childExitCode: number | null = null;
+pty.onData((chunk) => {
+  output += chunk;
+});
+pty.onExit(({ exitCode }) => {
+  exited = true;
+  childExitCode = exitCode;
+});
+
+async function waitFor(pred: () => boolean): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < PHASE_TIMEOUT_MS) {
+    if (pred()) return true;
+    if (exited) return pred();
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+  return pred();
+}
+
+function finish(code: number): never {
+  try {
+    pty.kill();
+  } catch {
+    // best-effort cleanup; the child may already be gone
+  }
+  process.exit(code);
+}
+
+// Phase 1: wait for the sentinel line.
+const sentinelSeen = await waitFor(() => output.includes(sentinel));
+if (!sentinelSeen) {
+  if (mode === 'elevated') {
+    console.error('SKIP: sentinel never observed under elevation -- precondition not met.');
+    if (exited) console.error(`  elevated child exited early with code ${childExitCode}`);
+    console.error('  (elevation not permitted, a password is required, or the target user cannot log in)');
+    console.error('  captured output (first 500 chars):');
+    console.error(output.slice(0, 500));
+    finish(2);
+  }
+  console.error('FAILED: login-shell sentinel never appeared within timeout.');
+  console.error('  captured output (first 500 chars):');
+  console.error(output.slice(0, 500));
+  finish(1);
+}
+
+const sentinelIndex = output.indexOf(sentinel);
+const preSentinel = output.slice(0, sentinelIndex);
+
+// Phase 2: inject a probe into the interactive shell that follows the sentinel.
+pty.write('echo SMOKE_MARKER_OK; whoami; echo "SMOKE_PATH=$PATH"\r');
+
+const markerSeen = await waitFor(() => output.includes('SMOKE_MARKER_OK'));
+if (!markerSeen) {
+  console.error('FAILED: injected probe never produced its marker (command was not executed).');
+  console.error('  captured output (first 800 chars):');
+  console.error(output.slice(0, 800));
+  finish(1);
+}
+
+// Wait for the probe's PATH line to flush (printed after the marker).
+await waitFor(() =>
+  output
+    .split(/\r?\n/)
+    .some((l) => {
+      const t = l.trim();
+      return t.startsWith('SMOKE_PATH=') && !t.includes('$PATH') && t.length > 'SMOKE_PATH='.length;
+    }),
+);
+
+// ---------- assertions ----------
+const failures: string[] = [];
+let passes = 0;
+const expect = (cond: boolean, label: string, detail?: string) => {
+  if (cond) {
+    console.log(`  OK    ${label}`);
+    passes++;
+  } else {
+    console.error(`  FAIL  ${label}${detail ? ` -- ${detail}` : ''}`);
+    failures.push(label);
+  }
+};
+
+const lines = output.split(/\r?\n/).map((l) => l.trim());
+const pathLine = lines.find((l) => l.startsWith('SMOKE_PATH=') && !l.includes('$PATH'));
+const smokePath = pathLine ? pathLine.slice('SMOKE_PATH='.length) : '';
+
+console.log(`==> login-shell sentinel protocol (${mode} mode)`);
+expect(output.includes(sentinel), 'sentinel appeared in PTY output');
+expect(
+  output.indexOf('SMOKE_MARKER_OK') > sentinelIndex,
+  'injected probe ran after the sentinel gate',
+);
+expect(
+  lines.includes(expectedUser),
+  `whoami reports the expected user (${expectedUser})`,
+  `no output line equal to "${expectedUser}"`,
+);
+expect(smokePath.length > 0, 'PATH is non-empty in the injected shell', `got: ${smokePath || '(empty)'}`);
+
+console.log('==> login-init PATH check');
+if (expectedHome) {
+  const includesHome = smokePath.split(':').some((p) => p === expectedHome || p.startsWith(`${expectedHome}/`));
+  if (includesHome) {
+    console.log(`  OK    PATH includes ${expectedHome} (login-init user tree)`);
+    passes++;
+  } else {
+    console.warn(`  WARN  PATH does not include ${expectedHome} -- acceptable if the`);
+    console.warn(`        user has no per-user bin tree, but if claude was installed`);
+    console.warn(`        under their home it will not resolve.`);
+  }
+} else {
+  console.warn('  WARN  could not resolve expected home; skipping login-init PATH check');
+}
+
+console.log('==> sentinel-gate negatives');
+expect(!preSentinel.includes('SMOKE_MARKER'), 'no probe output leaked before the sentinel gate');
+const afterGate = output.slice(sentinelIndex + sentinel.length);
+expect(
+  !afterGate.includes(sentinel),
+  'sentinel is a one-shot marker (not repeated after the gate)',
+);
+
+console.log();
+if (failures.length > 0) {
+  console.error(`FAILED: ${failures.length} assertion(s) failed`);
+  finish(1);
+}
+console.log(`PASSED: ${passes} assertion(s) passed`);
+finish(0);


### PR DESCRIPTION
## Summary

Agent worker PTYs now launch through a login shell, so `.bashrc` / `.profile` are loaded correctly.

### Problem

Agent workers were spawned with `sh -c '<command>'` — neither a login shell nor an interactive shell — so `.bashrc` / `.profile` were never read. As a result, agents started with an incomplete PATH that lacked entries like `~/.local/bin` and `~/.opencode/bin`.

### Solution: login-shell sentinel

1. **Login shell launch**: `sh -c 'unset VARS; exec $SHELL -l -c "echo SENTINEL; exec $SHELL"'`
2. **Sentinel detection**: the `onData` handler watches for the sentinel string (all login-shell output before it is skipped)
3. **Command injection**: once the shell is ready, the agent command is sent with `pty.write(command + '\r')`

### What this approach solves

| Problem | Resolution |
|------|------|
| Incomplete PATH | `.bashrc` / `.profile` are loaded |
| Double-escaping of quotes | Command is typed directly via `pty.write()` |
| ActivityDetector false positives | Login-shell output is skipped |
| The dotenv-loading problem of the earlier empty-string approach | The `unset` prefix is preserved |

### Changed files

- `packages/server/src/services/user-mode.ts` — add `sentinel` to `AgentPtySpawnRequest`; support the login-shell form in `spawnDirectPty`
- `packages/server/src/services/worker-manager.ts` — sentinel generation, detection, and command-injection logic
- `packages/server/src/services/worker-types.ts` — add `loginShellSentinel` / `pendingCommand` to `InternalAgentWorker`
- `packages/server/src/__tests__/utils/mock-pty.ts` — sentinel support in the mock PTY
- Test updates: `multi-user-mode.test.ts`, `worker-manager.test.ts`, `mcp-server.test.ts`

## Testing

- See the Verification subsection under "Completion review" below for the final full-suite results, and the Real-machine E2E section for both-environment verification and the post-deploy smoke script.

---

## Completion review (delegated finish work)

### Found & fixed during completion review: elevated path dropped all output

The initial implementation set the sentinel gate unconditionally in `worker-manager.ts`, but `MultiUserMode.spawnSudoPty` (the elevated spawn path) ignored `request.sentinel` and ran the agent command directly. No sentinel was ever emitted on that path, so the gate dropped **all** agent worker output forever in multi-user elevated sessions (worker appeared dead). The dogfood host runs multi-user, so this would have hit immediately after merge.

Fix (commit `baaef12`): the elevated path now mirrors the direct path — when `request.sentinel` is present, the inner command becomes `echo <sentinel>; exec $SHELL` and the worker-manager injects the real command after sentinel detection. `buildElevationArgs` is untouched (strict-thin-wrapper contract). Elevated-path spawn-shape tests added with polarity confirmed (the new test fails with the fix reverted).

Refs #999 (structural follow-up: enforce the UserMode agent-PTY spawn contract structurally).

### CI fixes

- **comment-blame-shift-lint / KNOWN_VIOLATIONS test**: the PR added 5 lines above an allowlisted `Issue #769` comment in `worker-manager.ts`, shifting it 440 → 445. Allowlist line number updated.
- **preflight (missing sibling test)**: added direct-path sentinel branch tests to `__tests__/user-mode.test.ts` covering the `spawnDirectPty` change.

### Real-machine E2E verification

**Single-user (host, real `.bashrc`/login init)** — server started on a spare port with a temp `AGENT_CONSOLE_HOME`, quick session + agent worker created through the shipping REST path:

- Sentinel string never appears in user-visible output (`grep -c __AGENT_CONSOLE_READY_` = 0 on the worker output stream).
- Login-shell PATH confirmed: worker env shows `/home/<user>/.local/bin`, `~/.bun/bin`, `~/.opencode/bin` — the exact paths this PR exists to restore.
- Built-in Claude Code agent boots to its interactive UI (the `claude` binary resolves via the login-shell PATH).
- ActivityDetector stays `idle` during login-shell init (pre-sentinel output is gated; no false detection).

**Multi-user elevated (Docker dev stack, `alice` ≠ service user, genuinely exercises the elevated spawn)**:

- Agent worker output flows (this is the path that dropped everything before the fix).
- Wire-level check via the client's own `/ws/session/:id/worker/:id` protocol (`request-history`): no sentinel in any frame; injected command, `whoami` = `alice`, and PATH output all present.
- Process table shows the elevated chain running the Option-A inner command (`...; echo __AGENT_CONSOLE_READY_<id>; exec $SHELL`) with the exec'd shell owned by `alice`.

### Observations (non-blocking, likely pre-existing)

- Cosmetic: on the host run, the injected command line can appear once as raw tty echo before the first prompt draw (timing-dependent; did not reproduce in the container run).
- Docker dev stack only: the vite proxy hangs WebSocket upgrades (`/ws/*` via port 15173) while direct server-port WebSockets work; REST via the proxy is fine. This PR touches neither client nor WS infra, but it was only observed on this branch, so noting for transparency.

### Verification

- `bun run typecheck` — exit 0
- `bun run test` (full suite) — exit 0: server 3125 pass / 1 skip / 0 fail; scripts 420 pass (run with `SSH_AUTH_SOCK` unset; the known non-hermetic `#918` test depends on the runner's ambient SSH agent socket)
- `node .claude/skills/orchestrator/preflight-check.js` — exit 0

