### PR TITLE
fix: warn when provider-keys.json mode is not 0600

### DIFF
--- a/packages/server/src/services/__tests__/provider-key-store.test.ts
+++ b/packages/server/src/services/__tests__/provider-key-store.test.ts
@@ -63,4 +63,57 @@ describe('loadProviderKey', () => {
     }
     expect(message).not.toContain('super-secret-value');
   });
+
+  describe('file mode warning', () => {
+    const makeSpyLogger = () => {
+      const calls: Array<[Record<string, unknown>, string]> = [];
+      return {
+        logger: { warn: (obj: Record<string, unknown>, msg: string) => calls.push([obj, msg]) },
+        calls,
+      };
+    };
+
+    it('warns when the file mode is world/group readable (0644)', async () => {
+      await Bun.write(keyFile, JSON.stringify({ openai: 'sk-test' }));
+      await Bun.spawn(['chmod', '644', keyFile]).exited;
+      const { logger: spyLogger, calls } = makeSpyLogger();
+
+      await loadProviderKey('openai', { filePath: keyFile, logger: spyLogger });
+
+      expect(calls).toHaveLength(1);
+      const [context, message] = calls[0];
+      expect(message).toContain('should be 0600');
+      expect(context.filePath).toBe(keyFile);
+      expect(message).not.toContain('sk-test');
+    });
+
+    it('warns when the file mode is group readable only (0640)', async () => {
+      await Bun.write(keyFile, JSON.stringify({ openai: 'sk-test' }));
+      await Bun.spawn(['chmod', '640', keyFile]).exited;
+      const { logger: spyLogger, calls } = makeSpyLogger();
+
+      await loadProviderKey('openai', { filePath: keyFile, logger: spyLogger });
+
+      expect(calls).toHaveLength(1);
+    });
+
+    it('does not warn when the file mode is already 0600', async () => {
+      await Bun.write(keyFile, JSON.stringify({ openai: 'sk-test' }));
+      await Bun.spawn(['chmod', '600', keyFile]).exited;
+      const { logger: spyLogger, calls } = makeSpyLogger();
+
+      await loadProviderKey('openai', { filePath: keyFile, logger: spyLogger });
+
+      expect(calls).toHaveLength(0);
+    });
+
+    it('does not fail activation when the mode is insecure', async () => {
+      await Bun.write(keyFile, JSON.stringify({ openai: 'sk-test' }));
+      await Bun.spawn(['chmod', '644', keyFile]).exited;
+
+      const key = await loadProviderKey('openai', { filePath: keyFile });
+
+      expect(key).toBe('sk-test');
+    });
+  });
 });

--- a/packages/server/src/services/provider-key-store.ts
+++ b/packages/server/src/services/provider-key-store.ts
@@ -14,6 +14,12 @@
  */
 import * as path from 'node:path';
 import { getConfigDir } from '../lib/config.js';
+import { createLogger } from '../lib/logger.js';
+
+const logger = createLogger('provider-key-store');
+
+/** Minimal structural type for the DI logger seam below (matches `pino.Logger['warn']`). */
+type WarnLogger = { warn: (obj: Record<string, unknown>, msg: string) => void };
 
 /**
  * Resolve a provider key by its reference name.
@@ -21,14 +27,17 @@ import { getConfigDir } from '../lib/config.js';
  * @param ref The `apiKeyRef` from an embedded-agent definition.
  * @param opts.filePath Override for the key-store path (test seam). Defaults to
  *   `<AGENT_CONSOLE_HOME>/provider-keys.json`.
+ * @param opts.logger Override for the mode-warning logger (test seam). Defaults to
+ *   the module's structured logger.
  * @throws Error when the file is missing, unparseable, or the ref does not map
  *   to a non-empty string. The key value is never included in the message.
  */
 export async function loadProviderKey(
   ref: string,
-  opts: { filePath?: string } = {},
+  opts: { filePath?: string; logger?: WarnLogger } = {},
 ): Promise<string> {
   const filePath = opts.filePath ?? path.join(getConfigDir(), 'provider-keys.json');
+  const log = opts.logger ?? logger;
 
   const file = Bun.file(filePath);
   if (!(await file.exists())) {
@@ -36,6 +45,8 @@ export async function loadProviderKey(
       `Provider key store not found at ${filePath}; cannot resolve apiKeyRef '${ref}'`,
     );
   }
+
+  await warnIfModeInsecure(file, filePath, log);
 
   let raw: string;
   try {
@@ -69,4 +80,34 @@ export async function loadProviderKey(
   }
 
   return value;
+}
+
+/**
+ * Warn (never throw) when the key store file's permission bits allow group
+ * or world access. Advisory only, matching the operator-managed v1 posture:
+ * a misconfigured mode should be visible in logs, not block activation.
+ *
+ * Reads via the same `BunFile` handle `loadProviderKey` uses for `.exists()`
+ * / `.text()` (not `node:fs`/`node:fs/promises`) so this stays consistent
+ * under bun:test's process-global `memfs` mock of `node:fs` in sibling test
+ * files — see the NOTE in `__tests__/provider-key-store.test.ts`.
+ */
+async function warnIfModeInsecure(
+  file: ReturnType<typeof Bun.file>,
+  filePath: string,
+  log: WarnLogger,
+): Promise<void> {
+  let mode: number;
+  try {
+    mode = (await file.stat()).mode & 0o777;
+  } catch {
+    return;
+  }
+
+  if ((mode & 0o077) !== 0) {
+    log.warn(
+      { filePath, mode: mode.toString(8) },
+      `provider-keys.json mode is 0${mode.toString(8)}, should be 0600 (world/group readable)`,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- `loadProviderKey` now stats the key-store file after confirming it exists and logs a structured `warn` (path + octal mode, never the key value) when the mode allows group or world access (`mode & 0o077 !== 0`).
- Advisory only — a misconfigured mode does not fail activation, matching the operator-managed v1 posture described in `docs/design/embedded-agent-worker.md` § Credentials.
- Mode check reads via the same `BunFile` handle (`file.stat()`) that `.exists()` / `.text()` already use, rather than `node:fs`/`node:fs/promises`, to stay consistent with the sibling test file's process-global `memfs` mock note (also avoids a real full-suite flake this caused during development).
- Adds an optional `opts.logger` DI seam (mirrors the existing `opts.filePath` test seam) so tests can assert on warn calls without `mock.module`.

## Test plan
- [x] TDD polarity confirmed: the two mode-warning tests (0644, 0640) fail against the pre-fix code and pass after the fix (verified via `git stash`-equivalent baseline swap).
- [x] `bun run test` (full suite): all pass except one pre-existing, unrelated failure in `multi-user-mode.test.ts` caused by this dogfood environment's real `SSH_AUTH_SOCK` (1Password) — reproduced identically on the unmodified baseline.
- [x] `bun run typecheck`: 0 errors.
- [x] `node .claude/skills/orchestrator/preflight-check.js`: clean (coverage, rule/skill duplication, language, blame-shift checks all pass).
- CodeRabbit CLI: authentication failed in this headless worktree (known limitation — no interactive browser auth available). Falling back to the GitHub-side bot review.

Closes #1018

## Note on CodeRabbit
Both local CodeRabbit CLI (headless-worktree auth failure) and GitHub-side bot (rate-limited, "Review limit reached", next review in 48 minutes) were unable to review this PR at the same review window. No CodeRabbit feedback obtainable from either source. Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority).