### PR TITLE
fix: align MessagePanel textarea with icon/Send buttons on the row baseline (closes #1093)

### DIFF
--- a/packages/client/src/components/sessions/MessagePanel.tsx
+++ b/packages/client/src/components/sessions/MessagePanel.tsx
@@ -320,7 +320,7 @@ export const MessagePanel = forwardRef<MessagePanelHandle, MessagePanelProps>(
             aria-label="Message input"
             placeholder="Send message to worker... (Ctrl+Enter to send)"
             rows={1}
-            className="w-full bg-slate-700 text-white text-sm rounded px-2 py-1 border border-slate-600 placeholder-gray-500 resize-none overflow-y-auto"
+            className="block w-full bg-slate-700 text-white text-sm rounded px-2 py-1 border border-slate-600 placeholder-gray-500 resize-none overflow-y-auto"
             style={{ maxHeight: '120px' }}
           />
         </div>

--- a/packages/client/src/components/sessions/__tests__/MessagePanel.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/MessagePanel.test.tsx
@@ -193,6 +193,19 @@ describe('MessagePanel', () => {
     expect(view.getByText('Send')).toBeTruthy();
   });
 
+  it('renders the message textarea with `block` display so it aligns with the icon/Send buttons on the row baseline', async () => {
+    // Regression test for #1093: a textarea without an explicit `display`
+    // utility defaults to `inline-block`, which reserves descender strut
+    // space in its wrapper and shifts the textarea ~6px above the
+    // bottom-aligned icon/Send buttons in the `items-end` row. `block`
+    // removes the inline formatting context that causes the misalignment.
+    const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
+    const view = within(container);
+
+    const textarea = view.getByLabelText('Message input');
+    expect(textarea.className.split(/\s+/)).toContain('block');
+  });
+
   it('renders file attach button', async () => {
     const { container } = await act(async () => renderWithRouter(<MessagePanel {...defaultProps} />));
     const view = within(container);


### PR DESCRIPTION
## Summary

- Pre-existing cosmetic bug: in `MessagePanel`, the message textarea and the adjacent icon buttons (template/attach) + Send button did not sit on the same vertical baseline inside the `flex items-end` row.
- Root cause: the textarea had no explicit `display` utility, so it rendered as the browser default `inline-block` inside its wrapper `<div className="flex-1 relative">`. An `inline-block` element with default `vertical-align: baseline` inside a block formatting context reserves descender-strut space based on the wrapper's inherited font metrics. That inflated the wrapper's rendered height (36px) beyond the textarea's own content height (30px), visually shifting the textarea ~6px above the bottom-aligned icon/Send buttons in the `items-end` row.
- Fix: add the `block` Tailwind utility class to the textarea, removing the inline formatting context. Verified live via `getBoundingClientRect`/`getComputedStyle` in a running dev instance: after the fix, the textarea's bottom edge becomes pixel-perfect flush with the icon/Send buttons' bottom edges (previously a 6px gap). A small ~2px difference remains between the textarea's top edge and the buttons' top edge — expected, since the textarea has a 1px top+bottom border that the icon/Send buttons do not.
- No height, padding, or border values were changed — purely a `display` property fix.

## Root cause detail

```
Before: row height 36px (wrapper 36px, buttons 28px, misaligned bottoms by 6px)
After:  row height 30px (wrapper 30px == textarea's own content height, buttons 28px, bottoms flush)
```

## Test plan

- [x] Added a regression test in `packages/client/src/components/sessions/__tests__/MessagePanel.test.tsx` asserting the message textarea carries the `block` class. TDD polarity confirmed: fails without the fix, passes with it.
- [x] `bun run typecheck` — exit 0, all packages.
- [x] `bun run test` (full suite) — exit 0. client 1864 pass, shared 518 pass, integration 63 pass, server 3427 pass / 1 skip, embedded-agent 189 pass, scripts/hooks 427 pass — 0 fail across all packages.
- [x] Manual Browser QA on an isolated dev instance, in the actual embedded-agent worker view (the same view referenced in the Issue screenshot) — reproduced the misalignment on the unmodified code, then confirmed the fix resolves it via live DOM experiment before delegating the code change, and re-confirmed against the final committed code via HMR. Before/after screenshots captured (zoomed 3x on the message-panel row for clarity); test session/worker paused and cleaned up afterward, no test artifacts left running.
- [ ] Integration test — preflight flagged an advisory "integration test gap" for `MessagePanel.tsx` (generic UI-component heuristic). Judged not applicable: this is a pure CSS `display` property change with no state transition, form behavior, or wire/schema impact. The AC for this Issue explicitly scopes test coverage to a CSS-class-presence assertion for this class of cosmetic fix.

## Scope note

File-disjoint from the parallel #1092 PR — only `MessagePanel.tsx` (+ its test) touched, `EmbeddedAgentWorkerView.tsx` untouched.

## Note on CodeRabbit

Local CodeRabbit CLI requires interactive browser auth, which is unavailable in this headless worktree session (stuck at `awaiting_browser_auth`). Relying on the GitHub-side CodeRabbit bot review; will confirm `reviewDecision: APPROVED` before merge.

Closes #1093