### PR TITLE
fix: group Working accordion by consecutive-run (per iteration), not per turn

### DIFF
--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -14,6 +14,7 @@ type GroupableEntry = Extract<EmbeddedAgentChatEntry, { kind: 'assistant-thinkin
 type OutsideEntry = Exclude<EmbeddedAgentChatEntry, { kind: 'assistant-thinking' | 'tool-call' }>;
 
 interface WorkingGroup {
+  /** turnId of this run's entries, used only to detect a turn boundary while extending the run. */
   turnId: string;
   entries: GroupableEntry[];
 }
@@ -27,28 +28,54 @@ function isGroupable(entry: EmbeddedAgentChatEntry): entry is GroupableEntry {
 }
 
 /**
- * Derived view: walk entries once, coalescing assistant-thinking/tool-call
- * entries into one WorkingGroup per turnId, placed at the position of that
- * turn's first groupable entry. A multi-iteration turn (thinking -> tools ->
- * thinking -> tools -> final message) folds into a single group even though
- * an intermediate assistant-message entry for the same turn sits between the
- * two rounds of tool activity in the raw entries list -- that intermediate
- * entry still renders at its own position, unchanged.
+ * A finalized assistant-message with no text is an iteration that only
+ * emitted tool calls -- there is nothing to show, so it must not render as
+ * an empty chat bubble. A still-streaming empty assistant-message is kept:
+ * it is the container the typing-cursor pulse renders inside while text is
+ * still arriving, so suppressing it would hide the in-progress indicator.
+ */
+function isSuppressedEmptyAssistantMessage(entry: EmbeddedAgentChatEntry): boolean {
+  return entry.kind === 'assistant-message' && !entry.streaming && entry.text.trim() === '';
+}
+
+/**
+ * Derived view: two passes over entries.
+ *
+ * 1. Suppress finalized-empty assistant-message entries (see
+ *    isSuppressedEmptyAssistantMessage) -- they carry no content and must
+ *    not fragment the grouping below.
+ * 2. Walk the reduced list once, coalescing RUNS of consecutive groupable
+ *    (assistant-thinking / tool-call) entries into one WorkingGroup each. A
+ *    run closes as soon as a non-groupable entry appears or the turnId
+ *    changes between consecutive groupable entries; the next groupable
+ *    entry starts a new run. A single turn therefore produces one Working
+ *    block per tool-use iteration, not one block for the whole turn -- an
+ *    intermediate assistant-message between two rounds of tool activity
+ *    closes the first run and starts a second one, and both render at their
+ *    chronological position, unchanged from the raw entries order.
+ *
+ * Suppression must run before grouping: if a finalized-empty
+ * assistant-message was the only thing separating two groupable runs, its
+ * removal makes those runs directly adjacent, and they must merge into a
+ * single Working block -- the empty message was never meaningful content,
+ * so it should never have fragmented the grouping.
  */
 function buildDisplayItems(entries: EmbeddedAgentChatEntry[]): DisplayItem[] {
-  const groups = new Map<string, WorkingGroup>();
+  const reduced = entries.filter((entry) => !isSuppressedEmptyAssistantMessage(entry));
+
   const items: DisplayItem[] = [];
-  for (const entry of entries) {
+  let openGroup: WorkingGroup | null = null;
+  for (const entry of reduced) {
     if (isGroupable(entry)) {
-      let group = groups.get(entry.turnId);
-      if (!group) {
-        group = { turnId: entry.turnId, entries: [] };
-        groups.set(entry.turnId, group);
-        items.push({ kind: 'working-group', group });
+      if (openGroup && openGroup.turnId === entry.turnId) {
+        openGroup.entries.push(entry);
+      } else {
+        openGroup = { turnId: entry.turnId, entries: [entry] };
+        items.push({ kind: 'working-group', group: openGroup });
       }
-      group.entries.push(entry);
       continue;
     }
+    openGroup = null;
     items.push({ kind: 'entry', entry });
   }
   return items;
@@ -136,7 +163,7 @@ export function EmbeddedAgentWorkerView({ sessionId, workerId, onStatusChange }:
         )}
         {displayItems.map((item) =>
           item.kind === 'working-group' ? (
-            <WorkingAccordion key={item.group.turnId} group={item.group} />
+            <WorkingAccordion key={item.group.entries[0].key} group={item.group} />
           ) : (
             <ChatEntryRow key={item.entry.key} entry={item.entry} onRestart={restart} />
           ),
@@ -292,7 +319,7 @@ function ToolCallCard({ entry }: { entry: ToolCallEntry }) {
 }
 
 /**
- * Fixed label for the per-turn "Working" accordion. A single named constant
+ * Fixed label for the per-run "Working" accordion. A single named constant
  * so the label can be renamed later without touching render logic.
  */
 const WORKING_LABEL = 'Working';
@@ -304,12 +331,20 @@ function formatWorkingSummary(group: WorkingGroup): string {
 }
 
 /**
- * Collapsed-by-default accordion that groups all thinking/tool-call
- * activity for one turn into a single row, keeping the chat surface a clean
- * transcript. Keyed by `turnId` at the call site so React reuses the same
- * DOM node across re-renders as the turn streams -- native <details open>
- * state lives on the DOM node, not React state, so a stable key is what
- * keeps a user-expanded accordion open while more entries are appended.
+ * Collapsed-by-default accordion that groups one consecutive run of
+ * thinking/tool-call activity into a single row, keeping the chat surface a
+ * clean transcript. A turn that iterates through several tool-use rounds
+ * produces one of these per run, interleaved with any narration between
+ * rounds -- not one accordion for the whole turn.
+ *
+ * Keyed at the call site by the run's FIRST entry's stable store-assigned
+ * key (not `turnId`, which is no longer unique per run once a turn can
+ * produce multiple runs) so React reuses the same DOM node across
+ * re-renders as the run streams -- native <details open> state lives on the
+ * DOM node, not React state, so a stable key is what keeps a user-expanded
+ * accordion open while more entries are appended to the same run. The first
+ * entry's key never changes while the run is open (new entries only ever
+ * append to the run's tail), so it is stable for the run's whole lifetime.
  */
 function WorkingAccordion({ group }: { group: WorkingGroup }) {
   const isStreaming = group.entries.some(

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -14,6 +14,11 @@ function flush(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 10));
 }
 
+/** True when `a` precedes `b` in document order -- used to assert chronological rendering across repeated element labels (e.g. multiple "Working" blocks) that text-index lookups can't disambiguate. */
+function isBefore(a: Node, b: Node): boolean {
+  return Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+}
+
 // MessagePanel (now embedded via EmbeddedAgentWorkerView) always fetches
 // message templates (a feature that works identically in embedded and PTY
 // per the architect's design), so this suite needs a minimal fetch mock even
@@ -620,7 +625,7 @@ describe('EmbeddedAgentWorkerView', () => {
   });
 
   describe('Unified Working accordion (#1088)', () => {
-    it('groups a multi-iteration turn (thinking -> tools -> thinking -> tools -> final) into ONE Working accordion, in chronological order', async () => {
+    it('groups a multi-iteration turn (thinking -> tools -> thinking -> tools -> final) into TWO Working accordions, interleaved chronologically around the intermediate narration (#1092)', async () => {
       const { container } = renderView({ sessionId: 's16', workerId: 'w16' });
       const ws = MockWebSocket.getLastInstance();
       act(() => {
@@ -642,20 +647,26 @@ describe('EmbeddedAgentWorkerView', () => {
       });
       await flush();
 
-      // Exactly one Working accordion for the whole turn.
-      expect(screen.getAllByText(/^Working/)).toHaveLength(1);
-      expect(screen.getByText('Working (2 tool calls)')).toBeTruthy();
+      // The non-empty intermediate assistant-message splits the turn's tool
+      // activity into two separate runs -- each iteration gets its own
+      // Working block, not one block for the whole turn.
+      const workingLabels = screen.getAllByText('Working (1 tool call)');
+      expect(workingLabels).toHaveLength(2);
 
-      // Chronological order preserved: the two outside assistant-message
-      // entries surround the (single, merged) Working accordion in text
-      // order, matching raw-entries arrival order.
+      // Chronological order preserved: block 1 -> intermediate note -> block
+      // 2 -> final answer, matching raw-entries arrival order. Text indices
+      // can't disambiguate the two identical "Working (1 tool call)" labels,
+      // so compare DOM position directly via compareDocumentPosition.
       const text = container.textContent ?? '';
-      const idxWorking = text.indexOf('Working (2 tool calls)');
       const idxIntermediate = text.indexOf('intermediate note');
       const idxFinal = text.indexOf('final answer');
-      expect(idxWorking).toBeGreaterThanOrEqual(0);
-      expect(idxIntermediate).toBeGreaterThan(idxWorking);
+      expect(idxIntermediate).toBeGreaterThanOrEqual(0);
       expect(idxFinal).toBeGreaterThan(idxIntermediate);
+
+      const [firstBlock, secondBlock] = workingLabels;
+      const intermediateNode = screen.getByText('intermediate note');
+      expect(isBefore(firstBlock, intermediateNode)).toBe(true);
+      expect(isBefore(intermediateNode, secondBlock)).toBe(true);
     });
 
     it('renders the Working accordion collapsed by default', async () => {
@@ -678,7 +689,7 @@ describe('EmbeddedAgentWorkerView', () => {
       expect(details?.hasAttribute('open')).toBe(false);
     });
 
-    it('keeps a user-expanded Working accordion open when more entries are appended for the same turn (A3 regression: requires key={turnId})', async () => {
+    it('keeps a user-expanded Working accordion open when more entries are appended to the same run (A3\' regression: keyed by the run\'s first-entry key, not turnId)', async () => {
       renderView({ sessionId: 's18', workerId: 'w18' });
       const ws = MockWebSocket.getLastInstance();
       act(() => {
@@ -698,6 +709,12 @@ describe('EmbeddedAgentWorkerView', () => {
       let details = document.querySelector('details');
       expect(details?.hasAttribute('open')).toBe(true);
 
+      // This tool-call belongs to the SAME turnId and follows immediately
+      // (no outside entry in between), so it extends the currently-open run
+      // rather than starting a new one -- the run's first entry (the
+      // thinking entry above) stays the same, so the React key derived from
+      // it (entries[0].key) is unchanged across this re-render, which is
+      // what keeps the <details> DOM node -- and its open state -- alive.
       const secondChunk = ndjson({ v: 1, type: 'tool-call', turnId: 't1', callId: 'c1', name: 'run_process', args: {} });
       act(() => {
         ws?.simulateMessage(
@@ -735,7 +752,7 @@ describe('EmbeddedAgentWorkerView', () => {
       expect(allDetails.every((d) => !d.contains(finalNode))).toBe(true);
     });
 
-    it('keeps an intermediate assistant-message (mid-turn, between two tool rounds) outside any accordion', async () => {
+    it('keeps an intermediate assistant-message (mid-turn, between two tool rounds) outside any accordion, and splits the two tool rounds into separate Working blocks (#1092)', async () => {
       renderView({ sessionId: 's20', workerId: 'w20' });
       const ws = MockWebSocket.getLastInstance();
       act(() => {
@@ -754,19 +771,24 @@ describe('EmbeddedAgentWorkerView', () => {
       });
       await flush();
 
+      // The intermediate message stays outside every accordion regardless of
+      // how many Working blocks the turn ends up producing.
       const intermediateNode = screen.getByText('mid-turn placeholder text');
       const allDetails = Array.from(document.querySelectorAll('details'));
       expect(allDetails.every((d) => !d.contains(intermediateNode))).toBe(true);
-      // Exactly one Working accordion still covers both tool rounds.
-      expect(screen.getAllByText(/^Working/)).toHaveLength(1);
-      expect(screen.getByText('Working (2 tool calls)')).toBeTruthy();
+      // The non-empty intermediate message splits the two tool rounds into
+      // two separate Working blocks, one tool call each.
+      expect(screen.getAllByText('Working (1 tool call)')).toHaveLength(2);
     });
 
-    it('produces equivalent visible output for the same event sequence via replay (one history message) and live (sequential output messages)', async () => {
+    it('produces equivalent visible output for the same event sequence via replay (one history message) and live (sequential output messages), including the multi-block case (#1092)', async () => {
       const events = [
         { v: 1, type: 'assistant-thinking-delta', turnId: 't1', text: 'thinking' },
         { v: 1, type: 'tool-call', turnId: 't1', callId: 'c1', name: 'run_process', args: { cmd: 'ls' } },
         { v: 1, type: 'tool-result', turnId: 't1', callId: 'c1', ok: true, result: 'done' },
+        { v: 1, type: 'assistant-message', turnId: 't1', text: 'intermediate note' },
+        { v: 1, type: 'tool-call', turnId: 't1', callId: 'c2', name: 'run_process_2', args: { cmd: 'ls -la' } },
+        { v: 1, type: 'tool-result', turnId: 't1', callId: 'c2', ok: true, result: 'done again' },
         { v: 1, type: 'assistant-message', turnId: 't1', text: 'final answer' },
       ];
 
@@ -801,19 +823,97 @@ describe('EmbeddedAgentWorkerView', () => {
       }
 
       // Both default-collapsed, so only the Working summary label+count and
-      // the outside final-message text are visible in either mode. Query
-      // scoped explicitly via `within(container)` -- RenderResult's own
-      // query methods are bound to `document.body` by default, so with BOTH
-      // views mounted simultaneously (no cleanup() between them) an
-      // unscoped query would see both views' content at once.
+      // the outside message text are visible in either mode. Query scoped
+      // explicitly via `within(container)` -- RenderResult's own query
+      // methods are bound to `document.body` by default, so with BOTH views
+      // mounted simultaneously (no cleanup() between them) an unscoped query
+      // would see both views' content at once.
       const replayScope = within(replayView.container);
       const liveScope = within(liveView.container);
-      expect(replayScope.getAllByText(/^Working/)).toHaveLength(1);
-      expect(liveScope.getAllByText(/^Working/)).toHaveLength(1);
-      expect(replayScope.getByText('Working (1 tool call)')).toBeTruthy();
-      expect(liveScope.getByText('Working (1 tool call)')).toBeTruthy();
+      // Two Working blocks (split by the intermediate note), one tool call each.
+      expect(replayScope.getAllByText('Working (1 tool call)')).toHaveLength(2);
+      expect(liveScope.getAllByText('Working (1 tool call)')).toHaveLength(2);
+      expect(replayScope.getByText('intermediate note')).toBeTruthy();
+      expect(liveScope.getByText('intermediate note')).toBeTruthy();
       expect(replayScope.getByText('final answer')).toBeTruthy();
       expect(liveScope.getByText('final answer')).toBeTruthy();
+    });
+
+    it('does not render a finalized-empty assistant-message as a chat bubble (#1092)', async () => {
+      renderView({ sessionId: 's22', workerId: 'w22' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const data = ndjson(
+        { v: 1, type: 'tool-call', turnId: 't1', callId: 'c1', name: 'first_tool', args: {} },
+        { v: 1, type: 'tool-result', turnId: 't1', callId: 'c1', ok: true, result: 'ok1' },
+        // An iteration that only emitted tool calls finalizes with empty text.
+        { v: 1, type: 'assistant-message', turnId: 't1', text: '' },
+      );
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      // Only the Working accordion's own bubble wrapper should exist -- no
+      // second, empty chat bubble for the finalized-empty assistant-message.
+      expect(screen.getByText('Working (1 tool call)')).toBeTruthy();
+      expect(document.querySelectorAll('.memo-content').length).toBe(0);
+    });
+
+    it('merges two groupable runs into ONE Working block when they are separated only by a finalized-empty assistant-message (suppress-then-group ordering, #1092)', async () => {
+      renderView({ sessionId: 's23', workerId: 'w23' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const data = ndjson(
+        { v: 1, type: 'tool-call', turnId: 't1', callId: 'c1', name: 'first_tool', args: {} },
+        { v: 1, type: 'tool-result', turnId: 't1', callId: 'c1', ok: true, result: 'ok1' },
+        // Finalized-empty assistant-message: not meaningful content, must be
+        // suppressed BEFORE grouping so it does not fragment the run.
+        { v: 1, type: 'assistant-message', turnId: 't1', text: '   ' },
+        { v: 1, type: 'tool-call', turnId: 't1', callId: 'c2', name: 'second_tool', args: {} },
+        { v: 1, type: 'tool-result', turnId: 't1', callId: 'c2', ok: true, result: 'ok2' },
+      );
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      // If suppression ran AFTER grouping, this would produce two separate
+      // one-tool-call blocks (the empty message would still act as a
+      // fragmenting boundary at grouping time). Suppress-then-group merges
+      // them into a single two-tool-call block instead.
+      expect(screen.getAllByText(/^Working/)).toHaveLength(1);
+      expect(screen.getByText('Working (2 tool calls)')).toBeTruthy();
+      expect(document.querySelectorAll('.memo-content').length).toBe(0);
+    });
+
+    it('still renders a streaming-empty assistant-message (the typing-indicator bubble), unlike a finalized-empty one (#1092)', async () => {
+      renderView({ sessionId: 's24', workerId: 'w24' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      // An `assistant-delta` with empty text opens a streaming assistant
+      // entry whose text is still empty -- this must render its bubble
+      // (with the typing-cursor pulse) rather than being suppressed like a
+      // finalized-empty entry.
+      const chunk = ndjson({ v: 1, type: 'assistant-delta', turnId: 't1', text: '' });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'output', data: chunk, offset: chunk.length, epoch: 1 }));
+      });
+      await flush();
+
+      const bubbles = document.querySelectorAll('.memo-content');
+      expect(bubbles.length).toBe(1);
+      // The typing-cursor pulse indicator lives inside the streaming bubble.
+      expect(bubbles[0].querySelector('.animate-pulse')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## Summary

PR #1089 (Issue #1088) shipped a per-turn "Working" accordion that coalesces ALL `assistant-thinking`/`tool-call` entries for a turn into ONE collapsed block. Owner's post-merge dogfood on a real 51-tool-call turn showed this is too coarse: it hoists a whole turn's internal processing to the top of the assistant response, pushing intermediate narration out of chronological position.

This PR revises the grouping to **consecutive-run** semantics (architect-approved AC, Issue #1092):

- `buildDisplayItems` now walks entries once, closing the current Working block whenever a non-groupable entry appears or `turnId` changes between consecutive groupable entries. A single turn normally produces multiple Working blocks, interleaved with narration in strict chronological order — never one block per turn.
- React key for each block changed from `turnId` to the block's first entry's stable store-assigned key (`entries[0].key`), since `turnId` is no longer unique per block. The first entry of a run never changes once the run starts, so this preserves DOM-node reuse (and therefore expand state) while a run streams — same mechanism as before, correct key.
- Bundled adjacent fix: a finalized-empty `assistant-message` (an iteration that only emitted tool calls, no prose) is suppressed instead of rendering a blank chat bubble. Streaming-empty ones (the typing-cursor container) still render. Suppression runs **before** grouping — if a finalized-empty message was the only thing separating two runs, they merge into one block once it's removed.

## Scope

Render-layer only, as required by A5: diff is limited to `packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx` + its sibling test. Zero diff in `packages/shared/`, `packages/server/`, `packages/embedded-agent/`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` (full monorepo suite) — all client/shared/integration/embedded-agent tests pass; 1 pre-existing server-package failure (`MultiUserMode > Issue #918 ... SSH_AUTH_SOCK`) reproduces identically on `main` HEAD with this branch's changes stashed — confirmed unrelated (host 1Password SSH agent socket leaking into `process.env` inside the test process; this PR touches zero server files)
- [x] TDD polarity check: new/revised tests for multi-block grouping and suppress-then-group ordering fail against the pre-fix (`turnId`-keyed) logic and pass with the fix
- [x] 6 new/revised unit tests covering: multi-block chronological grouping, finalized-empty suppression, suppress-then-group merge, streaming-empty preserved, A3' key stability, replay/live parity for the multi-block case
- [x] Manual Browser QA on an isolated dev instance (separate ports + `AGENT_CONSOLE_HOME`, local mock OpenAI-compatible SSE provider) driving a real multi-iteration turn end-to-end through the actual server → embedded-agent subprocess → MCP tools → WebSocket → client pipeline — confirmed two chronologically-ordered Working blocks around narration, empty-bubble suppression, and expand-state preserved across a live follow-up message

## Note on CodeRabbit

Local CodeRabbit CLI could not complete interactive auth in this headless worktree session (`coderabbit auth status` reports `signed out`; login requires an interactive browser flow unavailable here). The GitHub-side bot hit its PR review rate limit at PR open (13:45:44 UTC, "next review available in 33 minutes"). After the recovery window elapsed, `@coderabbitai review` was posted to retrigger (14:22 UTC); the bot replied "Review finished" but submitted no actual review (`reviewDecision` stayed empty, `reviews`/`latestReviews` stayed empty) — its incremental-review policy treats the original rate-limited event as an already-reviewed commit and declines to re-review, per this repo's documented `coderabbit-ops` "abandon-and-proceed" case.

**No CodeRabbit feedback is obtainable from either source for this PR.** Disposition follows existing PR Merge Authority (orchestrator / owner decision), per the `coderabbit-ops` skill's simultaneous-rate-limit disposition. CI (all 7 checks), typecheck, full test suite, and manual Browser QA are otherwise clean — see Test plan above.

## Note on integration test coverage

`preflight-check.js` flagged the usual "no integration test changes" advisory for a UI component diff. Not applicable here: this is a pure render-layer regrouping of already-delivered `EmbeddedAgentChatEntry[]` data with no new wire/schema shape (A5 scope restriction), so it's exhaustively covered by the client unit test suite; there is no new client/server boundary to exercise at the integration layer.

Closes #1092


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Working activity is now grouped into separate accordions when interrupted by narration or other content.
  * Empty finalized assistant messages no longer create unnecessary chat bubbles or split working activity.
  * Streaming assistant responses with no text continue to display a typing indicator.
  * Accordion state remains stable as new activity is added.

* **Tests**
  * Added coverage for repeated working sections, message ordering, empty messages, and live-versus-replay rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
