### PR TITLE
fix: skip retry for non-retryable provider errors in embedded-agent loop

### DIFF
--- a/packages/embedded-agent/src/__tests__/agent-loop.test.ts
+++ b/packages/embedded-agent/src/__tests__/agent-loop.test.ts
@@ -269,6 +269,20 @@ describe('AgentLoop — provider retries', () => {
     const turnError = h.events.find((e) => e.type === 'turn-error');
     expect(turnError).toMatchObject({ message: 'turn canceled' });
   });
+
+  it('fails fast on a non-retryable provider error without retrying or sleeping', async () => {
+    const h = makeLoop([
+      {
+        kind: 'throw',
+        error: new ProviderError('bad request', { retryable: false, status: 400 }),
+      },
+    ]);
+    await h.loop.runTurn('t1', 'hi');
+    expect(h.adapter.calls).toBe(1);
+    expect(h.sleeps).toEqual([]);
+    const turnError = h.events.find((e) => e.type === 'turn-error');
+    expect(turnError).toMatchObject({ message: 'bad request' });
+  });
 });
 
 describe('AgentLoop — malformed tool arguments', () => {

--- a/packages/embedded-agent/src/agent-loop.ts
+++ b/packages/embedded-agent/src/agent-loop.ts
@@ -271,6 +271,11 @@ export class AgentLoop {
         if (signal.aborted) {
           return { kind: 'canceled' };
         }
+        // Non-retryable provider errors (4xx like 400/401/404) fail fast without
+        // burning retries/backoff -- they will never succeed on retry.
+        if (err instanceof ProviderError && !err.retryable) {
+          return { kind: 'error', message: errorMessage(err) };
+        }
         if (attempt === MAX_PROVIDER_ATTEMPTS) {
           return { kind: 'error', message: errorMessage(err) };
         }


### PR DESCRIPTION
## Summary

- `runProviderWithRetries` in `packages/embedded-agent/src/agent-loop.ts` now short-circuits when the caught error is `instanceof ProviderError` and `!err.retryable`, returning `{ kind: 'error', message }` immediately instead of retrying up to `MAX_PROVIDER_ATTEMPTS`.
- Non-retryable 4xx failures (400/401/404) previously burned 2 wasted retries (2.5s backoff + 2 extra HTTP round trips) that could never succeed. They now fail fast on the first attempt.
- Non-`ProviderError` failures (network errors, timeouts) are unaffected — they carry no `retryable` signal and keep the existing retry-everything behavior.
- Cancellation still wins: the `signal.aborted` check runs before the new non-retryable check, unchanged from before.

## Wave position

Wave 2 residual (embedded-agent hardening).

## Note on CodeRabbit

Local CodeRabbit CLI could not complete browser-based auth in this headless worktree session (`automatic_login_failed` / `authentication_failed`). Relying on GitHub-side CodeRabbit bot review.

## Test plan

- Added `it('fails fast on a non-retryable provider error without retrying or sleeping', ...)` to `packages/embedded-agent/src/__tests__/agent-loop.test.ts`, asserting exactly 1 adapter call, 0 sleeps, and a `turn-error` carrying the provider's message.
- TDD polarity confirmed: the new test was written against the unfixed code first and failed (`adapter.calls` was 3, not 1); after the fix it passes.
- Baseline comparison (`git stash` fix only, test kept): re-ran the target test — fails without the fix, passes with it restored. Independently re-verified.
- Full `bun run test` (all 5 packages) — 1 pre-existing unrelated failure in `packages/server/src/services/inbound/__tests__/resolve-targets.test.ts` (`GitError: not a git repository`), confirmed via `git stash` baseline comparison to occur identically with and without this PR's diff, and to pass in isolation. Unrelated to this change (different package, different file, not touched by this PR).

### Full test output (tail 100 + exit code)

```
[36m│[0m [0m[32m 1930 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  4016 expect() calls
[36m│[0m Ran 1930 tests across 134 files. [57.42s]
└─ Running...
@agent-console/shared test $ bun test src/
bun test v1.3.10 (30e609e0)

 523 pass
 0 fail
 794 expect() calls
Ran 523 tests across 20 files. [481.00ms]
└─ Done in 506 ms
@agent-console/integration test $ bun test --preload ./src/setup.ts src/
[12784 lines elided]
    removedSessions: 0
    preservedSessions: 0
    serverPid: 3475144
[04:04:58.063] INFO: Database connection closed
    service: "database"

 66 pass
 0 fail
 346 expect() calls
Ran 66 tests across 23 files. [5.69s]
└─ Done in 5.76 s
@agent-console/server test $ bun test src/
[194461 lines elided]
      "exitCode": 128,
      "stderr": "fatal: not a git repository",
      "name": "GitError"
    }

 3438 pass
 1 skip
 1 fail
 9487 expect() calls
Ran 3440 tests across 153 files. [70.38s]
└─ Exited with code 1
error: script "test:only" exited with code 1
error: script "test" exited with code 1
TEST_EXIT: 1
```

The single failure (`resolve-targets.test.ts`, `GitError: not a git repository`) is pre-existing and unrelated to this PR's diff:
- Passes in isolation: `bun test src/services/inbound/__tests__/resolve-targets.test.ts` → 9 pass, 0 fail.
- Reproduces identically on `git stash` baseline (this PR's diff removed) — same single failure, same test, same error.
- File is not touched by this PR (scope is `packages/embedded-agent/` only).

- `bun run typecheck` — exit 0, all 4 packages clean.

Closes #1017
