### PR TITLE
fix: scope terminal select-all shortcut to Cmd+A, not Ctrl+A

### DIFF
--- a/packages/client/src/components/terminal/TerminalView.tsx
+++ b/packages/client/src/components/terminal/TerminalView.tsx
@@ -561,13 +561,25 @@ export function TerminalView({
       releaseDangling();
     };
 
-    // Cmd/Ctrl+A while THIS view's hidden input is focused selects the TERMINAL
+    // Cmd+A while THIS view's hidden input is focused selects the TERMINAL
     // content only (scrollback + viewport = the whole rows container), not the
     // page. Gated on our OWN input element (not any textarea) so on a page with
     // multiple terminals, select-all in one never selects another's rows. No
     // input ref -> select-all disabled (safer than a wrong-instance selection).
+    //
+    // Deliberately metaKey-only, NOT ctrlKey: Ctrl+A is reserved everywhere in
+    // terminal emulator convention for the shell's readline "move to beginning
+    // of line" binding, which TerminalKeyboardInput's onKeyDown already sends
+    // as the control byte \x01. Reacting to Ctrl+A here as well caused a real
+    // regression: this handler still runs after the React keydown handler
+    // (preventDefault does not stop propagation to a separately-registered
+    // window listener). Creating a DOM Selection outside the focused hidden
+    // textarea does not blur it, but the browser silently withholds
+    // subsequent input events on it — keydown keeps firing, but
+    // textarea.value never updates, so typed characters stopped reaching
+    // the PTY after a Ctrl+A.
     const onKeyDownSelectAll = (e: KeyboardEvent) => {
-      if (e.key !== 'a' || !(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+      if (e.key !== 'a' || !e.metaKey || e.shiftKey || e.altKey) return;
       if (inputRef?.current == null || document.activeElement !== inputRef.current) return;
       const sel = window.getSelection();
       if (!sel) return;

--- a/packages/client/src/components/terminal/__tests__/TerminalView.test.tsx
+++ b/packages/client/src/components/terminal/__tests__/TerminalView.test.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { describe, it, expect, afterEach, beforeEach, mock } from 'bun:test';
 import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
 import { TerminalView } from '../TerminalView';
@@ -146,6 +147,79 @@ describe('TerminalView link transforms', () => {
     expect(link.getAttribute('href')).toBe('https://console.example.com:3000/path');
     // title reveals the substitution.
     expect(link.getAttribute('title')).toContain('https://console.example.com:3000/path');
+  });
+});
+
+// Renders TerminalView alongside a real, mountable hidden textarea wired via
+// inputRef — mirrors how TerminalAdapter wires TerminalKeyboardInput's
+// textarea into TerminalView's select-all guard (`inputRef?.current ===
+// document.activeElement`). A plain <textarea> is enough here: the guard only
+// checks identity/focus, not TerminalKeyboardInput's own keydown handling.
+function TerminalViewWithHiddenInput({ instance }: { instance: TerminalInstance }) {
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  return (
+    <>
+      <textarea ref={inputRef} aria-label="hidden terminal input" />
+      <TerminalView instance={instance} inputRef={inputRef} />
+    </>
+  );
+}
+
+// Regression coverage for #1041: a native window keydown listener
+// (onKeyDownSelectAll) used to also react to Ctrl+A, racing React's keydown
+// handler on the hidden textarea (which already sends the readline \x01
+// control byte for Ctrl+A). Creating a DOM Selection over the terminal rows
+// does not blur the focused textarea, but the browser silently withholds
+// subsequent input events on it — keydown keeps firing, but the textarea's
+// value never updates, so typed characters stopped reaching the PTY. The fix
+// scopes the window listener to metaKey (Cmd+A) only.
+describe('TerminalView select-all keyboard shortcut', () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    window.getSelection()?.removeAllRanges();
+  });
+
+  it('does not select terminal content on Ctrl+A (regression guard, #1041)', () => {
+    render(<TerminalViewWithHiddenInput instance={makeInstance(makeSnapshot(ROWS))} />);
+    const textarea = screen.getByLabelText('hidden terminal input') as HTMLTextAreaElement;
+    textarea.focus();
+    expect(document.activeElement).toBe(textarea);
+
+    fireEvent.keyDown(window, { key: 'a', ctrlKey: true });
+
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+    expect(window.getSelection()?.toString()).toBe('');
+  });
+
+  it('still selects terminal content on Cmd+A (existing feature guard)', () => {
+    render(<TerminalViewWithHiddenInput instance={makeInstance(makeSnapshot(ROWS))} />);
+    const textarea = screen.getByLabelText('hidden terminal input') as HTMLTextAreaElement;
+    textarea.focus();
+
+    fireEvent.keyDown(window, { key: 'a', metaKey: true });
+
+    expect(window.getSelection()?.rangeCount).toBe(1);
+  });
+
+  it('does not select on Ctrl+Shift+A', () => {
+    render(<TerminalViewWithHiddenInput instance={makeInstance(makeSnapshot(ROWS))} />);
+    const textarea = screen.getByLabelText('hidden terminal input') as HTMLTextAreaElement;
+    textarea.focus();
+
+    fireEvent.keyDown(window, { key: 'a', ctrlKey: true, shiftKey: true });
+
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+  });
+
+  it('does not select on Cmd+Shift+A', () => {
+    render(<TerminalViewWithHiddenInput instance={makeInstance(makeSnapshot(ROWS))} />);
+    const textarea = screen.getByLabelText('hidden terminal input') as HTMLTextAreaElement;
+    textarea.focus();
+
+    fireEvent.keyDown(window, { key: 'a', metaKey: true, shiftKey: true });
+
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a High-priority regression found during Sprint 2026-07-11/12 dogfood: after the xterm-based terminal UI shipped, pressing **Ctrl+A** in a terminal worker made all subsequent keyboard input silently stop reaching the PTY.

## Root cause

Two independent keydown handlers reacted to Ctrl+A on the terminal's hidden input textarea:

1. `TerminalKeyboardInput.tsx`'s React `onKeyDown` — correct, already tested: sends `\x01` (readline "move to beginning of line") for Ctrl+A.
2. `TerminalView.tsx`'s native `window.addEventListener('keydown', onKeyDownSelectAll)` — matched **both** `metaKey` and `ctrlKey`, creating a browser `Selection` over the entire terminal rows container.

Because `preventDefault()` does not stop propagation to a separately-registered window listener, both fired for the same keystroke. Creating that DOM `Selection` outside the focused hidden textarea does **not** blur it (`document.activeElement` stays the textarea — verified live in Chrome), but the browser silently withholds subsequent `input` events on it: `keydown` keeps firing, but `textarea.value` never updates, so typed characters stop reaching the PTY. That's the exact "keystrokes silently go nowhere" symptom.

Ctrl+A is universally reserved for the shell's readline binding in every terminal emulator convention; "select all" (where offered) is bound to Cmd+A on macOS, which never conflicts with a shell binding. The fix scopes the window listener to `metaKey` only.

## Fix

`packages/client/src/components/terminal/TerminalView.tsx` — `onKeyDownSelectAll`'s trigger condition changed from `!(e.metaKey || e.ctrlKey)` to `!e.metaKey`. Comment updated to explain why Ctrl+A is excluded.

## Tests

`packages/client/src/components/terminal/__tests__/TerminalView.test.tsx` — new `describe('TerminalView select-all keyboard shortcut', ...)` block:
- Ctrl+A: asserts no `Selection` is created (regression guard, #1041).
- Cmd+A: asserts the selection still fires (existing-feature guard).
- Ctrl+Shift+A / Cmd+Shift+A: boundary guards.

**Regression polarity verified** (workflow.md TDD requirement): with only the production fix line reverted (test kept), the Ctrl+A test **failed** (`rangeCount` was `1`, not `0`); with the fix restored, all tests passed.

## Browser QA (Chrome DevTools MCP, real Chrome — not jsdom)

Verified end-to-end on a live dev instance, both directions:

- **Baseline (fix stashed):** focused a plain-shell terminal's hidden textarea, pressed Ctrl+A, then typed `blocked-test` via real keyboard events. Reproduced the bug exactly — the entire terminal scrollback became visibly selected (blue highlight), `textarea.value` stayed empty, `document.activeElement` remained the textarea (confirmed no blur — matches the diagnosed mechanism), and the typed text never appeared anywhere.
- **Fixed:** same steps — Ctrl+A created no selection, and subsequent typing was correctly inserted at the readline-repositioned cursor.
- **Existing feature preserved:** Cmd+A still selects all terminal content (`rangeCount: 1`, full scrollback text) — unaffected by this change.

## Verification

- `bun run typecheck`: exit 0 (all packages).
- `bun run test:only`: exit 1, but the **only** failure is pre-existing and unrelated — `packages/server/src/services/__tests__/multi-user-mode.test.ts:1107`, a test whose name references skipping the elevation helper on the direct (non-elevated) path and expects the SSH agent fallback to be ignored there. It fails because this local shell's real `SSH_AUTH_SOCK` (1Password agent socket) leaks into the test environment. Confirmed pre-existing by stashing this PR's diff entirely and re-running the same test — it fails identically on unmodified `origin/main`. This PR's diff never touches `packages/server`. Client suite: 1775 pass, 0 fail (includes the new/modified tests in this PR).
- `node .claude/skills/orchestrator/preflight-check.js`: coverage OK, language OK, blame-shift OK. Integration-test-gap warning noted below.
- CodeRabbit local CLI: not usable in this headless worktree session (auth requires interactive browser callback, unavailable here) — falling back to the GitHub-side bot per `coderabbit-ops` skill.

**Integration test gap (justified deferral):** preflight flags no `packages/integration` changes for this PR. This is a pure client-side DOM/browser-API fix (native `window` keydown listener + `Selection` API) with no server interaction, no wire schema, and no shared type — the bug and its fix are entirely browser-behavior-level. Coverage is provided by the new unit tests (regression polarity confirmed) plus the real-Chrome Browser QA above, which is the appropriate E2E layer for this class of change per `testing.md`'s "E2E / real-device verification is the default" rule.

## Closes #1041

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated terminal keyboard shortcuts so **Cmd+A** selects all terminal content.
  * **Ctrl+A** now remains available for the terminal’s readline behavior.
  * Prevented modified shortcuts such as Ctrl+Shift+A and Cmd+Shift+A from triggering select all.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->