### PR TITLE
test: add embedded-agent-store coverage for non-zero-fromOffset resume

### DIFF
--- a/packages/client/src/components/workers/__tests__/embedded-agent-store.test.ts
+++ b/packages/client/src/components/workers/__tests__/embedded-agent-store.test.ts
@@ -423,6 +423,53 @@ describe('embedded-agent-store', () => {
     expect(secondWs).not.toBe(firstWs);
   });
 
+  it('preserves accumulated entries on a plain reconnect resume (fromOffset > 0, same epoch, startOffset === requestedFromOffset)', async () => {
+    // Complements the epoch-bump tests below: this is the common-case
+    // reconnect (no server restart) where the client already has some
+    // history cached and asks only for the tail. Issue #1021/#1022's
+    // CRITICAL/MAJOR bugs were both in the epoch-reset paths; this test
+    // pins down the plain incremental-resume path so a future change to
+    // applyBytes's `isFresh` logic can't silently start resetting it too.
+    const instance = getOrCreateEmbeddedAgentWorker('s17c', 'w17c');
+    const ws1 = MockWebSocket.getLastInstance();
+    ws1!.simulateOpen();
+
+    const initialData = ndjson({ v: 1, type: 'user-message', id: 'u1', text: 'first' });
+    ws1!.simulateMessage(historyMessage(initialData, initialData.length, 0, 1));
+    await flush();
+    const entriesAfterFirst = instance.getSnapshot().entries;
+    expect(entriesAfterFirst).toHaveLength(1);
+    const firstEntryRef = entriesAfterFirst[0];
+
+    // Force a fresh WS connection without an epoch bump (a plain reconnect,
+    // e.g. a dropped connection resuming) -- lastOffset carries over from
+    // the prior connection.
+    instance.restart();
+    const ws2 = MockWebSocket.getLastInstance();
+    expect(ws2).not.toBe(ws1);
+    ws2!.simulateOpen();
+
+    const sent = lastSentMessages(ws2!);
+    expect(sent).toContainEqual({ type: 'request-history', fromOffset: initialData.length });
+
+    // The server's response starts exactly where requested (not a fresh
+    // load) and carries only the new tail.
+    const tailData = ndjson({ v: 1, type: 'user-message', id: 'u2', text: 'second' });
+    ws2!.simulateMessage(
+      historyMessage(tailData, initialData.length + tailData.length, initialData.length, 1),
+    );
+    await flush();
+
+    const entriesAfterSecond = instance.getSnapshot().entries;
+    // The pre-existing entry is the SAME object reference -- proof
+    // resetChatState was NOT invoked (a reset replaces `entries` with a
+    // brand-new empty array, which would also change this reference).
+    expect(entriesAfterSecond[0]).toBe(firstEntryRef);
+    expect(entriesAfterSecond).toHaveLength(2);
+    expect(entriesAfterSecond[0]).toMatchObject({ kind: 'user-message', text: 'first' });
+    expect(entriesAfterSecond[1]).toMatchObject({ kind: 'user-message', text: 'second' });
+  });
+
   it('resets accumulated entries on an epoch bump (worker restarted server-side)', async () => {
     const instance = getOrCreateEmbeddedAgentWorker('s17', 'w17');
     const ws = MockWebSocket.getLastInstance();


### PR DESCRIPTION
## Summary
- Adds a regression test for `embedded-agent-store.ts`'s plain incremental-resume reconnect path: `fromOffset > 0`, same epoch, `startOffset === requestedFromOffset` (not a fresh load).
- Asserts that accumulated chat entries are preserved (same object reference, not reset) and only the new tail is folded in — a bug in this path would silently start resetting history on every ordinary reconnect.

## Context
Non-blocking follow-up from the architect's audit of PR #1022 (Issue #1021, umbrella #1004). The existing suite covers the epoch-reset / fresh-history-load paths thoroughly, but had no test dedicated to the common-case reconnect (no server restart) where the client resumes from a non-zero offset. Both CRITICAL/MAJOR bugs found during PR #1022's review cycle were in the epoch-reset paths — this test closes the gap on the sibling path.

Note: the target file lives in `packages/client/src/components/workers/` (frontend), not `packages/server/` as the issue's file-pattern guess assumed. Confirmed with the Orchestrator to proceed as this delegate (test-only, no production code change).

## Test plan
- [x] New test passes against current code
- [x] Polarity verified: temporarily stubbed `applyBytes`'s `isFresh` branch to always-true, confirmed the new test fails, reverted, confirmed it passes again
- [x] `bun run test` (full suite) — 0 failures (one pre-existing environment-only failure in `multi-user-mode.test.ts` due to local `SSH_AUTH_SOCK`/1Password, reproduced identically on `main` via `git stash` baseline comparison — unrelated to this change)
- [x] `bun run typecheck` — 0 errors
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (no production files changed; language/duplication checks pass)

No production code was changed.

Closes #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that reconnecting without an epoch change preserves existing chat entries.
  * Confirmed that newly received events are appended without resetting previously displayed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->