### PR TITLE
feat: unify Thinking + tool-call/result into a single per-turn Working accordion

### DIFF
--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useMemo } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
@@ -7,6 +7,52 @@ import type { EmbeddedAgentChatEntry } from './embedded-agent-store';
 import { RefreshIcon, StopIcon, AlertCircleIcon } from '../Icons';
 import { MessagePanel } from '../sessions/MessagePanel';
 import type { ConnectionStatus } from '../terminal/terminal-contract';
+
+/** Entries folded into the collapsed-by-default "Working" accordion. */
+type GroupableEntry = Extract<EmbeddedAgentChatEntry, { kind: 'assistant-thinking' | 'tool-call' }>;
+/** Entries that always render as top-level transcript rows. */
+type OutsideEntry = Exclude<EmbeddedAgentChatEntry, { kind: 'assistant-thinking' | 'tool-call' }>;
+
+interface WorkingGroup {
+  turnId: string;
+  entries: GroupableEntry[];
+}
+
+type DisplayItem =
+  | { kind: 'entry'; entry: OutsideEntry }
+  | { kind: 'working-group'; group: WorkingGroup };
+
+function isGroupable(entry: EmbeddedAgentChatEntry): entry is GroupableEntry {
+  return entry.kind === 'assistant-thinking' || entry.kind === 'tool-call';
+}
+
+/**
+ * Derived view: walk entries once, coalescing assistant-thinking/tool-call
+ * entries into one WorkingGroup per turnId, placed at the position of that
+ * turn's first groupable entry. A multi-iteration turn (thinking -> tools ->
+ * thinking -> tools -> final message) folds into a single group even though
+ * an intermediate assistant-message entry for the same turn sits between the
+ * two rounds of tool activity in the raw entries list -- that intermediate
+ * entry still renders at its own position, unchanged.
+ */
+function buildDisplayItems(entries: EmbeddedAgentChatEntry[]): DisplayItem[] {
+  const groups = new Map<string, WorkingGroup>();
+  const items: DisplayItem[] = [];
+  for (const entry of entries) {
+    if (isGroupable(entry)) {
+      let group = groups.get(entry.turnId);
+      if (!group) {
+        group = { turnId: entry.turnId, entries: [] };
+        groups.set(entry.turnId, group);
+        items.push({ kind: 'working-group', group });
+      }
+      group.entries.push(entry);
+      continue;
+    }
+    items.push({ kind: 'entry', entry });
+  }
+  return items;
+}
 
 interface EmbeddedAgentWorkerViewProps {
   sessionId: string;
@@ -47,6 +93,8 @@ export function EmbeddedAgentWorkerView({ sessionId, workerId, onStatusChange }:
 
   const isTurnActive = activityState === 'active';
 
+  const displayItems = useMemo(() => buildDisplayItems(entries), [entries]);
+
   return (
     <div className="flex flex-col flex-1 min-h-0 bg-slate-900">
       <div className="px-4 py-2 bg-slate-800/60 border-b border-slate-700 text-gray-400 text-xs shrink-0">
@@ -86,9 +134,13 @@ export function EmbeddedAgentWorkerView({ sessionId, workerId, onStatusChange }:
         {entries.length === 0 && (
           <div className="text-gray-500 text-sm">No messages yet. Say hello to get started.</div>
         )}
-        {entries.map((entry) => (
-          <ChatEntryRow key={entry.key} entry={entry} onRestart={restart} />
-        ))}
+        {displayItems.map((item) =>
+          item.kind === 'working-group' ? (
+            <WorkingAccordion key={item.group.turnId} group={item.group} />
+          ) : (
+            <ChatEntryRow key={item.entry.key} entry={item.entry} onRestart={restart} />
+          ),
+        )}
       </div>
 
       {isTurnActive && (
@@ -118,7 +170,7 @@ export function EmbeddedAgentWorkerView({ sessionId, workerId, onStatusChange }:
 }
 
 interface ChatEntryRowProps {
-  entry: EmbeddedAgentChatEntry;
+  entry: OutsideEntry;
   onRestart: () => void;
 }
 
@@ -143,10 +195,6 @@ function ChatEntryRow({ entry, onRestart }: ChatEntryRowProps) {
           </div>
         </div>
       );
-    case 'assistant-thinking':
-      return <ThinkingAccordion entry={entry} />;
-    case 'tool-call':
-      return <ToolCallCard entry={entry} />;
     case 'turn-error':
       return (
         <div className="text-sm text-red-400 bg-red-950/40 border border-red-800/50 rounded px-3 py-2">
@@ -189,23 +237,25 @@ type ThinkingEntry = Extract<EmbeddedAgentChatEntry, { kind: 'assistant-thinking
  * out of scope per #1070) with the same overflow-wrap treatment as the
  * Markdown message bubbles (#1071), since thinking narrative can also
  * contain long unbroken tokens (e.g. quoted file contents).
+ *
+ * Only invoked from inside WorkingAccordion, which already supplies the
+ * chat-bubble positioning (flex justify-start / max-w-[80%]); this
+ * component renders just its own card so the two don't double-nest.
  */
 function ThinkingAccordion({ entry }: { entry: ThinkingEntry }) {
   return (
-    <div className="flex justify-start">
-      <div className="max-w-[80%] rounded-lg border border-slate-800 bg-slate-800/40 px-3 py-2 text-xs">
-        <details>
-          <summary className="cursor-pointer text-gray-500 flex items-center gap-1.5">
-            <span>Thinking</span>
-            {entry.streaming && (
-              <span className="inline-block w-1.5 h-3 bg-gray-500 animate-pulse align-middle" aria-hidden="true" />
-            )}
-          </summary>
-          <div className="mt-2 min-w-0 whitespace-pre-wrap text-gray-500 [overflow-wrap:anywhere]">
-            {entry.text}
-          </div>
-        </details>
-      </div>
+    <div className="rounded-lg border border-slate-800 bg-slate-800/40 px-3 py-2 text-xs">
+      <details>
+        <summary className="cursor-pointer text-gray-500 flex items-center gap-1.5">
+          <span>Thinking</span>
+          {entry.streaming && (
+            <span className="inline-block w-1.5 h-3 bg-gray-500 animate-pulse align-middle" aria-hidden="true" />
+          )}
+        </summary>
+        <div className="mt-2 min-w-0 whitespace-pre-wrap text-gray-500 [overflow-wrap:anywhere]">
+          {entry.text}
+        </div>
+      </details>
     </div>
   );
 }
@@ -237,6 +287,55 @@ function ToolCallCard({ entry }: { entry: ToolCallEntry }) {
           {entry.result?.result}
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * Fixed label for the per-turn "Working" accordion. A single named constant
+ * so the label can be renamed later without touching render logic.
+ */
+const WORKING_LABEL = 'Working';
+
+function formatWorkingSummary(group: WorkingGroup): string {
+  const toolCallCount = group.entries.filter((e) => e.kind === 'tool-call').length;
+  if (toolCallCount === 0) return WORKING_LABEL;
+  return `${WORKING_LABEL} (${toolCallCount} tool call${toolCallCount === 1 ? '' : 's'})`;
+}
+
+/**
+ * Collapsed-by-default accordion that groups all thinking/tool-call
+ * activity for one turn into a single row, keeping the chat surface a clean
+ * transcript. Keyed by `turnId` at the call site so React reuses the same
+ * DOM node across re-renders as the turn streams -- native <details open>
+ * state lives on the DOM node, not React state, so a stable key is what
+ * keeps a user-expanded accordion open while more entries are appended.
+ */
+function WorkingAccordion({ group }: { group: WorkingGroup }) {
+  const isStreaming = group.entries.some(
+    (e) => (e.kind === 'assistant-thinking' && e.streaming) || (e.kind === 'tool-call' && e.result === null),
+  );
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[80%] rounded-lg border border-slate-800 bg-slate-800/40 px-3 py-2 text-xs">
+        <details>
+          <summary className="cursor-pointer text-gray-500 flex items-center gap-1.5">
+            <span>{formatWorkingSummary(group)}</span>
+            {isStreaming && (
+              <span className="inline-block w-1.5 h-3 bg-gray-500 animate-pulse align-middle" aria-hidden="true" />
+            )}
+          </summary>
+          <div className="mt-2 space-y-2">
+            {group.entries.map((entry) =>
+              entry.kind === 'assistant-thinking' ? (
+                <ThinkingAccordion key={entry.key} entry={entry} />
+              ) : (
+                <ToolCallCard key={entry.key} entry={entry} />
+              ),
+            )}
+          </div>
+        </details>
+      </div>
     </div>
   );
 }

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -512,6 +512,36 @@ describe('EmbeddedAgentWorkerView', () => {
       expect(innerDetails?.hasAttribute('open')).toBe(false);
     });
 
+    it('clicking only the outer summary opens the Working accordion without auto-opening the nested Thinking accordion', async () => {
+      renderView({ sessionId: 's13b', workerId: 'w13b' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const chunk = ndjson({ v: 1, type: 'assistant-thinking-delta', turnId: 't1', text: 'pondering deeply' });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'output', data: chunk, offset: chunk.length, epoch: 1 }));
+      });
+      await flush();
+
+      // In a real browser, the nested <summary> is not clickable while its
+      // owning <details> is closed -- the UA stylesheet applies
+      // `details:not([open]) > *:not(summary) { display: none }`, which hides
+      // the inner Thinking <details> (a non-summary child of the outer
+      // Working <details>) entirely. A real user must click the OUTER
+      // summary first; only a separate, later click on the now-visible inner
+      // summary opens the inner accordion. This test drives that first click
+      // in isolation and asserts the inner accordion stays closed.
+      const user = userEvent.setup();
+      const [outerSummary] = Array.from(document.querySelectorAll('summary'));
+      await user.click(outerSummary);
+
+      const [outerDetails, innerDetails] = Array.from(document.querySelectorAll('details'));
+      expect(outerDetails?.hasAttribute('open')).toBe(true);
+      expect(innerDetails?.hasAttribute('open')).toBe(false);
+    });
+
     it('expands the thinking accordion body on clicking the nested summary (true-path)', async () => {
       renderView({ sessionId: 's14', workerId: 'w14' });
       const ws = MockWebSocket.getLastInstance();

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
-import { render, screen, cleanup, act, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, act, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { EmbeddedAgentWorkerView } from '../EmbeddedAgentWorkerView';
@@ -485,7 +485,7 @@ describe('EmbeddedAgentWorkerView', () => {
   });
 
   describe('Thinking accordion (#1070)', () => {
-    it('renders a thinking entry collapsed by default (body not in the accessible/queryable tree)', async () => {
+    it('renders a thinking entry collapsed by default inside a collapsed-by-default Working accordion', async () => {
       renderView({ sessionId: 's13', workerId: 'w13' });
       const ws = MockWebSocket.getLastInstance();
       act(() => {
@@ -498,17 +498,21 @@ describe('EmbeddedAgentWorkerView', () => {
       });
       await flush();
 
+      // Thinking-only turn: no tool calls, so the outer summary shows just
+      // the bare label (no "(N tool calls)" suffix).
+      expect(screen.getByText('Working')).toBeTruthy();
       expect(screen.getByText('Thinking')).toBeTruthy();
       // Native <details> hides non-<summary> children via the UA stylesheet
       // (`details:not([open]) > *:not(summary) { display: none }`) rather
       // than removing them from the DOM, so a happy-dom text query still
       // finds the body node structurally present -- the `open` attribute is
       // the authoritative collapsed/expanded signal.
-      const details = document.querySelector('details');
-      expect(details?.hasAttribute('open')).toBe(false);
+      const [outerDetails, innerDetails] = Array.from(document.querySelectorAll('details'));
+      expect(outerDetails?.hasAttribute('open')).toBe(false);
+      expect(innerDetails?.hasAttribute('open')).toBe(false);
     });
 
-    it('expands the thinking accordion body on clicking the summary (true-path)', async () => {
+    it('expands the thinking accordion body on clicking the nested summary (true-path)', async () => {
       renderView({ sessionId: 's14', workerId: 'w14' });
       const ws = MockWebSocket.getLastInstance();
       act(() => {
@@ -521,17 +525,24 @@ describe('EmbeddedAgentWorkerView', () => {
       });
       await flush();
 
-      // happy-dom's native <details> toggle only fires when the click
-      // target is the <summary> element itself, not a nested descendant
-      // (unlike real browsers, where the click bubbles up); click the
-      // <summary> directly to drive the true-path expand.
+      // happy-dom's native <details> toggle fires on the bubbling-phase
+      // click event for EVERY ancestor <details> along the click's
+      // propagation path, not just the summary's own direct parent (unlike
+      // a real browser, where only the summary's owning <details> toggles).
+      // For our nested Working > Thinking structure this means a single
+      // click on the innermost <summary> toggles BOTH <details> open in one
+      // go (the click bubbles from the inner summary, through the wrapper
+      // divs, up into the outer Working <details>). Click the inner
+      // <summary> directly (not a descendant of it) to drive the true-path
+      // expand of both accordions.
       const user = userEvent.setup();
-      const summary = document.querySelector('summary')!;
-      await user.click(summary);
+      const [, innerSummary] = Array.from(document.querySelectorAll('summary'));
+      await user.click(innerSummary);
 
       expect(screen.getByText('pondering deeply')).toBeTruthy();
-      const details = document.querySelector('details');
-      expect(details?.hasAttribute('open')).toBe(true);
+      const [outerDetails, innerDetails] = Array.from(document.querySelectorAll('details'));
+      expect(outerDetails?.hasAttribute('open')).toBe(true);
+      expect(innerDetails?.hasAttribute('open')).toBe(true);
     });
 
     it('applies overflow-wrap:anywhere to the thinking accordion body', async () => {
@@ -547,9 +558,12 @@ describe('EmbeddedAgentWorkerView', () => {
       });
       await flush();
 
+      // See the click-target rationale in the preceding test -- clicking the
+      // inner <summary> alone toggles both nested <details> open under
+      // happy-dom's bubbling-phase toggle behavior.
       const user = userEvent.setup();
-      const summary = document.querySelector('summary')!;
-      await user.click(summary);
+      const [, innerSummary] = Array.from(document.querySelectorAll('summary'));
+      await user.click(innerSummary);
 
       const body = screen.getByText('pondering');
       expect(body.className).toContain('[overflow-wrap:anywhere]');
@@ -570,7 +584,206 @@ describe('EmbeddedAgentWorkerView', () => {
 
       expect(screen.getByText('plain answer, no thinking')).toBeTruthy();
       expect(screen.queryByText('Thinking')).toBeNull();
+      expect(screen.queryByText('Working')).toBeNull();
       expect(document.querySelectorAll('details').length).toBe(0);
+    });
+  });
+
+  describe('Unified Working accordion (#1088)', () => {
+    it('groups a multi-iteration turn (thinking -> tools -> thinking -> tools -> final) into ONE Working accordion, in chronological order', async () => {
+      const { container } = renderView({ sessionId: 's16', workerId: 'w16' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const data = ndjson(
+        { v: 1, type: 'assistant-thinking-delta', turnId: 't1', text: 'first-round-thinking' },
+        { v: 1, type: 'tool-call', turnId: 't1', callId: 'c1', name: 'first_tool', args: {} },
+        { v: 1, type: 'tool-result', turnId: 't1', callId: 'c1', ok: true, result: 'first-tool-result' },
+        { v: 1, type: 'assistant-message', turnId: 't1', text: 'intermediate note' },
+        { v: 1, type: 'assistant-thinking-delta', turnId: 't1', text: 'second-round-thinking' },
+        { v: 1, type: 'tool-call', turnId: 't1', callId: 'c2', name: 'second_tool', args: {} },
+        { v: 1, type: 'tool-result', turnId: 't1', callId: 'c2', ok: true, result: 'second-tool-result' },
+        { v: 1, type: 'assistant-message', turnId: 't1', text: 'final answer' },
+      );
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      // Exactly one Working accordion for the whole turn.
+      expect(screen.getAllByText(/^Working/)).toHaveLength(1);
+      expect(screen.getByText('Working (2 tool calls)')).toBeTruthy();
+
+      // Chronological order preserved: the two outside assistant-message
+      // entries surround the (single, merged) Working accordion in text
+      // order, matching raw-entries arrival order.
+      const text = container.textContent ?? '';
+      const idxWorking = text.indexOf('Working (2 tool calls)');
+      const idxIntermediate = text.indexOf('intermediate note');
+      const idxFinal = text.indexOf('final answer');
+      expect(idxWorking).toBeGreaterThanOrEqual(0);
+      expect(idxIntermediate).toBeGreaterThan(idxWorking);
+      expect(idxFinal).toBeGreaterThan(idxIntermediate);
+    });
+
+    it('renders the Working accordion collapsed by default', async () => {
+      renderView({ sessionId: 's17', workerId: 'w17' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const data = ndjson(
+        { v: 1, type: 'tool-call', turnId: 't1', callId: 'c1', name: 'run_process', args: { cmd: 'ls' } },
+        { v: 1, type: 'tool-result', turnId: 't1', callId: 'c1', ok: true, result: 'done' },
+      );
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      const details = document.querySelector('details');
+      expect(details?.hasAttribute('open')).toBe(false);
+    });
+
+    it('keeps a user-expanded Working accordion open when more entries are appended for the same turn (A3 regression: requires key={turnId})', async () => {
+      renderView({ sessionId: 's18', workerId: 'w18' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const firstChunk = ndjson({ v: 1, type: 'assistant-thinking-delta', turnId: 't1', text: 'thinking one' });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'output', data: firstChunk, offset: firstChunk.length, epoch: 1 }));
+      });
+      await flush();
+
+      const user = userEvent.setup();
+      const outerSummary = document.querySelector('summary')!;
+      await user.click(outerSummary);
+
+      let details = document.querySelector('details');
+      expect(details?.hasAttribute('open')).toBe(true);
+
+      const secondChunk = ndjson({ v: 1, type: 'tool-call', turnId: 't1', callId: 'c1', name: 'run_process', args: {} });
+      act(() => {
+        ws?.simulateMessage(
+          JSON.stringify({ type: 'output', data: secondChunk, offset: firstChunk.length + secondChunk.length, epoch: 1 }),
+        );
+      });
+      await flush();
+
+      details = document.querySelector('details');
+      expect(details?.hasAttribute('open')).toBe(true);
+      expect(screen.getByText('Working (1 tool call)')).toBeTruthy();
+    });
+
+    it('keeps errors, fatal, exited, and final assistant messages outside any accordion', async () => {
+      renderView({ sessionId: 's19', workerId: 'w19' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const data = ndjson(
+        { v: 1, type: 'assistant-thinking-delta', turnId: 't1', text: 'thinking before error' },
+        { v: 1, type: 'turn-error', turnId: 't1', message: 'boom error' },
+        { v: 1, type: 'assistant-message', turnId: 't2', text: 'a final message' },
+      );
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      const errorNode = screen.getByText(/boom error/);
+      const finalNode = screen.getByText('a final message');
+      const allDetails = Array.from(document.querySelectorAll('details'));
+      expect(allDetails.every((d) => !d.contains(errorNode))).toBe(true);
+      expect(allDetails.every((d) => !d.contains(finalNode))).toBe(true);
+    });
+
+    it('keeps an intermediate assistant-message (mid-turn, between two tool rounds) outside any accordion', async () => {
+      renderView({ sessionId: 's20', workerId: 'w20' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const data = ndjson(
+        { v: 1, type: 'tool-call', turnId: 't1', callId: 'c1', name: 'first_tool', args: {} },
+        { v: 1, type: 'tool-result', turnId: 't1', callId: 'c1', ok: true, result: 'ok1' },
+        { v: 1, type: 'assistant-message', turnId: 't1', text: 'mid-turn placeholder text' },
+        { v: 1, type: 'tool-call', turnId: 't1', callId: 'c2', name: 'second_tool', args: {} },
+        { v: 1, type: 'tool-result', turnId: 't1', callId: 'c2', ok: true, result: 'ok2' },
+      );
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      const intermediateNode = screen.getByText('mid-turn placeholder text');
+      const allDetails = Array.from(document.querySelectorAll('details'));
+      expect(allDetails.every((d) => !d.contains(intermediateNode))).toBe(true);
+      // Exactly one Working accordion still covers both tool rounds.
+      expect(screen.getAllByText(/^Working/)).toHaveLength(1);
+      expect(screen.getByText('Working (2 tool calls)')).toBeTruthy();
+    });
+
+    it('produces equivalent visible output for the same event sequence via replay (one history message) and live (sequential output messages)', async () => {
+      const events = [
+        { v: 1, type: 'assistant-thinking-delta', turnId: 't1', text: 'thinking' },
+        { v: 1, type: 'tool-call', turnId: 't1', callId: 'c1', name: 'run_process', args: { cmd: 'ls' } },
+        { v: 1, type: 'tool-result', turnId: 't1', callId: 'c1', ok: true, result: 'done' },
+        { v: 1, type: 'assistant-message', turnId: 't1', text: 'final answer' },
+      ];
+
+      // (a) Replay: one history message.
+      const replayView = renderView({ sessionId: 's21a', workerId: 'w21a' });
+      const replayWs = MockWebSocket.getLastInstance();
+      act(() => {
+        replayWs?.simulateOpen();
+      });
+      const replayData = ndjson(...events);
+      act(() => {
+        replayWs?.simulateMessage(
+          JSON.stringify({ type: 'history', data: replayData, offset: replayData.length, startOffset: 0, epoch: 1 }),
+        );
+      });
+      await flush();
+
+      // (b) Live: sequential output messages, same order.
+      const liveView = renderView({ sessionId: 's21b', workerId: 'w21b' });
+      const liveWs = MockWebSocket.getLastInstance();
+      act(() => {
+        liveWs?.simulateOpen();
+      });
+      let offset = 0;
+      for (const event of events) {
+        const chunk = ndjson(event);
+        offset += chunk.length;
+        act(() => {
+          liveWs?.simulateMessage(JSON.stringify({ type: 'output', data: chunk, offset, epoch: 1 }));
+        });
+        await flush();
+      }
+
+      // Both default-collapsed, so only the Working summary label+count and
+      // the outside final-message text are visible in either mode. Query
+      // scoped explicitly via `within(container)` -- RenderResult's own
+      // query methods are bound to `document.body` by default, so with BOTH
+      // views mounted simultaneously (no cleanup() between them) an
+      // unscoped query would see both views' content at once.
+      const replayScope = within(replayView.container);
+      const liveScope = within(liveView.container);
+      expect(replayScope.getAllByText(/^Working/)).toHaveLength(1);
+      expect(liveScope.getAllByText(/^Working/)).toHaveLength(1);
+      expect(replayScope.getByText('Working (1 tool call)')).toBeTruthy();
+      expect(liveScope.getByText('Working (1 tool call)')).toBeTruthy();
+      expect(replayScope.getByText('final answer')).toBeTruthy();
+      expect(liveScope.getByText('final answer')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## Summary

Unifies the existing "Thinking" accordion (PR #1073) and the tool-call/tool-result display into ONE collapsed-by-default "Working" accordion per conversation turn in the embedded-agent chat view, so the chat surface stays a clean transcript of user/assistant messages while internal processing is tucked away by default.

- `assistant-thinking` and `tool-call` entries sharing the same `turnId` now render inside a single `<details>` accordion, placed at the position of that turn's first such entry, in chronological order. A multi-iteration turn (thinking → tools → thinking → tools → final message) folds into ONE group even when an intermediate assistant-message sits between the two tool rounds.
- Summary label is a single `WORKING_LABEL` constant plus a tool-call count (e.g. `Working (2 tool calls)`; bare `Working` when the turn has no tool calls, thinking only).
- `key={turnId}` on the accordion element is load-bearing: it lets React reuse the same `<details>` DOM node across re-renders, so a user-expanded accordion stays open while more entries stream in for that turn (native `<details open>` state lives on the DOM node, not React state).
- Final assistant messages, user messages, error/fatal/exited banners, and intermediate assistant-message text all continue to render outside the accordion, unchanged.

## Scope (render-layer only)

Pure client-side derived-view change. Zero diff to `packages/shared/`, `packages/server/`, or `packages/embedded-agent/` — `EmbeddedAgentChatEntry` already carries `turnId` on the relevant entry kinds; nothing needed to change server/wire/store side. Confirmed via `git diff origin/main...HEAD --name-only`:
```
packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
```

## Design note

`ThinkingAccordion` and `ToolCallCard` are reused unchanged internally (own nested `<details>` for thinking body / tool args) — the tool-call display format is intentionally untouched (positional move only), so the nested Working > Thinking / Working > tool-call structure is a deliberate double-`<details>` nesting, not an oversight. `ThinkingAccordion` had its own outer chat-bubble wrapper removed since `WorkingAccordion` now supplies that bubble (purely cosmetic, avoids double-nested bubble borders).

## Test plan

- [x] 6 new tests covering Issue #1088 AC A6: multi-iteration grouping into one accordion (chronological order), default-collapsed, expand-state preserved across streamed appends for the same turn (A3 regression), errors/fatal/final-message outside the accordion, intermediate assistant-message outside the accordion, replay-vs-live parity.
- [x] 3 existing "Thinking accordion (#1070)" tests updated for the new nested Working > Thinking structure.
- [x] `bun run typecheck` — clean, all packages.
- [x] `bun run test` (full suite) — `packages/client`: 1862/1862 pass (includes 33/33 in `EmbeddedAgentWorkerView.test.tsx`). One pre-existing unrelated server failure (`packages/server/src/services/inbound/__tests__/resolve-targets.test.ts`, `GitError: not a git repository`) — verified via `git stash` baseline comparison to reproduce the identical failure on unmodified `origin/main`; this PR touches no server files.
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (source-comment blame-shift: 0 new violations; language check: clean). One advisory: "Integration test coverage — no integration test changes in PR." Per A5 this is a render-layer-only change over an already-existing `turnId` field with zero wire/schema modification, so there is no new wire-crossing surface for an integration test to cover (see `pre-pr-completeness.md` Q10, which targets *derived fields added to a shared type crossing the wire* — not applicable here, since nothing was added to any shared/wire type).
- [ ] Manual Browser QA on an isolated dev instance — pending, will follow up in this PR thread before requesting merge.

## Note on CodeRabbit

Local CodeRabbit CLI could not complete browser-based authentication in this headless delegated worktree (`automatic_login_failed` / `authentication_failed`). Relying on the GitHub-side CodeRabbit bot review; will confirm `reviewDecision: APPROVED` before requesting merge.

Closes #1088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grouped assistant thinking and tool activity into a unified, collapsible **Working** section for each turn.
  * Preserved chronological activity across multi-step tool interactions.
  * Kept expanded Working sections open as new activity arrives.
  * Consistently displays grouped activity in both live and replay views.

* **Bug Fixes**
  * Prevented intermediate activity from obscuring final, error, or assistant messages.
  * Improved nested accordion behavior and visibility for thinking details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->