### PR TITLE
fix: validate embeddedAgentId against registry + fix stale draft restore (#1062)

### DIFF
--- a/packages/client/src/components/AgentSelector.tsx
+++ b/packages/client/src/components/AgentSelector.tsx
@@ -93,6 +93,19 @@ export function useResolvedAgentId(
   return valueExists ? value : sortedAgents[0]?.id;
 }
 
+/**
+ * Hook that resolves the effective embedded agent ID with fallback logic.
+ * Unlike useResolvedAgentId, embedded agent selection is optional: an unknown/stale
+ * value falls back to undefined (unset) rather than the first embedded agent.
+ */
+export function useResolvedEmbeddedAgentId(value: string | undefined): string | undefined {
+  const { embeddedAgents, isLoading } = useEmbeddedAgents();
+
+  if (isLoading) return value;
+  const valueExists = value != null && embeddedAgents.some((a) => a.id === value);
+  return valueExists ? value : undefined;
+}
+
 export function useAgents() {
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: agentKeys.all(),
@@ -146,7 +159,9 @@ export function WorktreeAgentSelector({
   const isLoading = agentsLoading || embeddedLoading;
 
   const terminalValueExists = agentId != null && sortedAgents.some((a) => a.id === agentId);
-  const selectedValue = embeddedAgentId
+  const embeddedValueExists =
+    embeddedAgentId != null && embeddedAgents.some((a) => a.id === embeddedAgentId);
+  const selectedValue = embeddedValueExists
     ? `embedded:${embeddedAgentId}`
     : terminalValueExists
       ? `terminal:${agentId}`

--- a/packages/client/src/components/__tests__/AgentSelector.test.tsx
+++ b/packages/client/src/components/__tests__/AgentSelector.test.tsx
@@ -2,7 +2,13 @@ import { describe, it, expect, mock, beforeEach, afterEach, afterAll } from 'bun
 import { render, screen, waitFor, cleanup, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { AgentSelector, useResolvedAgentId, WorktreeAgentSelector } from '../AgentSelector';
+import {
+  AgentSelector,
+  useResolvedAgentId,
+  useResolvedEmbeddedAgentId,
+  WorktreeAgentSelector,
+} from '../AgentSelector';
+import { useEmbeddedAgents } from '../../hooks/useEmbeddedAgents';
 
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
@@ -224,31 +230,97 @@ describe('useResolvedAgentId', () => {
   });
 });
 
-describe('WorktreeAgentSelector', () => {
-  const mockEmbeddedAgentsResponse = {
-    embeddedAgents: [
-      { id: 'embedded-1', name: 'Local GPT' },
-      { id: 'embedded-2', name: 'Ollama Agent' },
-    ],
-  };
+const mockEmbeddedAgentsResponse = {
+  embeddedAgents: [
+    { id: 'embedded-1', name: 'Local GPT' },
+    { id: 'embedded-2', name: 'Ollama Agent' },
+  ],
+};
 
-  function resolveUrl(input: unknown): string {
-    if (typeof input === 'string') return input;
-    if (input instanceof URL) return input.toString();
-    if (input && typeof input === 'object' && 'url' in input) return (input as Request).url;
-    return '';
-  }
+function resolveUrl(input: unknown): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  if (input && typeof input === 'object' && 'url' in input) return (input as Request).url;
+  return '';
+}
 
-  function mockFetchImplementation() {
-    mockFetch.mockImplementation((input) => {
-      const url = resolveUrl(input);
-      if (url.includes('embedded-agents')) {
-        return Promise.resolve(createMockResponse(mockEmbeddedAgentsResponse));
-      }
-      return Promise.resolve(createMockResponse(mockAgentsResponse));
+function mockFetchImplementation() {
+  mockFetch.mockImplementation((input) => {
+    const url = resolveUrl(input);
+    if (url.includes('embedded-agents')) {
+      return Promise.resolve(createMockResponse(mockEmbeddedAgentsResponse));
+    }
+    return Promise.resolve(createMockResponse(mockAgentsResponse));
+  });
+}
+
+describe('useResolvedEmbeddedAgentId', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetchImplementation();
+  });
+
+  it('should return the original value while loading', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(
+      () => useResolvedEmbeddedAgentId('embedded-1'),
+      { wrapper: createTestWrapper() }
+    );
+
+    expect(result.current).toBe('embedded-1');
+  });
+
+  it('should return undefined while loading when value is undefined', () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(
+      () => useResolvedEmbeddedAgentId(undefined),
+      { wrapper: createTestWrapper() }
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return undefined (not the first embedded agent) when value is undefined and embedded agents have loaded', async () => {
+    const { result } = renderHook(
+      () => {
+        const { isLoading } = useEmbeddedAgents();
+        return { isLoading, resolved: useResolvedEmbeddedAgentId(undefined) };
+      },
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
     });
-  }
+    expect(result.current.resolved).toBeUndefined();
+  });
 
+  it('should return the existing value unchanged when it matches a known embedded agent id', async () => {
+    const { result } = renderHook(
+      () => useResolvedEmbeddedAgentId('embedded-2'),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe('embedded-2');
+    });
+  });
+
+  it('should return undefined when the value does not match any embedded agent', async () => {
+    const { result } = renderHook(
+      () => useResolvedEmbeddedAgentId('nonexistent-embedded'),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBeUndefined();
+    });
+  });
+});
+
+describe('WorktreeAgentSelector', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     mockFetchImplementation();
@@ -286,6 +358,17 @@ describe('WorktreeAgentSelector', () => {
 
   it('defaults selection to the priority terminal agent when neither agentId nor embeddedAgentId is given', async () => {
     renderWorktreeAgentSelector({ priorityAgentId: 'another-agent' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Local GPT')).toBeTruthy();
+    });
+
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(select.value).toBe('terminal:another-agent');
+  });
+
+  it('falls back to the terminal default when embeddedAgentId does not match any embedded agent', async () => {
+    renderWorktreeAgentSelector({ embeddedAgentId: 'nonexistent-embedded', priorityAgentId: 'another-agent' });
 
     await waitFor(() => {
       expect(screen.getByText('Local GPT')).toBeTruthy();

--- a/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
+++ b/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { valibotResolver } from '@hookform/resolvers/valibot';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { FormField, Input, Textarea } from '../ui/FormField';
-import { WorktreeAgentSelector, useResolvedAgentId } from '../AgentSelector';
+import { WorktreeAgentSelector, useResolvedAgentId, useResolvedEmbeddedAgentId } from '../AgentSelector';
 import { Spinner } from '../ui/Spinner';
 import type { CreateWorktreeFormData } from '../../schemas/worktree-form';
 import { CreateWorktreeFormSchema } from '../../schemas/worktree-form';
@@ -121,12 +121,20 @@ export function CreateWorktreeForm({
         // getValues() returns initial defaults (form just mounted).
         // The draft overwrites them with previously saved user input.
         reset({ ...getValues(), ...draft }, { keepDefaultValues: true });
+        // agentId/embeddedAgentId are never register()-bound (custom select, driven by
+        // watch/setValue), so reset()'s keepDefaultValues silently discards them; restore explicitly.
+        if ('agentId' in draft) {
+          setValue('agentId', draft.agentId, { shouldDirty: true });
+        }
+        if ('embeddedAgentId' in draft) {
+          setValue('embeddedAgentId', draft.embeddedAgentId, { shouldDirty: true });
+        }
       }
     } catch {
       // Ignore corrupted drafts
     }
-    // reset and getValues are stable refs from react-hook-form
-  }, [draftKey, reset, getValues, prefillValues]);
+    // reset, getValues and setValue are stable refs from react-hook-form
+  }, [draftKey, reset, getValues, setValue, prefillValues]);
 
 
 
@@ -169,6 +177,7 @@ export function CreateWorktreeForm({
   const agentId = watch('agentId');
   const embeddedAgentId = watch('embeddedAgentId');
   const resolvedAgentId = useResolvedAgentId(agentId, defaultAgentId ?? undefined);
+  const resolvedEmbeddedAgentId = useResolvedEmbeddedAgentId(embeddedAgentId);
 
   const branchNameMode = watch('branchNameMode');
   const initialPrompt = watch('initialPrompt');
@@ -229,8 +238,8 @@ export function CreateWorktreeForm({
           initialPrompt: data.initialPrompt!.trim(),
           baseBranch: data.baseBranch?.trim() || undefined,
           autoStartSession: true,
-          agentId: embeddedAgentId ? undefined : resolvedAgentId,
-          embeddedAgentId: embeddedAgentId || undefined,
+          agentId: resolvedEmbeddedAgentId ? undefined : resolvedAgentId,
+          embeddedAgentId: resolvedEmbeddedAgentId || undefined,
           title: data.sessionTitle?.trim() || undefined,
           useRemote,
         };
@@ -240,8 +249,8 @@ export function CreateWorktreeForm({
           branch: data.customBranch!.trim(),
           baseBranch: data.baseBranch?.trim() || undefined,
           autoStartSession: true,
-          agentId: embeddedAgentId ? undefined : resolvedAgentId,
-          embeddedAgentId: embeddedAgentId || undefined,
+          agentId: resolvedEmbeddedAgentId ? undefined : resolvedAgentId,
+          embeddedAgentId: resolvedEmbeddedAgentId || undefined,
           initialPrompt: data.initialPrompt?.trim() || undefined,
           title: data.sessionTitle?.trim() || undefined,
           useRemote,
@@ -251,8 +260,8 @@ export function CreateWorktreeForm({
           mode: 'existing',
           branch: data.customBranch!.trim(),
           autoStartSession: true,
-          agentId: embeddedAgentId ? undefined : resolvedAgentId,
-          embeddedAgentId: embeddedAgentId || undefined,
+          agentId: resolvedEmbeddedAgentId ? undefined : resolvedAgentId,
+          embeddedAgentId: resolvedEmbeddedAgentId || undefined,
           initialPrompt: data.initialPrompt?.trim() || undefined,
           title: data.sessionTitle?.trim() || undefined,
         };
@@ -295,7 +304,7 @@ export function CreateWorktreeForm({
               <span className="text-sm text-gray-400">Agent:</span>
               <WorktreeAgentSelector
                 agentId={resolvedAgentId}
-                embeddedAgentId={embeddedAgentId}
+                embeddedAgentId={resolvedEmbeddedAgentId}
                 onChange={(selection) => {
                   if (selection.embeddedAgentId) {
                     setValue('embeddedAgentId', selection.embeddedAgentId, { shouldDirty: true });

--- a/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
@@ -430,6 +430,71 @@ describe('CreateWorktreeForm', () => {
       });
     });
 
+    describe('stale localStorage draft (Issue #1062)', () => {
+      const draftKey = 'stale-embedded-agent-draft-key';
+
+      beforeEach(() => {
+        localStorage.removeItem(draftKey);
+      });
+
+      afterEach(() => {
+        localStorage.removeItem(draftKey);
+      });
+
+      it('should drop a stale embeddedAgentId restored from localStorage and fall back to the resolved terminal agent', async () => {
+        const user = userEvent.setup();
+        localStorage.setItem(draftKey, JSON.stringify({ embeddedAgentId: 'nonexistent-embedded' }));
+
+        const { props } = renderCreateWorktreeForm({ defaultAgentId: 'claude-code', draftKey });
+
+        await waitFor(() => {
+          expect(screen.getByText('Local GPT')).toBeTruthy();
+        });
+
+        const branchInput = screen.getByPlaceholderText('New branch name');
+        await user.type(branchInput, 'feature/stale-embedded-draft');
+
+        const submitButton = screen.getByText('Create & Start Session');
+        await user.click(submitButton);
+
+        await waitFor(() => {
+          expect(props.onSubmit).toHaveBeenCalledTimes(1);
+        });
+
+        const submitCall = (props.onSubmit as ReturnType<typeof mock>).mock.calls[0];
+        expect(submitCall[0]).toMatchObject({
+          agentId: 'claude-code',
+          embeddedAgentId: undefined,
+        });
+      });
+
+      it('should restore a valid agentId from localStorage and use it in the submitted request', async () => {
+        const user = userEvent.setup();
+        localStorage.setItem(draftKey, JSON.stringify({ agentId: 'custom-agent' }));
+
+        const { props } = renderCreateWorktreeForm({ defaultAgentId: 'claude-code', draftKey });
+
+        await waitFor(() => {
+          expect(screen.getByText('Local GPT')).toBeTruthy();
+        });
+
+        const branchInput = screen.getByPlaceholderText('New branch name');
+        await user.type(branchInput, 'feature/valid-agent-draft');
+
+        const submitButton = screen.getByText('Create & Start Session');
+        await user.click(submitButton);
+
+        await waitFor(() => {
+          expect(props.onSubmit).toHaveBeenCalledTimes(1);
+        });
+
+        const submitCall = (props.onSubmit as ReturnType<typeof mock>).mock.calls[0];
+        expect(submitCall[0]).toMatchObject({
+          agentId: 'custom-agent',
+          embeddedAgentId: undefined,
+        });
+      });
+    });
   });
 
   describe('default agent sorting', () => {


### PR DESCRIPTION
## Summary

Fixes #1062: the worktree creation form's `embeddedAgentId` had no existence-check fallback against the current embedded-agent registry, unlike the terminal `agentId` (which already had `useResolvedAgentId`). A stale `embeddedAgentId` referencing a deleted embedded agent could survive localStorage draft hydration and reach the submit request, which the server's route-level pre-validation (added in #1058) rejects with a 400.

## Scope: two fixes, both needed (transparent disclosure)

**1. Existence-check parity (the originally-scoped fix)**

- New `useResolvedEmbeddedAgentId` hook in `AgentSelector.tsx`, mirroring `useResolvedAgentId`. Key difference: embedded selection is optional, so an unknown/stale value falls back to `undefined` (unset), not the first embedded agent.
- `WorktreeAgentSelector`'s internal `selectedValue` computation gets an `embeddedValueExists` check, paralleling the existing `terminalValueExists` check.
- `CreateWorktreeForm.tsx` uses the resolved value (not the raw watched value) in `buildRequest` and as the selector prop.

**2. Root-cause fix discovered during TDD polarity verification (scope expansion, approved by the Orchestrator)**

While verifying TDD polarity for fix #1, both a `WorktreeAgentSelector`-level test and the `CreateWorktreeForm` stale-draft regression test showed no real polarity (passed identically with/without the fix). Investigation traced this to react-hook-form 7.68.0's `reset()` implementation:

```js
V = d.shouldUnregister ? (t.keepDefaultValues ? clone(h) : {}) : clone(i)
```

`V` is the internal `_formValues` read by `watch`/`getValues`. `h` is the original `useForm()` constructor `defaultValues`. When `shouldUnregister: true` (set on this form) and `keepDefaultValues: true` (passed by the draft-restore effect), `V` becomes `clone(h)` — **completely discarding whatever was passed into `reset(...)`** for any field that was never `register()`-bound. `agentId` and `embeddedAgentId` are exactly such fields (driven only by `watch`/`setValue` for the custom `WorktreeAgentSelector`, never through `register()`).

**Consequence:** the draft-restore effect's `reset({ ...getValues(), ...draft }, { keepDefaultValues: true })` never actually restored `agentId` or `embeddedAgentId` from localStorage — for any value, valid or stale. **This affected the terminal `agentId` side too, not just embedded** — restoring a previously-selected terminal agent from a draft silently never worked either.

**Fix:** explicit `setValue('agentId', ...)` / `setValue('embeddedAgentId', ...)` calls right after `reset()` in the draft-restore effect, since `setValue` writes through a path not subject to the discard above.

## Layered TDD polarity verification (paste, not summary)

- Stash existence-check only, keep `setValue` fix: stale-draft regression test **FAILS** (`embeddedAgentId: "nonexistent-embedded"` reaches the submitted request) — proves the existence-check layer is necessary, not redundant.
- Stash `setValue` fix only, keep existence-check: new valid-`agentId` restore test **FAILS** (falls back to `defaultAgentId` instead of the drafted `agentId`) — proves the `setValue` fix is what makes restoration work at all.
- Full baseline (both reverted): `AgentSelector.test.tsx` fails to load (missing export); `CreateWorktreeForm` valid-agentId test fails; stale-draft test passes trivially (no restore happens at all, not neutralization).
- Full fix restored: `AgentSelector.test.tsx` 22/22 pass; `CreateWorktreeForm.test.tsx` 37/37 pass.

## Test results

```
bun run typecheck: exit 0 (all packages clean)
[client] 1839 pass, 0 fail, 3821 expect() calls, 130 files
[shared] 508 pass, 0 fail
[integration] 58 pass, 0 fail
[embedded-agent] 170 pass, 0 fail
[server] 3380 pass, 1 skip, 1 fail — packages/server/src/services/inbound/__tests__/resolve-targets.test.ts
  ("fatal: not a git repository"), reproduces identically on origin/main, passes in isolation,
  fails only in the full 150-file server suite. Pre-existing test-fixture-state issue; zero
  packages/server files touched by this diff.
```

## Browser QA (real end-to-end, both dev build and production build)

Drove the actual `QuickWorktreeDialog` (the component that passes `draftKey`) via Chrome DevTools MCP against a real running server, with a genuinely-registered embedded agent present in the dropdown (true-path, not "no embedded agents available" masking the bug):

- **Stale ID**: seeded an invalid `embeddedAgentId` draft → form correctly falls back to the terminal default, with the real embedded agent still visible/selectable in the dropdown. Submitted → `POST /api/worktrees` returned **202** with `{"agentId":"claude-code-builtin", ...}` and no `embeddedAgentId` key — confirms the exact 400-causing bug no longer reproduces through the real shipping path.
- **Valid ID** (bonus fix): seeded a real embedded agent's ID as the draft value → form correctly restores it as selected.

Screenshots (dropdown open, showing the real embedded agent option alongside the correctly-resolved selection) are attached via a follow-up comment on this PR (screenshot upload convention per `browser-qa` skill).

### A finding during QA, investigated and resolved as non-blocking (see #1077)

While testing the valid-ID restore under `bun run dev` (StrictMode-wrapped dev build), it intermittently failed to restore. Traced to React 18 StrictMode's dev-only double-invoke-effects behavior racing the draft-restore effect against a second effect's "save dirty fields on unmount" cleanup (a stale `dirtyFieldsRef` clobbers the just-restored draft between the two invocations). Confirmed this is **pre-existing and not specific to this PR** — reproduced identically for `sessionTitle`, an unrelated `register()`-bound field. Confirmed via an actual `vite build` + `NODE_ENV=production` run that **production is unaffected** (React's production runtime doesn't double-invoke effects). Filed as a separate, non-blocking follow-up: #1077.

## Test plan

- [x] Unit tests: existence-check hook (5 cases) + `WorktreeAgentSelector` fallback + `CreateWorktreeForm` stale-draft regression + valid-`agentId` restore regression
- [x] TDD polarity verified per-layer (see above)
- [x] `bun run typecheck && bun run test` full suite paste
- [x] Browser QA: stale-ID fallback + valid-ID restore, both via dev build and production build, real POST payload confirmed
- [x] `node .claude/skills/orchestrator/preflight-check.js` clean (coverage, integration-test advisory noted below, language check, blame-shift check)
- [ ] CodeRabbit 3-layer verdict (pending post-push)

**Integration test advisory:** `preflight-check.js` flagged both changed files as UI components with no integration-test changes. This fix is entirely client-side (no new field added to a shared wire type — `embeddedAgentId` already existed on `CreateWorktreeRequest`), so it doesn't match `pre-pr-completeness.md` Q10's specific trigger (derived field crossing the wire), but flagging per the advisory for reviewer awareness.

Closes #1062