### PR TITLE
test: add polarity tests for path-confinement non-existent-segment escapes

### DIFF
--- a/packages/embedded-agent/src/tools/__tests__/path-confinement.test.ts
+++ b/packages/embedded-agent/src/tools/__tests__/path-confinement.test.ts
@@ -78,4 +78,43 @@ describe('resolveConfinedPath', () => {
     const result = await resolveConfinedPath(locationPath, locationPath);
     expect(result.ok).toBe(true);
   });
+
+  describe('non-existent-segment escape shapes', () => {
+    it('rejects an escape through a non-existent middle segment', async () => {
+      const result = await resolveConfinedPath('foo/nonexistent/../../..', locationPath);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toBe(CONFINEMENT_REJECTED_MESSAGE);
+      }
+    });
+
+    it('rejects a relative escape climbing above locationPath', async () => {
+      const result = await resolveConfinedPath('../../etc/hosts', locationPath);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toBe(CONFINEMENT_REJECTED_MESSAGE);
+      }
+    });
+
+    it('rejects a chained non-existent-segment escape', async () => {
+      const result = await resolveConfinedPath('nonexistent/../../..', locationPath);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toBe(CONFINEMENT_REJECTED_MESSAGE);
+      }
+    });
+
+    it('accepts a normalized relative path that stays inside locationPath', async () => {
+      const nested = path.join(locationPath, 'foo', 'bar');
+      await fsPromises.mkdir(path.dirname(nested), { recursive: true });
+      await fsPromises.writeFile(nested, 'hi');
+
+      const result = await resolveConfinedPath('./foo/bar', locationPath);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const resolvedNested = await fsPromises.realpath(nested);
+        expect(result.resolvedPath).toBe(resolvedNested);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Non-blocking follow-up from the architect audit of PR #1050 (FF-1a). Adds polarity tests to `path-confinement.test.ts` covering escape shapes through non-existent path segments that were previously only covered by code review, not by tests.

## Test cases added

- Escape through a non-existent middle segment → reject
- Relative escape climbing multiple levels above `locationPath` → reject
- Chained non-existent-segment escape → reject
- Normalized relative path staying inside `locationPath` → accept

## Deviation from Issue #1054's literal example (transparency note)

The Issue's first bullet, `Read('foo/nonexistent/../..')`, does not actually escape `locationPath` when computed: `path.resolve` lexically cancels `foo`/`nonexistent` against the two `..` segments before any filesystem access, landing exactly back on `locationPath` itself (verified with `node -e "path.resolve(...)"`). That is the existing "confines locationPath itself" boundary-accept case, not an escape.

To preserve the bullet's stated intent ("escape via non-existent middle segment"), the test instead uses `foo/nonexistent/../../..` (one additional `..`), which nets to one level above `locationPath` and is a genuine escape. All other three bullets match the Issue's literal examples.

## Polarity verification (done before push, not committed)

Temporarily replaced the `confined` computation in `path-confinement.ts` with a hardcoded `true` bypass, ran the test file, and confirmed all 3 new reject-assertions (plus 3 pre-existing reject tests) failed as expected — proving the tests actually exercise the confinement check. Reverted the bypass and re-ran to confirm all 11 tests in the file pass. No production code changes are included in this PR (diff is test-file-only).

## Test plan

- [x] `bun test packages/embedded-agent/src/tools/__tests__/path-confinement.test.ts` — 11/11 pass
- [x] Synthetic bypass polarity check — reject tests fail without the check, pass with it restored
- [x] `bun run typecheck` — exit 0
- [x] `bun run test` (full suite) — exit 0 (one `multi-user-mode.test.ts` failure was reproduced with the diff stashed too — pre-existing `SSH_AUTH_SOCK` environment leak in this dev shell, unrelated to this change; suite is green with `SSH_AUTH_SOCK` unset)
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (coverage N/A test-only, no rule/skill duplication, language check clean, no new Issue/PR source comments)

Closes #1054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against path traversal attempts involving missing or chained path segments.
  * Relative paths that move outside the permitted location are now correctly rejected.

* **Tests**
  * Expanded validation coverage for escape attempts and confirmed that normalized paths remaining within the permitted location continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->