### PR TITLE
fix: preserve embedded-agent chat draft when the server rejects a send

### DIFF
--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -243,14 +243,14 @@ describe('EmbeddedAgentWorkerView', () => {
     expect(sent.some((m) => m.type === 'embedded-user-message')).toBe(false);
   });
 
-  it('sends a message on Ctrl+Enter and clears the draft', async () => {
+  it('sends a message on Ctrl+Enter but keeps the draft until the server confirms it, then clears it (#1024)', async () => {
     renderView({ sessionId: 's4', workerId: 'w4' });
     const ws = MockWebSocket.getLastInstance();
     act(() => {
       ws?.simulateOpen();
     });
 
-    const textarea = screen.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)');
+    const textarea = screen.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)') as HTMLTextAreaElement;
     await act(async () => {
       fireEvent.change(textarea, { target: { value: 'hello agent' } });
     });
@@ -260,7 +260,47 @@ describe('EmbeddedAgentWorkerView', () => {
 
     const sent = (ws!.send.mock.calls as string[][]).map((c) => JSON.parse(c[0]));
     expect(sent).toContainEqual({ type: 'embedded-user-message', text: 'hello agent' });
-    expect((textarea as HTMLTextAreaElement).value).toBe('');
+    // Not yet cleared -- the server hasn't confirmed the send. Clearing here
+    // optimistically is exactly the bug #1024 reports.
+    expect(textarea.value).toBe('hello agent');
+
+    // Server echoes the message back, confirming it was accepted.
+    const data = ndjson({ v: 1, type: 'user-message', id: 'u1', text: 'hello agent' });
+    await act(async () => {
+      ws?.simulateMessage(JSON.stringify({ type: 'output', data, offset: data.length, epoch: 1 }));
+    });
+    await flush();
+
+    expect(textarea.value).toBe('');
+  });
+
+  it('preserves the draft when the server rejects the send (TURN_IN_PROGRESS), letting the user retry without retyping (#1024)', async () => {
+    renderView({ sessionId: 's4b', workerId: 'w4b' });
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+    });
+
+    const textarea = screen.getByPlaceholderText('Send message to worker... (Ctrl+Enter to send)') as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'hello agent' } });
+    });
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+    });
+
+    await act(async () => {
+      ws?.simulateMessage(
+        JSON.stringify({ type: 'error', message: 'turn in progress', code: 'TURN_IN_PROGRESS' }),
+      );
+    });
+    await flush();
+
+    // The draft must survive the rejection -- the user should not have to retype it.
+    expect(textarea.value).toBe('hello agent');
+    // The Send button must be usable again, not stuck disabled from the failed send's `sending` state.
+    const sendButton = screen.getByText('Send') as HTMLButtonElement;
+    expect(sendButton.disabled).toBe(false);
   });
 
   it('renders a turn-in-progress error non-fatally, with a Dismiss action, keeping entries', async () => {

--- a/packages/client/src/components/workers/__tests__/embedded-agent-store.test.ts
+++ b/packages/client/src/components/workers/__tests__/embedded-agent-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import type { AppServerMessage } from '@agent-console/shared';
+import { WS_CLOSE_CODE, type AppServerMessage } from '@agent-console/shared';
 import { MockWebSocket, installMockWebSocket } from '../../../test/mock-websocket';
 import {
   getOrCreateEmbeddedAgentWorker,
@@ -487,6 +487,72 @@ describe('embedded-agent-store', () => {
       instance.dispose();
 
       await expect(sendPromise).rejects.toThrow();
+    });
+
+    it('rejects a pending send when the socket closes with a no-reconnect close code (architect audit R1a)', async () => {
+      const instance = getOrCreateEmbeddedAgentWorker('s36', 'w36');
+      const ws = MockWebSocket.getLastInstance();
+      ws!.simulateOpen();
+
+      const sendPromise = instance.sendUserMessage('hello agent');
+      // No reconnect will follow this code, so no future echo/error can ever
+      // settle the pending send.
+      ws!.simulateClose(WS_CLOSE_CODE.NORMAL_CLOSURE);
+
+      await expect(sendPromise).rejects.toThrow();
+    });
+
+    it('rejects a pending send when the socket closes after noReconnect was latched by a prior fatal error (architect audit R1a)', async () => {
+      const instance = getOrCreateEmbeddedAgentWorker('s36b', 'w36b');
+      const ws = MockWebSocket.getLastInstance();
+      ws!.simulateOpen();
+
+      // Latches noReconnect without itself leaving a pending send behind.
+      ws!.simulateMessage(JSON.stringify({ type: 'error', message: 'session deleted', code: 'SESSION_DELETED' }));
+
+      const sendPromise = instance.sendUserMessage('hello agent');
+      ws!.simulateClose();
+
+      await expect(sendPromise).rejects.toThrow();
+    });
+
+    it('rejects a pending send when a same-epoch reconnect\'s history reply carries no confirming echo (architect audit R1b)', async () => {
+      const instance = getOrCreateEmbeddedAgentWorker('s37', 'w37');
+      const firstWs = MockWebSocket.getLastInstance();
+      firstWs!.simulateOpen();
+
+      const sendPromise = instance.sendUserMessage('hello agent');
+
+      // Connection drops before the server received the write; a fresh
+      // connection is established for the SAME epoch (no epoch bump).
+      instance.restart();
+      const secondWs = MockWebSocket.getLastInstance();
+      secondWs!.simulateOpen();
+
+      // The reconnect's history reply covers everything from offset 0, but
+      // contains no echo of the message -- the write never reached the server.
+      secondWs!.simulateMessage(historyMessage('', 0, 0, 1));
+
+      await expect(sendPromise).rejects.toThrow();
+    });
+
+    it('resolves a pending send when a same-epoch reconnect\'s history reply DOES carry the confirming echo (architect audit R1b, positive polarity)', async () => {
+      const instance = getOrCreateEmbeddedAgentWorker('s37b', 'w37b');
+      const firstWs = MockWebSocket.getLastInstance();
+      firstWs!.simulateOpen();
+
+      const sendPromise = instance.sendUserMessage('hello agent');
+
+      // The write DID reach the server before the connection dropped -- the
+      // reconnect's history reply replays it back.
+      instance.restart();
+      const secondWs = MockWebSocket.getLastInstance();
+      secondWs!.simulateOpen();
+
+      const data = ndjson({ v: 1, type: 'user-message', id: 'u1', text: 'hello agent' });
+      secondWs!.simulateMessage(historyMessage(data, data.length, 0, 1));
+
+      await expect(sendPromise).resolves.toBeUndefined();
     });
   });
 

--- a/packages/client/src/components/workers/__tests__/embedded-agent-store.test.ts
+++ b/packages/client/src/components/workers/__tests__/embedded-agent-store.test.ts
@@ -394,10 +394,100 @@ describe('embedded-agent-store', () => {
     const ws = MockWebSocket.getLastInstance();
     ws!.simulateOpen();
 
-    instance.sendUserMessage('hello agent');
+    // Never confirmed within this test -- swallow the eventual dispose-time
+    // rejection (afterEach's _resetEmbeddedAgentWorkers) so it doesn't
+    // surface as an unhandled rejection.
+    instance.sendUserMessage('hello agent').catch(() => {});
 
     const sent = lastSentMessages(ws!);
     expect(sent).toContainEqual({ type: 'embedded-user-message', text: 'hello agent' });
+  });
+
+  describe('sendUserMessage confirmation (#1024: preserve draft on reject)', () => {
+    it('resolves once the server echoes the message back as a user-message event', async () => {
+      const instance = getOrCreateEmbeddedAgentWorker('s30', 'w30');
+      const ws = MockWebSocket.getLastInstance();
+      ws!.simulateOpen();
+
+      const sendPromise = instance.sendUserMessage('hello agent');
+      let settled = false;
+      sendPromise.then(() => {
+        settled = true;
+      });
+      await flush();
+      // Not yet confirmed -- the server hasn't echoed the message back.
+      expect(settled).toBe(false);
+
+      const data = ndjson({ v: 1, type: 'user-message', id: 'u1', text: 'hello agent' });
+      ws!.simulateMessage(outputMessage(data, data.length));
+
+      await expect(sendPromise).resolves.toBeUndefined();
+    });
+
+    it('rejects when the server rejects the send (e.g. TURN_IN_PROGRESS)', async () => {
+      const instance = getOrCreateEmbeddedAgentWorker('s31', 'w31');
+      const ws = MockWebSocket.getLastInstance();
+      ws!.simulateOpen();
+
+      const sendPromise = instance.sendUserMessage('hello agent');
+      ws!.simulateMessage(
+        JSON.stringify({ type: 'error', message: 'turn in progress', code: 'TURN_IN_PROGRESS' }),
+      );
+
+      await expect(sendPromise).rejects.toThrow();
+    });
+
+    it('rejects immediately when the socket is not open', async () => {
+      const instance = getOrCreateEmbeddedAgentWorker('s32', 'w32');
+      // Deliberately do NOT simulateOpen(): the socket stays CONNECTING.
+
+      await expect(instance.sendUserMessage('hello agent')).rejects.toThrow();
+    });
+
+    it('rejects a pending send when the worker epoch resets (server restart) before confirmation', async () => {
+      const instance = getOrCreateEmbeddedAgentWorker('s33', 'w33');
+      const ws = MockWebSocket.getLastInstance();
+      ws!.simulateOpen();
+
+      // Establish the baseline epoch (1) via the initial history response.
+      ws!.simulateMessage(historyMessage('', 0, 0, 1));
+      await flush();
+
+      const sendPromise = instance.sendUserMessage('hello agent');
+
+      // A larger epoch than recorded means the worker restarted server-side.
+      const data = ndjson({ v: 1, type: 'ready' });
+      ws!.simulateMessage(JSON.stringify({ type: 'output', data, offset: data.length, epoch: 2 }));
+
+      await expect(sendPromise).rejects.toThrow();
+    });
+
+    it('rejects a still-pending prior send when a newer send starts first (defensive, no hanging promise)', async () => {
+      const instance = getOrCreateEmbeddedAgentWorker('s34', 'w34');
+      const ws = MockWebSocket.getLastInstance();
+      ws!.simulateOpen();
+
+      const first = instance.sendUserMessage('first');
+      const second = instance.sendUserMessage('second');
+
+      await expect(first).rejects.toThrow();
+
+      const data = ndjson({ v: 1, type: 'user-message', id: 'u2', text: 'second' });
+      ws!.simulateMessage(outputMessage(data, data.length));
+
+      await expect(second).resolves.toBeUndefined();
+    });
+
+    it('rejects a pending send on dispose (cleanup, no hanging promise)', async () => {
+      const instance = getOrCreateEmbeddedAgentWorker('s35', 'w35');
+      const ws = MockWebSocket.getLastInstance();
+      ws!.simulateOpen();
+
+      const sendPromise = instance.sendUserMessage('hello agent');
+      instance.dispose();
+
+      await expect(sendPromise).rejects.toThrow();
+    });
   });
 
   it('cancel serializes the embedded-cancel client message', () => {

--- a/packages/client/src/components/workers/embedded-agent-store.ts
+++ b/packages/client/src/components/workers/embedded-agent-store.ts
@@ -327,8 +327,16 @@ class EmbeddedAgentController implements EmbeddedAgentInstance {
       if (this.disposed) return;
       this.ws = null;
       this.updateStatus('disconnected');
-      if (this.noReconnect) return;
-      if (!shouldReconnect(event.code)) return;
+      if (this.noReconnect) {
+        // No reconnect will ever happen, so no future echo/error can settle
+        // a pending send -- reject now rather than hanging forever.
+        this.rejectPendingSend('Connection closed before the message was confirmed');
+        return;
+      }
+      if (!shouldReconnect(event.code)) {
+        this.rejectPendingSend('Connection closed before the message was confirmed');
+        return;
+      }
       this.scheduleReconnect();
     };
   }
@@ -523,8 +531,17 @@ class EmbeddedAgentController implements EmbeddedAgentInstance {
     } else {
       this.patch({ loadingHistory: false });
     }
-    // A `history` response (startOffset is only ever set for those, never
-    // for live `output`) that lands while an epoch resync is outstanding
+    // A history response (startOffset is only ever set for those, never for
+    // live `output`) covers everything the server has from `requestedFromOffset`
+    // onward. If a send confirmation is still pending after folding it, the
+    // write must have been lost when the connection dropped before the
+    // server received it (an accepted send's echo would already have
+    // resolved it via foldEvent's user-message case above) -- reject so the
+    // caller doesn't hang waiting for a confirmation that will never arrive.
+    if (typeof startOffset === 'number') {
+      this.rejectPendingSend('Reconnected but the message was not confirmed');
+    }
+    // A `history` response that lands while an epoch resync is outstanding
     // completes that resync: replay whatever output arrived and was queued
     // in the meantime, now that we know exactly what this history payload
     // already covers.

--- a/packages/client/src/components/workers/embedded-agent-store.ts
+++ b/packages/client/src/components/workers/embedded-agent-store.ts
@@ -74,7 +74,7 @@ export interface EmbeddedAgentInstance {
    * accepted), or rejects if the WS is not connected, the server rejects the
    * send (e.g. `TURN_IN_PROGRESS`), or the worker restarts before either
    * happens. Callers (MessagePanel via `onSend`) rely on rejection to avoid
-   * clearing the input draft -- see Issue #1024.
+   * clearing the input draft.
    */
   sendUserMessage(text: string): Promise<void>;
   /** Abort the in-flight turn (`embedded-cancel`). */

--- a/packages/client/src/components/workers/embedded-agent-store.ts
+++ b/packages/client/src/components/workers/embedded-agent-store.ts
@@ -68,8 +68,15 @@ export interface EmbeddedAgentSnapshot {
 export interface EmbeddedAgentInstance {
   subscribe(listener: () => void): () => void;
   getSnapshot(): EmbeddedAgentSnapshot;
-  /** Send a user message (`embedded-user-message`). */
-  sendUserMessage(text: string): void;
+  /**
+   * Send a user message (`embedded-user-message`). Resolves once the server
+   * has echoed the message back as a `user-message` event (confirmed
+   * accepted), or rejects if the WS is not connected, the server rejects the
+   * send (e.g. `TURN_IN_PROGRESS`), or the worker restarts before either
+   * happens. Callers (MessagePanel via `onSend`) rely on rejection to avoid
+   * clearing the input draft -- see Issue #1024.
+   */
+  sendUserMessage(text: string): Promise<void>;
   /** Abort the in-flight turn (`embedded-cancel`). */
   cancel(): void;
   /**
@@ -147,6 +154,12 @@ class EmbeddedAgentController implements EmbeddedAgentInstance {
   private resyncing = false;
   private queuedOutput: Array<{ data: string; offset: number }> = [];
 
+  // Tracks the in-flight sendUserMessage promise, if any (§ sendUserMessage
+  // doc comment). Only one send can be outstanding at a time in practice --
+  // MessagePanel disables the Send button while its own onSend promise is
+  // pending -- so a single slot (rather than a queue/map) is sufficient.
+  private pendingSend: { resolve: () => void; reject: (err: Error) => void } | null = null;
+
   private splitter = new NdjsonLineSplitter();
 
   // Index maps for folding streamed events into the entries array. Cleared
@@ -188,8 +201,19 @@ class EmbeddedAgentController implements EmbeddedAgentInstance {
 
   getSnapshot = (): EmbeddedAgentSnapshot => this.snapshot;
 
-  sendUserMessage = (text: string): void => {
-    this.send({ type: 'embedded-user-message', text });
+  sendUserMessage = (text: string): Promise<void> => {
+    // Defensive: superseded by the new send below. Should not happen in
+    // practice (MessagePanel disables Send while a prior send is pending)
+    // but avoids leaking an unsettled promise if it ever does.
+    this.rejectPendingSend('Superseded by a newer send');
+    return new Promise((resolve, reject) => {
+      const sent = this.send({ type: 'embedded-user-message', text });
+      if (!sent) {
+        reject(new Error('Not connected'));
+        return;
+      }
+      this.pendingSend = { resolve, reject };
+    });
   };
 
   cancel = (): void => {
@@ -231,6 +255,7 @@ class EmbeddedAgentController implements EmbeddedAgentInstance {
   dispose = (): void => {
     if (this.disposed) return;
     this.disposed = true;
+    this.rejectPendingSend('Worker disposed');
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     this.reconnectTimer = null;
     if (this.idleTimer) clearTimeout(this.idleTimer);
@@ -346,9 +371,23 @@ class EmbeddedAgentController implements EmbeddedAgentInstance {
     this.ws = null;
   }
 
-  private send(message: EmbeddedAgentSendMessage): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+  /** Returns whether the message was actually written to an open socket. */
+  private send(message: EmbeddedAgentSendMessage): boolean {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return false;
     this.ws.send(JSON.stringify(message));
+    return true;
+  }
+
+  private resolvePendingSend(): void {
+    if (!this.pendingSend) return;
+    this.pendingSend.resolve();
+    this.pendingSend = null;
+  }
+
+  private rejectPendingSend(message: string): void {
+    if (!this.pendingSend) return;
+    this.pendingSend.reject(new Error(message));
+    this.pendingSend = null;
   }
 
   private requestHistory(): void {
@@ -424,6 +463,10 @@ class EmbeddedAgentController implements EmbeddedAgentInstance {
   }
 
   private beginEpochReset(newEpoch: number): void {
+    // The worker restarted server-side; whatever send was in flight will
+    // never be echoed back in the old epoch. Reject so the caller (and
+    // MessagePanel's draft-preservation) doesn't hang forever.
+    this.rejectPendingSend('Worker restarted before the message was confirmed');
     this.resetChatState();
     this.epoch = newEpoch;
     this.lastOffset = 0;
@@ -586,6 +629,9 @@ class EmbeddedAgentController implements EmbeddedAgentInstance {
         return true;
       case 'user-message':
         this.pushEntry({ key: `user-${event.id}`, kind: 'user-message', id: event.id, text: event.text });
+        // Confirms this client's own sendUserMessage() was accepted; see the
+        // `pendingSend` field comment.
+        this.resolvePendingSend();
         return true;
       case 'exited':
         this.pushEntry({ key: `exited-${this.entryKeyCounter++}`, kind: 'exited', code: event.code });
@@ -720,6 +766,10 @@ class EmbeddedAgentController implements EmbeddedAgentInstance {
 
   private handleError(message: string, code?: WorkerErrorCode): void {
     this.patch({ workerError: { message, code } });
+    // A send-reject (e.g. TURN_IN_PROGRESS) arrives here, not as a
+    // rejected `send()` call -- reject the pending promise so MessagePanel
+    // preserves the input draft instead of clearing it optimistically.
+    this.rejectPendingSend(message);
     if (code === 'SESSION_DELETED' || code === 'SESSION_PAUSED') {
       this.noReconnect = true;
       if (this.reconnectTimer) {

--- a/packages/client/src/components/workers/hooks/__tests__/useEmbeddedAgentWorker.test.ts
+++ b/packages/client/src/components/workers/hooks/__tests__/useEmbeddedAgentWorker.test.ts
@@ -54,7 +54,10 @@ describe('useEmbeddedAgentWorker', () => {
     });
 
     act(() => {
-      result.current.sendUserMessage('hello');
+      // Never confirmed within this test -- swallow the eventual dispose-time
+      // rejection (afterEach's _resetEmbeddedAgentWorkers) so it doesn't
+      // surface as an unhandled rejection.
+      result.current.sendUserMessage('hello').catch(() => {});
     });
 
     const sent = (ws!.send.mock.calls as unknown as string[][]).map((c) => JSON.parse(c[0]));

--- a/packages/client/src/components/workers/hooks/useEmbeddedAgentWorker.ts
+++ b/packages/client/src/components/workers/hooks/useEmbeddedAgentWorker.ts
@@ -18,7 +18,7 @@ interface UseEmbeddedAgentWorkerReturn {
   activityState: AgentActivityState;
   workerError: { message: string; code?: WorkerErrorCode } | null;
   loadingHistory: boolean;
-  sendUserMessage: (text: string) => void;
+  sendUserMessage: (text: string) => Promise<void>;
   cancel: () => void;
   restart: () => void;
   retry: () => void;
@@ -49,8 +49,8 @@ export function useEmbeddedAgentWorker(
   }, [sessionId, workerId]);
 
   const sendUserMessage = useCallback(
-    (text: string) => {
-      getOrCreateEmbeddedAgentWorker(sessionId, workerId).sendUserMessage(text);
+    (text: string): Promise<void> => {
+      return getOrCreateEmbeddedAgentWorker(sessionId, workerId).sendUserMessage(text);
     },
     [sessionId, workerId],
   );


### PR DESCRIPTION
## Summary
- `useEmbeddedAgentWorker`'s send flow optimistically cleared the input draft as soon as the WebSocket write succeeded, before the server had a chance to accept or reject it -- a `TURN_IN_PROGRESS` rejection, a `MESSAGE_TOO_LARGE` rejection, or a momentarily-closed socket all lost the typed message.
- `EmbeddedAgentController.sendUserMessage` now returns a `Promise<void>` that resolves once the server echoes the message back as a confirmed `user-message` event, and rejects if the socket isn't open at send time, the server sends an `error` message while the send is outstanding, or the worker restarts (epoch reset) before either happens.
- `MessagePanel` already only clears the draft after its `onSend` promise resolves and preserves it on rejection (existing behavior) -- this fix makes the embedded-agent store's promise actually reflect server confirmation instead of resolving immediately on write.

## Test plan
- [x] TDD: added the confirmation-behavior tests first, verified them failing against the pre-fix `sendUserMessage` (fire-and-forget `void`), then confirmed they pass after the fix.
- [x] `embedded-agent-store.test.ts`: new `sendUserMessage confirmation` suite -- resolves on `user-message` echo, rejects on server `error`, rejects immediately when the socket isn't open, rejects a pending send on epoch reset (worker restart) and on dispose, defensive supersede when a new send starts before a prior one confirmed.
- [x] `EmbeddedAgentWorkerView.test.tsx`: updated the existing Ctrl+Enter send test to assert the draft is NOT cleared until the server confirms, then clears once confirmed; added the primary regression test -- draft is preserved (and Send button re-enabled) when the server rejects with `TURN_IN_PROGRESS`.
- [x] `bun run typecheck` -- clean across all packages.
- [x] `bun run test` -- full suite, 1907+518+63+3428(-1 pre-existing)+190 tests. One pre-existing, unrelated failure: `packages/server/src/services/__tests__/multi-user-mode.test.ts:1107` fails only because this dev shell has a real `SSH_AUTH_SOCK` (1Password agent socket) set in `process.env`, which leaks into the test's environment assumption; confirmed by re-running with `env -u SSH_AUTH_SOCK` -- all 37 tests in that file pass. Not touched by this diff.
- [x] `node .claude/skills/orchestrator/preflight-check.js` -- clean (no coverage gaps, no rule/skill duplication, no language violations, no blame-shift issue-refs).

Closes #1024

## Note on CodeRabbit
Local CodeRabbit CLI failed to authenticate in this headless worktree session (`automatic_login_failed` / no interactive browser). Relying on the GitHub-side CodeRabbit bot review.


Update: the GitHub-side bot also hit "Review limit reached" at PR open (next review available in 54 minutes per the bot's comment). Both local CodeRabbit CLI and GitHub-side bot were unavailable at this PR's review window. No CodeRabbit feedback obtainable from either source. Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority).


## Update: architect-audit R1 fix

Architect audit found 2 await-hang windows in the original fix (pending `sendUserMessage` promise could hang forever, keeping MessagePanel's Send button permanently disabled):
- (A) `onclose` branches that don't schedule a reconnect (`noReconnect` latched, or a close code `shouldReconnect()` excludes) never touched the pending send.
- (B) A same-epoch reconnect's history reply could complete with no confirming echo (write reached the socket but the connection dropped before the server received it), also leaving the pending send unsettled.

Both now reject explicitly. Added 4 new polarity tests (2 for A's sub-cases, 2 for B's reject/resolve pair). Re-verified: TDD polarity confirmed via a standalone repro script (bun:test's own `--timeout` did not reliably abort a test awaiting a truly-unsettled promise in this environment, so polarity was proven with a manual `Promise.race`-based timeout outside the test harness instead -- worth a look separately, unrelated to this PR's scope). `bun run typecheck` clean, `bun run test` full suite green (client: 1911 pass, up from 1907) except the same pre-existing unrelated `multi-user-mode.test.ts:1107` SSH_AUTH_SOCK environment failure noted above. `preflight-check.js` clean.
