### PR TITLE
fix: unify embedded-agent status into shared bar, flush MessagePanel padding

### DIFF
--- a/packages/client/src/components/sessions/SessionPage.tsx
+++ b/packages/client/src/components/sessions/SessionPage.tsx
@@ -17,7 +17,7 @@ import { useWorkerRouting } from './hooks/useWorkerRouting';
 import { useTabManagement } from './hooks/useTabManagement';
 import { useSessionPageState, type PageState } from './hooks/useSessionPageState';
 import { getConnectionStatusColor, getConnectionStatusText } from './sessionStatus';
-import { getTabDotColor, isCloseableTabType, getWorkerTypeLabel } from './tabAppearance';
+import { getTabDotColor, isCloseableTabType, getWorkerTypeLabel, showsActivityBadge } from './tabAppearance';
 import { getNextTabIndex } from './tabKeyboardNavigation';
 import { extractRestartableSession, executeWorkerRestart } from './workerRestart';
 import { sendPtyWorkerMessage, escapePtyWorker } from './messagePanelHandlers';
@@ -493,6 +493,7 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
           <EmbeddedAgentWorkerView
             sessionId={sessionId}
             workerId={activeTab.id}
+            onStatusChange={handleStatusChange}
           />
         ) : activeTab.workerType === 'git-diff' ? (
           <GitDiffWorkerView
@@ -597,8 +598,8 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
         >
           {formatPath(session.locationPath)}
         </span>
-        {/* Activity state indicator (only for agent tab) */}
-        {activeTab?.workerType === 'agent' && activityState !== 'unknown' && (
+        {/* Activity state indicator (agent and embedded-agent tabs) */}
+        {activeTab && showsActivityBadge(activeTab.workerType) && activityState !== 'unknown' && (
           <span className={`text-xs px-2 py-0.5 rounded font-medium ${
             activityState === 'asking' ? 'bg-yellow-500/20 text-yellow-400' :
             activityState === 'active' ? 'bg-blue-500/20 text-blue-400' :

--- a/packages/client/src/components/sessions/__tests__/SessionPage.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/SessionPage.test.tsx
@@ -433,14 +433,14 @@ describe('embedded-agent tab bar wiring (Phase 3, Issue #1021)', () => {
   // (also extracted to tabAppearance.ts for the same testability reason as
   // above). embedded-agent workers drive `activityState` through the same
   // app-wide `worker-activity` WebSocket path as agent workers (see
-  // useSessionPageState.ts), so the badge must render for both -- unifying
-  // what used to be a duplicate status indicator inside EmbeddedAgentWorkerView
-  // itself with the one shared bar every other worker type already uses.
-  it('embedded-agent tabs show the shared status bar activity badge like agent tabs, unlike terminal/git-diff', () => {
-    expect(showsActivityBadge('agent')).toBe(true);
+  // useSessionPageState.ts), so the badge must render for embedded-agent too --
+  // unifying what used to be a duplicate status indicator inside
+  // EmbeddedAgentWorkerView itself with the one shared bar every other worker
+  // type already uses. Exhaustive coverage of showsActivityBadge across all
+  // worker types lives in tabAppearance.test.ts; this pins only the value
+  // SessionPage's JSX relies on.
+  it('embedded-agent tabs show the shared status bar activity badge like agent tabs', () => {
     expect(showsActivityBadge('embedded-agent')).toBe(true);
-    expect(showsActivityBadge('terminal')).toBe(false);
-    expect(showsActivityBadge('git-diff')).toBe(false);
   });
 
   it('addAgentTab is exposed by useTabManagement\'s result shape SessionPage destructures', () => {

--- a/packages/client/src/components/sessions/__tests__/SessionPage.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/SessionPage.test.tsx
@@ -14,7 +14,7 @@ import {
   type WorkerRestartResult,
 } from '../workerRestart';
 import { sessionToPageState } from '../SessionPage';
-import { getTabDotColor, isCloseableTabType, getWorkerTypeLabel } from '../tabAppearance';
+import { getTabDotColor, isCloseableTabType, getWorkerTypeLabel, showsActivityBadge } from '../tabAppearance';
 import type { UseTabManagementResult, AddAgentWorkerParams } from '../hooks/useTabManagement';
 import { AddAgentWorkerMenu } from '../AddAgentWorkerMenu';
 
@@ -426,6 +426,21 @@ describe('embedded-agent tab bar wiring (Phase 3, Issue #1021)', () => {
     expect(getTabDotColor('embedded-agent')).not.toBe(getTabDotColor('agent'));
     expect(isCloseableTabType('embedded-agent')).toBe(true);
     expect(getWorkerTypeLabel('embedded-agent')).toBe('Embedded Agent');
+  });
+
+  // SessionPage.tsx's shared bottom status bar gates the Idle/Working/Waiting-
+  // for-input activity badge on `showsActivityBadge(activeTab.workerType)`
+  // (also extracted to tabAppearance.ts for the same testability reason as
+  // above). embedded-agent workers drive `activityState` through the same
+  // app-wide `worker-activity` WebSocket path as agent workers (see
+  // useSessionPageState.ts), so the badge must render for both -- unifying
+  // what used to be a duplicate status indicator inside EmbeddedAgentWorkerView
+  // itself with the one shared bar every other worker type already uses.
+  it('embedded-agent tabs show the shared status bar activity badge like agent tabs, unlike terminal/git-diff', () => {
+    expect(showsActivityBadge('agent')).toBe(true);
+    expect(showsActivityBadge('embedded-agent')).toBe(true);
+    expect(showsActivityBadge('terminal')).toBe(false);
+    expect(showsActivityBadge('git-diff')).toBe(false);
   });
 
   it('addAgentTab is exposed by useTabManagement\'s result shape SessionPage destructures', () => {

--- a/packages/client/src/components/sessions/__tests__/tabAppearance.test.ts
+++ b/packages/client/src/components/sessions/__tests__/tabAppearance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import type { Worker } from '@agent-console/shared';
-import { getTabDotColor, isCloseableTabType, getWorkerTypeLabel } from '../tabAppearance';
+import { getTabDotColor, isCloseableTabType, getWorkerTypeLabel, showsActivityBadge } from '../tabAppearance';
 
 describe('getTabDotColor', () => {
   it('returns blue for agent workers', () => {
@@ -51,5 +51,23 @@ describe('getWorkerTypeLabel', () => {
     expect(getWorkerTypeLabel('agent')).toBe('Agent');
     expect(getWorkerTypeLabel('terminal')).toBe('Terminal');
     expect(getWorkerTypeLabel('embedded-agent')).toBe('Embedded Agent');
+  });
+});
+
+describe('showsActivityBadge', () => {
+  it('shows the badge for agent tabs', () => {
+    expect(showsActivityBadge('agent')).toBe(true);
+  });
+
+  it('shows the badge for embedded-agent tabs (unified with the shared status bar)', () => {
+    expect(showsActivityBadge('embedded-agent')).toBe(true);
+  });
+
+  it('hides the badge for terminal tabs', () => {
+    expect(showsActivityBadge('terminal')).toBe(false);
+  });
+
+  it('hides the badge for git-diff tabs', () => {
+    expect(showsActivityBadge('git-diff')).toBe(false);
   });
 });

--- a/packages/client/src/components/sessions/tabAppearance.ts
+++ b/packages/client/src/components/sessions/tabAppearance.ts
@@ -32,6 +32,17 @@ export function isCloseableTabType(workerType: Worker['type']): boolean {
   return workerType === 'terminal' || workerType === 'embedded-agent';
 }
 
+/**
+ * Worker types whose active tab shows the Idle/Working/Waiting-for-input
+ * activity badge in the shared bottom status bar. `agent` and
+ * `embedded-agent` both drive `activityState` via the app-wide
+ * `worker-activity` WebSocket event (see `useSessionPageState.ts`); other
+ * worker types (`terminal`, `git-diff`) have no comparable activity concept.
+ */
+export function showsActivityBadge(workerType: Worker['type']): boolean {
+  return workerType === 'agent' || workerType === 'embedded-agent';
+}
+
 /** Human-readable label for a worker type, used by `WorkerErrorFallback`'s
  * "<Type> Error: <name>" heading in `SessionPage.tsx`. */
 export function getWorkerTypeLabel(workerType: Worker['type']): string {

--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -6,13 +6,15 @@ import { useEmbeddedAgentWorker } from './hooks/useEmbeddedAgentWorker';
 import type { EmbeddedAgentChatEntry } from './embedded-agent-store';
 import { RefreshIcon, StopIcon, AlertCircleIcon } from '../Icons';
 import { MessagePanel } from '../sessions/MessagePanel';
+import type { ConnectionStatus } from '../terminal/terminal-contract';
 
 interface EmbeddedAgentWorkerViewProps {
   sessionId: string;
   workerId: string;
+  onStatusChange?: (status: ConnectionStatus) => void;
 }
 
-export function EmbeddedAgentWorkerView({ sessionId, workerId }: EmbeddedAgentWorkerViewProps) {
+export function EmbeddedAgentWorkerView({ sessionId, workerId, onStatusChange }: EmbeddedAgentWorkerViewProps) {
   const {
     status,
     entries,
@@ -34,6 +36,14 @@ export function EmbeddedAgentWorkerView({ sessionId, workerId }: EmbeddedAgentWo
     if (!el) return;
     el.scrollTop = el.scrollHeight;
   }, [entries.length]);
+
+  // Bridge the store's connection status up to the parent's shared status
+  // bar, mirroring TerminalAdapter's StatusCallbackBridge pattern -- the
+  // status lives in an external store, so a parent notification is a
+  // component-scoped side effect, not derivable state.
+  useEffect(() => {
+    onStatusChange?.(status);
+  }, [status, onStatusChange]);
 
   const isTurnActive = activityState === 'active';
 
@@ -81,58 +91,30 @@ export function EmbeddedAgentWorkerView({ sessionId, workerId }: EmbeddedAgentWo
         ))}
       </div>
 
-      <div className="border-t border-slate-700 px-4 py-3 shrink-0 flex flex-col gap-2">
-        <div className="flex items-center gap-2 text-xs text-gray-400">
-          <span className={`inline-block w-2 h-2 rounded-full ${activityStateColor(activityState)}`} aria-hidden="true" />
-          {activityStateLabel(status, activityState)}
-          {isTurnActive && (
-            <button
-              onClick={cancel}
-              className="ml-auto flex items-center gap-1 text-xs px-2 py-1 rounded bg-red-900/40 text-red-300 hover:bg-red-900/60"
-            >
-              <StopIcon className="w-3.5 h-3.5" />
-              Cancel
-            </button>
-          )}
+      {isTurnActive && (
+        <div className="px-4 py-1.5 shrink-0 flex justify-end">
+          <button
+            onClick={cancel}
+            className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-red-900/40 text-red-300 hover:bg-red-900/60"
+          >
+            <StopIcon className="w-3.5 h-3.5" />
+            Cancel
+          </button>
         </div>
-        <MessagePanel
-          sessionId={sessionId}
-          targetWorkerId={workerId}
-          newMessage={null}
-          onSend={async (content) => {
-            sendUserMessage(content);
-          }}
-          slashCompletionEnabled={false}
-          attachmentsEnabled={false}
-          sendDisabled={isTurnActive}
-        />
-      </div>
+      )}
+      <MessagePanel
+        sessionId={sessionId}
+        targetWorkerId={workerId}
+        newMessage={null}
+        onSend={async (content) => {
+          sendUserMessage(content);
+        }}
+        slashCompletionEnabled={false}
+        attachmentsEnabled={false}
+        sendDisabled={isTurnActive}
+      />
     </div>
   );
-}
-
-function activityStateColor(state: string): string {
-  switch (state) {
-    case 'active':
-      return 'bg-blue-500';
-    case 'idle':
-      return 'bg-green-500';
-    default:
-      return 'bg-gray-500';
-  }
-}
-
-function activityStateLabel(status: string, activityState: string): string {
-  if (status === 'connecting') return 'Connecting...';
-  if (status === 'disconnected') return 'Disconnected';
-  switch (activityState) {
-    case 'active':
-      return 'Working...';
-    case 'idle':
-      return 'Idle';
-    default:
-      return 'Connected';
-  }
 }
 
 interface ChatEntryRowProps {

--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -107,7 +107,7 @@ export function EmbeddedAgentWorkerView({ sessionId, workerId, onStatusChange }:
         targetWorkerId={workerId}
         newMessage={null}
         onSend={async (content) => {
-          sendUserMessage(content);
+          await sendUserMessage(content);
         }}
         slashCompletionEnabled={false}
         attachmentsEnabled={false}

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -67,6 +67,49 @@ describe('EmbeddedAgentWorkerView', () => {
     }
   });
 
+  it('notifies onStatusChange with the connection status, starting at connecting and moving to connected on WS open', async () => {
+    const onStatusChange = mock(() => {});
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })}>
+        <EmbeddedAgentWorkerView sessionId="s-status" workerId="w-status" onStatusChange={onStatusChange} />
+      </QueryClientProvider>,
+    );
+
+    expect(onStatusChange).toHaveBeenCalledWith('connecting');
+
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+    });
+
+    expect(onStatusChange).toHaveBeenLastCalledWith('connected');
+  });
+
+  it('does not render its own status/activity label, leaving that to the shared status bar', async () => {
+    renderView({ sessionId: 's-nolabel', workerId: 'w-nolabel' });
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+    });
+    await flush();
+
+    // The persistent amber notice text ("Conversation resets...") stays --
+    // only the removed per-view status row's exact labels are asserted absent.
+    expect(screen.queryByText('Connecting...')).toBeNull();
+    expect(screen.queryByText('Connected')).toBeNull();
+    expect(screen.queryByText('Disconnected')).toBeNull();
+    expect(screen.queryByText('Idle')).toBeNull();
+
+    act(() => {
+      ws?.simulateMessage(JSON.stringify({ type: 'activity', state: 'active' }));
+    });
+    await flush();
+    // 'Working...' is a duplicate concern of the removed status row; the
+    // Cancel button remains (asserted by the two tests below), but the
+    // "Working..." text label itself must not render inside the view.
+    expect(screen.queryByText('Working...')).toBeNull();
+  });
+
   it('always renders the persistent reset-on-restart note', () => {
     renderView({ sessionId: 's1', workerId: 'w1' });
 


### PR DESCRIPTION
## Summary

Client-only bundled fix for two owner-reported dogfood UI bugs in the embedded-agent worker view:

- **#1082 — "Connecting..." stuck / duplicate Idle indicator.** `SessionPage.tsx`'s shared bottom status bar only receives connection-status updates from `TerminalAdapter`'s `onStatusChange` callback. `EmbeddedAgentWorkerView` never wired this callback, so the shared bar's connection text stayed on its initial `"Connecting..."` value forever for embedded-agent tabs. Meanwhile `EmbeddedAgentWorkerView` rendered its own local status/Idle row, duplicating the shared bar's activity badge (which was also gated to `workerType === 'agent'` only).
- **#1083 — visible gap between MessagePanel and the status bar.** `EmbeddedAgentWorkerView` wrapped `MessagePanel` in an extra `border-t px-4 py-3` container. `MessagePanel` already ships its own top border/padding, so the wrapper's `py-3` left a visible gap before the shared status bar — unlike `agent`/`terminal` tabs, where `MessagePanel` renders as a bare sibling flush against the bar.

## Changes

- `EmbeddedAgentWorkerView.tsx`: bridges the store's connection `status` to a new optional `onStatusChange` prop via a `useEffect` (mirroring `TerminalAdapter`'s existing `StatusCallbackBridge` pattern). Removes the local status row and its now-dead `activityStateColor`/`activityStateLabel` helpers. Cancel button moves to its own thin, `isTurnActive`-gated strip with no `border-t`. `MessagePanel` is now a bare last child (no wrapping padding), matching `agent`/`terminal` tabs.
- `SessionPage.tsx`: passes `onStatusChange={handleStatusChange}` to `EmbeddedAgentWorkerView`. Widens the shared bar's activity badge gate to also cover `embedded-agent` (via a new `showsActivityBadge()` helper in `tabAppearance.ts`, following the existing extracted-predicate pattern in that file since `SessionPage.tsx` has no full-render test harness).
- `tabAppearance.ts`: adds `showsActivityBadge(workerType)`.

`activityState` itself was already correct for embedded-agent tabs — the server's `broadcastActivity` fires both the per-connection and the app-wide `worker-activity` WebSocket callback (same mechanism PTY agent workers use), so only the connection-status wiring and the badge/local-row duplication needed fixing.

## Verification

- `bun run typecheck` — 0 errors.
- `bun run test` (full suite): client package 1846 pass / 0 fail. One pre-existing, unrelated failure in `packages/server/src/services/inbound/__tests__/resolve-targets.test.ts` (`GitError: not a git repository`) — passes in isolation (9/9), a test-isolation/fixture-state flake outside this client-only diff.
- TDD polarity confirmed for both new test additions (stashed the fix, kept the tests — both failed against pre-fix code; restored the fix — both passed).
- Duplication check: grepped for the removed helpers and the padded-wrapper class string across `packages/client/src/` — zero other hits.
- **Real E2E Browser QA** via Chrome DevTools MCP against an isolated dev instance running this branch's code (separate ports/data dir from the shared dogfood dev server, to avoid disrupting other concurrent sessions on that instance — the shared instance runs from a different checkout at `/home/ms2sato/dev/agent-console` and does not reflect worktree branches). Registered a throwaway local embedded-agent definition, added it to a Quick Session, and confirmed via DOM inspection:
  - Only one "Idle" text node exists on the page (the shared bar's badge; `EmbeddedAgentWorkerView` renders none).
  - The shared bar's connection text transitions `"Connecting..."` → `"Connected"` (no longer stuck).
  - Sending a message flips the shared badge to `"Working..."` and shows the Cancel button in the view (no duplicate label); the request errored (fake local endpoint) and the badge correctly returned to `"Idle"`.
  - Gap between `MessagePanel`'s bottom edge and the shared status bar's top edge measured `0px` in both idle and active states.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (full suite, one pre-existing unrelated failure documented above)
- [x] TDD polarity verified for new tests
- [x] Real E2E Browser QA (screenshots/DOM measurements captured during review, not attached to keep the PR body concise — available on request)

## Note on integration test coverage

`preflight-check.js` flagged an advisory integration-test gap for the two touched UI components. This change is purely client-internal prop/state wiring (no new wire-protocol fields, no shared-type changes crossing the server/client boundary), so `packages/integration`'s WS/REST-boundary tests aren't the right layer here; the real E2E Browser QA above exercises the actual shipping path end-to-end instead.

Closes #1082
Closes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embedded-agent tabs now display connection and activity status in the shared status bar.
  * Activity badges appear for agent and embedded-agent tabs, while terminal and Git diff tabs remain unchanged.
  * Embedded-agent panels now provide a streamlined layout with contextual cancellation controls and messaging.

* **Bug Fixes**
  * Improved consistency of connection-status reporting across worker tabs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->