### PR TITLE
test: add request-history routes-layer coverage for embedded-agent worker

### DIFF
--- a/packages/server/src/websocket/__tests__/routes-embedded-agent.test.ts
+++ b/packages/server/src/websocket/__tests__/routes-embedded-agent.test.ts
@@ -433,6 +433,30 @@ describe('Worker WebSocket: embedded-agent branch', () => {
     expect(mockWs.closeCalls.length).toBe(0);
   });
 
+  it('serves request-history for an embedded-agent worker with the shared history-response shape', async () => {
+    // request-history is handled by shared isStreamWorker machinery before
+    // the embedded-agent worker-type branch (routes.ts), so this test guards
+    // that routes-layer coverage exists for the embedded-agent shape too --
+    // the PTY-focused routes-history.test.ts only exercises PTY workers.
+    const { sessionId, workerId } = await createEmbeddedAgentSession();
+    const { handlers, mockWs } = openConnection(sessionId, workerId);
+    await waitFor(() => fake.captured.length === 1);
+    mockWs.sentMessages.length = 0;
+
+    handlers.onMessage({ data: JSON.stringify({ type: 'request-history' }) }, mockWs);
+
+    await waitFor(() => mockWs.sentMessages.some((m) => JSON.parse(m).type === 'history'));
+    const historyMsg = mockWs.sentMessages.map((m) => JSON.parse(m)).find((m) => m.type === 'history');
+    expect(historyMsg).toMatchObject({
+      type: 'history',
+      data: expect.any(String),
+      offset: expect.any(Number),
+      startOffset: expect.any(Number),
+      epoch: expect.any(Number),
+    });
+    expect(mockWs.closeCalls.length).toBe(0);
+  });
+
   it('rejects input/resize with an error message and keeps the socket open', async () => {
     const { sessionId, workerId } = await createEmbeddedAgentSession();
     const { handlers, mockWs } = openConnection(sessionId, workerId);


### PR DESCRIPTION
## Summary
- Adds routes-layer test coverage for the `request-history` handler on an embedded-agent worker connection in `routes-embedded-agent.test.ts`.
- `request-history` is handled by shared `isStreamWorker` machinery in `routes.ts`, reached before the embedded-agent worker-type branch. Existing embedded-agent tests cover `embedded-user-message` / `embedded-cancel` / input-rejection / `turn-in-progress`, but not this shared handler — a gap that PTY-focused history tests (`routes-history.test.ts`) don't catch since they only exercise PTY workers.
- **Test-only change. No production code modified.**

## Test plan
- [x] Activate an embedded-agent worker, send `request-history`, assert the `history` response shape (`{ data, offset, startOffset, epoch }`).
- [x] `bun run typecheck` — exit 0.
- [x] Full `bun run test` — exit 0 (see pasted output below).

### Note on test environment
The first full-suite run in this session showed 1 failing test unrelated to this change: the `multi-user-mode.test.ts` elevation-skip direct-spawn-path test that ignores `sshAuthSockFallback`. Root cause: this session's shell has `SSH_AUTH_SOCK` set (1Password agent forwarding), and that test asserts `opts.env?.SSH_AUTH_SOCK` is `undefined` in the direct (non-elevated) spawn path — an assumption that only holds when the ambient environment has no SSH agent socket set. Confirmed unrelated to this PR's diff (`git diff --stat` shows only `routes-embedded-agent.test.ts` changed) and reproduced as an environment artifact: the test passes with `env -u SSH_AUTH_SOCK`. The pasted full-suite output below is from the `env -u SSH_AUTH_SOCK` run, which is fully green.

```
[36m│[0m  4016 expect() calls
[36m│[0m Ran 1930 tests across 134 files. [0m[2m[[1m61.72s[0m[2m][0m
[36m└─[0m [36mRunning...[0m
[1m@agent-console/shared[0m test $ [2mbun test src/[0m
[36m│[0m [0m[1mbun test [0m[2mv1.3.10 (30e609e0)[0m
[36m│[0m 
[36m│[0m [0m[32m 523 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  794 expect() calls
[36m│[0m Ran 523 tests across 20 files. [0m[2m[[1m468.00ms[0m[2m][0m
[36m└─[0m [36mDone in 477 ms[0m
[1m@agent-console/integration[0m test $ [2mbun test --preload ./src/setup.ts src/[0m
[36m│[0m [2m[12784 lines elided][0m
[36m│[0m     [35mremovedSessions[39m: 0
[36m│[0m     [35mpreservedSessions[39m: 0
[36m│[0m     [35mserverPid[39m: 3461682
[36m│[0m [04:00:46.142] [32mINFO[39m: [36mDatabase connection closed[39m
[36m│[0m     [35mservice[39m: "database"
[36m│[0m 
[36m│[0m [0m[32m 66 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  346 expect() calls
[36m│[0m Ran 66 tests across 23 files. [0m[2m[[1m5.07s[0m[2m][0m
[36m└─[0m [36mDone in 5.13 s[0m
[1m@agent-console/server[0m test $ [2mbun test src/[0m
[36m│[0m [2m[194691 lines elided][0m
[36m│[0m       "exitCode": 128,
[36m│[0m       "stderr": "fatal: not a git repository",
[36m│[0m       "name": "GitError"
[36m│[0m     }
[36m│[0m 
[36m│[0m [0m[32m 3440 pass[0m
[36m│[0m  [0m[33m1 skip[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  9489 expect() calls
[36m│[0m Ran 3441 tests across 153 files. [0m[2m[[1m73.76s[0m[2m][0m
[36m└─[0m [36mDone in 73.85 s[0m
[?2026l[?2026h[0G[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1A[K[1m@agent-console/embedded-agent[0m test $ [2mbun test src/[0m
[36m│[0m [0m[1mbun test [0m[2mv1.3.10 (30e609e0)[0m
[36m│[0m 
[36m│[0m [0m[32m 199 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  431 expect() calls
[36m│[0m Ran 199 tests across 19 files. [0m[2m[[1m5.97s[0m[2m][0m
[36m└─[0m [36mDone in 5.99 s[0m
[1m@agent-console/client[0m test $ [2mbun test --preload ./src/test/setup.ts src/[0m
[36m│[0m [2m[964 lines elided][0m
[36m│[0m [0m      [2mat [0m[0m[1m[3mhandleApiError[0m[2m ([0m[0m[36m[2m/var/lib/agent-console/repositories/ms2sato/agent-console/worktrees/wt-005-iy5n/packages/client/[0m[36msrc/lib/api.ts[0m[2m:[0m[33m78[0m[2m:[33m9[0m[2m)[0m
[36m│[0m [0m      [2mat [0m[0m[1m[3masync createWorker[0m[2m ([0m[0m[36m[2m/var/lib/agent-console/repositories/ms2sato/agent-console/worktrees/wt-005-iy5n/packages/client/[0m[36msrc/lib/api.ts[0m[2m:[0m[33m156[0m[2m:[33m11[0m[2m)[0m
[36m│[0m [0m      [2mat [0m[0m[2masync <anonymous>[0m[2m ([0m[0m[36m[2m/var/lib/agent-console/repositories/ms2sato/agent-console/worktrees/wt-005-iy5n/packages/client/[0m[36msrc/components/sessions/hooks/useTabManagement.ts[0m[2m:[0m[33m166[0m[2m:[33m32[0m[2m)[0m
[36m│[0m [0m      [2mat [0m[0m[2masync <anonymous>[0m[2m ([0m[0m[36m[2m/var/lib/agent-console/repositories/ms2sato/agent-console/worktrees/wt-005-iy5n/packages/client/[0m[36msrc/components/sessions/hooks/__tests__/useTabManagement.test.ts[0m[2m:[0m[33m510[0m[2m:[33m30[0m[2m)[0m
[36m│[0m [0m
[36m│[0m 
[36m│[0m [0m[32m 1930 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  4016 expect() calls
[36m│[0m Ran 1930 tests across 134 files. [0m[2m[[1m61.72s[0m[2m][0m
[36m└─[0m [36mDone in 61.95 s[0m
[1m@agent-console/shared[0m test $ [2mbun test src/[0m
[36m│[0m [0m[1mbun test [0m[2mv1.3.10 (30e609e0)[0m
[36m│[0m 
[36m│[0m [0m[32m 523 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  794 expect() calls
[36m│[0m Ran 523 tests across 20 files. [0m[2m[[1m468.00ms[0m[2m][0m
[36m└─[0m [36mDone in 477 ms[0m
[1m@agent-console/integration[0m test $ [2mbun test --preload ./src/setup.ts src/[0m
[36m│[0m [2m[12784 lines elided][0m
[36m│[0m     [35mremovedSessions[39m: 0
[36m│[0m     [35mpreservedSessions[39m: 0
[36m│[0m     [35mserverPid[39m: 3461682
[36m│[0m [04:00:46.142] [32mINFO[39m: [36mDatabase connection closed[39m
[36m│[0m     [35mservice[39m: "database"
[36m│[0m 
[36m│[0m [0m[32m 66 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  346 expect() calls
[36m│[0m Ran 66 tests across 23 files. [0m[2m[[1m5.07s[0m[2m][0m
[36m└─[0m [36mDone in 5.13 s[0m
[1m@agent-console/server[0m test $ [2mbun test src/[0m
[36m│[0m [2m[194691 lines elided][0m
[36m│[0m       "exitCode": 128,
[36m│[0m       "stderr": "fatal: not a git repository",
[36m│[0m       "name": "GitError"
[36m│[0m     }
[36m│[0m 
[36m│[0m [0m[32m 3440 pass[0m
[36m│[0m  [0m[33m1 skip[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  9489 expect() calls
[36m│[0m Ran 3441 tests across 153 files. [0m[2m[[1m73.76s[0m[2m][0m
[36m└─[0m [36mDone in 73.85 s[0m
[?2026l[0m[2m[35m$[0m [2m[1mbun test scripts/ ./.claude/hooks/__tests__/ ./.claude/skills/*/__tests__/[0m
[0m[1mbun test [0m[2mv1.3.10 (30e609e0)[0m

[0m[32m 427 pass[0m
[0m[2m 0 fail[0m
 1180 expect() calls
Ran 427 tests across 12 files. [0m[2m[[1m4.17s[0m[2m][0m
TEST_EXIT: 0
```

TEST_EXIT: 0

Closes #1027
