### PR TITLE
fix: warn on End/Pause session dialogs when an embedded-agent turn is active

### DIFF
--- a/packages/client/src/components/sessions/EndSessionDialog.tsx
+++ b/packages/client/src/components/sessions/EndSessionDialog.tsx
@@ -39,9 +39,10 @@ export function EndSessionDialog({
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
 
-  // Check if any agent workers are in 'active' or 'asking' state
+  // Check if any agent or embedded-agent workers are in 'active' or 'asking' state
+  // (embedded-agent workers only ever report 'active'/'idle', never 'asking')
   const hasActiveWorkers = session && workerActivityStates && session.workers.some(
-    w => w.type === 'agent' &&
+    w => (w.type === 'agent' || w.type === 'embedded-agent') &&
       (workerActivityStates[w.id] === 'active' || workerActivityStates[w.id] === 'asking')
   );
 

--- a/packages/client/src/components/sessions/PauseSessionDialog.tsx
+++ b/packages/client/src/components/sessions/PauseSessionDialog.tsx
@@ -39,9 +39,10 @@ export function PauseSessionDialog({
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
 
-  // Check if any agent workers are in 'active' or 'asking' state
+  // Check if any agent or embedded-agent workers are in 'active' or 'asking' state
+  // (embedded-agent workers only ever report 'active'/'idle', never 'asking')
   const hasActiveWorkers = session && workerActivityStates && session.workers.some(
-    w => w.type === 'agent' &&
+    w => (w.type === 'agent' || w.type === 'embedded-agent') &&
       (workerActivityStates[w.id] === 'active' || workerActivityStates[w.id] === 'asking')
   );
 

--- a/packages/client/src/components/sessions/__tests__/EndSessionDialog.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/EndSessionDialog.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, mock, afterEach, afterAll } from 'bun:test';
+import { render, screen, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EndSessionDialog, type EndSessionDialogProps } from '../EndSessionDialog';
+import type { Session, Worker, AgentActivityState } from '@agent-console/shared';
+
+const originalFetch = globalThis.fetch;
+const mockFetch = mock(() => Promise.resolve(new Response()));
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function createMockSession(workers: Worker[]): Session {
+  return {
+    type: 'quick',
+    id: 'session-1',
+    locationPath: '/tmp/session-1',
+    status: 'active',
+    activationState: 'running',
+    createdAt: '2026-01-01T00:00:00Z',
+    workers,
+    isShared: false,
+    recoveryState: 'healthy',
+  };
+}
+
+function agentWorker(id: string): Worker {
+  return { id, type: 'agent', name: 'Claude Code', createdAt: '2026-01-01T00:00:00Z', agentId: 'claude-code', activated: true };
+}
+
+function embeddedAgentWorker(id: string): Worker {
+  return { id, type: 'embedded-agent', name: 'Embedded Agent', createdAt: '2026-01-01T00:00:00Z', embeddedAgentId: 'embedded-1', activated: true };
+}
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function renderDialog(props: Partial<EndSessionDialogProps> = {}) {
+  const defaultProps: EndSessionDialogProps = {
+    open: true,
+    onOpenChange: mock(() => {}),
+    sessionId: 'session-1',
+  };
+
+  return render(
+    <TestWrapper>
+      <EndSessionDialog {...defaultProps} {...props} />
+    </TestWrapper>
+  );
+}
+
+const WARNING_TEXT = 'Warning: This session has active workers. Ending will stop all work in progress.';
+
+describe('EndSessionDialog', () => {
+  it('shows the active-worker warning when an embedded-agent worker is active', () => {
+    const session = createMockSession([embeddedAgentWorker('worker-1')]);
+    const workerActivityStates: Record<string, AgentActivityState> = { 'worker-1': 'active' };
+
+    renderDialog({ session, workerActivityStates });
+
+    expect(screen.getByText(WARNING_TEXT)).toBeTruthy();
+  });
+
+  it('shows the active-worker warning when a PTY agent worker is active', () => {
+    const session = createMockSession([agentWorker('worker-1')]);
+    const workerActivityStates: Record<string, AgentActivityState> = { 'worker-1': 'active' };
+
+    renderDialog({ session, workerActivityStates });
+
+    expect(screen.getByText(WARNING_TEXT)).toBeTruthy();
+  });
+
+  it('shows the active-worker warning when a PTY agent worker is asking', () => {
+    const session = createMockSession([agentWorker('worker-1')]);
+    const workerActivityStates: Record<string, AgentActivityState> = { 'worker-1': 'asking' };
+
+    renderDialog({ session, workerActivityStates });
+
+    expect(screen.getByText(WARNING_TEXT)).toBeTruthy();
+  });
+
+  it('does not show the warning when the embedded-agent worker is idle', () => {
+    const session = createMockSession([embeddedAgentWorker('worker-1')]);
+    const workerActivityStates: Record<string, AgentActivityState> = { 'worker-1': 'idle' };
+
+    renderDialog({ session, workerActivityStates });
+
+    expect(screen.queryByText(WARNING_TEXT)).toBeNull();
+  });
+
+  it('does not show the warning when session or workerActivityStates are undefined', () => {
+    renderDialog();
+
+    expect(screen.queryByText(WARNING_TEXT)).toBeNull();
+  });
+});

--- a/packages/client/src/components/sessions/__tests__/EndSessionDialog.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/EndSessionDialog.test.tsx
@@ -6,7 +6,7 @@ import type { Session, Worker, AgentActivityState } from '@agent-console/shared'
 
 const originalFetch = globalThis.fetch;
 const mockFetch = mock(() => Promise.resolve(new Response()));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} });
 
 afterAll(() => {
   globalThis.fetch = originalFetch;

--- a/packages/client/src/components/sessions/__tests__/PauseSessionDialog.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/PauseSessionDialog.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, mock, afterEach, afterAll } from 'bun:test';
+import { render, screen, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PauseSessionDialog, type PauseSessionDialogProps } from '../PauseSessionDialog';
+import type { Session, Worker, AgentActivityState } from '@agent-console/shared';
+
+const originalFetch = globalThis.fetch;
+const mockFetch = mock(() => Promise.resolve(new Response()));
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function createMockSession(workers: Worker[]): Session {
+  return {
+    type: 'worktree',
+    id: 'session-1',
+    locationPath: '/tmp/session-1',
+    status: 'active',
+    activationState: 'running',
+    createdAt: '2026-01-01T00:00:00Z',
+    workers,
+    isShared: false,
+    recoveryState: 'healthy',
+    repositoryId: 'repo-1',
+    repositoryName: 'repo',
+    worktreeId: 'feat/my-branch',
+    isMainWorktree: false,
+  };
+}
+
+function agentWorker(id: string): Worker {
+  return { id, type: 'agent', name: 'Claude Code', createdAt: '2026-01-01T00:00:00Z', agentId: 'claude-code', activated: true };
+}
+
+function embeddedAgentWorker(id: string): Worker {
+  return { id, type: 'embedded-agent', name: 'Embedded Agent', createdAt: '2026-01-01T00:00:00Z', embeddedAgentId: 'embedded-1', activated: true };
+}
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function renderDialog(props: Partial<PauseSessionDialogProps> = {}) {
+  const defaultProps: PauseSessionDialogProps = {
+    open: true,
+    onOpenChange: mock(() => {}),
+    sessionId: 'session-1',
+  };
+
+  return render(
+    <TestWrapper>
+      <PauseSessionDialog {...defaultProps} {...props} />
+    </TestWrapper>
+  );
+}
+
+const WARNING_TEXT = 'Warning: This session has active workers. Pausing will stop all work in progress.';
+
+describe('PauseSessionDialog', () => {
+  it('shows the active-worker warning when an embedded-agent worker is active', () => {
+    const session = createMockSession([embeddedAgentWorker('worker-1')]);
+    const workerActivityStates: Record<string, AgentActivityState> = { 'worker-1': 'active' };
+
+    renderDialog({ session, workerActivityStates });
+
+    expect(screen.getByText(WARNING_TEXT)).toBeTruthy();
+  });
+
+  it('shows the active-worker warning when a PTY agent worker is active', () => {
+    const session = createMockSession([agentWorker('worker-1')]);
+    const workerActivityStates: Record<string, AgentActivityState> = { 'worker-1': 'active' };
+
+    renderDialog({ session, workerActivityStates });
+
+    expect(screen.getByText(WARNING_TEXT)).toBeTruthy();
+  });
+
+  it('shows the active-worker warning when a PTY agent worker is asking', () => {
+    const session = createMockSession([agentWorker('worker-1')]);
+    const workerActivityStates: Record<string, AgentActivityState> = { 'worker-1': 'asking' };
+
+    renderDialog({ session, workerActivityStates });
+
+    expect(screen.getByText(WARNING_TEXT)).toBeTruthy();
+  });
+
+  it('does not show the warning when the embedded-agent worker is idle', () => {
+    const session = createMockSession([embeddedAgentWorker('worker-1')]);
+    const workerActivityStates: Record<string, AgentActivityState> = { 'worker-1': 'idle' };
+
+    renderDialog({ session, workerActivityStates });
+
+    expect(screen.queryByText(WARNING_TEXT)).toBeNull();
+  });
+
+  it('does not show the warning when session or workerActivityStates are undefined', () => {
+    renderDialog();
+
+    expect(screen.queryByText(WARNING_TEXT)).toBeNull();
+  });
+});

--- a/packages/client/src/components/sessions/__tests__/PauseSessionDialog.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/PauseSessionDialog.test.tsx
@@ -6,7 +6,7 @@ import type { Session, Worker, AgentActivityState } from '@agent-console/shared'
 
 const originalFetch = globalThis.fetch;
 const mockFetch = mock(() => Promise.resolve(new Response()));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} });
 
 afterAll(() => {
   globalThis.fetch = originalFetch;

--- a/packages/integration/src/session-sync-embedded-agent-activity-boundary.test.ts
+++ b/packages/integration/src/session-sync-embedded-agent-activity-boundary.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Client-Server Boundary Test: sessions-sync embedded-agent activity state (Issue #1028)
+ *
+ * `buildSessionsSyncMessage()` (packages/server/src/websocket/app-handler.ts)
+ * collects per-worker `activityState` for the `sessions-sync` payload that the
+ * client's `handleSessionsSync` uses to FULLY REPLACE its local
+ * `workerActivityStates` map on every WebSocket (re)connect. If this
+ * collection loop skips `embedded-agent` workers, an in-progress embedded-agent
+ * turn's 'active' state is silently dropped from the client on every reload
+ * or reconnect -- even though the live `worker-activity` broadcast sets it
+ * correctly in between syncs. The End/Pause session dialogs' "active worker"
+ * warning (Issue #1028) reads directly from this same client-side map, so a
+ * regression here makes that warning unreliable without any unit test
+ * (server-side or client-side) noticing, since both sides only ever exercise
+ * their own mocked half of the wire.
+ *
+ * This test exercises the real chain:
+ *   ctx.sessionManager.createWorker({ type: 'embedded-agent', ... })
+ *     -> directly flip the internal worker's activityState to 'active'
+ *        (simulating an in-flight turn, the same field
+ *        EmbeddedAgentWorkerService.broadcastActivity writes)
+ *     -> buildSessionsSyncMessage({ getAllSessions, getAllPausedSessions,
+ *        getWorkerActivityState } wired to the real sessionManager)
+ *     -> JSON serialize (wire transmission simulation)
+ *     -> AppServerMessageSchema.safeParse (the same parser the client uses)
+ *   assert the embedded-agent worker's 'active' state survives end-to-end.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as v from 'valibot';
+
+import {
+  setupTestEnvironment,
+  cleanupTestEnvironment,
+} from '@agent-console/server/src/__tests__/test-utils';
+import { createTestContext, shutdownAppContext } from '@agent-console/server/src/app-context';
+import type { AppContext } from '@agent-console/server/src/app-context';
+import { buildSessionsSyncMessage } from '@agent-console/server/src/websocket/app-handler';
+
+import { AppServerMessageSchema } from '@agent-console/shared';
+
+describe('Client-Server Boundary: sessions-sync embedded-agent activity state', () => {
+  let ctx: AppContext;
+
+  beforeEach(async () => {
+    await setupTestEnvironment();
+    ctx = await createTestContext();
+  });
+
+  afterEach(async () => {
+    await shutdownAppContext(ctx);
+    await cleanupTestEnvironment();
+  });
+
+  it('includes an in-progress embedded-agent turn in the sessions-sync payload', async () => {
+    const owner = await ctx.userRepository.upsertByOsUid(54322, 'owner2', '/home/owner2');
+
+    const def = await ctx.embeddedAgentManager.createEmbeddedAgent(
+      {
+        name: 'Ollama qwen3',
+        provider: { baseUrl: 'http://localhost:11434/v1', model: 'qwen3:32b' },
+      },
+      owner.id,
+    );
+
+    const created = await ctx.sessionManager.createSession(
+      { type: 'quick', locationPath: '/test/path', agentId: 'claude-code-builtin' },
+      { createdBy: owner.id },
+    );
+
+    const worker = await ctx.sessionManager.createWorker(created.id, {
+      type: 'embedded-agent',
+      embeddedAgentId: def.id,
+    });
+    expect(worker).not.toBeNull();
+    if (!worker) throw new Error('worker creation returned null');
+
+    // Simulate an in-flight turn: this is the exact field
+    // EmbeddedAgentWorkerService.broadcastActivity writes when the loop is
+    // calling the LLM / executing a tool.
+    const internalWorker = ctx.sessionManager.getWorker(created.id, worker.id);
+    if (!internalWorker || internalWorker.type !== 'embedded-agent') {
+      throw new Error('embedded-agent worker not found internally after creation');
+    }
+    internalWorker.activityState = 'active';
+
+    const syncMsg = await buildSessionsSyncMessage({
+      getAllSessions: () => ctx.sessionManager.getAllSessions(),
+      getAllPausedSessions: () => ctx.sessionManager.getAllPausedSessions(),
+      getWorkerActivityState: (sessionId, workerId) =>
+        ctx.sessionManager.getWorkerActivityState(sessionId, workerId),
+    });
+
+    expect(syncMsg.activityStates).toContainEqual({
+      sessionId: created.id,
+      workerId: worker.id,
+      activityState: 'active',
+    });
+
+    // Round-trip through the wire + the same parser the client uses.
+    const wirePayload = JSON.parse(JSON.stringify(syncMsg));
+    const parsed = v.safeParse(AppServerMessageSchema, wirePayload);
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      throw new Error(
+        `safeParse failed unexpectedly: ${JSON.stringify(parsed.issues.map((i) => i.message))}`,
+      );
+    }
+    if (parsed.output.type !== 'sessions-sync') {
+      throw new Error(`Expected sessions-sync, got: ${parsed.output.type}`);
+    }
+
+    expect(parsed.output.activityStates).toContainEqual({
+      sessionId: created.id,
+      workerId: worker.id,
+      activityState: 'active',
+    });
+  });
+});

--- a/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
+++ b/packages/server/src/services/__tests__/session-pause-resume-service.test.ts
@@ -316,6 +316,51 @@ describe('SessionPauseResumeService', () => {
       expect(onSessionResumed).toHaveBeenCalledTimes(1);
     });
 
+    it('should include embedded-agent worker activity states in the onSessionResumed callback', async () => {
+      const embeddedWorker = buildInternalEmbeddedAgentWorker({ id: 'w1' });
+      const restoredWorkers = new Map([['w1', embeddedWorker]]);
+      const persisted = buildPersistedWorktreeSession({
+        id: 'session-1',
+        serverPid: null,
+        pausedAt: '2026-01-01T00:00:00.000Z',
+        workers: [],
+      });
+
+      const onSessionResumed = mock(() => {});
+      const mockPublicSession = {
+        id: 'session-1',
+        type: 'worktree' as const,
+        workers: [{ id: 'w1', type: 'embedded-agent' as const }],
+      } as unknown as Session;
+
+      const deps = createMockDeps({
+        sessionRepository: {
+          ...createMockDeps().sessionRepository,
+          findById: mock(async () => persisted),
+          update: mock(async () => true),
+        },
+        workerManager: {
+          killWorker: mock(async () => {}),
+          restoreWorkersFromPersistence: mock(() => restoredWorkers),
+          activateAgentWorkerPty: mock(async () => {}),
+          activateTerminalWorkerPty: mock(async () => {}),
+        } satisfies SessionPauseResumeDeps['workerManager'],
+        toPublicSession: mock(() => mockPublicSession),
+        getWorkerActivityState: mock((sessionId: string, workerId: string) =>
+          sessionId === 'session-1' && workerId === 'w1' ? 'active' : undefined
+        ),
+        getSessionLifecycleCallbacks: () => ({ onSessionResumed }),
+      });
+      const service = new SessionPauseResumeService(deps);
+
+      await service.resumeSession('session-1');
+
+      expect(onSessionResumed).toHaveBeenCalledWith(
+        mockPublicSession,
+        [{ sessionId: 'session-1', workerId: 'w1', activityState: 'active' }]
+      );
+    });
+
     it('should prevent concurrent resume attempts for the same session', async () => {
       const persisted = buildPersistedWorktreeSession({ id: 'session-1', serverPid: null, pausedAt: '2026-01-01T00:00:00.000Z' });
 

--- a/packages/server/src/services/session-pause-resume-service.ts
+++ b/packages/server/src/services/session-pause-resume-service.ts
@@ -349,7 +349,7 @@ export class SessionPauseResumeService {
     // Collect activity states for resumed session's workers
     const activityStates: WorkerActivityInfo[] = [];
     for (const worker of publicSession.workers) {
-      if (worker.type === 'agent') {
+      if (worker.type === 'agent' || worker.type === 'embedded-agent') {
         const state = this.deps.getWorkerActivityState(id, worker.id);
         if (state) {
           activityStates.push({ sessionId: id, workerId: worker.id, activityState: state });

--- a/packages/server/src/websocket/__tests__/app-handler.test.ts
+++ b/packages/server/src/websocket/__tests__/app-handler.test.ts
@@ -105,6 +105,34 @@ describe('App Handler', () => {
       });
     });
 
+    it('should include embedded-agent workers', async () => {
+      const sessions: Session[] = [
+        buildQuickSession({
+          id: 'session-1',
+          locationPath: '/path/1',
+          createdAt: '2024-01-01',
+          workers: [
+            { id: 'worker-1', type: 'embedded-agent', embeddedAgentId: 'embedded-1', name: 'Embedded Agent', createdAt: '2024-01-01', activated: true },
+          ],
+        }),
+      ];
+
+      const deps = {
+        getAllSessions: () => sessions,
+        getAllPausedSessions: async () => [],
+        getWorkerActivityState: (sessionId: string, workerId: string): AgentActivityState | undefined => {
+          if (sessionId === 'session-1' && workerId === 'worker-1') return 'active';
+          return undefined;
+        },
+      };
+
+      const msg = await buildSessionsSyncMessage(deps);
+
+      expect(msg.activityStates).toEqual([
+        { sessionId: 'session-1', workerId: 'worker-1', activityState: 'active' },
+      ]);
+    });
+
     it('should skip terminal workers', async () => {
       const sessions: Session[] = [
         buildQuickSession({

--- a/packages/server/src/websocket/app-handler.ts
+++ b/packages/server/src/websocket/app-handler.ts
@@ -56,11 +56,11 @@ export async function buildSessionsSyncMessage(
   // Combine both lists
   const allSessions = [...activeSessions, ...pausedSessions];
 
-  // Collect activity states for all agent workers (only active sessions have activity states)
+  // Collect activity states for agent and embedded-agent workers (only active sessions have activity states)
   const activityStates: WorkerActivityInfo[] = [];
   for (const session of activeSessions) {
     for (const worker of session.workers) {
-      if (worker.type === 'agent') {
+      if (worker.type === 'agent' || worker.type === 'embedded-agent') {
         const state = deps.getWorkerActivityState(session.id, worker.id);
         if (state) {
           activityStates.push({


### PR DESCRIPTION
## Summary
- Extend the End/Pause session dialogs' existing "active worker" warning to also cover `embedded-agent` workers (previously scoped to `type === 'agent'` only), so ending/pausing a session mid-turn now warns the user before the in-flight embedded-agent turn is abandoned.
- Fix a related server-side gap discovered during Browser QA: `buildSessionsSyncMessage()` and the session-resume lifecycle callback only collected `activityState` for `type === 'agent'` workers. Since the client's `sessions-sync`/`session-resumed` handlers fully replace `workerActivityStates` from this payload, an in-progress embedded-agent turn's `'active'` state was silently dropped on every reload/reconnect/resume — making the dialog warning unreliable exactly when a user would most need it (re-opening the tab mid-turn).

## Changes
- `packages/client/src/components/sessions/EndSessionDialog.tsx` / `PauseSessionDialog.tsx`: widen the worker-type filter to `'agent' || 'embedded-agent'`.
- `packages/server/src/websocket/app-handler.ts`: `buildSessionsSyncMessage()` now collects activity states for embedded-agent workers too.
- `packages/server/src/services/session-pause-resume-service.ts`: same fix for the `onSessionResumed` activity-states payload (sibling call site, same root cause).
- Tests: unit tests for both dialogs (polarity-verified), unit tests for both server-side fixes (polarity-verified), and a new client-server boundary test (`packages/integration/src/session-sync-embedded-agent-activity-boundary.test.ts`) exercising the real `sessionManager -> buildSessionsSyncMessage -> wire -> AppServerMessageSchema.safeParse` chain.

## Test plan
- [x] TDD polarity confirmed for all four production fixes (tests fail without the fix, pass with it)
- [x] `bun run typecheck` — all packages pass
- [x] `bun run test` — full suite passes; only pre-existing failure is an environment-specific `MultiUserMode > Issue #918` test caused by this session's ambient `SSH_AUTH_SOCK` (1Password agent socket), unrelated to this diff (confirmed: file untouched by this PR, failure reproduces identically on a clean checkout in this environment)
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (all production files covered, integration test present)
- [x] Browser QA (true-path): registered a test embedded agent pointing at a non-responding local endpoint to produce a genuinely in-flight turn, sent a message, confirmed "Working..." + Send→Cancel morph (existing PR #1104 mechanism), reloaded the page (full `sessions-sync` re-sync), and confirmed the End Session dialog still shows the warning after reload — the exact scenario the server-side fix restores.

Closes #1028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Active-worker warnings now appear correctly for sessions with active embedded-agent workers when ending or pausing sessions.
  * Embedded-agent activity states are now preserved during session synchronization and resume operations.

* **Tests**
  * Added coverage for warning behavior, activity-state synchronization, and session resume handling across supported worker types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->