### PR TITLE
fix: remove max-width constraint on assistant message bubble

### DIFF
--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -214,7 +214,7 @@ function ChatEntryRow({ entry, onRestart }: ChatEntryRowProps) {
     case 'assistant-message':
       return (
         <div className="flex justify-start">
-          <div className="memo-content min-w-0 max-w-[80%] rounded-lg bg-slate-800 text-gray-100 px-3 py-2 text-sm">
+          <div className="memo-content min-w-0 rounded-lg bg-slate-800 text-gray-100 px-3 py-2 text-sm">
             <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
               {entry.text}
             </Markdown>

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -487,6 +487,30 @@ describe('EmbeddedAgentWorkerView', () => {
       expect(userBubble.className).toContain('whitespace-pre-wrap');
       expect(userBubble.className).toContain('[overflow-wrap:anywhere]');
     });
+
+    it('renders the assistant message bubble at full width (no max-w- constraint) while the user bubble keeps its max-w-[80%] cap (#1095)', async () => {
+      const { container } = renderView({ sessionId: 's12b', workerId: 'w12b' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const data = ndjson(
+        { v: 1, type: 'user-message', id: 'u1', text: 'hi' },
+        { v: 1, type: 'assistant-message', turnId: 't1', text: 'hello' },
+      );
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      const assistantBubble = container.querySelector('.memo-content');
+      expect(assistantBubble).not.toBeNull();
+      expect(assistantBubble?.className).not.toMatch(/max-w-/);
+
+      const userBubble = screen.getByText('hi');
+      expect(userBubble.className).toContain('max-w-[80%]');
+    });
   });
 
   describe('Thinking accordion (#1070)', () => {

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -511,6 +511,35 @@ describe('EmbeddedAgentWorkerView', () => {
       const userBubble = screen.getByText('hi');
       expect(userBubble.className).toContain('max-w-[80%]');
     });
+
+    it('keeps the wrap-enabling classes (.memo-content, min-w-0) on the assistant bubble for a long unbroken token at full width, with no max-w- constraint reintroduced (#1095)', async () => {
+      const { container } = renderView({ sessionId: 's12c', workerId: 'w12c' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      // A single unbroken token (no spaces) long enough that, without
+      // overflow-wrap:anywhere on `.memo-content` (styles.css) plus
+      // min-w-0 on the flex item, it would force the bubble wider than
+      // its container per the CSS Flexbox/Sizing spec (see the #1071
+      // comment in styles.css). happy-dom does not load external
+      // stylesheets, so this test cannot observe the actual wrap layout;
+      // it locks in that the classes the CSS rule depends on remain
+      // present once the max-w- cap is removed.
+      const longToken = 'https://example.com/' + 'a'.repeat(300);
+      const data = ndjson({ v: 1, type: 'assistant-message', turnId: 't1', text: longToken });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      const assistantBubble = container.querySelector('.memo-content');
+      expect(assistantBubble).not.toBeNull();
+      expect(assistantBubble?.className).toContain('min-w-0');
+      expect(assistantBubble?.className).not.toMatch(/max-w-/);
+      expect(assistantBubble?.textContent).toContain(longToken);
+    });
   });
 
   describe('Thinking accordion (#1070)', () => {


### PR DESCRIPTION
## Summary

- Removes the `max-w-[80%]` class from the assistant-message chat bubble in `EmbeddedAgentWorkerView.tsx` so it spans the full available width, instead of leaving unused whitespace on the right.
- User messages are untouched: they keep their right-aligned, `max-w-[80%]`-constrained bubble (chat convention preserved).
- No changes to background color, padding, or border-radius.

## Verification

- `bun run typecheck` — clean (all packages).
- `bun run test` (full suite) — client/shared/integration/embedded-agent all green. One **pre-existing, unrelated** failure in `packages/server/src/services/__tests__/multi-user-mode.test.ts` (Issue #918, the non-elevated direct path ignoring `sshAuthSockFallback`), caused by this dogfood machine's real 1Password SSH agent socket leaking into `process.env.SSH_AUTH_SOCK`, which the test doesn't isolate. Confirmed via baseline comparison (`git stash` -> same failure on unmodified tree -> `git stash pop`) that it is unrelated to this diff.
- TDD polarity confirmed: the new regression test fails against the unmodified bubble className and passes after the fix.

## Test plan

- [x] Unit test added: `renders the assistant message bubble at full width (no max-w- constraint) while the user bubble keeps its max-w-[80%] cap (#1095)` in `EmbeddedAgentWorkerView.test.tsx`.
- [x] Browser QA (real dev server + real production WebSocket/embedded-agent pipeline, Chrome DevTools MCP) — see screenshots comment below, covering:
  - Before: assistant bubble capped at 80% width
  - After: assistant bubble spans full width; user bubble unchanged
  - Long unbroken token still wraps correctly at full width (`overflow-wrap: anywhere` from #1071 intact)

Closes #1095

## Note on CodeRabbit
Local CodeRabbit CLI timed out (rate-limited). GitHub-side bot reviewed the first commit and left 2 findings (1 Major, 1 Minor); both addressed in commit bc8dd8c and confirmed/withdrawn by the bot itself in-thread. The bot then hit its own review-limit on the incremental re-review of bc8dd8c ("Next review available in: 50 minutes"), so no top-level APPROVED verdict was submitted (reviewDecision stays empty). Per coderabbit-ops troubleshooting (simultaneous CLI+bot rate-limit / abandon-the-wait dispositions): pre-merge checks are 5/5 passed, and all actionable inline comments are resolved/withdrawn by the bot's own confirmation. Proceeding under existing PR Merge Authority.