### PR TITLE
feat: mark Embedded Agent as Experimental in UI (4 locations)

### DIFF
--- a/packages/client/src/components/embedded-agents/EmbeddedAgentForm.tsx
+++ b/packages/client/src/components/embedded-agents/EmbeddedAgentForm.tsx
@@ -123,6 +123,9 @@ export function EmbeddedAgentForm({
     <div className={`relative ${mode === 'create' ? 'card mb-6' : 'card'}`}>
       <FormOverlay isVisible={isPending} message={pendingMessage} />
       {mode === 'create' && <h3 className="text-lg font-medium mb-4">{title}</h3>}
+      <div className="text-xs text-gray-500 mb-4">
+        Embedded Agent is an experimental feature. API and behavior may change.
+      </div>
       <form onSubmit={handleSubmit(onSubmit)}>
         <fieldset disabled={isPending} className="flex flex-col gap-4">
           <FormField label="Name" error={errors.name}>

--- a/packages/client/src/components/embedded-agents/__tests__/EmbeddedAgentForm.test.tsx
+++ b/packages/client/src/components/embedded-agents/__tests__/EmbeddedAgentForm.test.tsx
@@ -189,6 +189,14 @@ describe('EmbeddedAgentForm', () => {
       expect(formData.enabledTools).toEqual([]);
     });
 
+    it('shows the experimental-feature banner', () => {
+      renderEmbeddedAgentForm();
+
+      expect(
+        screen.getByText('Embedded Agent is an experimental feature. API and behavior may change.'),
+      ).toBeTruthy();
+    });
+
     it('should show an amber "not yet available" warning associated with the Bash checkbox group', () => {
       renderEmbeddedAgentForm();
 
@@ -240,6 +248,14 @@ describe('EmbeddedAgentForm', () => {
       expect(screen.getByDisplayValue('Be helpful')).toBeTruthy();
       expect(screen.getByDisplayValue('25')).toBeTruthy();
       expect(screen.getByText('Save Changes')).toBeTruthy();
+    });
+
+    it('shows the experimental-feature banner in edit mode too', () => {
+      renderEmbeddedAgentForm({ mode: 'edit', initialData });
+
+      expect(
+        screen.getByText('Embedded Agent is an experimental feature. API and behavior may change.'),
+      ).toBeTruthy();
     });
 
     it('should submit updated data, allowing an optional field to be cleared', async () => {

--- a/packages/client/src/components/sessions/AddAgentWorkerMenu.tsx
+++ b/packages/client/src/components/sessions/AddAgentWorkerMenu.tsx
@@ -118,7 +118,7 @@ export function AddAgentWorkerMenu({ onSelect, onSelectShell }: AddAgentWorkerMe
             >
               <span className="truncate">{embeddedAgent.name}</span>
               <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-900/40 text-purple-300 shrink-0 ml-2">
-                Embedded
+                Embedded · Experimental
               </span>
             </button>
           ))}

--- a/packages/client/src/components/sessions/__tests__/AddAgentWorkerMenu.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/AddAgentWorkerMenu.test.tsx
@@ -74,7 +74,7 @@ describe('AddAgentWorkerMenu', () => {
       expect(screen.getByText('Ollama qwen3')).toBeTruthy();
     });
     expect(screen.getByText('Terminal')).toBeTruthy();
-    expect(screen.getByText('Embedded')).toBeTruthy();
+    expect(screen.getByText('Embedded · Experimental')).toBeTruthy();
   });
 
   it('empty embedded registry still shows terminal agents plus a link to create one', async () => {

--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -36,6 +36,10 @@ export function EmbeddedAgentWorkerView({ sessionId, workerId }: EmbeddedAgentWo
 
   return (
     <div className="flex flex-col flex-1 min-h-0 bg-slate-900">
+      <div className="px-4 py-2 bg-slate-800/60 border-b border-slate-700 text-gray-400 text-xs shrink-0">
+        This is an experimental Embedded Agent. Restart resets the conversation.
+      </div>
+
       {/* Persistent, non-dismissable reset-on-restart notice. This is a
           permanent fixture of the view (v1 worker-type inconsistency called
           out in docs/design/embedded-agent-worker.md "Design Decisions"),

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -75,6 +75,14 @@ describe('EmbeddedAgentWorkerView', () => {
     ).toBeTruthy();
   });
 
+  it('always renders the experimental-agent notice', () => {
+    renderView({ sessionId: 's1c', workerId: 'w1c' });
+
+    expect(
+      screen.getByText('This is an experimental Embedded Agent. Restart resets the conversation.'),
+    ).toBeTruthy();
+  });
+
   it('mounts MessagePanel with an accessible name for the message input', () => {
     renderView({ sessionId: 's1b', workerId: 'w1b' });
 

--- a/packages/client/src/routes/agents/index.tsx
+++ b/packages/client/src/routes/agents/index.tsx
@@ -296,6 +296,7 @@ function EmbeddedAgentsSection() {
           <span className="text-xs px-1.5 py-0.5 rounded bg-purple-900/40 text-purple-300">
             Embedded
           </span>
+          <span className="text-xs text-gray-500 font-normal">(Experimental)</span>
         </h2>
         <button
           onClick={() => setShowAddForm(true)}


### PR DESCRIPTION
## Summary

Marks the Embedded Agent feature as "Experimental" in the 4 UI locations decided in Issue #1039, using muted (non-alarm) styling to signal informational status rather than a warning/error:

1. **Add/Edit Embedded Agent form** (`EmbeddedAgentForm.tsx`) — banner shown in both create and edit mode: "Embedded Agent is an experimental feature. API and behavior may change."
2. **Agent picker badge** (`AddAgentWorkerMenu.tsx`) — the embedded-agent kind badge text changed from "Embedded" to "Embedded · Experimental".
3. **EmbeddedAgentWorkerView persistent notice** (`EmbeddedAgentWorkerView.tsx`) — a new muted notice line added above the existing (unmodified) amber reset-on-restart notice: "This is an experimental Embedded Agent. Restart resets the conversation."
4. **Agents umbrella section header** (`routes/agents/index.tsx`) — a new `(Experimental)` label added next to the existing "Embedded Agents" heading and "Embedded" kind badge.

All four changes are additive only — no existing element was removed or restyled, and no existing behavior changed.

## Semantic-preserving lock

Per the sprint's semantic-preserving-lock note, existing test assertions/accessible names were audited case by case:

- (1) and (4): implemented as new sibling elements alongside existing text, so no existing `getByText(...)` exact-match assertion needed to change (`getNodeText` only joins an element's own direct text nodes, not descendant elements').
- (3): the pre-existing amber notice div and its test are completely untouched; the new experimental notice is a separate element.
- (2): this one **does** require an intentional test-assertion update, since the badge's own literal text changed to include "· Experimental" per the owner-specified wording. Updated `AddAgentWorkerMenu.test.tsx` line 77 from `getByText('Embedded')` to `getByText('Embedded · Experimental')` — the only such assertion in the codebase (grepped to confirm no other collisions).

Sibling test files were also updated for (1) and (3) (`EmbeddedAgentForm.test.tsx`, `EmbeddedAgentWorkerView.test.tsx`) with new test cases asserting the new banner/notice text renders, per `pre-pr-completeness.md` Q3.

## Test plan

- [x] `bun run typecheck` — exit 0
- [x] `bun run test:only` (full monorepo) — all packages pass; the single `packages/server` failure (`multi-user-mode.test.ts` SSH_AUTH_SOCK assertion) is a pre-existing environment-dependent baseline failure (this dev host's real 1Password SSH agent socket leaks into `process.env`), confirmed unrelated via isolated re-run — this PR's diff is entirely within `packages/client` and cannot affect server-side env-derived test behavior.
- [x] `node .claude/skills/orchestrator/preflight-check.js` — 0 missing test coverage; one advisory (non-blocking) "integration test gap" note, judged safe to skip since this PR is pure UI text/styling with no shared-type, schema, or wire-level changes.
- [x] Manual Browser QA of all 4 locations via chrome-devtools MCP — screenshots confirmed all 4 labels render correctly with muted, non-alarm styling.

## Note on CodeRabbit

Both local CodeRabbit CLI (auth timeout in this headless worktree session) and the GitHub-side bot (`Review limit reached ... Next review available in: 28 minutes`) were unavailable at this PR's review window. All other pre-merge checks (test, preflight, structure, CodeQL, comment-blame-shift-lint) are SUCCESS. No CodeRabbit feedback obtainable from either source at PR-open time. Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority) — deferring the merge decision to the Orchestrator per this task's UI-polish scope.

Closes #1039
