### PR TITLE
feat: unify shell and agent worker creation into single picker

### DIFF
--- a/packages/client/src/components/sessions/AddAgentWorkerMenu.tsx
+++ b/packages/client/src/components/sessions/AddAgentWorkerMenu.tsx
@@ -6,14 +6,18 @@ import type { AddAgentWorkerParams } from './hooks/useTabManagement';
 
 interface AddAgentWorkerMenuProps {
   onSelect: (params: AddAgentWorkerParams) => Promise<void>;
+  onSelectShell: () => Promise<void>;
 }
 
 /**
- * Unified agent-selection entry point (owner requirement, spec §UI in
- * docs/design/embedded-agent-worker.md): lists terminal `AgentDefinition`s
- * and `EmbeddedAgentDefinition`s in ONE list, each item carrying a kind
- * badge. The user never picks a "worker type" as a separate prior step --
- * the kind is a property of the item they click.
+ * Unified worker-creation entry point (owner requirement; spec §UI in
+ * docs/design/embedded-agent-worker.md): lists a plain "Shell"
+ * (terminal worker) item, terminal `AgentDefinition`s, and
+ * `EmbeddedAgentDefinition`s in ONE list, each item carrying a kind badge.
+ * The user never picks a "worker type" as a separate prior step -- the kind
+ * is a property of the item they click. Shell is always first, since it
+ * doesn't depend on the agents/embedded-agents queries and is the most
+ * common action.
  *
  * Judgment call: `POST /api/sessions/:sessionId/workers`
  * (`CreateWorkerRequestSchema`) only accepts `terminal` / `embedded-agent`
@@ -28,7 +32,7 @@ interface AddAgentWorkerMenuProps {
  * The empty-embedded-registry footer links to `/agents`, which now hosts the
  * `EmbeddedAgentDefinition` management UI (Phase 3.5).
  */
-export function AddAgentWorkerMenu({ onSelect }: AddAgentWorkerMenuProps) {
+export function AddAgentWorkerMenu({ onSelect, onSelectShell }: AddAgentWorkerMenuProps) {
   const [open, setOpen] = useState(false);
   const { agents, isLoading: agentsLoading } = useAgents();
   const { embeddedAgents, isLoading: embeddedLoading } = useEmbeddedAgents();
@@ -50,6 +54,11 @@ export function AddAgentWorkerMenu({ onSelect }: AddAgentWorkerMenuProps) {
     await onSelect({ type: 'embedded-agent', embeddedAgentId });
   };
 
+  const handleSelectShell = async () => {
+    setOpen(false);
+    await onSelectShell();
+  };
+
   const isLoading = agentsLoading || embeddedLoading;
   const isEmpty = !isLoading && agents.length === 0 && embeddedAgents.length === 0;
 
@@ -64,13 +73,24 @@ export function AddAgentWorkerMenu({ onSelect }: AddAgentWorkerMenuProps) {
         aria-haspopup="menu"
         aria-expanded={open}
       >
-        + Agent
+        +
       </button>
       {open && (
         <div
           role="menu"
           className="absolute left-0 top-full z-20 mt-1 w-72 max-h-96 overflow-y-auto bg-slate-800 border border-slate-600 rounded shadow-lg"
         >
+          <button
+            role="menuitem"
+            type="button"
+            onClick={() => void handleSelectShell()}
+            className="w-full flex items-center justify-between px-3 py-2 text-sm text-left text-gray-200 hover:bg-slate-700"
+          >
+            <span className="truncate">Shell</span>
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-900/40 text-green-300 shrink-0 ml-2">
+              Shell
+            </span>
+          </button>
           {isLoading && <div className="px-3 py-2 text-sm text-gray-400">Loading...</div>}
           {isEmpty && <div className="px-3 py-2 text-sm text-gray-400">No agents configured.</div>}
           {agents.map((agent) => (

--- a/packages/client/src/components/sessions/SessionPage.tsx
+++ b/packages/client/src/components/sessions/SessionPage.tsx
@@ -524,15 +524,7 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
         <div role="tablist" aria-label="Worker tabs" className="flex items-center overflow-x-auto scrollbar-hide" onKeyDown={handleTabKeyDown}>
           {tabButtons}
         </div>
-        <button
-          onClick={addTerminalTab}
-          className="px-3 py-2 text-gray-400 hover:text-white hover:bg-slate-700"
-          title="Add shell tab"
-          aria-label="Add shell tab"
-        >
-          +
-        </button>
-        <AddAgentWorkerMenu onSelect={addAgentTab} />
+        <AddAgentWorkerMenu onSelect={addAgentTab} onSelectShell={addTerminalTab} />
 
         {/* Spacer */}
         <div className="flex-1" />

--- a/packages/client/src/components/sessions/__tests__/AddAgentWorkerMenu.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/AddAgentWorkerMenu.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
-import { screen, cleanup, waitFor } from '@testing-library/react';
+import { screen, cleanup, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithRouter } from '../../../test/renderWithRouter';
 import { AddAgentWorkerMenu } from '../AddAgentWorkerMenu';
@@ -63,7 +63,9 @@ describe('AddAgentWorkerMenu', () => {
     };
     const onSelect = mock(async () => {});
 
-    await renderWithRouter(<AddAgentWorkerMenu onSelect={onSelect} />);
+    await renderWithRouter(
+      <AddAgentWorkerMenu onSelect={onSelect} onSelectShell={async () => {}} />,
+    );
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'Add agent worker' }));
 
@@ -81,7 +83,9 @@ describe('AddAgentWorkerMenu', () => {
     };
     embeddedAgentsResponse = { embeddedAgents: [] };
 
-    await renderWithRouter(<AddAgentWorkerMenu onSelect={async () => {}} />);
+    await renderWithRouter(
+      <AddAgentWorkerMenu onSelect={async () => {}} onSelectShell={async () => {}} />,
+    );
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'Add agent worker' }));
 
@@ -99,7 +103,9 @@ describe('AddAgentWorkerMenu', () => {
   it('clicking the empty-state "Create one" link closes the menu', async () => {
     embeddedAgentsResponse = { embeddedAgents: [] };
 
-    await renderWithRouter(<AddAgentWorkerMenu onSelect={async () => {}} />);
+    await renderWithRouter(
+      <AddAgentWorkerMenu onSelect={async () => {}} onSelectShell={async () => {}} />,
+    );
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'Add agent worker' }));
 
@@ -123,7 +129,9 @@ describe('AddAgentWorkerMenu', () => {
       ],
     };
 
-    await renderWithRouter(<AddAgentWorkerMenu onSelect={async () => {}} />);
+    await renderWithRouter(
+      <AddAgentWorkerMenu onSelect={async () => {}} onSelectShell={async () => {}} />,
+    );
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'Add agent worker' }));
 
@@ -148,7 +156,9 @@ describe('AddAgentWorkerMenu', () => {
     };
     const onSelect = mock(async () => {});
 
-    await renderWithRouter(<AddAgentWorkerMenu onSelect={onSelect} />);
+    await renderWithRouter(
+      <AddAgentWorkerMenu onSelect={onSelect} onSelectShell={async () => {}} />,
+    );
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'Add agent worker' }));
 
@@ -166,7 +176,9 @@ describe('AddAgentWorkerMenu', () => {
     };
     const onSelect = mock(async () => {});
 
-    await renderWithRouter(<AddAgentWorkerMenu onSelect={onSelect} />);
+    await renderWithRouter(
+      <AddAgentWorkerMenu onSelect={onSelect} onSelectShell={async () => {}} />,
+    );
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'Add agent worker' }));
 
@@ -181,12 +193,63 @@ describe('AddAgentWorkerMenu', () => {
   });
 
   it('shows "No agents configured" when both registries are empty', async () => {
-    await renderWithRouter(<AddAgentWorkerMenu onSelect={async () => {}} />);
+    await renderWithRouter(
+      <AddAgentWorkerMenu onSelect={async () => {}} onSelectShell={async () => {}} />,
+    );
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'Add agent worker' }));
 
     await waitFor(() => {
       expect(screen.getByText('No agents configured.')).toBeTruthy();
     });
+  });
+
+  it('shows a "Shell" item as the first item, with a distinct "Shell" badge, regardless of loading/empty state', async () => {
+    await renderWithRouter(
+      <AddAgentWorkerMenu onSelect={async () => {}} onSelectShell={async () => {}} />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Add agent worker' }));
+
+    const menu = screen.getByRole('menu');
+    const menuItems = within(menu).getAllByRole('menuitem');
+    expect(menuItems[0].textContent).toContain('Shell');
+
+    const badges = within(menu).getAllByText('Shell');
+    expect(badges.length).toBeGreaterThan(0);
+  });
+
+  it('shows the "Shell" item first even while agents/embedded-agents queries are loading', async () => {
+    // Never-resolving fetch keeps the queries in the loading state indefinitely.
+    globalThis.fetch = Object.assign(
+      mock(() => new Promise<Response>(() => {})),
+      { preconnect: originalFetch.preconnect },
+    );
+
+    await renderWithRouter(
+      <AddAgentWorkerMenu onSelect={async () => {}} onSelectShell={async () => {}} />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Add agent worker' }));
+
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getByRole('menuitem', { name: /Shell/ })).toBeTruthy();
+    expect(within(menu).getByText('Loading...')).toBeTruthy();
+  });
+
+  it('clicking the "Shell" item closes the menu and calls onSelectShell', async () => {
+    const onSelectShell = mock(async () => {});
+
+    await renderWithRouter(
+      <AddAgentWorkerMenu onSelect={async () => {}} onSelectShell={onSelectShell} />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Add agent worker' }));
+
+    const menu = screen.getByRole('menu');
+    await user.click(within(menu).getByRole('menuitem', { name: /Shell/ }));
+
+    expect(onSelectShell).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).toBeNull();
   });
 });

--- a/packages/client/src/components/sessions/__tests__/SessionPage.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/SessionPage.test.tsx
@@ -16,6 +16,7 @@ import {
 import { sessionToPageState } from '../SessionPage';
 import { getTabDotColor, isCloseableTabType, getWorkerTypeLabel } from '../tabAppearance';
 import type { UseTabManagementResult, AddAgentWorkerParams } from '../hooks/useTabManagement';
+import { AddAgentWorkerMenu } from '../AddAgentWorkerMenu';
 
 // Test helpers
 
@@ -441,5 +442,32 @@ describe('embedded-agent tab bar wiring (Phase 3, Issue #1021)', () => {
       updateTabsFromSession: () => {},
     };
     expect(typeof result.addAgentTab).toBe('function');
+  });
+});
+
+describe('unified shell/agent picker wiring', () => {
+  it('addTerminalTab is wired to AddAgentWorkerMenu\'s onSelectShell prop, and no standalone shell button is rendered', () => {
+    // Type-level contract check: SessionPage.tsx no longer renders a separate
+    // "Add shell tab" button -- it passes `addTerminalTab` (from
+    // useTabManagement) as AddAgentWorkerMenu's `onSelectShell` prop instead.
+    // If AddAgentWorkerMenu ever dropped `onSelectShell`, or its signature
+    // diverged from `addTerminalTab: () => Promise<void>`, this file would
+    // fail to typecheck.
+    const result: UseTabManagementResult = {
+      tabs: [],
+      activeTabId: null,
+      addTerminalTab: async () => {},
+      addAgentTab: async (_params: AddAgentWorkerParams) => {},
+      closeTab: async () => {},
+      handleTabClick: () => {},
+      updateTabsFromSession: () => {},
+    };
+
+    const props: Parameters<typeof AddAgentWorkerMenu>[0] = {
+      onSelect: result.addAgentTab,
+      onSelectShell: result.addTerminalTab,
+    };
+
+    expect(typeof props.onSelectShell).toBe('function');
   });
 });


### PR DESCRIPTION
## Summary

Unifies the standalone "+" (Add shell tab) button and the "+ Agent" picker menu into a single combined picker (owner-approved Option B: full unification), per Issue #1037.

- `AddAgentWorkerMenu` now renders a "Shell" menu item as the first item in the dropdown list, alongside the existing terminal `AgentDefinition` items (disabled, "Terminal" badge) and `EmbeddedAgentDefinition` items ("Embedded" badge). The Shell item has its own distinct "Shell" badge (green, `bg-green-900/40 text-green-300`) and is rendered unconditionally, independent of the `isLoading`/`isEmpty` state of the other two lists.
- Added a new required prop `onSelectShell: () => Promise<void>` to `AddAgentWorkerMenu`, wired to the existing `addTerminalTab` from `useTabManagement`.
- The trigger button's visible label changed from `+ Agent` to `+`. Its `aria-label`/`title` remain `"Add agent worker"` unchanged (semantic-preserving lock — existing tests assert this accessible name).
- Removed the standalone `+` "Add shell tab" button from `SessionPage.tsx`'s tab bar.
- No server-side or REST contract changes — this is a client-only UI reorganization. `useTabManagement.ts`'s `addTerminalTab`/`addAgentTab` signatures are unchanged.

## Test plan

- [x] `bun run typecheck` — zero errors (full monorepo)
- [x] `bun run test` (full suite) — client: 1805 pass / 0 fail; server: 3346 pass / 1 skip / 1 fail (pre-existing, environment-specific `SSH_AUTH_SOCK` leak in `multi-user-mode.test.ts`, confirmed present on `origin/main` unmodified — unrelated to this client-only change, verified via `git stash` baseline comparison)
- [x] `node .claude/skills/orchestrator/preflight-check.js` — production files have sibling test diffs; no rule/skill duplication; no language-check violations; no new blame-shift Issue/PR refs in source comments. Integration-test-coverage advisory noted (no wire/schema change — pure UI reorganization of existing hooks, so no integration test added)
- [x] Updated `AddAgentWorkerMenu.test.tsx`: all existing assertions kept verbatim (accessible name `'Add agent worker'`, `Terminal`/`Embedded` badges, disabled terminal items, empty states); added new tests for the "Shell" item (first-in-list, distinct badge, renders during loading, click calls `onSelectShell` and closes the menu)
- [x] Updated `SessionPage.test.tsx`: added a type-level contract test pinning `addTerminalTab` -> `AddAgentWorkerMenu`'s `onSelectShell` wiring (matching the existing pattern for `addAgentTab` -> `onSelect`)
- [ ] Browser QA (owner will perform manually with Chrome DevTools MCP access)

Closes #1037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Shell option to the worker creation menu.
  * Shell appears first in the menu with a clear badge, including while other options are loading or unavailable.
  * Selecting Shell now creates a terminal tab and closes the menu.

* **UI Improvements**
  * Consolidated shell and embedded-agent creation into a single menu, replacing the standalone add-shell button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->