### PR TITLE
chore: pin implementation specialists to sonnet

### DIFF
--- a/.claude/agents/backend-specialist.md
+++ b/.claude/agents/backend-specialist.md
@@ -2,7 +2,7 @@
 name: backend-specialist
 description: Implement backend features and fixes. Use for API endpoints, WebSocket handlers, services, and server-side logic in packages/server.
 tools: Read, Grep, Glob, Edit, Write, Bash
-model: opus
+model: sonnet
 skills: code-quality-standards, backend-standards, test-standards
 ---
 

--- a/.claude/agents/claude-config-specialist.md
+++ b/.claude/agents/claude-config-specialist.md
@@ -2,7 +2,7 @@
 name: claude-config-specialist
 description: Analyze and improve Claude Code configuration. Use for skills, agents, CLAUDE.md, and workflow optimization in .claude/ directory.
 tools: Read, Grep, Glob, Edit, Write, Task, WebFetch, WebSearch
-model: opus
+model: sonnet
 ---
 
 You are a Claude Code configuration specialist. Your responsibility is to analyze, improve, and maintain Claude Code settings to make development workflows more efficient.

--- a/.claude/agents/frontend-specialist.md
+++ b/.claude/agents/frontend-specialist.md
@@ -2,7 +2,7 @@
 name: frontend-specialist
 description: Implement frontend features and fixes. Use for React components, hooks, routes, styling, and client-side logic in packages/client.
 tools: Read, Grep, Glob, Edit, Write, Bash
-model: opus
+model: sonnet
 skills: code-quality-standards, frontend-standards, test-standards
 ---
 


### PR DESCRIPTION
## Summary

Change `model: opus` → `model: sonnet` in the frontmatter of the three implementation specialists (`backend-specialist`, `frontend-specialist`, `claude-config-specialist`).

Owner direction: implementation work runs on sonnet-class models — the normative specs carry the design load. The opus frontmatter pin silently overrode the session-level model choice (Task-tool frontmatter precedence), so production code was written by opus subagents regardless of the delegated session's model. Structure-over-convention fix: pin the definitions; per-invocation override via the Task tool's `model` parameter stays available for exceptional cases. Reviewer/runner agents (sonnet / haiku) unchanged.

## Test plan

- `bun run check:lang` exit 0. Agent-definition-only change (non-production); `[skip ci]` per workflow.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the configured AI model for backend, frontend, and configuration-focused agents.
  * No other agent behavior or settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->