### PR TITLE
feat: instructions file-path list editor for embedded agent forms

### DIFF
--- a/packages/client/src/components/embedded-agents/AddEmbeddedAgentForm.tsx
+++ b/packages/client/src/components/embedded-agents/AddEmbeddedAgentForm.tsx
@@ -2,7 +2,12 @@ import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createEmbeddedAgent } from '../../lib/api';
 import { embeddedAgentKeys } from '../../lib/query-keys';
-import { EmbeddedAgentForm, parseMaxToolIterations, type EmbeddedAgentFormData } from './EmbeddedAgentForm';
+import {
+  EmbeddedAgentForm,
+  parseMaxToolIterations,
+  toInstructionPaths,
+  type EmbeddedAgentFormData,
+} from './EmbeddedAgentForm';
 
 export interface AddEmbeddedAgentFormProps {
   onSuccess: () => void;
@@ -46,6 +51,7 @@ export function AddEmbeddedAgentForm({ onSuccess, onCancel }: AddEmbeddedAgentFo
       systemPrompt: data.systemPrompt || undefined,
       maxToolIterations: parseMaxToolIterations(data.maxToolIterationsInput),
       enabledTools: data.enabledTools,
+      instructions: data.instructions.length > 0 ? toInstructionPaths(data.instructions) : undefined,
     });
   };
 

--- a/packages/client/src/components/embedded-agents/EditEmbeddedAgentForm.tsx
+++ b/packages/client/src/components/embedded-agents/EditEmbeddedAgentForm.tsx
@@ -3,7 +3,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { UpdateEmbeddedAgentRequest } from '@agent-console/shared';
 import { updateEmbeddedAgent } from '../../lib/api';
 import { embeddedAgentKeys } from '../../lib/query-keys';
-import { EmbeddedAgentForm, parseMaxToolIterations, type EmbeddedAgentFormData } from './EmbeddedAgentForm';
+import {
+  EmbeddedAgentForm,
+  parseMaxToolIterations,
+  toInstructionPaths,
+  type EmbeddedAgentFormData,
+} from './EmbeddedAgentForm';
 
 export interface EditEmbeddedAgentFormProps {
   embeddedAgentId: string;
@@ -58,6 +63,9 @@ export function EditEmbeddedAgentForm({
       // this form exists precisely to remove the "default vs explicit" PATCH
       // ambiguity that null/undefined would otherwise carry.
       enabledTools: data.enabledTools,
+      // Send null to clear (server: null = clear, undefined = no change), matching
+      // the description/systemPrompt/maxToolIterations pattern above.
+      instructions: data.instructions.length > 0 ? toInstructionPaths(data.instructions) : null,
     });
   };
 

--- a/packages/client/src/components/embedded-agents/EmbeddedAgentForm.tsx
+++ b/packages/client/src/components/embedded-agents/EmbeddedAgentForm.tsx
@@ -1,4 +1,4 @@
-import { useForm, type FieldError } from 'react-hook-form';
+import { useForm, useFieldArray, type FieldError } from 'react-hook-form';
 import { valibotResolver } from '@hookform/resolvers/valibot';
 import * as v from 'valibot';
 import {
@@ -40,6 +40,13 @@ if (
 ) {
   throw new Error('EmbeddedAgentForm tool groups do not partition EMBEDDED_AGENT_TOOL_NAMES');
 }
+
+const InstructionPathSchema = v.pipe(
+  v.string(),
+  v.trim(),
+  v.minLength(1, 'File path is required'),
+  v.check((val) => !val.startsWith('/'), 'Absolute paths are not allowed')
+);
 
 /**
  * Client-side form schema for embedded-agent creation/editing.
@@ -85,6 +92,12 @@ const EmbeddedAgentFormSchema = v.object({
   // Checkboxes structurally cannot produce a duplicate, so no need to
   // re-check duplicates client-side (unlike the server-side schema).
   enabledTools: v.array(v.picklist(EMBEDDED_AGENT_TOOL_NAMES)),
+
+  // Each entry is a literal relative file path; order matters (concatenated
+  // in array order into the system prompt — see docs/design/embedded-agent-worker.md).
+  // Modeled as {path: string}[] (not string[]) because useFieldArray requires
+  // an array of objects to key rows by `field.id`.
+  instructions: v.array(v.object({ path: InstructionPathSchema })),
 });
 
 export type EmbeddedAgentFormData = v.InferOutput<typeof EmbeddedAgentFormSchema>;
@@ -109,6 +122,7 @@ export function EmbeddedAgentForm({
   const {
     register,
     handleSubmit,
+    control,
     formState: { errors },
   } = useForm<EmbeddedAgentFormData>({
     resolver: valibotResolver(EmbeddedAgentFormSchema),
@@ -121,9 +135,12 @@ export function EmbeddedAgentForm({
       systemPrompt: '',
       maxToolIterationsInput: '',
       enabledTools: [...DEFAULT_EMBEDDED_AGENT_ENABLED_TOOLS],
+      instructions: [],
     },
     mode: 'onBlur',
   });
+
+  const { fields, append, remove } = useFieldArray({ control, name: 'instructions' });
 
   const title = mode === 'create' ? 'Add New Embedded Agent' : 'Edit Embedded Agent';
   const submitLabel = mode === 'create' ? 'Add Embedded Agent' : 'Save Changes';
@@ -249,6 +266,46 @@ export function EmbeddedAgentForm({
             </div>
           </FormField>
 
+          <FormField label="Instructions (optional)">
+            <div className="flex flex-col gap-2">
+              {fields.map((field, index) => (
+                <div key={field.id} className="flex gap-2 items-start">
+                  <div className="flex-1">
+                    <Input
+                      {...register(`instructions.${index}.path` as const)}
+                      placeholder="e.g., docs/AGENTS.md"
+                      error={errors.instructions?.[index]?.path}
+                    />
+                    {errors.instructions?.[index]?.path && (
+                      <p className="text-sm text-red-400 mt-1">
+                        {errors.instructions[index]?.path?.message}
+                      </p>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => remove(index)}
+                    className="btn btn-danger text-sm"
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={() => append({ path: '' })}
+                className="btn btn-secondary text-sm self-start"
+              >
+                + Add file
+              </button>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">
+              Explicit instruction files loaded into the system prompt, in the order listed.
+              Relative file paths only (resolved within the session's working tree); absolute
+              paths are rejected.
+            </p>
+          </FormField>
+
           {error && <p className="text-sm text-red-400">{error}</p>}
           <div className="flex gap-2">
             <button type="submit" className="btn btn-primary text-sm">
@@ -271,4 +328,12 @@ export function EmbeddedAgentForm({
 export function parseMaxToolIterations(input?: string): number | undefined {
   const trimmed = input?.trim();
   return trimmed ? Number(trimmed) : undefined;
+}
+
+/**
+ * Flatten the form's `{path: string}[]` instructions rows into the plain
+ * `string[]` shape the API expects.
+ */
+export function toInstructionPaths(instructions: EmbeddedAgentFormData['instructions']): string[] {
+  return instructions.map((entry) => entry.path);
 }

--- a/packages/client/src/components/embedded-agents/__tests__/AddEmbeddedAgentForm.test.tsx
+++ b/packages/client/src/components/embedded-agents/__tests__/AddEmbeddedAgentForm.test.tsx
@@ -112,6 +112,24 @@ describe('AddEmbeddedAgentForm', () => {
     });
   });
 
+  it('includes instructions in the POST body when file paths are added', async () => {
+    const user = userEvent.setup();
+    const onSuccess = mock(() => {});
+    renderAddEmbeddedAgentForm({ onSuccess, onCancel: () => {} });
+
+    await fillRequiredFields(user);
+    await user.click(screen.getByText('+ Add file'));
+    await user.type(screen.getByPlaceholderText('e.g., docs/AGENTS.md'), 'docs/AGENTS.md');
+    await user.click(screen.getByText('Add Embedded Agent'));
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    const body = await getLastFetchBody();
+    expect(body).toMatchObject({ instructions: ['docs/AGENTS.md'] });
+  });
+
   it('invalidates the embedded-agents query on success (does not rely solely on the WS broadcast)', async () => {
     const user = userEvent.setup();
     const onSuccess = mock(() => {});

--- a/packages/client/src/components/embedded-agents/__tests__/EditEmbeddedAgentForm.test.tsx
+++ b/packages/client/src/components/embedded-agents/__tests__/EditEmbeddedAgentForm.test.tsx
@@ -93,6 +93,7 @@ const initialData: EmbeddedAgentFormData = {
   systemPrompt: '',
   maxToolIterationsInput: '',
   enabledTools: ['Read', 'Glob', 'Grep'],
+  instructions: [],
 };
 
 describe('EditEmbeddedAgentForm', () => {
@@ -126,6 +127,7 @@ describe('EditEmbeddedAgentForm', () => {
       systemPrompt: null,
       maxToolIterations: null,
       enabledTools: ['Read', 'Glob', 'Grep'],
+      instructions: null,
     });
   });
 
@@ -150,6 +152,51 @@ describe('EditEmbeddedAgentForm', () => {
 
     const body = (await getLastFetchBody()) as { enabledTools: string[] };
     expect([...body.enabledTools].sort()).toEqual(['Bash', 'Glob', 'Read']);
+  });
+
+  it('sends the added instruction file paths in the PATCH body', async () => {
+    const user = userEvent.setup();
+    const onSuccess = mock(() => {});
+    renderEditEmbeddedAgentForm({
+      embeddedAgentId: 'embedded-1',
+      initialData,
+      onSuccess,
+      onCancel: () => {},
+    });
+
+    await user.click(screen.getByText('+ Add file'));
+    await user.type(screen.getByPlaceholderText('e.g., docs/AGENTS.md'), 'docs/new-note.md');
+
+    await user.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    const body = await getLastFetchBody();
+    expect(body).toMatchObject({ instructions: ['docs/new-note.md'] });
+  });
+
+  it('sends instructions: null when all instruction entries are removed', async () => {
+    const user = userEvent.setup();
+    const onSuccess = mock(() => {});
+    renderEditEmbeddedAgentForm({
+      embeddedAgentId: 'embedded-1',
+      initialData: { ...initialData, instructions: [{ path: 'existing/note.md' }] },
+      onSuccess,
+      onCancel: () => {},
+    });
+
+    await user.click(screen.getByText('Remove'));
+
+    await user.click(screen.getByText('Save Changes'));
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    const body = await getLastFetchBody();
+    expect(body).toMatchObject({ instructions: null });
   });
 
   it('invalidates the embedded-agents query on success (does not rely solely on the WS broadcast)', async () => {

--- a/packages/client/src/components/embedded-agents/__tests__/EmbeddedAgentForm.test.tsx
+++ b/packages/client/src/components/embedded-agents/__tests__/EmbeddedAgentForm.test.tsx
@@ -281,6 +281,7 @@ describe('EmbeddedAgentForm', () => {
       systemPrompt: 'Be helpful',
       maxToolIterationsInput: '25',
       enabledTools: ['Read', 'Glob', 'Grep'],
+      instructions: [{ path: 'docs/AGENTS.md' }],
     };
 
     it('should render form with pre-filled data', () => {
@@ -321,6 +322,147 @@ describe('EmbeddedAgentForm', () => {
       const formData = (props.onSubmit as ReturnType<typeof mock>).mock.calls[0][0] as EmbeddedAgentFormData;
       expect(formData.name).toBe('Existing Embedded Agent');
       expect(formData.apiKeyRef).toBe('');
+    });
+  });
+
+  describe('instructions', () => {
+    it('should render with no instruction entries by default', () => {
+      renderEmbeddedAgentForm();
+
+      expect(screen.queryByPlaceholderText('e.g., docs/AGENTS.md')).toBeNull();
+      expect(screen.getByText('+ Add file')).toBeTruthy();
+    });
+
+    it('should add and submit an instruction file path entry', async () => {
+      const user = userEvent.setup();
+      const { props } = renderEmbeddedAgentForm();
+
+      await user.type(screen.getByPlaceholderText('e.g., Ollama qwen3:32b'), 'My Embedded Agent');
+      await user.type(screen.getByPlaceholderText('http://localhost:11434/v1'), 'http://localhost:11434/v1');
+      await user.type(screen.getByPlaceholderText('e.g., qwen3:32b'), 'qwen3:32b');
+
+      await user.click(screen.getByText('+ Add file'));
+      await user.type(screen.getByPlaceholderText('e.g., docs/AGENTS.md'), 'docs/AGENTS.md');
+
+      await user.click(screen.getByText('Add Embedded Agent'));
+
+      await waitFor(() => {
+        expect(props.onSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      const formData = (props.onSubmit as ReturnType<typeof mock>).mock.calls[0][0] as EmbeddedAgentFormData;
+      expect(formData.instructions).toEqual([{ path: 'docs/AGENTS.md' }]);
+    });
+
+    it('should show a validation error for an empty instruction file path', async () => {
+      const user = userEvent.setup();
+      const { props } = renderEmbeddedAgentForm();
+
+      await user.type(screen.getByPlaceholderText('e.g., Ollama qwen3:32b'), 'My Embedded Agent');
+      await user.type(screen.getByPlaceholderText('http://localhost:11434/v1'), 'http://localhost:11434/v1');
+      await user.type(screen.getByPlaceholderText('e.g., qwen3:32b'), 'qwen3:32b');
+
+      await user.click(screen.getByText('+ Add file'));
+
+      await user.click(screen.getByText('Add Embedded Agent'));
+
+      await waitFor(() => {
+        expect(screen.getByText('File path is required')).toBeTruthy();
+      });
+      expect(props.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('should show a validation error for an absolute instruction file path', async () => {
+      const user = userEvent.setup();
+      const { props } = renderEmbeddedAgentForm();
+
+      await user.type(screen.getByPlaceholderText('e.g., Ollama qwen3:32b'), 'My Embedded Agent');
+      await user.type(screen.getByPlaceholderText('http://localhost:11434/v1'), 'http://localhost:11434/v1');
+      await user.type(screen.getByPlaceholderText('e.g., qwen3:32b'), 'qwen3:32b');
+
+      await user.click(screen.getByText('+ Add file'));
+      await user.type(screen.getByPlaceholderText('e.g., docs/AGENTS.md'), '/etc/passwd');
+
+      await user.click(screen.getByText('Add Embedded Agent'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Absolute paths are not allowed')).toBeTruthy();
+      });
+      expect(props.onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('should remove an instruction file path entry', async () => {
+      const user = userEvent.setup();
+      const { props } = renderEmbeddedAgentForm();
+
+      await user.type(screen.getByPlaceholderText('e.g., Ollama qwen3:32b'), 'My Embedded Agent');
+      await user.type(screen.getByPlaceholderText('http://localhost:11434/v1'), 'http://localhost:11434/v1');
+      await user.type(screen.getByPlaceholderText('e.g., qwen3:32b'), 'qwen3:32b');
+
+      await user.click(screen.getByText('+ Add file'));
+      await user.click(screen.getByText('+ Add file'));
+      const pathInputs = screen.getAllByPlaceholderText('e.g., docs/AGENTS.md');
+      await user.type(pathInputs[0], 'docs/first.md');
+      await user.type(pathInputs[1], 'docs/second.md');
+
+      await user.click(screen.getAllByText('Remove')[0]);
+
+      await user.click(screen.getByText('Add Embedded Agent'));
+
+      await waitFor(() => {
+        expect(props.onSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      const formData = (props.onSubmit as ReturnType<typeof mock>).mock.calls[0][0] as EmbeddedAgentFormData;
+      expect(formData.instructions).toEqual([{ path: 'docs/second.md' }]);
+    });
+
+    it('should pre-fill instructions in edit mode', () => {
+      renderEmbeddedAgentForm({
+        mode: 'edit',
+        initialData: {
+          name: 'Existing Embedded Agent',
+          description: 'Test description',
+          baseUrl: 'http://localhost:11434/v1',
+          model: 'qwen3:32b',
+          apiKeyRef: 'my-key',
+          systemPrompt: 'Be helpful',
+          maxToolIterationsInput: '25',
+          enabledTools: ['Read', 'Glob', 'Grep'],
+          instructions: [{ path: 'docs/AGENTS.md' }],
+        },
+      });
+
+      expect(screen.getByDisplayValue('docs/AGENTS.md')).toBeTruthy();
+    });
+
+    it('should allow clearing all instructions in edit mode', async () => {
+      const user = userEvent.setup();
+      const { props } = renderEmbeddedAgentForm({
+        mode: 'edit',
+        initialData: {
+          name: 'Existing Embedded Agent',
+          description: 'Test description',
+          baseUrl: 'http://localhost:11434/v1',
+          model: 'qwen3:32b',
+          apiKeyRef: 'my-key',
+          systemPrompt: 'Be helpful',
+          maxToolIterationsInput: '25',
+          enabledTools: ['Read', 'Glob', 'Grep'],
+          instructions: [{ path: 'docs/AGENTS.md' }],
+        },
+      });
+
+      await user.click(screen.getByText('Remove'));
+
+      await user.click(screen.getByText('Save Changes'));
+
+      await waitFor(() => {
+        expect(props.onSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      const formData = (props.onSubmit as ReturnType<typeof mock>).mock.calls[0][0] as EmbeddedAgentFormData;
+      expect(formData.instructions).toEqual([]);
     });
   });
 });

--- a/packages/client/src/routes/agents/index.tsx
+++ b/packages/client/src/routes/agents/index.tsx
@@ -345,6 +345,7 @@ function EmbeddedAgentsSection() {
                   systemPrompt: embeddedAgent.systemPrompt ?? '',
                   maxToolIterationsInput: embeddedAgent.maxToolIterations?.toString() ?? '',
                   enabledTools: embeddedAgent.enabledTools ?? DEFAULT_EMBEDDED_AGENT_ENABLED_TOOLS.slice(),
+                  instructions: (embeddedAgent.instructions ?? []).map((path) => ({ path })),
                 }}
                 onSuccess={() => setEditingAgentId(null)}
                 onCancel={() => setEditingAgentId(null)}


### PR DESCRIPTION
## Summary

Adds a file-path list editor (add / remove entries) for `EmbeddedAgentDefinition.instructions` to both the create and edit forms. This was the remaining follow-up from Wave 5-4 (#1076, #1072), which shipped the schema/API/loader but left the field API-only.

- New `Instructions (optional)` field in `EmbeddedAgentForm.tsx`, backed by `react-hook-form`'s `useFieldArray` (first use of it in `packages/client`).
- Client-side validation: empty entries rejected, absolute paths rejected (`starts with /`) — a UI-only nicety, since the server just silently skips/warns on unreadable or out-of-confinement paths (never a hard error) per `docs/design/embedded-agent-worker.md`.
- Payload mapping preserves the existing PATCH preserve/clear/replace semantics established in #1076:
  - Create: 0 entries -> `instructions` omitted (`undefined`); N entries -> `instructions: string[]`.
  - Edit: 0 entries -> `instructions: null` (explicit clear); N entries -> `instructions: string[]` (replace). `undefined`/"no change" is not reachable from the edit form by design, since the field is now always explicitly represented once exposed in the UI (mirrors the existing `enabledTools` field's same "always explicit" comment in `EditEmbeddedAgentForm.tsx`).
- `routes/agents/index.tsx`'s edit-mode `initialData` now maps `embeddedAgent.instructions ?? []` into the form's `{path: string}[]` row shape.

No server or shared-package changes — the schema/API/loader are unchanged from #1076.

## Test coverage strategy (pre-pr-completeness.md Q10 / testing.md E2E discipline)

`preflight-check.js` flags a "strongly recommended" integration-test gap for the three modified UI files. This PR intentionally satisfies that via the **E2E branch** of the discipline rather than adding a new automated integration test, for these reasons:

1. The wire-boundary contract (`instructions` surviving the server -> JSON -> `AppServerMessageSchema` round-trip, including the `null`-clears / `undefined`-preserves / array-replaces semantics) is already covered by `packages/integration/src/embedded-agent-instructions-boundary.test.ts` and `packages/server/src/services/__tests__/embedded-agent-worker-service.test.ts`, both from #1076. This PR does not touch the schema or server code those tests exercise.
2. Manual Browser QA (see below) drove the actual shipping-path UI against a live server and inspected the real HTTP request/response bodies via Chrome DevTools MCP network inspection — this is the E2E verification, not a mechanism probe.
3. Per the Orchestrator's guidance during this PR's review, activation-reflects-instructions-in-system-prompt (the one part that would require a real LLM/embedded-agent activation) was already real-E2E-verified in Wave 5-4 dogfood and is out of scope for this UI-only PR.

## Browser QA (isolated dev instance, dummy embedded agent)

Ran an isolated dev instance (separate port + separate `AGENT_CONSOLE_HOME`, cleaned up after) rather than the shared dogfood instance, per Orchestrator guidance, with a dummy (non-functional) provider since only UI + persistence needed verification, not real LLM activation.

Verified true-path:
1. **Create** with two instruction entries (`docs/AGENTS.md`, `CONTRIBUTING.md`) -> POST body: `"instructions":["docs/AGENTS.md","CONTRIBUTING.md"]` -> 201 response includes them in order.
2. **Absolute-path validation**: typing `/etc/passwd` shows "Absolute paths are not allowed" and blocks submit.
3. **Re-opening the edit form** shows both entries pre-filled in the original order.
4. **Removing all entries and saving**: PATCH body -> `"instructions":null` -> 200 response omits the field entirely (cleared).

## Test plan

- [x] `bun run typecheck` — exit 0 (all 4 packages)
- [x] `bun run test` — full suite passes except one pre-existing, environment-dependent failure unrelated to this diff (`multi-user-mode.test.ts` SSH_AUTH_SOCK/1Password leak into `process.env`; confirmed present on `main` with this PR's changes stashed)
- [x] Unit tests added/updated: `EmbeddedAgentForm.test.tsx` (7 new instructions tests: default-empty render, add+submit, empty-path validation, absolute-path validation, remove, edit-mode prefill, edit-mode clear-all), `AddEmbeddedAgentForm.test.tsx` (POST body includes `instructions`), `EditEmbeddedAgentForm.test.tsx` (PATCH body includes `instructions` array / `null` on clear)
- [x] Manual Browser QA (isolated dev instance) — see above
- [x] `coderabbit review --agent --base main` run before merge

Closes #1079