### PR TITLE
feat(client): rewrite localhost URLs in terminal output for remote-access clickability (closes #988)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -201,6 +201,13 @@ The backend HTTP port the server is bound to, exposed to the client so it can co
 - **Related:** [`buildMcpInstallCommand`](../packages/client/src/lib/mcp-install-url.ts), the "Install MCP server in Claude Code" Settings section ([`McpInstallSection`](../packages/client/src/components/settings/McpInstallSection.tsx)).
 - **See:** Issue [#991](https://github.com/ms2sato/agent-console/issues/991).
 
+### user-accessible host
+The hostname the user's browser can actually reach the server (and its sibling ports) at, derived from `window.location.hostname`. When AgentConsole is accessed remotely, `localhost` / `127.0.0.1` on the server side is meaningless to the browser, so the user-accessible host is used instead.
+
+- **Canonical helpers:** [`getUserAccessibleHost()`](../packages/client/src/lib/user-accessible-host.ts) (returns `window.location.hostname` verbatim), [`isRemoteAccess()`](../packages/client/src/lib/user-accessible-host.ts) (true when the browser is not on a loopback host), and `bracketHostForUrl()` (IPv6 bracket-wrapping when composing a URL authority) in [`packages/client/src/lib/user-accessible-host.ts`](../packages/client/src/lib/user-accessible-host.ts).
+- **Consumers:** VSCode remote-URL open ([`openInVSCode`](../packages/client/src/lib/api.ts)), MCP install-command composition ([`buildMcpInstallCommand`](../packages/client/src/lib/mcp-install-url.ts)), and terminal localhost-URL rewrite ([`localhost-rewrite.ts`](../packages/client/src/components/terminal/transforms/localhost-rewrite.ts)), which rewrites a printed `localhost` URL's href to the user-accessible host so a remote browser can click it.
+- **See:** Issues [#987](https://github.com/ms2sato/agent-console/issues/987) (introduces the browser-host derivation), [#988](https://github.com/ms2sato/agent-console/issues/988) (extracts the helpers and adds the terminal URL rewrite).
+
 ## Events & Communication
 
 ### ConditionalWakeup

--- a/packages/client/src/components/terminal/TerminalAdapter.tsx
+++ b/packages/client/src/components/terminal/TerminalAdapter.tsx
@@ -11,11 +11,13 @@ import { TerminalView } from './TerminalView';
 import { TerminalKeyboardInput } from './TerminalKeyboardInput';
 import { toStatusChangeArgs } from './status-mapping';
 import { githubRefDecorator } from './transforms/github-refs';
-import type { SegmentDecorator, TransformContext } from './row-transforms';
+import { localhostRewriteTransform } from './transforms/localhost-rewrite';
+import type { SegmentDecorator, LinkTransform, TransformContext } from './row-transforms';
 import { useSessionRepoFullName } from './useSessionRepoFullName';
 
 // Constant decorator list — memoized identity so the memoized Row is stable.
 const SEGMENT_DECORATORS: readonly SegmentDecorator[] = [githubRefDecorator];
+const LINK_TRANSFORMS: readonly LinkTransform[] = [localhostRewriteTransform];
 
 /**
  * Drop-in replacement for `components/Terminal.tsx` implementing the exact
@@ -105,6 +107,7 @@ export function TerminalAdapter({
           onFilesReceived={onFilesReceived}
           inputRef={inputRef}
           segmentDecorators={SEGMENT_DECORATORS}
+          linkTransforms={LINK_TRANSFORMS}
           transformContext={transformContext}
         />
         <AdapterRecoveryOverlay

--- a/packages/client/src/components/terminal/TerminalView.tsx
+++ b/packages/client/src/components/terminal/TerminalView.tsx
@@ -5,10 +5,17 @@ import type { TerminalRow, TerminalSegment, TerminalStyle } from './buffer-to-ro
 import type { LinkRange } from './link-detection';
 import { joinSelectedRows, collectSelectedRowPieces } from './copy-text';
 import { reduceDragCounter } from './drag-state';
-import { applySegmentDecorators, type SegmentDecorator, type TransformContext } from './row-transforms';
+import {
+  applySegmentDecorators,
+  applyLinkTransforms,
+  type SegmentDecorator,
+  type LinkTransform,
+  type TransformContext,
+} from './row-transforms';
 import { TerminalScrollIndicator } from './TerminalScrollIndicator';
 
 const EMPTY_DECORATORS: readonly SegmentDecorator[] = [];
+const EMPTY_LINK_TRANSFORMS: readonly LinkTransform[] = [];
 const DEFAULT_TRANSFORM_CONTEXT: TransformContext = { repoFullName: null };
 // A dotted underline distinguishes decorator links (e.g. GitHub refs) without
 // the heavier solid underline; matches the URL-link affordance.
@@ -43,6 +50,10 @@ interface TerminalViewProps {
   // render time, plus their context. Callers memoize both so the memoized Row
   // is not invalidated every render.
   segmentDecorators?: readonly SegmentDecorator[];
+  // Presentation-layer link transforms applied to each row's detected URL links
+  // (parallel to segmentDecorators). Used e.g. to rewrite a localhost href to
+  // the user-accessible host for remote browsers. Callers memoize the list.
+  linkTransforms?: readonly LinkTransform[];
   transformContext?: TransformContext;
 }
 
@@ -108,6 +119,9 @@ function renderSegment(seg: TerminalSegment, segStart: number, key: number, link
       <a
         key={pi++}
         href={link.href}
+        // Set by a link transform (e.g. localhost rewrite) to explain the href
+        // substitution on hover; undefined when the href was not rewritten.
+        title={link.title}
         target="_blank"
         rel="noopener noreferrer"
         // Link click opens the URL; stop propagation so the container's
@@ -138,21 +152,27 @@ function renderSegment(seg: TerminalSegment, segStart: number, key: number, link
 const Row = memo(function Row({
   row,
   decorators,
+  linkTransforms,
   ctx,
 }: {
   row: TerminalRow;
   decorators: readonly SegmentDecorator[];
+  linkTransforms: readonly LinkTransform[];
   ctx: TransformContext;
 }) {
   // Decorators split segments but preserve the row's concatenated text, so the
   // URL `links` column offsets used by renderSegment stay aligned.
   const segments =
     decorators.length > 0 ? applySegmentDecorators(row.segments, decorators, ctx) : row.segments;
+  // Link transforms only change href/title, never the ranges, so the column
+  // offsets used by renderSegment stay aligned with the (unchanged) row text.
+  const links =
+    linkTransforms.length > 0 ? applyLinkTransforms(row.links, linkTransforms, ctx) : row.links;
   let offset = 0;
   return (
     <div style={{ whiteSpace: 'pre', height: LINE_HEIGHT_PX, lineHeight: `${LINE_HEIGHT_PX}px` }}>
       {segments.map((seg: TerminalSegment, i) => {
-        const node = renderSegment(seg, offset, i, row.links);
+        const node = renderSegment(seg, offset, i, links);
         offset += seg.text.length;
         return node;
       })}
@@ -166,6 +186,7 @@ export function TerminalView({
   onFilesReceived,
   inputRef,
   segmentDecorators = EMPTY_DECORATORS,
+  linkTransforms = EMPTY_LINK_TRANSFORMS,
   transformContext = DEFAULT_TRANSFORM_CONTEXT,
 }: TerminalViewProps) {
   const snapshot = useSyncExternalStore(instance.subscribe, instance.getSnapshot);
@@ -692,7 +713,13 @@ export function TerminalView({
         }}
       >
         {snapshot.rows.map((row) => (
-          <Row key={row.key} row={row} decorators={segmentDecorators} ctx={transformContext} />
+          <Row
+            key={row.key}
+            row={row}
+            decorators={segmentDecorators}
+            linkTransforms={linkTransforms}
+            ctx={transformContext}
+          />
         ))}
       </div>
 

--- a/packages/client/src/components/terminal/__tests__/TerminalAdapter.test.tsx
+++ b/packages/client/src/components/terminal/__tests__/TerminalAdapter.test.tsx
@@ -166,4 +166,45 @@ describe('TerminalAdapter', () => {
     // so status-mapping passes it through rather than normalizing to undefined).
     expect(onStatusChange).toHaveBeenCalledWith('exited', { code: 0, signal: null });
   });
+
+  it('wires the localhost link transform but does not rewrite when the browser is on loopback', async () => {
+    // The adapter wires the real localhostRewriteTransform, which reads
+    // window.location at call time. Pin the browser to a loopback host so the
+    // rewrite is a no-op — this proves the lane is wired without exploding.
+    const originalLocation = Object.getOwnPropertyDescriptor(window, 'location');
+    Object.defineProperty(window, 'location', {
+      value: { protocol: 'http:', hostname: 'localhost', host: 'localhost' },
+      writable: true,
+      configurable: true,
+    });
+    try {
+      const LOCALHOST_URL = 'http://localhost:3000/path';
+      const snapshot: TerminalSnapshot = {
+        ...EXITED_SNAPSHOT,
+        status: 'connected',
+        exitInfo: null,
+        rows: [
+          {
+            key: 0,
+            isWrapped: false,
+            links: [{ start: 0, end: LOCALHOST_URL.length, href: LOCALHOST_URL }],
+            segments: [{ text: LOCALHOST_URL, style: null }],
+          },
+        ],
+      };
+      const instance: TerminalInstance = { ...stubInstance, getSnapshot: () => snapshot };
+      const createInstance = mock((_sessionId: string, _workerId: string, _opts?: unknown) => instance);
+
+      await act(async () =>
+        renderWithRouter(<TerminalAdapter sessionId="s" workerId="w" createInstance={createInstance} />),
+      );
+
+      const link = screen.getByText(LOCALHOST_URL);
+      expect(link.tagName).toBe('A');
+      expect(link.getAttribute('href')).toBe(LOCALHOST_URL);
+      expect(link.getAttribute('title')).toBeNull();
+    } finally {
+      if (originalLocation) Object.defineProperty(window, 'location', originalLocation);
+    }
+  });
 });

--- a/packages/client/src/components/terminal/__tests__/TerminalView.test.tsx
+++ b/packages/client/src/components/terminal/__tests__/TerminalView.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, beforeEach, mock } from 'bun:test';
 import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
 import { TerminalView } from '../TerminalView';
+import { createLocalhostRewriteTransform } from '../transforms/localhost-rewrite';
 import type { TerminalInstance, TerminalSnapshot } from '../terminal-store';
 import { getOrCreateTerminal, _resetTerminals, _inspect } from '../terminal-store';
 import type { TerminalRow } from '../buffer-to-rows';
@@ -103,6 +104,48 @@ describe('TerminalView row rendering', () => {
     expect(link.getAttribute('href')).toBe('https://github.com/acme/widgets/issues/123');
     expect(link.getAttribute('target')).toBe('_blank');
     expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+});
+
+// A URL link (row.links) rendered as an anchor. When a link transform rewrites
+// its href, the display text is unchanged and a title reveals the substitution.
+const LOCALHOST_URL = 'http://localhost:3000/path';
+const URL_ROWS: TerminalRow[] = [
+  {
+    key: 0,
+    isWrapped: false,
+    links: [{ start: 0, end: LOCALHOST_URL.length, href: LOCALHOST_URL }],
+    segments: [{ text: LOCALHOST_URL, style: null }],
+  },
+];
+
+describe('TerminalView link transforms', () => {
+  afterEach(cleanup);
+
+  it('renders the original href and no title when no linkTransforms are given', () => {
+    render(<TerminalView instance={makeInstance(makeSnapshot(URL_ROWS))} />);
+    const link = screen.getByText(LOCALHOST_URL);
+    expect(link.tagName).toBe('A');
+    expect(link.getAttribute('href')).toBe(LOCALHOST_URL);
+    expect(link.getAttribute('title')).toBeNull();
+  });
+
+  it('rewrites the href for a remote browser while keeping the display text and adding a title', () => {
+    render(
+      <TerminalView
+        instance={makeInstance(makeSnapshot(URL_ROWS))}
+        linkTransforms={[
+          createLocalhostRewriteTransform({ protocol: 'https:', hostname: 'console.example.com' }),
+        ]}
+      />,
+    );
+    // Display text is still the original localhost URL.
+    const link = screen.getByText(LOCALHOST_URL);
+    expect(link.tagName).toBe('A');
+    // href is rewritten to the user-accessible host.
+    expect(link.getAttribute('href')).toBe('https://console.example.com:3000/path');
+    // title reveals the substitution.
+    expect(link.getAttribute('title')).toContain('https://console.example.com:3000/path');
   });
 });
 

--- a/packages/client/src/components/terminal/__tests__/row-transforms.test.ts
+++ b/packages/client/src/components/terminal/__tests__/row-transforms.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'bun:test';
-import { applySegmentDecorators, type SegmentDecorator, type TransformContext } from '../row-transforms';
+import {
+  applySegmentDecorators,
+  applyLinkTransforms,
+  type SegmentDecorator,
+  type LinkTransform,
+  type TransformContext,
+} from '../row-transforms';
 import type { TerminalSegment } from '../buffer-to-rows';
+import type { LinkRange } from '../link-detection';
 
 const CTX: TransformContext = { repoFullName: 'acme/widgets' };
 
@@ -44,6 +51,43 @@ describe('applySegmentDecorators', () => {
       return segments;
     };
     applySegmentDecorators(segs('x'), [spy, spy], { repoFullName: 'o/r' });
+    expect(seen).toEqual(['o/r', 'o/r']);
+  });
+});
+
+function links(...hrefs: string[]): LinkRange[] {
+  return hrefs.map((href, i) => ({ start: i, end: i + 1, href }));
+}
+
+describe('applyLinkTransforms', () => {
+  it('returns the input unchanged (same reference) when the transform list is empty', () => {
+    const input = links('http://a');
+    const out = applyLinkTransforms(input, [], CTX);
+    expect(out).toBe(input);
+  });
+
+  it('threads output of one transform into the next, in order', () => {
+    const order: string[] = [];
+    const a: LinkTransform = (ls) => {
+      order.push('a');
+      return ls.map((l) => ({ ...l, href: `${l.href}#a` }));
+    };
+    const b: LinkTransform = (ls) => {
+      order.push('b');
+      return ls.map((l) => ({ ...l, href: `${l.href}#b` }));
+    };
+    const out = applyLinkTransforms(links('http://x'), [a, b], CTX);
+    expect(order).toEqual(['a', 'b']);
+    expect(out[0].href).toBe('http://x#a#b');
+  });
+
+  it('passes the transform context through to every transform', () => {
+    const seen: (string | null)[] = [];
+    const spy: LinkTransform = (ls, ctx) => {
+      seen.push(ctx.repoFullName);
+      return ls;
+    };
+    applyLinkTransforms(links('http://x'), [spy, spy], { repoFullName: 'o/r' });
     expect(seen).toEqual(['o/r', 'o/r']);
   });
 });

--- a/packages/client/src/components/terminal/link-detection.ts
+++ b/packages/client/src/components/terminal/link-detection.ts
@@ -10,6 +10,10 @@ export interface LinkRange {
   start: number; // inclusive column offset into the row's text
   end: number; // exclusive
   href: string; // the full (joined, punctuation-trimmed) URL
+  // Optional hover text set by link transforms (e.g. the localhost -> user-
+  // accessible-host rewrite) to explain an href substitution. Absent when the
+  // href was not rewritten.
+  title?: string;
 }
 
 export interface DetectRow {

--- a/packages/client/src/components/terminal/row-transforms.ts
+++ b/packages/client/src/components/terminal/row-transforms.ts
@@ -1,4 +1,5 @@
 import type { TerminalSegment } from './buffer-to-rows';
+import type { LinkRange } from './link-detection';
 
 /**
  * Row-transform pipeline (issue #958), first stage: segment decorators.
@@ -29,6 +30,32 @@ export function applySegmentDecorators(
   let result = segments;
   for (const decorate of decorators) {
     result = decorate(result, ctx);
+  }
+  return result;
+}
+
+/**
+ * Second, parallel transform lane: link transforms.
+ *
+ * URL links are detected separately from segments (link-detection.ts stores
+ * `LinkRange[]` on each row) and do NOT flow through the SegmentDecorator lane.
+ * A link transform post-processes those detected links — e.g. rewriting a
+ * localhost href to the user-accessible host so a remote browser can click it.
+ * It MUST preserve range offsets (`[start, end)` stay aligned to the row text);
+ * only `href` / `title` may change, so the view's column-offset math is
+ * unaffected.
+ */
+export type LinkTransform = (links: LinkRange[], ctx: TransformContext) => LinkRange[];
+
+/** Run each link transform in order, threading the output of one into the next. */
+export function applyLinkTransforms(
+  links: LinkRange[],
+  transforms: readonly LinkTransform[],
+  ctx: TransformContext,
+): LinkRange[] {
+  let result = links;
+  for (const transform of transforms) {
+    result = transform(result, ctx);
   }
   return result;
 }

--- a/packages/client/src/components/terminal/transforms/__tests__/localhost-rewrite.test.ts
+++ b/packages/client/src/components/terminal/transforms/__tests__/localhost-rewrite.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  rewriteLocalhostHref,
+  createLocalhostRewriteTransform,
+} from '../localhost-rewrite';
+import type { UserAccessibleLocation } from '../../../../lib/user-accessible-host';
+import type { LinkRange } from '../../link-detection';
+
+const REMOTE_HTTP: UserAccessibleLocation = { protocol: 'http:', hostname: 'console.example.com' };
+const REMOTE_HTTPS: UserAccessibleLocation = { protocol: 'https:', hostname: 'console.example.com' };
+const LOCAL: UserAccessibleLocation = { protocol: 'http:', hostname: 'localhost' };
+
+describe('rewriteLocalhostHref', () => {
+  it('rewrites localhost host to the remote browser host, preserving port and path', () => {
+    const out = rewriteLocalhostHref('http://localhost:3000/path', REMOTE_HTTP);
+    expect(out?.href).toBe('http://console.example.com:3000/path');
+  });
+
+  it('preserves the query string and fragment', () => {
+    const out = rewriteLocalhostHref('https://127.0.0.1:8443/path?q=x#frag', REMOTE_HTTPS);
+    expect(out?.href).toBe('https://console.example.com:8443/path?q=x#frag');
+  });
+
+  it('rewrites the 0.0.0.0 source host', () => {
+    const out = rewriteLocalhostHref('http://0.0.0.0:5173/', REMOTE_HTTP);
+    expect(out?.href).toBe('http://console.example.com:5173/');
+  });
+
+  it('adopts the browser scheme (http source under an https browser)', () => {
+    const out = rewriteLocalhostHref('http://localhost:3000/', REMOTE_HTTPS);
+    expect(out?.href).toBe('https://console.example.com:3000/');
+  });
+
+  it('returns null when the browser is itself on a loopback host', () => {
+    expect(rewriteLocalhostHref('http://localhost:3000/', LOCAL)).toBeNull();
+    expect(rewriteLocalhostHref('http://localhost:3000/', { protocol: 'http:', hostname: '127.0.0.1' })).toBeNull();
+    expect(rewriteLocalhostHref('http://localhost:3000/', { protocol: 'http:', hostname: '::1' })).toBeNull();
+    expect(rewriteLocalhostHref('http://localhost:3000/', { protocol: 'http:', hostname: '[::1]' })).toBeNull();
+  });
+
+  it('does not rewrite when the URL host is not loopback (embedded query URL is not the click target)', () => {
+    // The parsed host is example.com; the localhost in the query is never the authority.
+    expect(rewriteLocalhostHref('http://example.com/?redirect=http://localhost:3000', REMOTE_HTTP)).toBeNull();
+  });
+
+  it('keeps an embedded query URL verbatim when the primary host is rewritten', () => {
+    const out = rewriteLocalhostHref('http://localhost:5173/login?next=http://localhost:3000/cb', REMOTE_HTTP);
+    expect(out?.href).toBe('http://console.example.com:5173/login?next=http://localhost:3000/cb');
+  });
+
+  it('preserves varied ports and adds no port token when the source has none', () => {
+    expect(rewriteLocalhostHref('http://localhost:8080/', REMOTE_HTTP)?.href).toBe(
+      'http://console.example.com:8080/',
+    );
+    expect(rewriteLocalhostHref('http://localhost/', REMOTE_HTTP)?.href).toBe(
+      'http://console.example.com/',
+    );
+  });
+
+  it('returns null for non-loopback source hosts', () => {
+    expect(rewriteLocalhostHref('http://example.org:3000/', REMOTE_HTTP)).toBeNull();
+    // Exact-match only: localhost.evil.com is not loopback.
+    expect(rewriteLocalhostHref('http://localhost.evil.com:3000/', REMOTE_HTTP)).toBeNull();
+  });
+
+  it('bracket-wraps an IPv6 browser hostname in the composed URL', () => {
+    const out = rewriteLocalhostHref('http://localhost:3000/path', { protocol: 'http:', hostname: '2001:db8::1' });
+    expect(out?.href).toBe('http://[2001:db8::1]:3000/path');
+  });
+
+  it('returns null for an unparseable URL', () => {
+    expect(rewriteLocalhostHref('http://[not-a-url', REMOTE_HTTP)).toBeNull();
+  });
+
+  it('sets a title that mentions both the original and rewritten URL', () => {
+    const out = rewriteLocalhostHref('http://localhost:3000/path', REMOTE_HTTP);
+    expect(out?.title).toContain('http://localhost:3000/path');
+    expect(out?.title).toContain('http://console.example.com:3000/path');
+  });
+});
+
+describe('createLocalhostRewriteTransform', () => {
+  const transform = createLocalhostRewriteTransform(REMOTE_HTTP);
+  const CTX = { repoFullName: null };
+
+  function range(href: string, start = 0, end = 10): LinkRange {
+    return { start, end, href };
+  }
+
+  it('rewrites a target link, keeping the range offsets and adding a title', () => {
+    const input = [range('http://localhost:3000/path', 4, 30)];
+    const [out] = transform(input, CTX);
+    expect(out.href).toBe('http://console.example.com:3000/path');
+    expect(out.start).toBe(4);
+    expect(out.end).toBe(30);
+    expect(out.title).toBeDefined();
+  });
+
+  it('passes a non-target link through unchanged (same reference)', () => {
+    const link = range('http://example.org:3000/');
+    const input = [link];
+    const [out] = transform(input, CTX);
+    expect(out).toBe(link);
+  });
+
+  it('maps an empty array to an empty array', () => {
+    expect(transform([], CTX)).toEqual([]);
+  });
+});

--- a/packages/client/src/components/terminal/transforms/localhost-rewrite.ts
+++ b/packages/client/src/components/terminal/transforms/localhost-rewrite.ts
@@ -1,0 +1,67 @@
+import type { LinkRange } from '../link-detection';
+import type { LinkTransform } from '../row-transforms';
+import { isRemoteAccess, bracketHostForUrl, type UserAccessibleLocation } from '../../../lib/user-accessible-host';
+
+/**
+ * Rewrite terminal URL links that point at the server's own loopback address so
+ * a remote browser can click them.
+ *
+ * When AgentConsole is accessed from a remote host, a URL printed as
+ * `http://localhost:3000/...` is unreachable from the user's machine. This
+ * transform rewrites only the href to `<browser scheme>//<browser host>:<source
+ * port><path/query/hash>` — the display text is untouched, and a `title`
+ * reveals the substitution on hover. Only the primary URL's authority is
+ * considered; URLs embedded inside a query string are naturally left alone
+ * because they are not the parsed URL's host.
+ */
+
+const REWRITE_SOURCE_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0']);
+
+export interface LocalhostRewrite {
+  href: string;
+  title: string;
+}
+
+/**
+ * Return the rewritten href + hover title for a loopback-hosted URL when the
+ * browser is on a remote host, or null when no rewrite applies (non-loopback
+ * host, browser also on loopback, or an unparseable URL).
+ */
+export function rewriteLocalhostHref(
+  href: string,
+  loc: UserAccessibleLocation = window.location,
+): LocalhostRewrite | null {
+  let url: URL;
+  try {
+    // link-detection's regex is permissive, so the href may not be a valid URL.
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  // Exact hostname match: `localhost.evil.com` / `example.com` are untouched.
+  if (!REWRITE_SOURCE_HOSTS.has(url.hostname)) return null;
+  // Browser itself is on loopback -> the original URL already works locally.
+  if (!isRemoteAccess(loc)) return null;
+
+  // Browser scheme (avoids mixed-content blocking under HTTPS), browser host
+  // (bracket-wrapped for IPv6), source port + path/query/hash preserved.
+  const port = url.port ? `:${url.port}` : '';
+  const rewritten = `${loc.protocol}//${bracketHostForUrl(loc.hostname)}${port}${url.pathname}${url.search}${url.hash}`;
+  return { href: rewritten, title: `original: ${href} -> rewritten to: ${rewritten}` };
+}
+
+/**
+ * Build a link transform that rewrites loopback hrefs against `loc`. When `loc`
+ * is omitted, each call resolves `window.location` lazily via
+ * {@link rewriteLocalhostHref}'s default argument, so no `window` access happens
+ * at module load time.
+ */
+export function createLocalhostRewriteTransform(loc?: UserAccessibleLocation): LinkTransform {
+  return (links: LinkRange[]) =>
+    links.map((link) => {
+      const rewrite = rewriteLocalhostHref(link.href, loc);
+      return rewrite ? { ...link, href: rewrite.href, title: rewrite.title } : link;
+    });
+}
+
+export const localhostRewriteTransform: LinkTransform = createLocalhostRewriteTransform();

--- a/packages/client/src/lib/__tests__/mcp-install-url.test.ts
+++ b/packages/client/src/lib/__tests__/mcp-install-url.test.ts
@@ -65,4 +65,12 @@ describe('buildMcpInstallCommand', () => {
     const cmd = buildMcpInstallCommand(3457, location);
     expect(cmd).toBe('claude mcp add --transport http agent-console http://[::1]:3457/mcp');
   });
+
+  it('wraps a full bare IPv6 address in brackets on the split-port dev path', () => {
+    // Bracket-wrapping is delegated to bracketHostForUrl; a full IPv6 literal
+    // must be wrapped the same way as the loopback / link-local cases above.
+    const location = makeLocation('http:', '2001:db8::1', '5173');
+    const cmd = buildMcpInstallCommand(3457, location);
+    expect(cmd).toBe('claude mcp add --transport http agent-console http://[2001:db8::1]:3457/mcp');
+  });
 });

--- a/packages/client/src/lib/__tests__/user-accessible-host.test.ts
+++ b/packages/client/src/lib/__tests__/user-accessible-host.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  getUserAccessibleHost,
+  isRemoteAccess,
+  bracketHostForUrl,
+  type UserAccessibleLocation,
+} from '../user-accessible-host';
+
+function loc(protocol: string, hostname: string): UserAccessibleLocation {
+  return { protocol, hostname };
+}
+
+describe('getUserAccessibleHost', () => {
+  it('returns the hostname verbatim', () => {
+    expect(getUserAccessibleHost(loc('http:', 'console.example.com'))).toBe('console.example.com');
+    expect(getUserAccessibleHost(loc('http:', '192.168.1.5'))).toBe('192.168.1.5');
+  });
+});
+
+describe('isRemoteAccess', () => {
+  it('is false for loopback hosts', () => {
+    expect(isRemoteAccess(loc('http:', 'localhost'))).toBe(false);
+    expect(isRemoteAccess(loc('http:', '127.0.0.1'))).toBe(false);
+    expect(isRemoteAccess(loc('http:', '::1'))).toBe(false);
+    // IPv6 loopback may be reported bracketed.
+    expect(isRemoteAccess(loc('http:', '[::1]'))).toBe(false);
+  });
+
+  it('is true for non-loopback hosts', () => {
+    expect(isRemoteAccess(loc('http:', 'example.com'))).toBe(true);
+    expect(isRemoteAccess(loc('http:', '192.168.1.5'))).toBe(true);
+    expect(isRemoteAccess(loc('http:', '2001:db8::1'))).toBe(true);
+  });
+});
+
+describe('bracketHostForUrl', () => {
+  it('leaves a non-IPv6 hostname unchanged', () => {
+    expect(bracketHostForUrl('example.com')).toBe('example.com');
+  });
+
+  it('wraps a bare IPv6 literal in brackets', () => {
+    expect(bracketHostForUrl('::1')).toBe('[::1]');
+    expect(bracketHostForUrl('2001:db8::1')).toBe('[2001:db8::1]');
+  });
+
+  it('does not double-bracket an already-bracketed IPv6 literal', () => {
+    expect(bracketHostForUrl('[::1]')).toBe('[::1]');
+  });
+});

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -40,6 +40,7 @@ export type { ConfigResponse } from '@agent-console/shared';
 import { api } from './api-client';
 import { getVSCodeOpenMode, getVSCodeRemoteHost } from './capabilities';
 import { buildVSCodeRemoteUrl } from './vscode-url';
+import { getUserAccessibleHost } from './user-accessible-host';
 
 // Base URL kept only for the wildcard worktree delete endpoint which Hono RPC doesn't handle well
 const API_BASE = '/api';
@@ -614,7 +615,7 @@ export async function openPath(path: string): Promise<void> {
 
 export async function openInVSCode(path: string): Promise<void> {
   if (getVSCodeOpenMode() === 'remote-url-scheme') {
-    const host = getVSCodeRemoteHost() ?? window.location.hostname;
+    const host = getVSCodeRemoteHost() ?? getUserAccessibleHost();
     const url = buildVSCodeRemoteUrl(path, host);
     window.open(url, '_self');
     return;

--- a/packages/client/src/lib/mcp-install-url.ts
+++ b/packages/client/src/lib/mcp-install-url.ts
@@ -1,3 +1,5 @@
+import { bracketHostForUrl } from './user-accessible-host';
+
 /**
  * Minimal shape of `window.location` used by {@link buildMcpInstallCommand}.
  * Declared as a subset so the function can be unit-tested with fabricated
@@ -38,10 +40,7 @@ export function buildMcpInstallCommand(
   // IPv6 literals must be bracket-wrapped in URLs (e.g. `[::1]:3457`).
   // location.origin is already properly bracketed by the browser, so we only
   // need to wrap when composing the split-port dev path ourselves.
-  const bracketedHost =
-    hostname.includes(':') && !hostname.startsWith('[')
-      ? `[${hostname}]`
-      : hostname;
+  const bracketedHost = bracketHostForUrl(hostname);
   const base = sameOrigin
     ? location.origin
     : `${protocol}//${bracketedHost}:${serverPort}`;

--- a/packages/client/src/lib/user-accessible-host.ts
+++ b/packages/client/src/lib/user-accessible-host.ts
@@ -1,0 +1,51 @@
+/**
+ * Helpers for deriving the host the user's browser can actually reach the
+ * server (and its sibling ports) at, from `window.location`.
+ *
+ * When AgentConsole is accessed from a remote machine, `localhost` /
+ * `127.0.0.1` on the server side is meaningless to the browser — the
+ * user-accessible host is `window.location.hostname` instead. These helpers
+ * consolidate that derivation so VSCode remote-URL open, MCP install-command
+ * composition, and terminal localhost-URL rewriting all agree on it.
+ */
+
+/**
+ * Minimal subset of `window.location` used by these helpers. Declared as a
+ * subset so callers can unit-test with fabricated objects (no need to stub the
+ * global `window`), mirroring `McpInstallLocation` in `mcp-install-url.ts`.
+ */
+export interface UserAccessibleLocation {
+  protocol: string; // e.g. 'http:'
+  hostname: string;
+}
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+
+/** Strip one pair of surrounding brackets from an IPv6 literal, if present. */
+function stripBrackets(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+}
+
+/** The hostname the user's browser reached the server at, verbatim. */
+export function getUserAccessibleHost(loc: UserAccessibleLocation = window.location): string {
+  return loc.hostname;
+}
+
+/**
+ * True when the browser is NOT on a loopback host — i.e. AgentConsole is being
+ * accessed remotely. IPv6 loopback may be reported bracketed or bare, so one
+ * pair of surrounding brackets is stripped before comparison.
+ */
+export function isRemoteAccess(loc: UserAccessibleLocation = window.location): boolean {
+  return !LOOPBACK_HOSTS.has(stripBrackets(loc.hostname));
+}
+
+/**
+ * Bracket-wrap an IPv6 literal when composing a URL authority ourselves (e.g.
+ * `::1` -> `[::1]`). `window.location.hostname` reports IPv6 literals without
+ * brackets, but URLs require the bracketed form. Already-bracketed and
+ * non-IPv6 hostnames pass through unchanged.
+ */
+export function bracketHostForUrl(hostname: string): string {
+  return hostname.includes(':') && !hostname.startsWith('[') ? `[${hostname}]` : hostname;
+}

--- a/packages/client/src/routes/labs/terminal.tsx
+++ b/packages/client/src/routes/labs/terminal.tsx
@@ -7,10 +7,12 @@ import { TerminalView } from '../../components/terminal/TerminalView';
 import { TerminalKeyboardInput } from '../../components/terminal/TerminalKeyboardInput';
 import { useVisualViewportHeight } from '../../components/terminal/useVisualViewportHeight';
 import { githubRefDecorator } from '../../components/terminal/transforms/github-refs';
-import type { SegmentDecorator, TransformContext } from '../../components/terminal/row-transforms';
+import { localhostRewriteTransform } from '../../components/terminal/transforms/localhost-rewrite';
+import type { SegmentDecorator, LinkTransform, TransformContext } from '../../components/terminal/row-transforms';
 import { useSessionRepoFullName } from '../../components/terminal/useSessionRepoFullName';
 
 const SEGMENT_DECORATORS: readonly SegmentDecorator[] = [githubRefDecorator];
+const LINK_TRANSFORMS: readonly LinkTransform[] = [localhostRewriteTransform];
 
 interface TerminalSearch {
   sessionId?: string;
@@ -93,6 +95,7 @@ function TerminalPage({ sessionId, workerId }: { sessionId: string; workerId: st
         onFilesReceived={handleFilesReceived}
         inputRef={inputRef}
         segmentDecorators={SEGMENT_DECORATORS}
+        linkTransforms={LINK_TRANSFORMS}
         transformContext={transformContext}
       />
 


### PR DESCRIPTION
# feat(client): rewrite localhost URLs in terminal output for remote-access clickability

Closes #988

## Summary

When AgentConsole is accessed from a remote host, URLs printed in the terminal as `http://localhost:PORT/...` (dev-server banners, framework CLI output) point at the user's own machine and force manual URL editing on every click. This PR rewrites the **href only** of loopback-hosted URLs (`localhost` / `127.0.0.1` / `0.0.0.0`) to `<browser scheme>//<browser hostname>:<source port><path/query/hash>`, automatically and only when the browser itself is not on a loopback host. The display text is untouched, and a `title` attribute reveals the substitution on hover.

## Feature overview (plain language)

You run `bun run dev` inside an AgentConsole terminal from your laptop, while the server runs on a remote machine. The dev server prints `http://localhost:5173/`. Before this PR, clicking that link opened `localhost:5173` **on your laptop** — nothing there. After this PR, the link's click target silently becomes `http://<remote-host>:5173/` (the text you see is unchanged), so the click lands on the machine that actually runs the dev server. Hovering the link shows exactly what substitution was made. When you access AgentConsole locally (`localhost` in the address bar), nothing changes at all.

## Implementation

- **`lib/user-accessible-host.ts` (new)** — shared helpers `getUserAccessibleHost()`, `isRemoteAccess()`, `bracketHostForUrl()`. Issue #987 landed the browser-host derivation inline in `api.ts` (`openInVSCode`); per the Issue's instruction this PR extracts the shared helper and re-points that call site. The IPv6 bracket-wrap logic previously inlined in `mcp-install-url.ts` is consolidated here too (repo duplication-check rule).
- **`components/terminal/transforms/localhost-rewrite.ts` (new)** — `rewriteLocalhostHref()` (pure, location-injectable) + `localhostRewriteTransform`. Exact-hostname match on the parsed URL's authority, so `localhost.evil.com` and URLs *embedded inside query strings* are never rewritten.
- **`row-transforms.ts`** — new parallel `LinkTransform` lane (`applyLinkTransforms`). Detected URL links (`row.links` from `link-detection.ts`) do not flow through the existing `SegmentDecorator` stage, so link post-processing needs its own lane. Transforms may only change `href`/`title`, never range offsets.
- **`link-detection.ts`** — `LinkRange` gains optional `title`.
- **`TerminalView.tsx`** — `linkTransforms` prop threaded to the memoized `Row`; `title` attribute rendered on URL anchors.
- **`TerminalAdapter.tsx` / `routes/labs/terminal.tsx`** — wire `localhostRewriteTransform` (module-const list, stable identity).
- **`docs/glossary.md`** — new `user-accessible host` entry (glossary-maintenance trigger: new shared domain concept).

## Scope guardrails (per the Issue, v1 = Level 1)

- Client-side href rewrite only, automatic activation, no config/preference.
- Display text unchanged; only `href` + `title`.
- URLs embedded in query strings are NOT rewritten (verified by unit + browser QA).
- Out of scope: Level 2 reverse proxy, IPv6 `[::1]` source URLs, bare-domain URLs.

## Test plan (Issue checklist)

- [x] Unit: `http://localhost:3000/path` with remote browser -> `http://<host>:3000/path`
- [x] Unit: `https://127.0.0.1:8443/path?q=x#frag` -> query/fragment preserved
- [x] Unit: `http://0.0.0.0:5173/` rewritten
- [x] Unit: scheme adapts to browser protocol (https)
- [x] Unit: no-op when browser is `localhost` / `127.0.0.1` / `::1` / `[::1]`
- [x] Unit: query-string-embedded URL NOT rewritten
- [x] Unit: fragment / query / port preserved; no-port URL gains no port token
- [x] Unit: IPv6 browser hostname bracket-wrapped in rewritten URL (`2001:db8::1` -> `[2001:db8::1]`)
- [x] Unit: non-loopback hosts (`example.org`, `localhost.evil.com`) untouched; invalid URL -> no-op
- [x] Integration: `TerminalView` renders rewritten `<a href>` with original text + `title` (and original href without transforms)
- [x] Wiring: `TerminalAdapter` no-op path with loopback browser location
- [x] Manual (browser QA): see below

New tests: 11 (`user-accessible-host`), 16 (`localhost-rewrite`), +3 (`row-transforms`), +2 (`TerminalView`), +1 (`TerminalAdapter`), +1 (`mcp-install-url`).

## Verification

- `bun run typecheck` exit 0; full `bun run test` exit 0 (client 1650 / shared 408 / integration 50 / server 3122 pass+1 skip / scripts 420 — zero failures).
- `bun run check:lang` exit 0; preflight (`preflight-check.js`) exit 0 after commit.
- Preflight noted the generic "UI component -> integration test review recommended" advisory. This change is client-render-only (no wire-schema / shared-type field changes; Q10 does not trigger), and the Issue's integration item is covered by the `TerminalView` end-to-end render test.

## Browser QA (isolated dev instance, ports 3557/5273)

True path was exercised for real by serving the vite dev server on the machine's LAN IP (`192.168.1.12`), so `window.location.hostname` is genuinely non-loopback — no stubbing.

- **True path (browser at `http://192.168.1.12:5273`)**: terminal `echo` of test URLs rendered anchors with `href="http://192.168.1.12:3000/path"` (text still `http://localhost:3000/path`), `title="original: http://localhost:3000/path -> rewritten to: http://192.168.1.12:3000/path"`; `https://127.0.0.1:8443/a?q=x#f` -> `http://192.168.1.12:8443/a?q=x#f` (browser scheme, query+fragment preserved); wrapped-row link pieces rewritten consistently; `http://example.org:3000/` untouched; `http://example.com/?redirect=http://localhost:3000` untouched (embedded-URL negative case).
- **False path (same session at `http://localhost:5273`)**: all anchors keep original hrefs, no `title`.
- **Not exercised**: physically clicking through to a live dev server (starting a network-exposed throwaway HTTP server was outside the sandbox's allowed scope). Click navigation is browser-native `href` following with no additional code path in this PR, and the href values are verified above; the Issue's manual dogfood step (`python -m http.server 8000` click-through) is left for owner post-merge dogfood.

Screenshots posted as a PR comment (true path + false path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
