### PR TITLE
chore: skip CodeRabbit auto-review for docs-titled PRs (#1013)

### DIFF
--- a/.claude/skills/coderabbit-ops/SKILL.md
+++ b/.claude/skills/coderabbit-ops/SKILL.md
@@ -42,6 +42,8 @@ GitHub surfaces CodeRabbit info in three distinct layers that are easy to confus
 
 An empty `reviewDecision` means the bot has not yet reviewed and the PR is **not** yet clean — wait for the bot to submit, do not merge. (Exception: under the rate-limit fallback in `troubleshooting.md`, an empty state may persist; in that exception path, follow the fallback's verification steps before merge.)
 
+**Docs-only PR carve-out (by configuration).** `.coderabbit.yaml` sets `reviews.auto_review.ignore_title_keywords: ["docs:"]`, so PRs titled with the conventional `docs:` prefix are skipped by auto-review ON PURPOSE (quota preservation — docs-only PRs were rate-limiting code PRs during PR-dense sprints). For such PRs an empty `reviewDecision` with no bot activity is the EXPECTED state, not a wait condition: verify the diff is genuinely docs-only (no production code), then treat layer 2 as N/A. When a docs PR warrants a bot pass anyway (e.g. a large design doc), trigger one manually with an `@coderabbitai review` comment — the manual path is unaffected by the title skip. Note the file also carries the review profile (`chill`) previously configured in the web UI, because a repo config file takes precedence over UI settings.
+
 "CodeRabbit clean" requires all three. Pre-merge checks alone are insufficient. (Sprint 2026-04-25 PR #694 — agent declared "clean" based on pre-merge 5/5 while review state was `CHANGES_REQUESTED` with 3 actionable issues.)
 
 ## Case-by-case dispositions

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,19 @@
+# CodeRabbit repository configuration.
+#
+# NOTE: this file takes precedence over the CodeRabbit web-UI settings for
+# this repository. Settings previously configured in the UI must be carried
+# over here explicitly (currently: review profile "chill").
+#
+# Why this file exists: docs-only PRs (spec-sync, glossary, rules) were
+# consuming the org's auto-review quota and rate-limiting code PRs during
+# PR-dense sprints. PRs titled with the conventional "docs:" prefix skip
+# auto-review; a manual `@coderabbitai review` comment still triggers a
+# review on demand. Deliberately NOT excluding `**/*.md` via path_filters —
+# spec updates that ride along in code PRs must stay in review context.
+language: en-US
+reviews:
+  profile: chill
+  auto_review:
+    enabled: true
+    ignore_title_keywords:
+      - "docs:"


### PR DESCRIPTION
## Summary

- Add `.coderabbit.yaml`: `reviews.auto_review.ignore_title_keywords: ["docs:"]` — PRs titled with the conventional `docs:` prefix skip auto-review (case-insensitive substring per CodeRabbit docs). Manual `@coderabbitai review` still works on demand.
- Carry over the web-UI review profile (`chill`) explicitly — a repo config file takes precedence over UI settings.
- Deliberately NOT excluding `**/*.md` via `path_filters`: spec updates riding along in code PRs must stay in the bot's review context (that channel caught spec/DDL drift in PR #677).
- `coderabbit-ops` skill: document the docs-only carve-out — for `docs:` PRs an empty `reviewDecision` is the expected state (verify the diff is genuinely docs-only, then treat layer 2 as N/A) — plus the manual-trigger fallback.

## Why

Three CodeRabbit rate-limit hits in Sprint 2026-07-11/12 (PRs #1008 / #1009 / #1012), each costing 30-60 min on the phase-sequenced critical path. Docs-only PRs consume the same quota as code PRs with far lower bot-review value. Owner-approved direction.

## Test plan

- `bun run check:lang` exit 0.
- Config semantics verified against the official configuration reference (ignore_title_keywords: case-insensitive substring on PR title).
- Post-merge observation: next `docs:`-titled PR should show no auto-review; next code PR should auto-review normally. (This PR itself is `chore:`-titled and should be auto-reviewed — serving as the code-PR-path check.)

Closes #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)