### PR TITLE
fix: bound process-tree ps spawn and guard killWorker descendant lookup

### DIFF
--- a/packages/server/src/lib/__tests__/process-tree.test.ts
+++ b/packages/server/src/lib/__tests__/process-tree.test.ts
@@ -5,6 +5,7 @@ import {
   collectDescendantPids,
   listDescendantPids,
   signalPids,
+  readProcessTable,
   type ProcessTableEntry,
 } from '../process-tree.js';
 
@@ -106,6 +107,36 @@ describe('collectDescendantPids', () => {
     ];
     expect(() => collectDescendantPids(1, table)).not.toThrow();
     expect(collectDescendantPids(1, table).sort()).toEqual([2]);
+  });
+});
+
+describe('readProcessTable', () => {
+  it('returns a non-empty real process table (happy path sanity check)', async () => {
+    const table = await readProcessTable();
+    expect(table.length).toBeGreaterThan(0);
+    // The current test process itself must appear in the real table.
+    expect(table.some((entry) => entry.pid === process.pid)).toBe(true);
+  });
+
+  it('does not hang past the bounded timeout when the spawned command never exits, and returns [] instead of throwing', async () => {
+    const start = Date.now();
+    // `sleep 30` never writes to stdout and never exits on its own within the
+    // test's own timeout budget below -- if the bounded `timeout` option
+    // (added by this fix) did not fire, this call would hang until `sleep`
+    // itself exits at 30s, which the outer `it(..., 15000)` budget would
+    // catch as a failure either way.
+    const table = await readProcessTable(['sleep', '30']);
+    const elapsed = Date.now() - start;
+
+    // Comfortably bounded well under `sleep 30`'s own duration, proving the
+    // internal timeout fired the kill rather than the process exiting on
+    // its own.
+    expect(elapsed).toBeLessThan(9000);
+    expect(table).toEqual([]);
+  }, 15000);
+
+  it('returns [] rather than throwing when the spawned command does not exist', async () => {
+    await expect(readProcessTable(['__agent-console-nonexistent-command__'])).resolves.toEqual([]);
   });
 });
 

--- a/packages/server/src/lib/process-tree.ts
+++ b/packages/server/src/lib/process-tree.ts
@@ -95,19 +95,44 @@ export function collectDescendantPids(rootPid: number, table: ProcessTableEntry[
 }
 
 /**
+ * `ps -Ao pid,ppid` normally completes in well under 100ms; 5s is a generous
+ * safety margin against a wedged/hung `ps`, not a normal-path latency
+ * budget. `killWorker` awaits `readProcessTable` before `pty.kill()`, so an
+ * unbounded hang here would stall the entire kill cleanup path.
+ */
+const READ_PROCESS_TABLE_TIMEOUT_MS = 5000;
+
+/**
  * I/O: spawns `ps -Ao pid,ppid` and returns the parsed process table.
  * `-A` (all processes) and `-o pid,ppid` (custom columns) are supported by
  * both GNU `ps` (Linux) and BSD `ps` (macOS), and `procps` is installed in
  * the production Docker image.
+ *
+ * Bounded by `timeout`, which kills the process with `killSignal` (default
+ * `SIGTERM`) if it hasn't exited in time -- Bun handles the timer itself, no
+ * manual race needed. `stderr` is ignored rather than piped: we don't
+ * consume it, and an unconsumed pipe can fill up and block the child.
+ * `spawnCommand` is a test seam (mirrors the `readTableImpl` seam on
+ * `listDescendantPids` one level up) for exercising the timeout/failure path
+ * without depending on a real `ps` hang.
  */
-export async function readProcessTable(): Promise<ProcessTableEntry[]> {
-  const proc = Bun.spawn(['ps', '-Ao', 'pid,ppid'], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  await proc.exited;
-  const stdout = await new Response(proc.stdout).text();
-  return parseProcessTable(stdout);
+export async function readProcessTable(
+  spawnCommand: string[] = ['ps', '-Ao', 'pid,ppid'],
+): Promise<ProcessTableEntry[]> {
+  try {
+    const proc = Bun.spawn(spawnCommand, {
+      stdout: 'pipe',
+      stderr: 'ignore',
+      timeout: READ_PROCESS_TABLE_TIMEOUT_MS,
+    });
+    await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    return parseProcessTable(stdout);
+  } catch {
+    // Spawn failure or a read error -- behave like an empty process table,
+    // matching the existing safe fallback (collectDescendantPids returns []).
+    return [];
+  }
 }
 
 /**

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -806,6 +806,35 @@ describe('WorkerManager', () => {
 
         expect(signalCalls).toEqual([]);
       });
+
+      it('still kills the PTY and never calls signalPidsImpl when listDescendantPidsImpl throws', async () => {
+        const signalCalls: Array<{ pids: number[]; signal: NodeJS.Signals }> = [];
+
+        const listDescendantPidsImplFake: typeof listDescendantPids = async () => {
+          throw new Error('ps read failed');
+        };
+        const signalPidsImplFake: typeof signalPids = (pids, signal) => {
+          signalCalls.push({ pids, signal });
+        };
+
+        const wm = buildManagerWithProcessTreeSeams({
+          listDescendantPidsImpl: listDescendantPidsImplFake,
+          signalPidsImpl: signalPidsImplFake,
+        });
+        const worker = wm.initializeAgentWorker({
+          id: 'agent-tree-3',
+          name: 'Test Agent',
+          createdAt: new Date().toISOString(),
+          agentId: CLAUDE_CODE_AGENT_ID,
+        });
+        await wm.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+        const mockPty = ptyFactory.instances[ptyFactory.instances.length - 1];
+
+        await expect(wm.killWorker(worker, 'test-session')).resolves.toBeUndefined();
+
+        expect(mockPty.killed).toBe(true);
+        expect(signalCalls).toEqual([]);
+      });
     });
   });
 

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -1043,7 +1043,21 @@ export class WorkerManager {
         // first (rather than after kill) avoids depending on how quickly a
         // killed shell's children get reparented to init, which would still
         // resolve via ppid=1 but adds a race against the read.
-        const descendantPids = await this.listDescendantPidsImpl(pty.pid);
+        let descendantPids: number[];
+        try {
+          descendantPids = await this.listDescendantPidsImpl(pty.pid);
+        } catch (err) {
+          // Must not abort the rest of killWorker (pty.kill() below) on a
+          // process-tree read failure -- that would leak the PTY entirely.
+          // Falling back to [] only affects this one kill cycle; any
+          // descendant that leaks as a result is still caught by the next
+          // kill cycle's own tree walk.
+          logger.warn(
+            { pid: pty.pid, err },
+            'Failed to list descendant pids before kill, proceeding without descendant signaling',
+          );
+          descendantPids = [];
+        }
 
         // Kill PTY process
         pty.kill();


### PR DESCRIPTION
## Summary

Post-merge hardening follow-up to PR #1090. Two CodeRabbit MAJOR findings landed on that PR after the rate-limited review finally ran (post-merge). Both point to the same underlying gap: the process-tree read in the `killWorker` cleanup path is unbounded and unguarded.

- `packages/server/src/lib/process-tree.ts` `readProcessTable` spawned `ps -Ao pid,ppid` with no timeout and a piped-but-unconsumed `stderr`. `killWorker` awaits this before calling `pty.kill()`, so a wedged/slow `ps` (or a full stderr pipe) could stall the entire kill cleanup path indefinitely.
- `packages/server/src/services/worker-manager.ts` `killWorker` awaited `this.listDescendantPidsImpl(pty.pid)` unguarded. Any rejection aborted cleanup before `pty.kill()` ever ran, leaking the PTY process.

## Changes

- `readProcessTable` now spawns with a bounded 5000ms `timeout` (Bun kills the process with `SIGTERM` on timeout, no manual timer needed) and `stderr: 'ignore'` instead of `'pipe'` (we never consumed it). Wrapped in try/catch returning `[]` on any failure, matching the existing safe-fallback semantics of an empty process table. Added an optional `spawnCommand` parameter (default `['ps', '-Ao', 'pid,ppid']`) as a minimal DI test seam, mirroring the existing `readTableImpl` seam on `listDescendantPids`.
- `killWorker` now wraps `await this.listDescendantPidsImpl(pty.pid)` in try/catch; on exception, falls back to `descendantPids = []` and logs a warning, while `pty.kill()` and the rest of the function are otherwise unchanged.

Combined, `killWorker` can no longer stall or throw before reaching `pty.kill()`, regardless of `ps` availability or process-tree read failures.

## Test plan

- `packages/server/src/lib/__tests__/process-tree.test.ts`: added a `readProcessTable` describe block — happy-path sanity check against the real process table, a timeout test that spawns `sleep 30` via the DI seam and asserts resolution well under 9s with `[]` returned, and a nonexistent-command test.
- `packages/server/src/services/__tests__/worker-manager.test.ts`: added a test in the existing `process-tree descendant signaling` block where `listDescendantPidsImpl` throws, asserting `killWorker` resolves without throwing, `signalPidsImpl` is never called, and the PTY is still killed.
- TDD polarity confirmed for both fixes via `git stash` (production file only): both new behavioral tests fail against the pre-fix code and pass against the fix.
- `bun run typecheck`: exit 0 (all packages).
- `bun run test` (full suite): 3426 pass / 1 skip / 1 fail in server (plus shared 518 pass, integration 63 pass, embedded-agent 189 pass, client 1863 pass — all green). The 1 server failure is a pre-existing, environment-caused failure in `multi-user-mode.test.ts` (Issue #918, elevation-skip direct path vs `sshAuthSockFallback`) triggered by this sandbox's real `SSH_AUTH_SOCK` (1Password agent socket) leaking into the test's env assumptions — the exact same unrelated failure documented in PR #1090's own description, confirmed present on `main` before this change.
- `node .claude/skills/orchestrator/preflight-check.js`: all checks green (coverage, rule/skill duplication, language, blame-shift).
- CodeRabbit CLI could not authenticate in this headless worktree (same known limitation noted in PR #1090); relying on GitHub-side CodeRabbit review once this PR is open.

Closes #1091

## CodeRabbit disposition

CodeRabbit flagged 1 CRITICAL finding ([r3579312604](https://github.com/ms2sato/agent-console/pull/1096#discussion_r3579312604)): a claimed duplicate `const signalCalls` declaration "in the same scope" at `worker-manager.test.ts:811`, said to cause a parse-time `SyntaxError`. Verified against primary source and determined to be a **false positive**: each of the three `signalCalls` declarations (lines 752, 786, 811) lives inside its own separate `it(async () => { ... })` callback — three distinct function scopes, not one shared scope. A genuine same-scope duplicate `const` would prevent the file from parsing at all; instead `bun test packages/server/src/services/__tests__/worker-manager.test.ts` runs clean (87 pass / 0 fail), and the full-suite CI `test` check on this PR is green. Replied on the thread with this reasoning; no code change made for this finding. No other CRITICAL/MAJOR/MINOR findings were posted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented process monitoring from hanging when system process commands fail or do not respond.
  * Process-table failures now safely return no results instead of causing errors.
  * Improved worker termination so cleanup continues even when descendant-process detection fails.

* **Tests**
  * Added coverage for process-table success, timeout, and command-failure scenarios.
  * Added regression coverage for worker termination when process-tree operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
