### PR TITLE
fix: atomicWrite preserves file mode across Write/Edit

### DIFF
--- a/packages/embedded-agent/src/tools/__tests__/atomic-write.test.ts
+++ b/packages/embedded-agent/src/tools/__tests__/atomic-write.test.ts
@@ -54,6 +54,32 @@ describe('atomicWrite', () => {
     expect(entries).toEqual(['clean.txt']);
   });
 
+  it('preserves the existing file mode (exec bit) across an overwrite', async () => {
+    const target = path.join(dir, 'script.sh');
+    await fsPromises.writeFile(target, '#!/bin/sh\necho old\n');
+    await fsPromises.chmod(target, 0o755);
+
+    await atomicWrite(target, '#!/bin/sh\necho new\n');
+
+    const { mode } = await fsPromises.stat(target);
+    expect(mode & 0o777).toBe(0o755);
+  });
+
+  it('applies the default umask mode (no mode to preserve) for a newly-created file', async () => {
+    const target = path.join(dir, 'new-file.txt');
+    const control = path.join(dir, 'control.txt');
+    // Umask-dependent baseline: what Bun.write produces with no prior file at
+    // the destination, established independently of atomicWrite's own logic.
+    await Bun.write(control, 'baseline');
+    const { mode: controlMode } = await fsPromises.stat(control);
+
+    await atomicWrite(target, 'content');
+
+    const { mode } = await fsPromises.stat(target);
+    expect(mode & 0o777).toBe(controlMode & 0o777);
+    expect(mode & 0o777).not.toBe(0o755);
+  });
+
   it('cleans up the temp file and rethrows when the final rename fails', async () => {
     // Renaming a plain file onto an existing directory fails at the OS level
     // (EISDIR) -- this simulates the temp-write succeeding but the rename

--- a/packages/embedded-agent/src/tools/atomic-write.ts
+++ b/packages/embedded-agent/src/tools/atomic-write.ts
@@ -12,7 +12,7 @@
  * the rename still severs them, since the target inode is replaced regardless
  * of the temp file's mode. Preserving hardlink identity would require an
  * in-place write (truncate+write) instead, which sacrifices crash safety;
- * that trade-off is accepted here per architect review (Issue #1067).
+ * that trade-off is accepted here per architect review.
  */
 
 import * as fsPromises from 'node:fs/promises';

--- a/packages/embedded-agent/src/tools/atomic-write.ts
+++ b/packages/embedded-agent/src/tools/atomic-write.ts
@@ -4,6 +4,15 @@
  * same-filesystem and atomic on POSIX), then renames it onto the target path.
  * On any failure between the temp-write and the rename, best-effort cleans up
  * the temp file before rethrowing — callers decide how to render the error.
+ *
+ * Mode preservation: the rename replaces the target's inode, so an existing
+ * file's permission bits (notably the executable bit) would otherwise reset
+ * to the process umask default. Before renaming, the target's existing mode
+ * (if any) is copied onto the temp file. This does NOT preserve hardlinks —
+ * the rename still severs them, since the target inode is replaced regardless
+ * of the temp file's mode. Preserving hardlink identity would require an
+ * in-place write (truncate+write) instead, which sacrifices crash safety;
+ * that trade-off is accepted here per architect review (Issue #1067).
  */
 
 import * as fsPromises from 'node:fs/promises';
@@ -22,6 +31,13 @@ export async function atomicWrite(resolvedPath: string, content: string): Promis
   const tempPath = path.join(path.dirname(resolvedPath), `${path.basename(resolvedPath)}.tmp-${crypto.randomUUID()}`);
   try {
     const bytesWritten = await Bun.write(tempPath, content);
+    try {
+      const { mode } = await fsPromises.stat(resolvedPath);
+      await fsPromises.chmod(tempPath, mode);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      // Target does not exist yet -- new file, no mode to preserve.
+    }
     await fsPromises.rename(tempPath, resolvedPath);
     return { bytesWritten };
   } catch (err) {

--- a/packages/embedded-agent/src/tools/atomic-write.ts
+++ b/packages/embedded-agent/src/tools/atomic-write.ts
@@ -35,7 +35,9 @@ export async function atomicWrite(resolvedPath: string, content: string): Promis
       const { mode } = await fsPromises.stat(resolvedPath);
       await fsPromises.chmod(tempPath, mode);
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      if (!(typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT')) {
+        throw err;
+      }
       // Target does not exist yet -- new file, no mode to preserve.
     }
     await fsPromises.rename(tempPath, resolvedPath);


### PR DESCRIPTION
## Summary
- `atomicWrite`'s temp-file-then-rename replaced the target inode on Write/Edit, silently resetting existing file permissions (notably the executable bit) to the process umask default.
- Before the final rename, stat the existing target's mode (if any) and chmod it onto the temp file so the rename preserves permissions. New-file creation is unaffected (no prior mode to preserve).
- Hardlinks to the original inode are still severed by the rename — documented as an accepted trade-off in the function's doc comment (preserving hardlink identity would require an in-place write, sacrificing the crash-safety property).

## Test plan
- [x] TDD polarity confirmed: reverted the production fix, confirmed the new "preserves the existing file mode (exec bit) across an overwrite" test fails (0755 -> 0644), restored the fix, confirmed it passes.
- [x] Added a sibling test asserting new-file creation still gets the umask-default mode (compared against a control file written independently, so the assertion is umask-agnostic).
- [x] Full suite: `bun run test` — all packages pass (server's `MultiUserMode` SSH_AUTH_SOCK-leak test failure was a pre-existing environment artifact from this host's `1Password` agent socket in `process.env`, unrelated to this change and reproduced identically on `main`; confirmed green with `SSH_AUTH_SOCK` unset).
- [x] `bun run typecheck` — exit 0.
- [x] `node .claude/skills/orchestrator/preflight-check.js` — coverage / duplication / language / blame-shift checks all clean.

Closes #1067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File updates now preserve the existing file’s permissions, including executable status.
  * Newly created files continue to use the platform’s default permission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->