### PR TITLE
feat(client): add copy raw markdown button to assistant message bubbles

### DIFF
--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo } from 'react';
+import { useRef, useEffect, useMemo, useState } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
@@ -7,7 +7,7 @@ import type { JSX } from 'react';
 import type { ExtraProps } from 'react-markdown';
 import { useEmbeddedAgentWorker } from './hooks/useEmbeddedAgentWorker';
 import type { EmbeddedAgentChatEntry } from './embedded-agent-store';
-import { RefreshIcon, AlertCircleIcon } from '../Icons';
+import { RefreshIcon, AlertCircleIcon, CopyIcon, CheckIcon } from '../Icons';
 import { MessagePanel } from '../sessions/MessagePanel';
 import type { ConnectionStatus } from '../terminal/terminal-contract';
 import { PreviewPanel } from './PreviewPanel';
@@ -261,6 +261,39 @@ function PreviewablePre(props: JSX.IntrinsicElements['pre'] & ExtraProps) {
   );
 }
 
+/** How long the Check-icon/"Copied!" feedback state holds before reverting to the idle Copy icon (#1118). */
+const COPY_MARKDOWN_FEEDBACK_MS = 1500;
+
+/**
+ * Icon-only button pinned to the bottom-right of an assistant message
+ * bubble. Copies the message's raw markdown SOURCE (the `text` prop, as
+ * received from the agent) to the clipboard -- never the rendered HTML the
+ * Markdown pipeline produces. On click, swaps to a Check icon and a
+ * "Copied!" tooltip for COPY_MARKDOWN_FEEDBACK_MS before reverting.
+ */
+function CopyMarkdownButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), COPY_MARKDOWN_FEEDBACK_MS);
+  };
+
+  const label = copied ? 'Copied!' : 'Copy as markdown';
+
+  return (
+    <button
+      onClick={handleCopy}
+      title={label}
+      aria-label={label}
+      className="text-gray-500 hover:text-gray-200 p-1 rounded hover:bg-slate-700 shrink-0"
+    >
+      {copied ? <CheckIcon className="w-3.5 h-3.5" /> : <CopyIcon className="w-3.5 h-3.5" />}
+    </button>
+  );
+}
+
 interface ChatEntryRowProps {
   entry: OutsideEntry;
   onRestart: () => void;
@@ -293,6 +326,9 @@ function ChatEntryRow({ entry, onRestart }: ChatEntryRowProps) {
               {entry.text}
             </Markdown>
             {entry.streaming && <span className="inline-block w-1.5 h-3.5 ml-0.5 bg-gray-400 animate-pulse align-middle" aria-hidden="true" />}
+            <div className="flex justify-end mt-1">
+              <CopyMarkdownButton text={entry.text} />
+            </div>
           </div>
         </div>
       );

--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -11,6 +11,7 @@ import { RefreshIcon, AlertCircleIcon, CopyIcon, CheckIcon } from '../Icons';
 import { MessagePanel } from '../sessions/MessagePanel';
 import type { ConnectionStatus } from '../terminal/terminal-contract';
 import { PreviewPanel } from './PreviewPanel';
+import { logger } from '../../lib/logger';
 
 /** Entries folded into the collapsed-by-default "Working" accordion. */
 type GroupableEntry = Extract<EmbeddedAgentChatEntry, { kind: 'assistant-thinking' | 'tool-call' }>;
@@ -273,11 +274,24 @@ const COPY_MARKDOWN_FEEDBACK_MS = 1500;
  */
 function CopyMarkdownButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
+  const revertTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (revertTimeoutRef.current !== null) clearTimeout(revertTimeoutRef.current);
+    };
+  }, []);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (err) {
+      logger.error('Failed to copy markdown:', err);
+      return;
+    }
     setCopied(true);
-    setTimeout(() => setCopied(false), COPY_MARKDOWN_FEEDBACK_MS);
+    if (revertTimeoutRef.current !== null) clearTimeout(revertTimeoutRef.current);
+    revertTimeoutRef.current = setTimeout(() => setCopied(false), COPY_MARKDOWN_FEEDBACK_MS);
   };
 
   const label = copied ? 'Copied!' : 'Copy as markdown';

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -1114,4 +1114,121 @@ describe('EmbeddedAgentWorkerView', () => {
       expect(bubbles[0].querySelector('.animate-pulse')).toBeTruthy();
     });
   });
+
+  describe('Copy markdown button (#1118)', () => {
+    // Preserve the original clipboard descriptor so we can restore it per-test.
+    // happy-dom provides a real clipboard implementation; we swap it out for a
+    // jest-mock so we can assert on `writeText` calls without touching the OS.
+    const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(navigator),
+      'clipboard',
+    );
+
+    // Fresh writeText mock per test so counts / args do not bleed across tests.
+    let writeTextMock: ReturnType<typeof mock>;
+
+    function installClipboardMock() {
+      writeTextMock = mock(() => Promise.resolve());
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: writeTextMock },
+        writable: true,
+        configurable: true,
+      });
+    }
+
+    function restoreClipboard() {
+      Reflect.deleteProperty(navigator, 'clipboard');
+      if (originalClipboardDescriptor && !('clipboard' in navigator)) {
+        Object.defineProperty(Object.getPrototypeOf(navigator), 'clipboard', originalClipboardDescriptor);
+      }
+    }
+
+    beforeEach(() => {
+      installClipboardMock();
+    });
+
+    afterEach(() => {
+      restoreClipboard();
+    });
+
+    async function renderWithAssistantMessage(sessionId: string, workerId: string, text: string) {
+      renderView({ sessionId, workerId });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+      const data = ndjson(
+        { v: 1, type: 'user-message', id: 'u1', text: 'hi' },
+        { v: 1, type: 'assistant-message', turnId: 't1', text },
+      );
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+    }
+
+    it('renders a copy-markdown button on an assistant message bubble', async () => {
+      await renderWithAssistantMessage('s30', 'w30', '**hello** world');
+
+      expect(screen.getByRole('button', { name: 'Copy as markdown' })).toBeTruthy();
+    });
+
+    it('does not render a copy-markdown button on a user message bubble', async () => {
+      renderView({ sessionId: 's31', workerId: 'w31' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+      const data = ndjson({ v: 1, type: 'user-message', id: 'u1', text: 'only a user message' });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      expect(screen.getByText('only a user message')).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Copy as markdown' })).toBeNull();
+    });
+
+    it('copies the raw markdown text (not rendered HTML) to the clipboard on click', async () => {
+      const markdown = '# Heading\n\n**bold** and `code`';
+      await renderWithAssistantMessage('s32', 'w32', markdown);
+
+      const button = screen.getByRole('button', { name: 'Copy as markdown' });
+      // We use `fireEvent` rather than `userEvent` because `userEvent.setup()`
+      // installs its own clipboard stub via a `navigator.clipboard` getter,
+      // which shadows the mock installed above. `fireEvent.click` bypasses
+      // that setup and dispatches the click directly; the extra
+      // `await Promise.resolve()` yields so the async click handler's
+      // `await navigator.clipboard.writeText` microtask resolves before we
+      // assert (mirrors the McpInstallSection copy-button test pattern).
+      await act(async () => {
+        fireEvent.click(button);
+        await Promise.resolve();
+      });
+
+      expect(writeTextMock).toHaveBeenCalledTimes(1);
+      expect(writeTextMock.mock.calls[0]?.[0]).toBe(markdown);
+    });
+
+    it('switches to a Check icon + "Copied!" tooltip after clicking, then reverts to idle after 1.5s', async () => {
+      await renderWithAssistantMessage('s33', 'w33', 'copy me');
+
+      const button = screen.getByRole('button', { name: 'Copy as markdown' });
+      await act(async () => {
+        fireEvent.click(button);
+        await Promise.resolve();
+      });
+
+      const copiedButton = screen.getByRole('button', { name: 'Copied!' });
+      expect(copiedButton.title).toBe('Copied!');
+      expect(screen.queryByRole('button', { name: 'Copy as markdown' })).toBeNull();
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1600));
+      });
+
+      expect(screen.getByRole('button', { name: 'Copy as markdown' })).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Copied!' })).toBeNull();
+    });
+  });
 });

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test';
 import { render, screen, cleanup, act, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -1229,6 +1229,116 @@ describe('EmbeddedAgentWorkerView', () => {
 
       expect(screen.getByRole('button', { name: 'Copy as markdown' })).toBeTruthy();
       expect(screen.queryByRole('button', { name: 'Copied!' })).toBeNull();
+    });
+
+    it('a second click before the first feedback window elapses keeps "Copied!" visible until the SECOND click\'s own 1.5s window elapses (rapid-click timer reset, CodeRabbit #1121)', async () => {
+      await renderWithAssistantMessage('s34', 'w34', 'copy me twice');
+      const button = screen.getByRole('button', { name: 'Copy as markdown' });
+
+      await act(async () => {
+        fireEvent.click(button);
+        await Promise.resolve();
+      });
+      expect(screen.getByRole('button', { name: 'Copied!' })).toBeTruthy();
+
+      // 800ms after the FIRST click -- well under the first click's own 1.5s
+      // window, so this alone proves nothing about timer-reset behavior yet.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 800));
+      });
+      expect(screen.getByRole('button', { name: 'Copied!' })).toBeTruthy();
+
+      // Second click while still in the "Copied!" state must clear the first
+      // click's pending revert timer and arm a fresh one.
+      await act(async () => {
+        fireEvent.click(button);
+        await Promise.resolve();
+      });
+
+      // 800ms after the SECOND click = 1600ms after the FIRST click. Without
+      // the timer-reset fix, the first click's timer would have fired at
+      // 1500ms and already reverted the button by this point.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 800));
+      });
+      expect(screen.getByRole('button', { name: 'Copied!' })).toBeTruthy();
+
+      // 800ms further (1600ms after the SECOND click) -- the second click's
+      // own timer has now elapsed and the button reverts.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 800));
+      });
+      expect(screen.getByRole('button', { name: 'Copy as markdown' })).toBeTruthy();
+    });
+
+    it('clears the pending revert timeout on unmount instead of leaking a scheduled setState (CodeRabbit #1121)', async () => {
+      const view = renderView({ sessionId: 's35', workerId: 'w35' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+      const data = ndjson(
+        { v: 1, type: 'user-message', id: 'u1', text: 'hi' },
+        { v: 1, type: 'assistant-message', turnId: 't1', text: 'copy me' },
+      );
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'history', data, offset: data.length, startOffset: 0, epoch: 1 }));
+      });
+      await flush();
+
+      // Spy on the real global timer functions (pass-through, not mocked
+      // implementations) rather than switching to fake timers -- sibling
+      // subsystems mounted alongside this component (TanStack Query's
+      // garbage-collection timer, the mock WebSocket) schedule their OWN
+      // timers on unmount, which would pollute a raw vi.getTimerCount()
+      // delta. Identifying our button's specific revert timer by its
+      // COPY_MARKDOWN_FEEDBACK_MS (1500ms) delay avoids that ambiguity.
+      const setTimeoutSpy = spyOn(globalThis, 'setTimeout');
+      const clearTimeoutSpy = spyOn(globalThis, 'clearTimeout');
+      try {
+        const button = screen.getByRole('button', { name: 'Copy as markdown' });
+        await act(async () => {
+          fireEvent.click(button);
+          await Promise.resolve();
+        });
+        expect(screen.getByRole('button', { name: 'Copied!' })).toBeTruthy();
+
+        const revertTimerCallIndex = setTimeoutSpy.mock.calls.findIndex((call) => call[1] === 1500);
+        expect(revertTimerCallIndex).toBeGreaterThanOrEqual(0);
+        const revertTimerId = setTimeoutSpy.mock.results[revertTimerCallIndex]?.value;
+        expect(revertTimerId).toBeTruthy();
+
+        view.unmount();
+
+        // Unmount's effect cleanup must clear exactly this revert timer --
+        // not merely leave it dangling to fire a setState against an
+        // unmounted component later.
+        expect(clearTimeoutSpy.mock.calls.some((call) => call[0] === revertTimerId)).toBe(true);
+      } finally {
+        setTimeoutSpy.mockRestore();
+        clearTimeoutSpy.mockRestore();
+      }
+    });
+
+    it('logs and leaves the button in the idle "Copy as markdown" state when clipboard.writeText rejects, instead of throwing an unhandled rejection (CodeRabbit #1121)', async () => {
+      const consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        writeTextMock.mockRejectedValueOnce(new Error('document not focused'));
+        await renderWithAssistantMessage('s36', 'w36', 'copy me');
+
+        const button = screen.getByRole('button', { name: 'Copy as markdown' });
+        await act(async () => {
+          fireEvent.click(button);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: 'Copy as markdown' })).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Copied!' })).toBeNull();
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a small always-visible "Copy as markdown" icon button to the bottom-right of every **assistant** message bubble in `EmbeddedAgentWorkerView.tsx`. Clicking copies the message's raw markdown source (`entry.text`, not the rendered HTML) to the clipboard via `navigator.clipboard.writeText`.
- Click feedback: the icon swaps `Copy` -> `Check` and the tooltip text becomes "Copied!" for 1.5s, then reverts.
- User message bubbles are unaffected (no button).
- Uses the project's existing hand-rolled `CopyIcon` / `CheckIcon` from `components/Icons.tsx` (no `lucide-react` dependency exists in this repo, so the Issue's "lucide-react Copy icon" note is satisfied via "match the project's existing icon library" instead).
- **Round 2 (CodeRabbit MINOR, 3 concerns):** rapid clicks could let an earlier revert-timer fire and hide the "Copied!" feedback for a later click; an unmounted component could receive a late `setState` from its pending revert timer; a rejected `navigator.clipboard.writeText` was an unhandled promise rejection. Fixed with a ref-tracked timeout (cleared and re-armed on every click, cleared again on unmount) plus a `try/catch` around the clipboard write that logs via the project's `logger.error` (matching `SessionSettingsMenu`'s existing copy-button pattern) instead of `console.error` directly.

## Test plan

- [x] TDD polarity confirmed for both rounds: new tests fail against the pre-fix production code (baseline via `git diff > patch` + `git checkout --`, restored via `git apply`, per this repo's `git stash`-is-shared-across-worktrees caveat) and pass after each fix. One negative test ("no button on a user message bubble") legitimately passes in both states since it asserts an absence — expected, not a partial-polarity gap.
- [x] `bun run test` (full monorepo suite) — client package: 1908 pass / 0 fail (51 in this file, 3 new for the round-2 CodeRabbit fix). One **pre-existing, unrelated** failure in `packages/server/src/services/__tests__/multi-user-mode.test.ts` ("Issue #918: sudo-skip (direct) path ignores sshAuthSockFallback") caused by this developer's local `SSH_AUTH_SOCK` (1Password agent socket) leaking into the test's env-isolation assertion — not touched by this PR (no `packages/server` files changed) and not expected to reproduce in CI.
- [x] `bun run typecheck` — all packages pass.
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (coverage, rule/skill duplication, language, blame-shift checks all pass). Integration-test-gap heuristic flagged (generic "UI component" trigger) — no `packages/integration` test added because this change has no server/wire-boundary surface: no new WebSocket/REST field, no shared type change, purely a client-local render + Clipboard API interaction. Covered instead by client unit tests + Browser QA below.
- [x] **Browser QA (real E2E, not a mechanism probe):** started an isolated dev instance for this worktree (ports 13457/15173, separate `AGENT_CONSOLE_HOME`), registered a throwaway "Embedded Agent" definition pointed at a local mock OpenAI-compatible SSE server (`scratchpad/mock-llm.ts`, not committed) returning canned markdown, and drove a real user message through the actual `EmbeddedAgentWorkerView` shipping path (session -> embedded-agent worker -> SSE stream -> WebSocket -> client store -> render). Confirmed: the button renders on the assistant bubble only (not the user bubble); `navigator.clipboard.writeText` is called with the exact raw markdown source (fenced code block included, not the rendered HTML) on click; the button transitions to `Check` + "Copied!" immediately and reverts to idle at exactly the 1500ms boundary (verified via in-page timestamped sampling, since the ~1.5-2s MCP round-trip between separate `click`/`screenshot` tool calls made catching the transient state in a single screenshot unreliable — documented here for transparency). Screenshot of the true-path (button visible on a rendered assistant message) attached below.
- CodeRabbit: local CLI could not authenticate in this headless worktree (`automatic_login_failed` — no browser available for the OAuth callback). GitHub-side bot hit its own rate limit at PR open ("Review limit reached ... next review available in: 2 minutes"), then reviewed successfully after a manual `@coderabbitai review` retrigger and raised the round-2 finding above. **3-layer clean verdict confirmed** after the round-2 push (commit `d0146b4`): pre-merge `CodeRabbit` status = `success` / "Review completed" for the current head commit; `reviewDecision` is empty (the bot's review type was `COMMENTED`, never `CHANGES_REQUESTED`); the sole inline comment thread is `isResolved: true` / `isOutdated: false` via the GraphQL `reviewThreads` API, and no new comments were posted against the round-2 commit.

## Definition of Done tracking

- [x] Production code implemented
- [x] Sibling tests added (`packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx`)
- [x] Local verification (`typecheck` + `test`) passes (pre-existing unrelated server failure noted above)
- [x] Committed with conventional commit format
- [x] Pushed to origin
- [x] PR opened with linked Issue
- [x] CI fully green
- [x] CodeRabbit clean — the one MINOR finding (3 concerns) is addressed in the round-2 commit; 3-layer clean verdict confirmed (see Test plan above).

Closes #1118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a button to copy assistant messages as raw Markdown.
  * Added visual “Copied!” feedback after copying, which automatically resets.
  * Copy controls appear only on assistant messages.

* **Tests**
  * Added coverage for copying Markdown, button visibility, feedback behavior, and reset timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

