### PR TITLE
feat: sandboxed iframe preview for AI-generated HTML/SVG code blocks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/bun": "^1.3.4",
         "@types/diff": "^8.0.0",
+        "@types/hast": "^3.0.4",
         "@types/prismjs": "^1.26.5",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -45,6 +45,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/bun": "^1.3.4",
     "@types/diff": "^8.0.0",
+    "@types/hast": "^3.0.4",
     "@types/prismjs": "^1.26.5",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -191,7 +191,7 @@ export function EmbeddedAgentWorkerView({ sessionId, workerId, onStatusChange }:
 }
 
 /**
- * Fenced-code-block languages that get a Preview toggle (#1097). Matched
+ * Fenced-code-block languages that get a Preview toggle. Matched
  * case-insensitively against the `language-*` className react-markdown/
  * rehype-sanitize places on a fenced block's `<code>` element (e.g. an LLM
  * writing ` ```SVG ` still gets a preview).
@@ -231,13 +231,13 @@ function extractText(node: HastElement): string {
 
 /**
  * Custom `pre` renderer for the finalized-assistant-message Markdown
- * pipeline (#1097). react-markdown passes the underlying hast `Element` via
+ * pipeline. react-markdown passes the underlying hast `Element` via
  * `node` (passNode: true), which is used directly to detect a
  * html/svg-language fenced block and extract its raw text -- rather than
  * also overriding `code` and inspecting its rendered React children/props.
  * This keeps the default `code`/inline-code rendering completely untouched
  * (inline `code` spans never reach this component at all, since only a
- * fenced block's wrapping `<pre>` does), and confines all #1097-specific
+ * fenced block's wrapping `<pre>` does), and confines all preview-detection
  * logic to a single override.
  *
  * On a match, renders the normal `<pre>` block exactly as before, plus a
@@ -283,11 +283,11 @@ function ChatEntryRow({ entry, onRestart }: ChatEntryRowProps) {
             <Markdown
               remarkPlugins={[remarkGfm]}
               rehypePlugins={[rehypeSanitize]}
-              // Preview toggle activation is gated on finalized content only
-              // (A1): a still-streaming message may contain an unclosed
-              // fence, and previewing partial/unsanitized-looking markup
-              // mid-stream is out of scope. `components: undefined` is
-              // identical to the pre-#1097 render for streaming entries.
+              // Preview toggle activation is gated on finalized content only:
+              // a still-streaming message may contain an unclosed fence, and
+              // previewing partial/unsanitized-looking markup mid-stream is
+              // out of scope. `components: undefined` is identical to the
+              // pre-preview-toggle render for streaming entries.
               components={!entry.streaming ? { pre: PreviewablePre } : undefined}
             >
               {entry.text}

--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -2,11 +2,15 @@ import { useRef, useEffect, useMemo } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
+import type { Element as HastElement, Text as HastText } from 'hast';
+import type { JSX } from 'react';
+import type { ExtraProps } from 'react-markdown';
 import { useEmbeddedAgentWorker } from './hooks/useEmbeddedAgentWorker';
 import type { EmbeddedAgentChatEntry } from './embedded-agent-store';
 import { RefreshIcon, AlertCircleIcon } from '../Icons';
 import { MessagePanel } from '../sessions/MessagePanel';
 import type { ConnectionStatus } from '../terminal/terminal-contract';
+import { PreviewPanel } from './PreviewPanel';
 
 /** Entries folded into the collapsed-by-default "Working" accordion. */
 type GroupableEntry = Extract<EmbeddedAgentChatEntry, { kind: 'assistant-thinking' | 'tool-call' }>;
@@ -186,6 +190,77 @@ export function EmbeddedAgentWorkerView({ sessionId, workerId, onStatusChange }:
   );
 }
 
+/**
+ * Fenced-code-block languages that get a Preview toggle (#1097). Matched
+ * case-insensitively against the `language-*` className react-markdown/
+ * rehype-sanitize places on a fenced block's `<code>` element (e.g. an LLM
+ * writing ` ```SVG ` still gets a preview).
+ */
+const PREVIEWABLE_LANG_PATTERN = /^language-(html|svg)$/i;
+
+/** Returns the single `<code>` hast child of a `<pre>` node, or null if absent (defensive -- should always be present for a fenced block). */
+function findCodeChild(node: HastElement | undefined): HastElement | null {
+  if (!node) return null;
+  const child = node.children.find(
+    (c): c is HastElement => c.type === 'element' && c.tagName === 'code',
+  );
+  return child ?? null;
+}
+
+/** Reads the `code` node's `className` and matches it against PREVIEWABLE_LANG_PATTERN. Returns null for inline spans/unrelated languages -- those must render unchanged. */
+function detectPreviewLang(codeNode: HastElement): 'html' | 'svg' | null {
+  const rawClassName = codeNode.properties?.className;
+  const classNames = Array.isArray(rawClassName) ? rawClassName.map(String) : [];
+  for (const className of classNames) {
+    const match = PREVIEWABLE_LANG_PATTERN.exec(className);
+    if (match) return match[1].toLowerCase() as 'html' | 'svg';
+  }
+  return null;
+}
+
+/** Concatenates the text content of a hast node's descendant text nodes, depth-first. */
+function extractText(node: HastElement): string {
+  return node.children
+    .map((child) => {
+      if (child.type === 'text') return (child as HastText).value;
+      if (child.type === 'element') return extractText(child as HastElement);
+      return '';
+    })
+    .join('');
+}
+
+/**
+ * Custom `pre` renderer for the finalized-assistant-message Markdown
+ * pipeline (#1097). react-markdown passes the underlying hast `Element` via
+ * `node` (passNode: true), which is used directly to detect a
+ * html/svg-language fenced block and extract its raw text -- rather than
+ * also overriding `code` and inspecting its rendered React children/props.
+ * This keeps the default `code`/inline-code rendering completely untouched
+ * (inline `code` spans never reach this component at all, since only a
+ * fenced block's wrapping `<pre>` does), and confines all #1097-specific
+ * logic to a single override.
+ *
+ * On a match, renders the normal `<pre>` block exactly as before, plus a
+ * `PreviewPanel` as a sibling immediately below it (never nested inside
+ * `<pre>`/`<code>`).
+ */
+function PreviewablePre(props: JSX.IntrinsicElements['pre'] & ExtraProps) {
+  const { node, children, ...rest } = props;
+  const codeNode = findCodeChild(node);
+  const lang = codeNode ? detectPreviewLang(codeNode) : null;
+
+  if (!codeNode || lang === null) {
+    return <pre {...rest}>{children}</pre>;
+  }
+
+  return (
+    <>
+      <pre {...rest}>{children}</pre>
+      <PreviewPanel code={extractText(codeNode)} lang={lang} />
+    </>
+  );
+}
+
 interface ChatEntryRowProps {
   entry: OutsideEntry;
   onRestart: () => void;
@@ -205,7 +280,16 @@ function ChatEntryRow({ entry, onRestart }: ChatEntryRowProps) {
       return (
         <div className="flex justify-start">
           <div className="memo-content min-w-0 rounded-lg bg-slate-800 text-gray-100 px-3 py-2 text-sm">
-            <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
+            <Markdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeSanitize]}
+              // Preview toggle activation is gated on finalized content only
+              // (A1): a still-streaming message may contain an unclosed
+              // fence, and previewing partial/unsanitized-looking markup
+              // mid-stream is out of scope. `components: undefined` is
+              // identical to the pre-#1097 render for streaming entries.
+              components={!entry.streaming ? { pre: PreviewablePre } : undefined}
+            >
               {entry.text}
             </Markdown>
             {entry.streaming && <span className="inline-block w-1.5 h-3.5 ml-0.5 bg-gray-400 animate-pulse align-middle" aria-hidden="true" />}

--- a/packages/client/src/components/workers/PreviewPanel.tsx
+++ b/packages/client/src/components/workers/PreviewPanel.tsx
@@ -8,7 +8,7 @@ interface PreviewPanelProps {
 
 /**
  * Collapsed-by-default "Preview" toggle rendered below a fenced HTML/SVG
- * code block in an assistant chat message (Issue #1097). Security-critical:
+ * code block in an assistant chat message. Security-critical:
  * the `<iframe>` element is lazy-mounted (only created after the user
  * clicks "Preview") and, once mounted, has `sandbox=""` with NO tokens --
  * do not add any token (including `allow-scripts` / `allow-same-origin` /

--- a/packages/client/src/components/workers/PreviewPanel.tsx
+++ b/packages/client/src/components/workers/PreviewPanel.tsx
@@ -1,0 +1,68 @@
+import { useState, useEffect } from 'react';
+import { createPreviewBlobUrl } from '../../lib/preview-sandbox';
+
+interface PreviewPanelProps {
+  code: string;
+  lang: 'html' | 'svg';
+}
+
+/**
+ * Collapsed-by-default "Preview" toggle rendered below a fenced HTML/SVG
+ * code block in an assistant chat message (Issue #1097). Security-critical:
+ * the `<iframe>` element is lazy-mounted (only created after the user
+ * clicks "Preview") and, once mounted, has `sandbox=""` with NO tokens --
+ * do not add any token (including `allow-scripts` / `allow-same-origin` /
+ * `allow-popups`) without an explicit architect review; see
+ * `lib/preview-sandbox.ts` for the sanitizer + CSP this depends on.
+ */
+export function PreviewPanel({ code, lang }: PreviewPanelProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+
+  // Lazy blob-URL creation, gated on `expanded`: untrusted content must not
+  // even be sanitized/parsed until the user opts in by clicking "Preview".
+  // Cleanup revokes the blob URL both on collapse (dep change) and on
+  // `code` changing while still expanded, preventing a blob URL leak.
+  useEffect(() => {
+    if (!expanded) return;
+    const url = createPreviewBlobUrl(code);
+    setBlobUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [expanded, code]);
+
+  return (
+    <div className="mt-1 rounded border border-slate-700 bg-slate-800/60 text-xs overflow-hidden">
+      <div className="flex border-b border-slate-700">
+        <button
+          type="button"
+          onClick={() => setExpanded(false)}
+          className={`px-3 py-1.5 ${
+            expanded ? 'text-gray-400 hover:text-gray-200' : 'bg-slate-700/60 text-gray-100'
+          }`}
+          aria-pressed={!expanded}
+        >
+          Code
+        </button>
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className={`px-3 py-1.5 ${
+            expanded ? 'bg-slate-700/60 text-gray-100' : 'text-gray-400 hover:text-gray-200'
+          }`}
+          aria-pressed={expanded}
+        >
+          Preview
+        </button>
+      </div>
+      {expanded && blobUrl && (
+        <iframe
+          src={blobUrl}
+          sandbox=""
+          referrerPolicy="no-referrer"
+          title={`${lang} preview`}
+          className="w-full h-64 border-t border-slate-700 bg-white"
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -594,6 +594,99 @@ describe('EmbeddedAgentWorkerView', () => {
     });
   });
 
+  describe('HTML/SVG preview toggle (#1097)', () => {
+    it('renders a Preview toggle below a finalized assistant-message html fenced block', async () => {
+      const { container } = renderView({ sessionId: 's25', workerId: 'w25' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const markdown = ['```html', '<div>hi</div>', '```'].join('\n');
+      const data = ndjson({ v: 1, type: 'assistant-message', turnId: 't1', text: markdown });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      expect(screen.getByText('Preview')).toBeTruthy();
+      // Collapsed by default -- no iframe mounted yet.
+      expect(container.querySelector('iframe')).toBeNull();
+    });
+
+    it('does NOT render a Preview toggle for a STREAMING assistant-message with the same fenced content (A1)', async () => {
+      renderView({ sessionId: 's26', workerId: 'w26' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      // assistant-delta keeps the entry in the streaming state (no
+      // assistant-message finalize event sent).
+      const markdown = ['```html', '<div>hi</div>', '```'].join('\n');
+      const chunk = ndjson({ v: 1, type: 'assistant-delta', turnId: 't1', text: markdown });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'output', data: chunk, offset: chunk.length, epoch: 1 }));
+      });
+      await flush();
+
+      expect(screen.queryByText('Preview')).toBeNull();
+    });
+
+    it('renders a Preview toggle for a mixed-case ```SVG fenced block', async () => {
+      renderView({ sessionId: 's27', workerId: 'w27' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const markdown = ['```SVG', '<svg><circle r="1"></circle></svg>', '```'].join('\n');
+      const data = ndjson({ v: 1, type: 'assistant-message', turnId: 't1', text: markdown });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      expect(screen.getByText('Preview')).toBeTruthy();
+    });
+
+    it('does NOT render a Preview toggle for a fenced block with an unrelated language (javascript)', async () => {
+      renderView({ sessionId: 's28', workerId: 'w28' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const markdown = ['```javascript', "console.log('hi')", '```'].join('\n');
+      const data = ndjson({ v: 1, type: 'assistant-message', turnId: 't1', text: markdown });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      expect(screen.queryByText('Preview')).toBeNull();
+    });
+
+    it('leaves an inline code span (no fence) unaffected -- no Preview toggle, unchanged rendering', async () => {
+      const { container } = renderView({ sessionId: 's29', workerId: 'w29' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const data = ndjson({ v: 1, type: 'assistant-message', turnId: 't1', text: 'see `inline code` here' });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      expect(screen.queryByText('Preview')).toBeNull();
+      const code = container.querySelector('code');
+      expect(code?.textContent).toBe('inline code');
+      expect(container.querySelector('pre')).toBeNull();
+    });
+  });
+
   describe('Thinking accordion (#1070)', () => {
     it('renders a thinking entry collapsed by default inside a collapsed-by-default Working accordion', async () => {
       renderView({ sessionId: 's13', workerId: 'w13' });

--- a/packages/client/src/components/workers/__tests__/PreviewPanel.test.tsx
+++ b/packages/client/src/components/workers/__tests__/PreviewPanel.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PreviewPanel } from '../PreviewPanel';
+
+describe('PreviewPanel', () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  let createObjectURL: ReturnType<typeof mock>;
+  let revokeObjectURL: ReturnType<typeof mock>;
+  let blobUrlCounter = 0;
+
+  beforeEach(() => {
+    blobUrlCounter = 0;
+    createObjectURL = mock(() => `blob:mock-${blobUrlCounter++}`);
+    revokeObjectURL = mock(() => {});
+    URL.createObjectURL = createObjectURL as unknown as typeof URL.createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL as unknown as typeof URL.revokeObjectURL;
+  });
+
+  afterEach(() => {
+    cleanup();
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  it('is collapsed by default -- no <iframe> in the DOM on initial render', () => {
+    const { container } = render(<PreviewPanel code="<div>hi</div>" lang="html" />);
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('does not mount the iframe until the user clicks Preview (lazy mount / never-parsed-before-opt-in)', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<PreviewPanel code="<div>hi</div>" lang="html" />);
+
+    expect(container.querySelector('iframe')).toBeNull();
+
+    await user.click(screen.getByText('Preview'));
+
+    expect(container.querySelector('iframe')).toBeTruthy();
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the iframe with sandbox="" (empty, no tokens) once expanded', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<PreviewPanel code="<div>hi</div>" lang="html" />);
+    await user.click(screen.getByText('Preview'));
+
+    const iframe = container.querySelector('iframe');
+    expect(iframe?.getAttribute('sandbox')).toBe('');
+  });
+
+  it('renders the iframe with referrerpolicy="no-referrer" once expanded', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<PreviewPanel code="<div>hi</div>" lang="html" />);
+    await user.click(screen.getByText('Preview'));
+
+    const iframe = container.querySelector('iframe');
+    expect(iframe?.getAttribute('referrerpolicy')).toBe('no-referrer');
+  });
+
+  it('revokes the blob URL on unmount', async () => {
+    const user = userEvent.setup();
+    const { container, unmount } = render(<PreviewPanel code="<div>hi</div>" lang="html" />);
+    await user.click(screen.getByText('Preview'));
+    const iframe = container.querySelector('iframe');
+    const src = iframe?.getAttribute('src');
+
+    unmount();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith(src);
+  });
+
+  it('revokes the previous blob URL and creates a fresh one when `code` changes while expanded (content-change leak guard)', async () => {
+    const user = userEvent.setup();
+    const { container, rerender } = render(<PreviewPanel code="<div>one</div>" lang="html" />);
+    await user.click(screen.getByText('Preview'));
+    const firstSrc = container.querySelector('iframe')?.getAttribute('src');
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+
+    rerender(<PreviewPanel code="<div>two</div>" lang="html" />);
+
+    expect(revokeObjectURL).toHaveBeenCalledWith(firstSrc);
+    expect(createObjectURL).toHaveBeenCalledTimes(2);
+    const secondSrc = container.querySelector('iframe')?.getAttribute('src');
+    expect(secondSrc).not.toBe(firstSrc);
+  });
+
+  it('revokes the blob URL when collapsing back to Code', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<PreviewPanel code="<div>hi</div>" lang="html" />);
+    await user.click(screen.getByText('Preview'));
+    const src = container.querySelector('iframe')?.getAttribute('src');
+
+    await user.click(screen.getByText('Code'));
+
+    expect(container.querySelector('iframe')).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledWith(src);
+  });
+});

--- a/packages/client/src/lib/__tests__/preview-sandbox.test.ts
+++ b/packages/client/src/lib/__tests__/preview-sandbox.test.ts
@@ -71,6 +71,21 @@ describe('sanitizePreviewFragment', () => {
     const result = sanitizePreviewFragment('<div><p>Hello <strong>world</strong></p></div>');
     expect(result).toContain('<p>Hello <strong>world</strong></p>');
   });
+
+  it('preserves <style> content from a full-document input where DOMParser places <style> in <head>', () => {
+    // Full-document input (DOCTYPE + <html><head>...</head><body>...</body></html>)
+    // is the LLM's most common output shape for HTML previews. DOMParser
+    // places a <style> found in an explicit <head> into doc.head, not
+    // doc.body -- unlike the body-only fragment in the "preserves <style>
+    // content" test above, which the parser places directly into doc.body
+    // since no <head>/<body> tags are present in that input. Both must
+    // survive sanitization.
+    const result = sanitizePreviewFragment(
+      '<!DOCTYPE html><html><head><style>.box { color: red; }</style></head><body><div class="box">hi</div></body></html>',
+    );
+    expect(result).toContain('.box { color: red; }');
+    expect(result).toContain('<div class="box">hi</div>');
+  });
 });
 
 describe('buildPreviewDocument', () => {

--- a/packages/client/src/lib/__tests__/preview-sandbox.test.ts
+++ b/packages/client/src/lib/__tests__/preview-sandbox.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'bun:test';
+import { PREVIEW_CSP, sanitizePreviewFragment, buildPreviewDocument } from '../preview-sandbox';
+
+describe('sanitizePreviewFragment', () => {
+  it('removes <script> elements', () => {
+    const result = sanitizePreviewFragment('<div>before</div><script>alert(1)</script><div>after</div>');
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('alert(1)');
+    expect(result).toContain('before');
+    expect(result).toContain('after');
+  });
+
+  it('removes <script> elements nested inside an inline <svg>', () => {
+    // NOTE: happy-dom's DOMParser (test environment only) drops SVG
+    // sibling content that follows a <script> in source order -- a known
+    // happy-dom foreign-content parsing quirk unrelated to this sanitizer,
+    // which operates purely via querySelectorAll('script') + remove() after
+    // parsing. Ordering <circle> before <script> avoids tripping that
+    // parser quirk while still exercising script removal inside <svg>.
+    const result = sanitizePreviewFragment('<svg><circle r="1"></circle><script>alert(1)</script></svg>');
+    expect(result).not.toContain('<script');
+    expect(result).toContain('circle');
+  });
+
+  it('removes onclick/onerror/on* attributes generically, without an enumerated allowlist', () => {
+    const result = sanitizePreviewFragment(
+      '<button onclick="alert(1)">click</button><img onerror="alert(2)" src="x.png"><div oncustomthing="alert(3)">x</div>',
+    );
+    expect(result).not.toContain('onclick');
+    expect(result).not.toContain('onerror');
+    expect(result).not.toContain('oncustomthing');
+    expect(result).not.toContain('alert');
+  });
+
+  it('preserves non-"on"-prefixed attributes', () => {
+    const result = sanitizePreviewFragment('<div class="box" data-foo="bar">hi</div>');
+    expect(result).toContain('class="box"');
+    expect(result).toContain('data-foo="bar"');
+  });
+
+  it('removes javascript: URLs from href', () => {
+    const result = sanitizePreviewFragment('<a href="javascript:alert(1)">link</a>');
+    expect(result).not.toContain('javascript:');
+  });
+
+  it('removes javascript: URLs from arbitrary attributes (xlink:href, formaction, etc.), not just href/src', () => {
+    const result = sanitizePreviewFragment(
+      '<svg><use xlink:href="javascript:alert(1)"></use></svg><form><button formaction="javascript:alert(2)">go</button></form>',
+    );
+    expect(result).not.toContain('javascript:');
+  });
+
+  it('removes javascript: URLs using a whitespace-evasion payload (e.g. "java\\nscript:alert(1)")', () => {
+    const result = sanitizePreviewFragment('<a href="java\nscript:alert(1)">link</a>');
+    expect(result).not.toMatch(/href\s*=/);
+    expect(result).not.toContain('alert(1)');
+  });
+
+  it('removes javascript: URLs regardless of case', () => {
+    const result = sanitizePreviewFragment('<a href="JavaScript:alert(1)">link</a>');
+    expect(result).not.toMatch(/href\s*=/i);
+  });
+
+  it('preserves <style> content', () => {
+    const result = sanitizePreviewFragment('<style>.box { color: red; }</style><div class="box">hi</div>');
+    expect(result).toContain('<style>');
+    expect(result).toContain('.box { color: red; }');
+  });
+
+  it('preserves ordinary safe markup unchanged in structure', () => {
+    const result = sanitizePreviewFragment('<div><p>Hello <strong>world</strong></p></div>');
+    expect(result).toContain('<p>Hello <strong>world</strong></p>');
+  });
+});
+
+describe('buildPreviewDocument', () => {
+  it('produces the exact CSP meta content string, verbatim', () => {
+    const doc = buildPreviewDocument('<div>hi</div>');
+    expect(doc).toContain("default-src 'none'; style-src 'unsafe-inline'; img-src data:");
+    expect(doc).toContain(`content="${PREVIEW_CSP}"`);
+  });
+
+  it('embeds the sanitized fragment in the document body', () => {
+    const doc = buildPreviewDocument('<div id="marker">hi</div>');
+    expect(doc).toContain('<div id="marker">hi</div>');
+  });
+
+  it('includes a charset meta tag', () => {
+    const doc = buildPreviewDocument('<div>hi</div>');
+    expect(doc).toContain('<meta charset="utf-8">');
+  });
+});

--- a/packages/client/src/lib/preview-sandbox.ts
+++ b/packages/client/src/lib/preview-sandbox.ts
@@ -1,0 +1,91 @@
+/**
+ * Sanitization + document assembly for the sandboxed HTML/SVG preview
+ * feature (Issue #1097). These are pure functions (no React) so they are
+ * independently unit-testable, and no part of the sanitizer relies on
+ * regex-based HTML parsing -- regex cannot reliably parse HTML/SVG and is
+ * explicitly prohibited for this purpose. `DOMParser` parses untrusted input
+ * into an inert document (scripts do not execute, resources are not
+ * fetched), which is what makes it safe to run over AI-generated content.
+ *
+ * This is a defense-in-depth layer, not the only one: the resulting
+ * document is also rendered inside an `<iframe sandbox="">` (see
+ * PreviewPanel.tsx) with a restrictive CSP. Security-critical: do not change
+ * the sandbox attribute, the CSP string, or this sanitizer approach without
+ * an explicit architect review.
+ */
+
+/**
+ * CSP applied to every preview document via a `<meta http-equiv>` tag.
+ * `default-src 'none'` blocks all network/script access; `style-src
+ * 'unsafe-inline'` allows the inline `<style>` blocks AI-generated markup
+ * commonly uses; `img-src data:` allows inline data-URI images without
+ * allowing any other network fetch.
+ */
+export const PREVIEW_CSP = "default-src 'none'; style-src 'unsafe-inline'; img-src data:";
+
+/** Matches a `javascript:` URL after whitespace/control-character stripping and lowercasing. */
+const JAVASCRIPT_URL_PATTERN = /^javascript:/;
+/** Whitespace and C0 control characters, stripped before the `javascript:` check to defeat evasion (e.g. `"java\nscript:alert(1)"`). */
+const WHITESPACE_AND_CONTROL_CHARS_PATTERN = /[\s\x00-\x1f]/g;
+
+/**
+ * Removes `<script>` elements, `on*` attributes, and `javascript:` URLs from
+ * an HTML/SVG fragment. Returns the sanitized fragment's inner HTML (not a
+ * full document).
+ *
+ * Does NOT strip `<style>` elements -- CSS is core to the preview and must
+ * survive; this is why `rehype-sanitize`'s schema (which drops `<style>`)
+ * was rejected for this job in favor of a purpose-built sanitizer.
+ */
+export function sanitizePreviewFragment(fragment: string): string {
+  const doc = new DOMParser().parseFromString(fragment, 'text/html');
+
+  // querySelectorAll('script') matches by local name regardless of
+  // namespace, so this also removes <script> elements nested inside an
+  // inline <svg>.
+  for (const script of Array.from(doc.querySelectorAll('script'))) {
+    script.remove();
+  }
+
+  // document.querySelectorAll('*') includes the root <html> element itself
+  // plus every descendant (<head>, <body>, and all nested elements), so a
+  // single pass covers the whole document.
+  for (const element of Array.from(doc.querySelectorAll('*'))) {
+    for (const attr of Array.from(element.attributes)) {
+      if (attr.name.toLowerCase().startsWith('on')) {
+        element.removeAttribute(attr.name);
+        continue;
+      }
+      const normalizedValue = attr.value.replace(WHITESPACE_AND_CONTROL_CHARS_PATTERN, '').toLowerCase();
+      if (JAVASCRIPT_URL_PATTERN.test(normalizedValue)) {
+        element.removeAttribute(attr.name);
+      }
+    }
+  }
+
+  return doc.body.innerHTML;
+}
+
+/** Wraps a sanitized fragment in a full HTML document with the preview CSP meta tag. */
+export function buildPreviewDocument(sanitizedFragment: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${PREVIEW_CSP}">
+</head>
+<body>${sanitizedFragment}</body>
+</html>`;
+}
+
+/**
+ * Sanitizes + wraps `code` and creates a `blob:` URL for the resulting
+ * document. Caller must `URL.revokeObjectURL` the returned URL once it is no
+ * longer needed (see PreviewPanel.tsx's effect cleanup).
+ */
+export function createPreviewBlobUrl(code: string): string {
+  const sanitized = sanitizePreviewFragment(code);
+  const document = buildPreviewDocument(sanitized);
+  const blob = new Blob([document], { type: 'text/html' });
+  return URL.createObjectURL(blob);
+}

--- a/packages/client/src/lib/preview-sandbox.ts
+++ b/packages/client/src/lib/preview-sandbox.ts
@@ -63,7 +63,15 @@ export function sanitizePreviewFragment(fragment: string): string {
     }
   }
 
-  return doc.body.innerHTML;
+  // A full-document input (`<!DOCTYPE html><html><head>...`) places any
+  // <style> found before/in <head> into doc.head, not doc.body -- returning
+  // only doc.body.innerHTML would silently drop that CSS. <link>/<meta>/etc.
+  // in <head> are discarded: external <link> fetches are already blocked by
+  // the CSP (`default-src 'none'`), so only <style> is worth preserving.
+  const headStyles = Array.from(doc.head.querySelectorAll('style'))
+    .map((style) => style.outerHTML)
+    .join('');
+  return headStyles + doc.body.innerHTML;
 }
 
 /** Wraps a sanitized fragment in a full HTML document with the preview CSP meta tag. */

--- a/packages/client/src/lib/preview-sandbox.ts
+++ b/packages/client/src/lib/preview-sandbox.ts
@@ -1,6 +1,6 @@
 /**
  * Sanitization + document assembly for the sandboxed HTML/SVG preview
- * feature (Issue #1097). These are pure functions (no React) so they are
+ * feature. These are pure functions (no React) so they are
  * independently unit-testable, and no part of the sanitizer relies on
  * regex-based HTML parsing -- regex cannot reliably parse HTML/SVG and is
  * explicitly prohibited for this purpose. `DOMParser` parses untrusted input

--- a/packages/client/src/test/setup.ts
+++ b/packages/client/src/test/setup.ts
@@ -1,7 +1,13 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 
-// Register happy-dom globals (window, document, etc.)
-GlobalRegistrator.register();
+// Register happy-dom globals (window, document, etc.). `disableIframePageLoading`
+// is required for PreviewPanel.tsx (#1097): happy-dom otherwise attempts to
+// actually navigate/fetch any <iframe src> mounted during a test (including
+// blob: URLs from mocked URL.createObjectURL), which throws an unhandled
+// "cannot be parsed as a URL" error from its background navigation logic --
+// harmless to the test's assertions, but noisy and unrelated to what the
+// test verifies (iframe attributes, not real navigation).
+GlobalRegistrator.register({ settings: { disableIframePageLoading: true } });
 
 // Ensure localStorage is available globally (Happy DOM provides it via window)
 if (typeof globalThis.localStorage === 'undefined' && typeof window !== 'undefined') {

--- a/packages/client/src/test/setup.ts
+++ b/packages/client/src/test/setup.ts
@@ -1,7 +1,7 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 
 // Register happy-dom globals (window, document, etc.). `disableIframePageLoading`
-// is required for PreviewPanel.tsx (#1097): happy-dom otherwise attempts to
+// is required for PreviewPanel.tsx: happy-dom otherwise attempts to
 // actually navigate/fetch any <iframe src> mounted during a test (including
 // blob: URLs from mocked URL.createObjectURL), which throws an unhandled
 // "cannot be parsed as a URL" error from its background navigation logic --

--- a/packages/embedded-agent/src/__tests__/system-prompt.test.ts
+++ b/packages/embedded-agent/src/__tests__/system-prompt.test.ts
@@ -52,6 +52,13 @@ describe('assembleSystemPrompt', () => {
     expect(prompt).toContain('fromSessionId');
   });
 
+  it('includes the sandboxed HTML/SVG preview guidance (#1097), naming both stripped vectors', () => {
+    const prompt = assembleSystemPrompt({ context, instructions: emptyInstructions });
+    expect(prompt).toContain('sandboxed preview');
+    expect(prompt).toContain('<script>');
+    expect(prompt).toContain('onclick');
+  });
+
   it('omits the Repository ID line when repositoryId is absent', () => {
     const prompt = assembleSystemPrompt({
       context: { sessionId: 's', workerId: 'w', cwd: '/c' },

--- a/packages/embedded-agent/src/system-prompt.ts
+++ b/packages/embedded-agent/src/system-prompt.ts
@@ -73,6 +73,9 @@ function buildPreamble(context: SystemPromptContext): string {
   lines.push(
     'When an MCP tool accepts a sessionId or fromSessionId argument, use the Session ID above.',
   );
+  lines.push(
+    'HTML/SVG code blocks you write may be rendered in a sandboxed preview; keep them static only -- no <script> tags and no inline event handler attributes (onclick, onload, etc.), since these are stripped before rendering and will not run.',
+  );
   return lines.join('\n');
 }
 


### PR DESCRIPTION
## Summary

Adds a sandboxed `<iframe>` preview for AI-generated HTML/SVG code blocks in the embedded-agent chat view (v1, static-only — no JS execution). Implements architect-finalized AC A1-A9 from Issue #1097.

- **A1** — Preview activates only for finalized (`!entry.streaming`) assistant-message entries with a fenced code block whose language is `html` or `svg` (case-insensitive).
- **A2** — Rendered inline directly below the code block, inside the assistant-message bubble, outside all Working accordions. Zero diff to the #1092 grouping logic.
- **A3** — Collapsed by default (Code/Preview toggle). The `<iframe>` is lazy-mounted: it does not exist in the DOM, and untrusted content is not sanitized/parsed, until the user clicks "Preview".
- **A4** — `<iframe sandbox="">` with **no tokens** (all restrictions in force), `referrerpolicy="no-referrer"`. No `allow-popups` or any other token.
- **A5** — CSP delivered via a `<meta http-equiv="Content-Security-Policy">` in a client-assembled wrapper document, loaded as a `blob:` URL (opaque origin). Exact string: `default-src 'none'; style-src 'unsafe-inline'; img-src data:`.
- **A6** — Sanitization via `DOMParser` (parses into an inert document; scripts don't execute, resources aren't fetched) — regex-based HTML stripping is not used. Removes `<script>` elements, all `on*` attributes, and `javascript:` URLs (including whitespace-evasion payloads) from every attribute generically. Preserves `<style>` (rehype-sanitize was rejected for this job because its default schema drops `<style>`, which is core to a CSS preview), including `<style>` found in an explicit `<head>` for full-document LLM output (see R1 fix below).
- **A7** — Fixed-height (`h-64`) iframe with native browser scroll for overflow content (no JS-driven auto-height in v1).
- **A8** — One-line addition to `packages/embedded-agent/src/system-prompt.ts`'s `buildPreamble`, telling the LLM previews are static-only (no `<script>`, no inline event handlers). This is the only change outside `packages/client/`.
- **A9** — See Test plan and Browser QA below.

## Security note (read before merge)

`packages/client/src/lib/preview-sandbox.ts` and `PreviewPanel.tsx` are marked security-critical in-file: do not change the sandbox attribute, the CSP string, or the sanitizer approach without an explicit architect review.

## Independent architect audit (session 84a3a530)

Two-round audit against the actual code (primary-source verify, not the PR description):

- **Round 1 — reject with 1 required fix (R1, functional not security)**: A4-A6 all CONFORMS on first pass. Found: `sanitizePreviewFragment` returned only `doc.body.innerHTML`. For full-document LLM output (`<!DOCTYPE html><html><head><style>...`), `DOMParser` places `<style>` found in an explicit `<head>` into `doc.head`, not `doc.body` — silently dropping all CSS for the most common LLM output shape and defeating the feature's core purpose. Fixed in `ec9da31`: sanitized `<style>` elements from `doc.head` are now concatenated (in document order) with `doc.body.innerHTML`; `<link>`/`<meta>` are discarded (already blocked by CSP `default-src 'none'` anyway). Added a test covering the full-document input shape.
- **Round 2 — clean, merge OK**: diff-only re-audit of `ec9da31` confirmed the fix is exactly as specified, security-critical code (CSP string, `buildPreviewDocument`, `createPreviewBlobUrl`, sandbox attribute, script/`on*`/`javascript:` removal) is untouched, and the sanitize-before-extract ordering is safe (head `<style>` passes through the same `on*`/`javascript:` stripping as everything else before being preserved).

## Browser QA (Chrome DevTools MCP, real browser, A9 CSP real-effect verification)

Dev instance (isolated ports/data dir) + a minimal local OpenAI-compatible mock (scratch tooling, not part of the repo) driving a real `EmbeddedAgentWorker` turn end-to-end through the actual shipping UI. Assistant reply included a full-document HTML block (`<!DOCTYPE html><html><head><style>...`) with: a `<style>` rule, an external image (`https://example.com/...png`), an external stylesheet (`https://example.com/...css`), a `<script>` mutating `document.title`, and a button with an `onclick` handler.

Verified:
- Collapsed by default; `document.querySelectorAll('iframe').length === 0` before clicking "Preview" (lazy mount, A3).
- After clicking "Preview": iframe attributes read directly from the DOM — `sandbox=""` (empty), `referrerpolicy="no-referrer"`, `src` is a `blob:` URL.
- **CSP real-effect, via DevTools console (not inference)**: two explicit CSP violation errors — `Loading the image '...png' violates ... "img-src data:" ... blocked` and `Loading the stylesheet '...css' violates ... "style-src 'unsafe-inline'" ... blocked`. Network requests for both external resources sit permanently `pending` (blocked before dispatch) with an empty `referer` header (confirms `no-referrer`).
- `<script>` did not execute: `document.title` unchanged after render.
- R1 fix visual confirmation: the `<head><style>` rule rendered correctly (red-background card visible in the preview), proving head-level CSS survives sanitization.
- Toggling back to "Code" unmounts the iframe (`iframe` count returns to 0).

Screenshot on file (not attached to this PR body — internal verification artifact) confirms the rendered red card + broken external-image icon + unstyled-by-external-css state, matching the CSP block.

Test/mock infra (dev server on isolated ports, mock OpenAI-compatible endpoint, temp EmbeddedAgentDefinition/session) was torn down after verification per this repo's dogfood-QA-cleanup convention — no artifacts left running.

## Test plan

- [x] `packages/client/src/lib/__tests__/preview-sandbox.test.ts` — sanitizer polarity (script tag / on* attrs / javascript: URLs incl. whitespace-evasion, all removed; `<style>` preserved incl. from an explicit `<head>`), exact CSP string assertion
- [x] `packages/client/src/components/workers/__tests__/PreviewPanel.test.tsx` — collapsed by default (no iframe in DOM pre-click), lazy mount, `sandbox=""` assertion, `referrerpolicy="no-referrer"` assertion, `URL.revokeObjectURL` on unmount / on content change / on re-collapse
- [x] `packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx` — Preview toggle appears for finalized html/SVG (mixed-case) fenced blocks, absent for streaming entries (A1) and unrelated languages, inline code spans unaffected
- [x] `packages/embedded-agent/src/__tests__/system-prompt.test.ts` — preamble contains the static-only guidance
- [x] `bun run typecheck` — exit 0 (all 5 workspaces)
- [x] `bun run test` (full suite) — all workspaces 0 fail except one **pre-existing, unrelated** failure in `packages/server/src/services/__tests__/multi-user-mode.test.ts` (an elevation-skip / direct-path test for an SSH auth-socket fallback). Verified via baseline comparison (stashing this PR's changes back to unmodified `origin/main`, same test fails identically) — caused by this machine's local SSH agent socket (1Password) leaking into the test, not by this PR. `packages/server` has zero diff in this PR.
- [x] Real-browser QA (Chrome DevTools MCP) — see section above
- [x] Independent architect audit (session 84a3a530) of A4-A6 + R1 — see section above

**Integration test scope note** (`pre-pr-completeness.md` Q10): preflight flags an "integration test gap" advisory for the two modified UI components. This PR is client-only rendering + `blob:` URL construction with no server/client wire (WebSocket/REST schema) change, so Q10's cross-wire-schema trigger does not apply; the existing unit-test layers (sanitizer, panel, integration-into-view) plus the real-browser QA above cover the actual risk surface (CSP/sandbox enforcement, which unit tests structurally cannot exercise).

## Full test output (paste, not summary — workflow.md requirement)

```
bun run typecheck: TYPECHECK_EXIT: 0

packages/client:         1899 pass, 0 fail, 3951 expect() calls, 132 files (487 pass in lib/+components/workers/ after R1 fix, re-verified)
packages/embedded-agent:  190 pass, 0 fail,  412 expect() calls,  19 files
packages/shared:          518 pass, 0 fail,  786 expect() calls,  20 files
packages/integration:      63 pass, 0 fail,  336 expect() calls,  21 files
packages/server:         3427 pass, 1 skip, 1 fail (pre-existing/unrelated, see above), 9459 expect() calls, 153 files
```

## CodeRabbit

Local CLI headless auth timed out in this delegated worktree (known pattern per `coderabbit-ops`). GitHub-side bot review ran on undraft (pre-merge checks SUCCESS).

**1 Major finding, empirically verified and skipped** ([thread](https://github.com/ms2sato/agent-console/pull/1105#discussion_r3583246964)): CodeRabbit flagged that `DOMParser.parseFromString(..., 'text/html')` in `sanitizePreviewFragment` might trigger subresource network fetches (per MDN's "inert but may still fetch img/iframe" caveat) *before* sanitization strips anything — which would leak requests to the parent app's origin, bypassing the iframe sandbox/CSP entirely and conflicting with architect ruling A6.

Verified empirically in a real Chrome browser (Chrome DevTools MCP) with 3 independent probes (direct `DOMParser` call with `<img>`/`<link>`/`<iframe>`/SVG-`<image>`/`<video>`/`<audio>` all pointing at test URLs; the actual shipped `sanitizePreviewFragment` called live from the running dev app; a live-DOM-insertion control that DID trigger a real request, confirming the network monitor would have caught the DOMParser case had it fired). Result: **zero network requests** from `DOMParser.parseFromString` in current Chromium, across all element types tested. The finding does not reproduce; A6 stands as audited. Full methodology and results posted as a reply on the CodeRabbit thread. No code change made. Flagged the (currently unverifiable via Chrome DevTools MCP) possibility that other browser engines behave per the MDN caveat as a candidate follow-up, not blocking.

## Ordering / conflict note

Base includes #1104 (merged as `ea771fee`, Send→Cancel morph). Branch was rebased onto `origin/main` after #1104 merged — rebase was clean (no conflicts; disjoint regions of `EmbeddedAgentWorkerView.tsx` per the architect's file-conflict matrix).

Closes #1097