### PR TITLE
fix: preserve initialPromptDelivered across session resume (closes #1100)

### DIFF
--- a/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
+++ b/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
@@ -507,6 +507,44 @@ describe('SessionPauseResumeService', () => {
       expect(activateTerminalMock.mock.calls[0][1].revived).toBe(true);
     });
 
+    // initialPromptDelivered must survive resume/restart so the
+    // embedded-agent worker's re-fire guard (`if (session.initialPromptDelivered)
+    // return;`) still holds after the session is reloaded from the database.
+    it('should preserve initialPromptDelivered when resuming a session', async () => {
+      const agentWorker = buildInternalAgentWorker({ id: 'w1' });
+      const restoredWorkers = new Map([['w1', agentWorker]]);
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-1',
+        serverPid: null,
+        pausedAt: '2026-01-01T00:00:00.000Z',
+        initialPromptDelivered: true,
+        workers: [buildPersistedAgentWorker({ id: 'w1', agentId: 'test-agent' })],
+      });
+
+      const setSessionMock = mock((_id: string, _session: InternalSession) => {});
+      const deps = createMockDeps({
+        setSession: setSessionMock,
+        sessionRepository: {
+          ...createMockDeps().sessionRepository,
+          findById: mock(async () => persisted),
+          update: mock(async () => true),
+        },
+        workerManager: {
+          killWorker: mock(async () => {}),
+          restoreWorkersFromPersistence: mock(() => restoredWorkers),
+          activateAgentWorkerPty: mock(async () => {}),
+          activateTerminalWorkerPty: mock(async () => {}),
+        } satisfies SessionPauseResumeDeps['workerManager'],
+      });
+      const service = new SessionPauseResumeService(deps);
+
+      await service.resumeSession('session-1');
+
+      expect(setSessionMock).toHaveBeenCalledTimes(1);
+      const [, internalSession] = setSessionMock.mock.calls[0];
+      expect(internalSession.initialPromptDelivered).toBe(true);
+    });
+
     it('should restore terminal workers during resume', async () => {
       const terminalWorker = buildInternalTerminalWorker({ id: 'w1' });
       const restoredWorkers = new Map([['w1', terminalWorker]]);

--- a/packages/server/src/services/session-pause-resume-service.ts
+++ b/packages/server/src/services/session-pause-resume-service.ts
@@ -220,6 +220,7 @@ export class SessionPauseResumeService {
       createdAt: persisted.createdAt,
       workers,
       initialPrompt: persisted.initialPrompt,
+      initialPromptDelivered: persisted.initialPromptDelivered,
       title: persisted.title,
       parentSessionId: persisted.parentSessionId,
       parentWorkerId: persisted.parentWorkerId,


### PR DESCRIPTION
## Summary
- `resumeSessionInternal()` rebuilt the in-memory `InternalSession` from the persisted DB row but did not copy `initialPromptDelivered`, so every resume (including a server restart) left it `undefined` on the in-memory session.
- This broke the embedded-agent worker's re-fire guard (`if (session.initialPromptDelivered) return;`), causing an already-delivered initial prompt to be re-sent — and the provider to re-respond — after a resume/restart, contrary to the documented design intent in `docs/design/embedded-agent-worker.md` Part II ("Never re-fires... this is intentional").
- Fix: copy `initialPromptDelivered: persisted.initialPromptDelivered` alongside the existing sibling field `initialPrompt: persisted.initialPrompt` in the `baseSession` object literal.

## Test plan
- [x] Added a polarity-flip regression test in `packages/server/src/services/__tests__/session-pause-resume-service.test.ts`: resumes a persisted session with `initialPromptDelivered: true` and asserts the `InternalSession` passed to `setSession` carries the flag through.
- [x] Verified polarity: `git stash` of only the production fix (test kept) → test **fails** (`Received: undefined`); `git stash pop` → test **passes**.
- [x] `bun run typecheck` — 0 errors across all packages.
- [x] Full suite (`bun run test`, with `SSH_AUTH_SOCK` unset to match CI) — all packages green (server 3428 pass/1 skip/0 fail, client 1863 pass, shared 518 pass, integration 63 pass, embedded-agent 189 pass, scripts/hooks 427 pass).

Closes #1100

---

**CodeRabbit note:** Both local CodeRabbit CLI and GitHub-side bot were rate-limited at this PR's review window (local CLI auth timed out; GitHub bot posted "review limit reached, next review available in 48 minutes"). No CodeRabbit feedback obtainable from either source at PR-open time. Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority).
