### PR TITLE
fix: add per-file byte cap to embedded-agent Read tool

### DIFF
--- a/packages/embedded-agent/src/__tests__/truncate.test.ts
+++ b/packages/embedded-agent/src/__tests__/truncate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { truncateToBytes } from '../truncate.js';
+import { truncateToBytes, trimToUtf8Boundary } from '../truncate.js';
 
 const byteLen = (s: string) => new TextEncoder().encode(s).length;
 
@@ -39,5 +39,28 @@ describe('truncateToBytes', () => {
     expect(byteLen(r.text)).toBeLessThanOrEqual(16384);
     // No replacement character introduced by a mid-codepoint cut.
     expect(r.text.includes('�')).toBe(false);
+  });
+});
+
+describe('trimToUtf8Boundary', () => {
+  const encoder = new TextEncoder();
+
+  it('returns the input unchanged when it already fits', () => {
+    const bytes = encoder.encode('abcd');
+    expect(trimToUtf8Boundary(bytes, 10)).toBe(bytes);
+  });
+
+  it('backs off a raw byte buffer to a code-point boundary given a lookahead byte', () => {
+    // 'a' (1 byte) + 'あ' (3 bytes), over-read by 1 byte past the maxBytes cut
+    // so the boundary check can see into the split character.
+    const bytes = encoder.encode('aあ');
+    const trimmed = trimToUtf8Boundary(bytes, 2);
+    expect(new TextDecoder().decode(trimmed)).toBe('a');
+  });
+
+  it('keeps a whole multibyte character when the cut lands exactly after it', () => {
+    const bytes = encoder.encode('aあb'); // 'a'(1) + 'あ'(3) + 'b'(1) = 5 bytes
+    const trimmed = trimToUtf8Boundary(bytes, 4);
+    expect(new TextDecoder().decode(trimmed)).toBe('aあ');
   });
 });

--- a/packages/embedded-agent/src/tools/__tests__/read.test.ts
+++ b/packages/embedded-agent/src/tools/__tests__/read.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { readTool } from '../read.js';
+import { readTool, READ_MAX_BYTES } from '../read.js';
 
 describe('readTool', () => {
   let locationPath: string;
@@ -70,5 +70,60 @@ describe('readTool', () => {
     const result = await readTool.execute({ path: 'a.txt' }, { locationPath }, controller.signal);
 
     expect(result).toEqual({ ok: false, result: 'aborted' });
+  });
+
+  describe('byte cap', () => {
+    it('reads a file exactly at the cap unchanged, with no truncation notice', async () => {
+      const content = 'a'.repeat(READ_MAX_BYTES);
+      await fsPromises.writeFile(path.join(locationPath, 'exact.txt'), content);
+
+      const result = await readTool.execute({ path: 'exact.txt' }, { locationPath });
+
+      expect(result.ok).toBe(true);
+      expect(result.result).toBe(`1\t${content}`);
+      expect(result.result).not.toContain('truncated');
+    });
+
+    it('truncates a file exactly 1 byte over the cap and appends a truncation notice', async () => {
+      const content = 'a'.repeat(READ_MAX_BYTES + 1);
+      await fsPromises.writeFile(path.join(locationPath, 'over-by-one.txt'), content);
+
+      const result = await readTool.execute({ path: 'over-by-one.txt' }, { locationPath });
+
+      expect(result.ok).toBe(true);
+      expect(result.result).toContain(`1\t${'a'.repeat(READ_MAX_BYTES)}`);
+      expect(result.result).toContain(
+        `[Read truncated: file is ${READ_MAX_BYTES + 1} bytes, exceeding the ${READ_MAX_BYTES}-byte read cap.`,
+      );
+    });
+
+    it('truncates a file well over the cap to the cap size, plus a truncation notice', async () => {
+      const totalSize = READ_MAX_BYTES * 3;
+      const content = 'b'.repeat(totalSize);
+      await fsPromises.writeFile(path.join(locationPath, 'well-over.txt'), content);
+
+      const result = await readTool.execute({ path: 'well-over.txt' }, { locationPath });
+
+      expect(result.ok).toBe(true);
+      const [body, ...rest] = result.result.split('\n\n[Read truncated');
+      expect(body).toBe(`1\t${'b'.repeat(READ_MAX_BYTES)}`);
+      expect(rest.join('')).toContain(`file is ${totalSize} bytes`);
+    });
+
+    it('never splits a multibyte character at the truncation boundary', async () => {
+      // Fill up to one byte before the cap with ASCII, then place a 3-byte
+      // multibyte character straddling the cap so the backoff logic must
+      // drop the whole character rather than emit a partial/invalid tail.
+      const asciiPrefix = 'a'.repeat(READ_MAX_BYTES - 1);
+      const content = asciiPrefix + 'あ' + 'more content after the cap to push the file over the limit';
+      await fsPromises.writeFile(path.join(locationPath, 'multibyte.txt'), content);
+
+      const result = await readTool.execute({ path: 'multibyte.txt' }, { locationPath });
+
+      expect(result.ok).toBe(true);
+      expect(result.result).toContain('[Read truncated');
+      expect(result.result).not.toContain('あ');
+      expect(result.result).not.toContain('�');
+    });
   });
 });

--- a/packages/embedded-agent/src/tools/read.ts
+++ b/packages/embedded-agent/src/tools/read.ts
@@ -3,11 +3,30 @@
  * locationPath, and returns `cat -n`-style line-numbered output.
  */
 
+import * as fsPromises from 'node:fs/promises';
 import type { BuiltinTool, BuiltinToolContext, BuiltinToolResult } from './types.js';
 import { resolveConfinedPath } from './path-confinement.js';
+import { trimToUtf8Boundary } from '../truncate.js';
 
 const DEFAULT_LIMIT = 2000;
 const DEFAULT_OFFSET = 0;
+
+/**
+ * Per-file byte cap on how much of a file this tool loads into subprocess
+ * memory, matching Grep's per-file size threshold (see `grep.ts`). A file
+ * over the cap is not rejected outright (unlike Grep, which skips it) -- the
+ * first READ_MAX_BYTES bytes are still useful to the model, so Read returns
+ * that prefix plus an explicit truncation notice instead of loading the
+ * entire file (which could be arbitrarily large) into memory first.
+ */
+export const READ_MAX_BYTES = 1024 * 1024;
+
+/**
+ * Extra bytes read past the cap so `trimToUtf8Boundary` can see the byte
+ * immediately after the cut and back off if it would split a multibyte
+ * character (UTF-8 code points are at most 4 bytes).
+ */
+const UTF8_BOUNDARY_LOOKAHEAD_BYTES = 4;
 
 interface ReadArgs {
   path: string;
@@ -56,13 +75,30 @@ async function execute(args: unknown, ctx: BuiltinToolContext, signal?: AbortSig
   }
 
   try {
-    const text = await Bun.file(confinement.resolvedPath).text();
+    const stat = await fsPromises.stat(confinement.resolvedPath);
+    const bunFile = Bun.file(confinement.resolvedPath);
+    let text: string;
+    let truncated = false;
+    if (stat.size > READ_MAX_BYTES) {
+      const bytes = new Uint8Array(
+        await bunFile.slice(0, READ_MAX_BYTES + UTF8_BOUNDARY_LOOKAHEAD_BYTES).arrayBuffer(),
+      );
+      text = new TextDecoder().decode(trimToUtf8Boundary(bytes, READ_MAX_BYTES));
+      truncated = true;
+    } else {
+      text = await bunFile.text();
+    }
+
     const lines = text.split('\n');
     const selected = lines.slice(offset, offset + limit);
     const formatted = selected
       .map((lineContent, index) => `${offset + index + 1}\t${lineContent}`)
       .join('\n');
-    return { ok: true, result: formatted };
+    const notice = truncated
+      ? `\n\n[Read truncated: file is ${stat.size} bytes, exceeding the ${READ_MAX_BYTES}-byte read cap. ` +
+        `Showing content from the first ${READ_MAX_BYTES} bytes only.]`
+      : '';
+    return { ok: true, result: formatted + notice };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { ok: false, result: `Failed to read file: ${message}` };

--- a/packages/embedded-agent/src/truncate.ts
+++ b/packages/embedded-agent/src/truncate.ts
@@ -17,15 +17,28 @@ function isContinuationByte(byte: number): boolean {
   return (byte & 0xc0) === 0x80;
 }
 
+/**
+ * Backs `maxBytes` off to the nearest UTF-8 code-point boundary within `bytes`,
+ * so a cut never splits a multibyte character. Requires `bytes` to include at
+ * least one byte past `maxBytes` (the byte at index `maxBytes` itself) to
+ * detect whether the boundary lands mid-sequence; callers reading a bounded
+ * slice of a larger source (e.g. a file) should over-read by a few bytes.
+ */
+export function trimToUtf8Boundary(bytes: Uint8Array, maxBytes: number): Uint8Array {
+  if (bytes.length <= maxBytes) {
+    return bytes;
+  }
+  let end = maxBytes;
+  while (end > 0 && isContinuationByte(bytes[end])) {
+    end--;
+  }
+  return bytes.subarray(0, end);
+}
+
 export function truncateToBytes(input: string, maxBytes: number): TruncateResult {
   const bytes = encoder.encode(input);
   if (bytes.length <= maxBytes) {
     return { text: input, truncated: false };
   }
-  let end = maxBytes;
-  // Back off if the boundary lands inside a multibyte sequence.
-  while (end > 0 && isContinuationByte(bytes[end])) {
-    end--;
-  }
-  return { text: decoder.decode(bytes.subarray(0, end)), truncated: true };
+  return { text: decoder.decode(trimToUtf8Boundary(bytes, maxBytes)), truncated: true };
 }


### PR DESCRIPTION
## Summary

`Read` previously loaded an entire file into subprocess memory via `Bun.file(path).text()` before the wire-level 16 KiB tool-result truncation (`agent-loop.ts`) applied. A very large file (e.g. a 100 MB log) was therefore a subprocess memory-pressure vector even though only a small slice of it ever reached the model or the wire.

- Added a named `READ_MAX_BYTES` cap (1 MiB), matching `Grep`'s existing per-file size threshold (`MAX_FILE_SIZE_BYTES` in `grep.ts`). Unlike `Grep` (which skips oversized files outright), `Read` still returns a useful partial view: the first `READ_MAX_BYTES` bytes of the file, read via a lazy `Bun.file(...).slice(0, cap)` (does not open/copy/read the rest of the file), plus an explicit truncation notice appended to the result so the model knows the content is partial.
- Extracted the UTF-8 boundary-backoff logic in `truncate.ts` into a new exported `trimToUtf8Boundary(bytes, maxBytes)` helper, reused by both the existing string-based `truncateToBytes` (unchanged behavior/tests) and `Read`'s new raw-byte truncation, so a cut never splits a multibyte character in either path.
- Below the cap, `Read`'s behavior is unchanged (still reads the full file via `.text()`).

## Test plan

- [x] TDD polarity verified: stashed `read.ts` + `truncate.ts` (keeping the new tests) — the new tests fail against unmodified production code (missing `READ_MAX_BYTES` export); restored the fix — all tests pass.
- [x] New tests cover the boundary values called out in Issue #1053: exactly-at-cap (unchanged, no notice), cap + 1 byte (truncated + notice), well over cap (truncated to cap size + notice), and a multibyte character straddling the truncation boundary (never split, no replacement character).
- [x] `bun run typecheck` — exit 0, all packages.
- [x] `bun run test` (full suite) — all packages pass except one pre-existing, unrelated failure: `packages/server/src/services/__tests__/multi-user-mode.test.ts` "Issue #918 ... does NOT inject any SSH_AUTH_SOCK ...", caused by this dev environment's real `SSH_AUTH_SOCK` (1Password agent socket) leaking into a test that asserts it's undefined. Verified this fails identically on unmodified `main` (reproduced via `git stash`), unrelated to this PR's diff (which touches only `packages/embedded-agent/`).
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (test coverage, language, duplication, blame-shift checks all pass).
- [ ] CodeRabbit CLI (`coderabbit review --agent --base main`) could not authenticate in this headless worktree session (browser-based login unavailable); relying on the GitHub-side bot review on this PR instead.

Closes #1053

## Note on CodeRabbit
Both local CodeRabbit CLI (auth timed out in this headless worktree session) and GitHub-side bot (rate-limited: "Review limit reached... next review available in 49 minutes") were unavailable during this PR's review window. No CodeRabbit feedback obtainable from either source. Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority).