### PR TITLE
fix: extend get_session_status MCP tool mapWorkers to include embedded-agent activityState

### DIFF
--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -35,6 +35,7 @@ import { McpTokenRegistry, type McpAuthMode } from '../mcp-auth.js';
 import { createWorktreeWithSession } from '../../services/worktree-creation-service.js';
 import { deleteWorktree, _getDeletionsInProgress } from '../../services/worktree-deletion-service.js';
 import type { SuggestSessionMetadataFn } from '../../services/session-metadata-suggester.js';
+import type { EmbeddedAgentDefinition } from '@agent-console/shared';
 
 // Mock session-metadata-suggester to avoid spawning real agent processes.
 // Declaring the parameter type makes `mock.calls` typed correctly so the
@@ -59,6 +60,23 @@ const mockFetchPullRequestUrl = mock<
 // Test config directory
 const TEST_CONFIG_DIR = '/test/config';
 const TEST_REPO_PATH = '/test/repo';
+
+// Embedded-agent definition the createWorker path resolves against, mirroring
+// worker-lifecycle-manager.test.ts's EMBEDDED_AGENT_DEF. Used by the
+// get_session_status activityState tests (Issue #1128).
+const TEST_EMBEDDED_AGENT_DEF: EmbeddedAgentDefinition = {
+  id: 'def-1',
+  name: 'My Local Model',
+  provider: { baseUrl: 'http://localhost:11434/v1', model: 'qwen3:32b' },
+  createdBy: 'user-1',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+const testEmbeddedAgentManagerStub = {
+  getEmbeddedAgent: (id: string): EmbeddedAgentDefinition | undefined =>
+    id === TEST_EMBEDDED_AGENT_DEF.id ? TEST_EMBEDDED_AGENT_DEF : undefined,
+};
 
 // Create mock PTY factory
 const ptyFactory = createMockPtyFactory(30000);
@@ -282,6 +300,7 @@ describe('MCP Server Tools', () => {
         },
         getWorktreeIndexNumber: async () => 0,
       },
+      embeddedAgentManager: testEmbeddedAgentManagerStub,
     });
 
     // Create RepositoryManager (initially empty). Tests that create worktree
@@ -961,6 +980,42 @@ describe('MCP Server Tools', () => {
       const agentWorker = data.workers.find((w) => w.type === 'agent');
       expect(agentWorker).toBeDefined();
       expect(agentWorker!.activityState).toBeDefined();
+    });
+
+    it('should report embedded-agent worker activity state (Issue #1128)', async () => {
+      const session = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: 'claude-code',
+      });
+
+      const embeddedWorker = await sessionManager.createWorker(session.id, {
+        type: 'embedded-agent',
+        embeddedAgentId: TEST_EMBEDDED_AGENT_DEF.id,
+      });
+      expect(embeddedWorker).toBeDefined();
+
+      // Simulate a loop-emitted activityState update (see
+      // worker-lifecycle-manager.ts getWorkerActivityState, which reads this
+      // field directly for embedded-agent workers instead of going through
+      // ActivityDetector).
+      const internalWorker = sessionManager.getWorker(session.id, embeddedWorker!.id)!;
+      expect(internalWorker).toBeDefined();
+      expect(internalWorker.type).toBe('embedded-agent');
+      if (internalWorker.type === 'embedded-agent') {
+        internalWorker.activityState = 'active';
+      }
+
+      const response = await callTool(app, mcpSessionId, 'get_session_status', {
+        sessionId: session.id,
+      }, nextId++);
+      const data = parseToolResult(response) as {
+        workers: Array<{ id: string; type: string; activityState: string }>;
+      };
+
+      const embeddedAgentWorker = data.workers.find((w) => w.type === 'embedded-agent');
+      expect(embeddedAgentWorker).toBeDefined();
+      expect(embeddedAgentWorker!.activityState).toBe('active');
     });
 
     it('should report terminated worker when PTY has exited', async () => {

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -262,7 +262,7 @@ export function createMcpApp(deps: McpDependencies): Hono {
       id: w.id,
       type: w.type,
       activityState:
-        w.type === 'agent'
+        w.type === 'agent' || w.type === 'embedded-agent'
           ? sessionManager.getWorkerActivityState(session.id, w.id) ?? 'unknown'
           : ('unknown' as AgentActivityState),
     }));


### PR DESCRIPTION
## Summary

- `mapWorkers` in `packages/server/src/mcp/mcp-server.ts` hard-filtered on `w.type === 'agent'` when reading worker `activityState`, so `embedded-agent` workers always reported `'unknown'` via the `get_session_status` MCP tool — even though `getWorkerActivityState` in `worker-lifecycle-manager.ts` already routes both worker types correctly (agent via `ActivityDetector`, embedded-agent via the loop-emitted `activityState` field directly).
- This is a silent-fail bug: the Orchestrator's own diagnostic tool (`get_session_status`) was misreporting embedded-agent worker activity, undermining agent-console's own dogfooding of embedded agents.
- This is the 5th and last sibling of the `w.type === 'agent'` filter pattern; PR #1127 (Issue #1028) already fixed client dialogs, server sessions-sync, and resume-service.

## Change

Widened the condition to `w.type === 'agent' || w.type === 'embedded-agent'` so both worker types call `sessionManager.getWorkerActivityState`. Other worker types (`terminal`, `git-diff`, etc.) are unaffected and keep falling through to `'unknown'`.

## Test added

`packages/server/src/mcp/__tests__/mcp-server.test.ts`: new test `'should report embedded-agent worker activity state (Issue #1128)'` in the `get_session_status` describe block. Creates an embedded-agent worker, sets its internal `activityState` directly (simulating the loop-emitted update), calls `get_session_status`, and asserts the reported `activityState` matches.

TDD polarity verified: with the old `w.type === 'agent'`-only filter the test fails (`'unknown'` reported instead of `'active'`); with the fix applied it passes. Also wired an `embeddedAgentManager` stub into the test file's `SessionManager.create(...)` call (previously absent, so `type: 'embedded-agent'` worker creation would fail to resolve a definition).

## Test plan

- [x] `bun run test` — full suite green (server 3432 pass / 1 skip / 0 fail; excluding one unrelated local-environment-only failure caused by `SSH_AUTH_SOCK` leaking from the host shell into `multi-user-mode.test.ts`, confirmed by rerunning with `env -u SSH_AUTH_SOCK` — 0 fail)
- [x] `bun run typecheck` — clean
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (no coverage-pattern gaps; `mcp/` is outside the tracked coverage patterns, tests added anyway)

Closes #1128
Refs #1127

## Note on CodeRabbit
Local CodeRabbit CLI could not authenticate in this headless worktree (browser-based login flow times out with no interactive browser available). The GitHub-side bot reported "Review limit reached" (59-minute wait) at PR open. No CodeRabbit feedback obtainable from either source at this time. Will re-check `reviewDecision` before requesting merge; if it remains unavailable, disposition follows the "both layers simultaneously rate-limited" case in the `coderabbit-ops` skill (PR Merge Authority).
