### PR TITLE
fix: guard mappers.ts enabled_tools JSON.parse + document edit-save pinning (closes #1055)

### DIFF
--- a/docs/design/embedded-agent-worker.md
+++ b/docs/design/embedded-agent-worker.md
@@ -444,6 +444,8 @@ The undefined→default resolution happens **in the subprocess** (`resolveEnable
 
 **Persistence.** New nullable `embedded_agents.enabled_tools TEXT` column (JSON array string; `NULL` ↔ `undefined`, `'[]'` ↔ `[]`, `'["Read","Glob"]'` ↔ `['Read','Glob']`). PATCH semantics on `UpdateEmbeddedAgentRequestSchema` follow the same convention as the sibling optional fields: `enabledTools: null` resets to `undefined` (default), `undefined` (key absent) means no change, an explicit array replaces.
 
+**Edit-save pinning.** The Add/Edit form always writes an explicit array for `enabledTools` on save — it never leaves the field `undefined`. Once a definition has been through Add/Edit, its `enabledTools` is pinned to that snapshot and will NOT track future changes to `DEFAULT_EMBEDDED_AGENT_ENABLED_TOOLS`. Only definitions that have never been saved through the form (still `NULL`/`undefined` at the DB level) pick up a default change.
+
 ### Path confinement (the FF-1a "minimum floor")
 
 All three FF-1a tools resolve their target path through `resolveConfinedPath` (`packages/embedded-agent/src/tools/path-confinement.ts`) before touching the filesystem:

--- a/packages/server/src/database/__tests__/mappers.test.ts
+++ b/packages/server/src/database/__tests__/mappers.test.ts
@@ -1445,5 +1445,30 @@ describe('mappers', () => {
       expect(restored.enabledTools).toEqual([]);
       expect(restored.instructions).toEqual([]);
     });
+
+    it('does not throw and falls back to undefined when enabled_tools contains malformed JSON', () => {
+      const selectRow: EmbeddedAgentRow = {
+        id: 'def-malformed',
+        name: 'Malformed',
+        description: null,
+        provider_base_url: 'http://localhost:11434/v1',
+        provider_model: 'llama3',
+        provider_api_key_ref: null,
+        system_prompt: null,
+        max_tool_iterations: null,
+        enabled_tools: '["Read"',
+        instructions: null,
+        created_by: 'user-uuid',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      };
+
+      let restored: EmbeddedAgentDefinition | undefined;
+      expect(() => {
+        restored = toEmbeddedAgentDefinition(selectRow);
+      }).not.toThrow();
+
+      expect(restored?.enabledTools).toBeUndefined();
+    });
   });
 });

--- a/packages/server/src/database/__tests__/mappers.test.ts
+++ b/packages/server/src/database/__tests__/mappers.test.ts
@@ -1470,5 +1470,80 @@ describe('mappers', () => {
 
       expect(restored?.enabledTools).toBeUndefined();
     });
+
+    it('does not throw and falls back to undefined when instructions contains malformed JSON', () => {
+      const selectRow: EmbeddedAgentRow = {
+        id: 'def-malformed-instructions',
+        name: 'Malformed',
+        description: null,
+        provider_base_url: 'http://localhost:11434/v1',
+        provider_model: 'llama3',
+        provider_api_key_ref: null,
+        system_prompt: null,
+        max_tool_iterations: null,
+        enabled_tools: null,
+        instructions: '["docs/note.md"',
+        created_by: 'user-uuid',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      };
+
+      let restored: EmbeddedAgentDefinition | undefined;
+      expect(() => {
+        restored = toEmbeddedAgentDefinition(selectRow);
+      }).not.toThrow();
+
+      expect(restored?.instructions).toBeUndefined();
+    });
+
+    it('does not throw and falls back to undefined when enabled_tools parses to a non-array value', () => {
+      const selectRow: EmbeddedAgentRow = {
+        id: 'def-non-array-tools',
+        name: 'NonArray',
+        description: null,
+        provider_base_url: 'http://localhost:11434/v1',
+        provider_model: 'llama3',
+        provider_api_key_ref: null,
+        system_prompt: null,
+        max_tool_iterations: null,
+        enabled_tools: '{}',
+        instructions: null,
+        created_by: 'user-uuid',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      };
+
+      let restored: EmbeddedAgentDefinition | undefined;
+      expect(() => {
+        restored = toEmbeddedAgentDefinition(selectRow);
+      }).not.toThrow();
+
+      expect(restored?.enabledTools).toBeUndefined();
+    });
+
+    it('does not throw and falls back to undefined when instructions parses to a non-array value', () => {
+      const selectRow: EmbeddedAgentRow = {
+        id: 'def-non-array-instructions',
+        name: 'NonArray',
+        description: null,
+        provider_base_url: 'http://localhost:11434/v1',
+        provider_model: 'llama3',
+        provider_api_key_ref: null,
+        system_prompt: null,
+        max_tool_iterations: null,
+        enabled_tools: null,
+        instructions: '"foo"',
+        created_by: 'user-uuid',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      };
+
+      let restored: EmbeddedAgentDefinition | undefined;
+      expect(() => {
+        restored = toEmbeddedAgentDefinition(selectRow);
+      }).not.toThrow();
+
+      expect(restored?.instructions).toBeUndefined();
+    });
   });
 });

--- a/packages/server/src/database/mappers.ts
+++ b/packages/server/src/database/mappers.ts
@@ -540,6 +540,21 @@ export function toEmbeddedAgentRow(def: EmbeddedAgentDefinition): NewEmbeddedAge
  * @returns The EmbeddedAgentDefinition object
  */
 export function toEmbeddedAgentDefinition(row: EmbeddedAgentRow): EmbeddedAgentDefinition {
+  // enabledTools: NULL in DB is the "follow the default" signal. Once a
+  // definition is edited via the Add/Edit form, it is written as an
+  // explicit array (per Q1 裁定) — this pins the enabled set to the
+  // values shown at edit time. Future default changes do NOT propagate
+  // to edited definitions.
+  let enabledTools: EmbeddedAgentToolName[] | undefined;
+  if (row.enabled_tools !== null) {
+    try {
+      enabledTools = JSON.parse(row.enabled_tools) as EmbeddedAgentToolName[];
+    } catch {
+      logger.warn({ embeddedAgentId: row.id }, 'Failed to parse enabled_tools, ignoring');
+      enabledTools = undefined;
+    }
+  }
+
   return {
     id: row.id,
     name: row.name,
@@ -551,8 +566,7 @@ export function toEmbeddedAgentDefinition(row: EmbeddedAgentRow): EmbeddedAgentD
     },
     systemPrompt: row.system_prompt ?? undefined,
     maxToolIterations: row.max_tool_iterations ?? undefined,
-    enabledTools:
-      row.enabled_tools !== null ? (JSON.parse(row.enabled_tools) as EmbeddedAgentToolName[]) : undefined,
+    enabledTools,
     instructions: row.instructions !== null ? (JSON.parse(row.instructions) as string[]) : undefined,
     createdBy: row.created_by,
     createdAt: row.created_at,

--- a/packages/server/src/database/mappers.ts
+++ b/packages/server/src/database/mappers.ts
@@ -533,6 +533,36 @@ export function toEmbeddedAgentRow(def: EmbeddedAgentDefinition): NewEmbeddedAge
 }
 
 /**
+ * Parse a nullable JSON-array-string embedded-agent column (`enabled_tools`,
+ * `instructions`) into a typed array. This is the only boundary where DB
+ * content becomes a typed policy value, so both failure modes are guarded
+ * and treated the same as a NULL column (warn + fall back to `undefined`):
+ * the string not being valid JSON at all, and the JSON parsing successfully
+ * to a non-array value (e.g. `'"foo"'` or `'{}'`) that would otherwise
+ * silently misbehave when a caller iterates it as an array.
+ */
+function parseEmbeddedAgentJsonArrayColumn<T>(
+  value: string | null,
+  embeddedAgentId: string,
+  fieldName: 'enabled_tools' | 'instructions'
+): T[] | undefined {
+  if (value === null) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      logger.warn({ embeddedAgentId }, `Failed to parse ${fieldName}, ignoring`);
+      return undefined;
+    }
+    return parsed as T[];
+  } catch {
+    logger.warn({ embeddedAgentId }, `Failed to parse ${fieldName}, ignoring`);
+    return undefined;
+  }
+}
+
+/**
  * Convert a database embedded agent row to an EmbeddedAgentDefinition.
  * Unflattens the `provider_*` columns into the nested `provider` object.
  *
@@ -540,20 +570,17 @@ export function toEmbeddedAgentRow(def: EmbeddedAgentDefinition): NewEmbeddedAge
  * @returns The EmbeddedAgentDefinition object
  */
 export function toEmbeddedAgentDefinition(row: EmbeddedAgentRow): EmbeddedAgentDefinition {
-  // enabledTools: NULL in DB is the "follow the default" signal. Once a
-  // definition is edited via the Add/Edit form, it is written as an
-  // explicit array (per Q1 裁定) — this pins the enabled set to the
-  // values shown at edit time. Future default changes do NOT propagate
-  // to edited definitions.
-  let enabledTools: EmbeddedAgentToolName[] | undefined;
-  if (row.enabled_tools !== null) {
-    try {
-      enabledTools = JSON.parse(row.enabled_tools) as EmbeddedAgentToolName[];
-    } catch {
-      logger.warn({ embeddedAgentId: row.id }, 'Failed to parse enabled_tools, ignoring');
-      enabledTools = undefined;
-    }
-  }
+  // enabledTools / instructions: NULL in DB is the "follow the default" (or
+  // "no instructions") signal. Once a definition is edited via the Add/Edit
+  // form, it is written as an explicit array (per the Q1 design decision) —
+  // this pins the enabled set to the values shown at edit time. Future
+  // default changes do NOT propagate to edited definitions.
+  const enabledTools = parseEmbeddedAgentJsonArrayColumn<EmbeddedAgentToolName>(
+    row.enabled_tools,
+    row.id,
+    'enabled_tools'
+  );
+  const instructions = parseEmbeddedAgentJsonArrayColumn<string>(row.instructions, row.id, 'instructions');
 
   return {
     id: row.id,
@@ -567,7 +594,7 @@ export function toEmbeddedAgentDefinition(row: EmbeddedAgentRow): EmbeddedAgentD
     systemPrompt: row.system_prompt ?? undefined,
     maxToolIterations: row.max_tool_iterations ?? undefined,
     enabledTools,
-    instructions: row.instructions !== null ? (JSON.parse(row.instructions) as string[]) : undefined,
+    instructions,
     createdBy: row.created_by,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/packages/shared/src/types/embedded-agent.ts
+++ b/packages/shared/src/types/embedded-agent.ts
@@ -24,7 +24,15 @@
 export const EMBEDDED_AGENT_TOOL_NAMES = ['Read', 'Glob', 'Grep', 'Bash', 'Write', 'Edit'] as const;
 export type EmbeddedAgentToolName = (typeof EMBEDDED_AGENT_TOOL_NAMES)[number];
 
-/** Default when a definition's `enabledTools` is absent: read-only tools ON, Bash OFF. */
+/**
+ * Default when a definition's `enabledTools` is absent: read-only tools ON, Bash OFF.
+ *
+ * Note that a definition that has ever been through the Add/Edit form persists
+ * `enabledTools` as an explicit array (never leaves it `undefined`) — so a
+ * change to this default does NOT propagate to already-edited definitions.
+ * Only definitions that have never been saved through the form (still
+ * `undefined` at the DB level) pick up a change here.
+ */
 export const DEFAULT_EMBEDDED_AGENT_ENABLED_TOOLS: readonly EmbeddedAgentToolName[] = [
   'Read',
   'Glob',


### PR DESCRIPTION
## Summary

Low-priority follow-up from the architect audit of PR #1050 (FF-1a, embedded-agent feature). Two items in `packages/server/src/database/mappers.ts` `toEmbeddedAgentDefinition`:

1. **Guard `JSON.parse` for `enabled_tools`.** The parse was unguarded; malformed DB content (manual edit, corruption, future migration bug) would throw and fail the whole embedded-agent load. Wrapped in try/catch mirroring the existing sibling pattern for `activity_patterns` in `toAgentDefinition`, falling back to `undefined` (the default) on failure, with a structured `warn` log naming the row id.
2. **Document `enabledTools` edit-save pinning.** Per the Q1 design decision from PR #1050, the Add/Edit form always writes an explicit array for `enabledTools` on save (never `undefined`). This is architecturally correct but has a non-obvious consequence: once a definition is edited, its `enabledTools` is pinned to that snapshot and will NOT track future changes to `DEFAULT_EMBEDDED_AGENT_ENABLED_TOOLS`. Documented in three places:
   - Comment in `toEmbeddedAgentDefinition` (`packages/server/src/database/mappers.ts`)
   - Docstring on `DEFAULT_EMBEDDED_AGENT_ENABLED_TOOLS` (`packages/shared/src/types/embedded-agent.ts`)
   - New "Edit-save pinning" paragraph in the `enabledTools` policy section (`docs/design/embedded-agent-worker.md`)

### Follow-up commit (addressing an independent architect re-audit)

The embedded-agent architect independently audited the first commit and returned a required fix, addressed in a second commit:

- **R1 (required): sibling `instructions` field had the exact same unguarded `JSON.parse`.** The very next line in `toEmbeddedAgentDefinition` had the identical corruption class. Both `enabled_tools` and `instructions` are now routed through a shared `parseEmbeddedAgentJsonArrayColumn` helper rather than duplicating the try/catch inline at two call sites.
- **Additional hardening: "parsed but wrong type" guard.** Both fields now also check `Array.isArray(parsed)` after a successful `JSON.parse` — a value like `'"foo"'` or `'{}'` parses without throwing but is not an array, and would previously have silently propagated to callers that iterate the result. Both failure modes (parse throws, and parse succeeds to a non-array) now warn and fall back to `undefined` identically.
- Also reworded the `enabledTools` edit-save-pinning comment to drop a non-English phrase CodeRabbit flagged as a MINOR "quick win" (`per Q1 裁定` → `per the Q1 design decision`), keeping the same canonical-reference meaning in English per this repo's Language Policy.

## Test plan

- [x] TDD: added a regression test asserting `toEmbeddedAgentDefinition` does not throw and falls back to `enabledTools: undefined` on malformed `enabled_tools` JSON; verified it fails against the unguarded code, then passes after the fix.
- [x] TDD (follow-up commit): added 3 more regression tests — `instructions` malformed JSON, `enabled_tools` parses to a non-array (`'{}'`), `instructions` parses to a non-array (`'"foo"'`) — each verified to fail against the pre-fix code and pass after.
- [x] `bun run typecheck` — zero errors.
- [x] `bun run test` (full suite) — zero failures (one unrelated environment-only failure from a leaked local `SSH_AUTH_SOCK` env var reproduces identically with and without this change; suite is fully green with that var unset — see pasted output below).
- [x] `bun run check:lang` — exit 0.
- [x] Grepped the full diff for any other non-Latin/Greek/Cyrillic characters introduced in source comments — none found besides the one CodeRabbit flagged, which is now fixed.
- [ ] CodeRabbit CLI (`coderabbit review --agent --base main`) — installed but could not complete: the CLI requires interactive browser auth, which is unavailable in this headless worktree (`automatic_login_failed` / `authentication_failed`). Falling back to the GitHub-side CodeRabbit bot review on this PR per the `coderabbit-ops` skill's headless-worktree disposition. (The GitHub-side bot's MINOR finding on the Japanese phrase has been addressed in the follow-up commit.)

No Browser QA needed: this is a server-side data-layer fix + documentation-only change, no UI surface touched.

### Full `bun run test` output (last 100 lines, after the follow-up commit) + exit code

```
@agent-console/shared test $ bun test src/
 523 pass
 0 fail
 794 expect() calls
Ran 523 tests across 20 files. [445.00ms]

@agent-console/integration test $ bun test --preload ./src/setup.ts src/
 66 pass
 0 fail
 346 expect() calls
Ran 66 tests across 23 files. [4.57s]

@agent-console/server test $ bun test src/
 3443 pass
 1 skip
 0 fail
 9495 expect() calls
Ran 3444 tests across 153 files. [69.81s]

@agent-console/embedded-agent test $ bun test src/
 199 pass
 0 fail
 431 expect() calls
Ran 199 tests across 19 files. [6.03s]

@agent-console/client test $ bun test --preload ./src/test/setup.ts src/
 1930 pass
 0 fail
 4011 expect() calls
Ran 1930 tests across 134 files. [69.80s]

$ bun test scripts/ ./.claude/hooks/__tests__/ ./.claude/skills/*/__tests__/
 427 pass
 0 fail
 1180 expect() calls
Ran 427 tests across 12 files. [5.65s]
```

TEST_EXIT: 0

(Run with `env -u SSH_AUTH_SOCK` to eliminate the local-environment-only `multi-user-mode.test.ts` failure caused by this developer machine's 1Password SSH agent socket leaking into the test process; this is a known, pre-existing, unrelated environmental issue — reproduces identically on unmodified `main`.)

The `packages/server` line went from 3441 tests (first commit) to 3444 (follow-up commit) — the 3 new regression tests for R1 + the type-guard hardening.

## Merge policy note

Embedded-agent area merge policy: this PR can merge on architect audit clean (session `84a3a530-86a8-4825-b103-bc3edfe764ee`) + Orchestrator acceptance, no owner Browser QA gate needed.

## CodeRabbit follow-up review fallback disposition

Follow-up commit `36a7b87` (R1 architect audit fix + CR "裁定"→"decision") pushed at ~04:22.
CodeRabbit GitHub-side bot has not posted a re-review for this commit after 25+ minutes,
including a manual `@coderabbitai review` trigger. Bot's latest review object remains
anchored to prior commit `8b99d6c`.

Proceeding under the coderabbit-ops "GitHub-side bot unresponsive" fallback disposition:
- Pre-merge checks: all SUCCESS
- reviewDecision: (still on prior commit, non-CHANGES_REQUESTED)
- Inline comments (prior commit): all addressed in `36a7b87` per architect re-audit
- Architect audit (independent, embedded-agent domain): clean on `36a7b87` (per session 84a3a530)
- Merged by Orchestrator per owner directive (2026-07-16, embedded-agent area architect+Orchestrator merge authority)

Closes #1055
