### PR TITLE
fix: parse HTTP-date retry-after headers in openai-chat-adapter (closes #1020)

### DIFF
--- a/packages/embedded-agent/src/providers/__tests__/openai-chat-adapter.test.ts
+++ b/packages/embedded-agent/src/providers/__tests__/openai-chat-adapter.test.ts
@@ -331,6 +331,59 @@ describe('OpenAIChatAdapter — HTTP errors', () => {
     expect((caught as ProviderError).retryable).toBe(true);
   });
 
+  it('parses an HTTP-date retry-after header in the future into a positive retryAfterMs', async () => {
+    const future = new Date(Date.now() + 5000).toUTCString();
+    const adapter = new OpenAIChatAdapter({
+      baseUrl: 'http://x/v1',
+      fetchFn: async () => mockResponse({ status: 429, headers: { 'retry-after': future } }),
+    });
+    let caught: unknown;
+    try {
+      await collect(
+        adapter.run({ model: 'm', messages, tools: [], signal: new AbortController().signal }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    const retryAfterMs = (caught as ProviderError).retryAfterMs;
+    expect(retryAfterMs).toBeGreaterThan(0);
+    expect(retryAfterMs).toBeLessThanOrEqual(5000);
+  });
+
+  it('clamps an HTTP-date retry-after header in the past to 0', async () => {
+    const past = new Date(Date.now() - 5000).toUTCString();
+    const adapter = new OpenAIChatAdapter({
+      baseUrl: 'http://x/v1',
+      fetchFn: async () => mockResponse({ status: 429, headers: { 'retry-after': past } }),
+    });
+    let caught: unknown;
+    try {
+      await collect(
+        adapter.run({ model: 'm', messages, tools: [], signal: new AbortController().signal }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as ProviderError).retryAfterMs).toBe(0);
+  });
+
+  it('ignores an invalid retry-after header', async () => {
+    const adapter = new OpenAIChatAdapter({
+      baseUrl: 'http://x/v1',
+      fetchFn: async () =>
+        mockResponse({ status: 429, headers: { 'retry-after': 'not-a-valid-value' } }),
+    });
+    let caught: unknown;
+    try {
+      await collect(
+        adapter.run({ model: 'm', messages, tools: [], signal: new AbortController().signal }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as ProviderError).retryAfterMs).toBeUndefined();
+  });
+
   it('marks 5xx retryable and 4xx non-retryable', async () => {
     const server = new OpenAIChatAdapter({
       baseUrl: 'http://x/v1',

--- a/packages/embedded-agent/src/providers/openai-chat-adapter.ts
+++ b/packages/embedded-agent/src/providers/openai-chat-adapter.ts
@@ -71,12 +71,21 @@ function toOpenAITools(tools: ToolDefinition[]): unknown[] {
   }));
 }
 
-/** Parse a `retry-after` header (delta-seconds only; HTTP-date is ignored). */
+/**
+ * Parse a `retry-after` header. Supports both forms allowed by RFC 9110
+ * § 10.2.3: delta-seconds (`"120"`) and HTTP-date (`"Wed, 21 Oct 2026
+ * 07:28:00 GMT"`).
+ */
 function parseRetryAfterMs(header: string | null): number | undefined {
   if (header === null) return undefined;
-  const seconds = Number(header.trim());
+  const trimmed = header.trim();
+  const seconds = Number(trimmed);
   if (Number.isFinite(seconds) && seconds >= 0) {
     return Math.round(seconds * 1000);
+  }
+  const date = new Date(trimmed);
+  if (!Number.isNaN(date.getTime())) {
+    return Math.max(0, date.getTime() - Date.now());
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- `parseRetryAfterMs` in `openai-chat-adapter.ts` only handled delta-seconds `Retry-After` values. Per RFC 9110 section 10.2.3, an HTTP-date value (e.g. `Wed, 21 Oct 2026 07:28:00 GMT`) is also valid; `Number(header)` on such a value is `NaN`, so `retryAfterMs` silently stayed `undefined`.
- When the numeric parse fails, the function now falls back to `new Date(header)`. If the resulting date is valid, it returns `Math.max(0, date.getTime() - Date.now())` (0 for a date already in the past); otherwise it returns `undefined` as before.
- Follows on from #1017 / PR #1138, which made `runProviderWithRetries` respect `ProviderError.retryable`. This PR extends the hint-consumption contract on the parsing side.

## Test plan
- [x] Added HTTP-date coverage to `packages/embedded-agent/src/providers/__tests__/openai-chat-adapter.test.ts`: future HTTP-date → positive `retryAfterMs`, past HTTP-date → `0`, invalid string → `undefined`. Tests use relative offsets from `Date.now()` at test-run time (no injected clock; consistent with the rest of this test file, which has no existing Date-mocking pattern).
- [x] `bun run typecheck` — clean across all packages.
- [x] `bun run test` — full suite output below.

**Note on the one pre-existing failure below:** `packages/server/src/services/inbound/__tests__/resolve-targets.test.ts` fails only when run as part of the full `packages/server` suite (fixture-state leakage between test files, matching the known pattern in `workflow.md`); it passes in isolation. Verified via baseline comparison (`git stash` this PR's diff, same failure reproduces identically). Unrelated to this change, which touches only `packages/embedded-agent`.

```
│       at async <anonymous> (/var/lib/agent-console/repositories/ms2sato/agent-console/worktrees/wt-005-ej2h/packages/client/src/components/sessions/hooks/useTabManagement.ts:166:32)
│       at async <anonymous> (/var/lib/agent-console/repositories/ms2sato/agent-console/worktrees/wt-005-ej2h/packages/client/src/components/sessions/hooks/__tests__/useTabManagement.test.ts:510:30)
│ 
│ 
│  1930 pass
│  0 fail
│  4016 expect() calls
│ Ran 1930 tests across 134 files. [53.36s]
└─ Running...
@agent-console/shared test $ bun test src/
│ bun test v1.3.10 (30e609e0)
│ 
│  523 pass
│  0 fail
│  794 expect() calls
│ Ran 523 tests across 20 files. [312.00ms]
└─ Done in 323 ms
@agent-console/integration test $ bun test --preload ./src/setup.ts src/
│ [12784 lines elided]
│     removedSessions: 0
│     preservedSessions: 0
│     serverPid: 3532729
│ [04:38:58.033] INFO: Database connection closed
│     service: "database"
│ 
│  66 pass
│  0 fail
│  346 expect() calls
│ Ran 66 tests across 23 files. [3.97s]
└─ Done in 4.00 s
@agent-console/server test $ bun test src/
│ [194706 lines elided]
│       "exitCode": 128,
│       "stderr": "fatal: not a git repository",
│       "name": "GitError"
│     }
│ 
│  3439 pass
│  1 skip
│  1 fail
│  9489 expect() calls
│ Ran 3441 tests across 153 files. [66.11s]
└─ Exited with code 1
^[[?2026l^[[?2026h@agent-console/embedded-agent test $ bun test src/
│ bun test v1.3.10 (30e609e0)
│ 
│  203 pass
│  0 fail
│  438 expect() calls
│ Ran 203 tests across 19 files. [5.78s]
└─ Done in 5.80 s
@agent-console/client test $ bun test --preload ./src/test/setup.ts src/
│ [964 lines elided]
│       at handleApiError (/var/lib/agent-console/repositories/ms2sato/agent-console/worktrees/wt-005-ej2h/packages/client/src/lib/api.ts:78:9)
│       at async createWorker (/var/lib/agent-console/repositories/ms2sato/agent-console/worktrees/wt-005-ej2h/packages/client/src/lib/api.ts:156:11)
│       at async <anonymous> (/var/lib/agent-console/repositories/ms2sato/agent-console/worktrees/wt-005-ej2h/packages/client/src/components/sessions/hooks/useTabManagement.ts:166:32)
│       at async <anonymous> (/var/lib/agent-console/repositories/ms2sato/agent-console/worktrees/wt-005-ej2h/packages/client/src/components/sessions/hooks/__tests__/useTabManagement.test.ts:510:30)
│ 
│ 
│  1930 pass
│  0 fail
│  4016 expect() calls
│ Ran 1930 tests across 134 files. [53.36s]
└─ Done in 53.50 s
@agent-console/shared test $ bun test src/
│ bun test v1.3.10 (30e609e0)
│ 
│  523 pass
│  0 fail
│  794 expect() calls
│ Ran 523 tests across 20 files. [312.00ms]
└─ Done in 323 ms
@agent-console/integration test $ bun test --preload ./src/setup.ts src/
│ [12784 lines elided]
│     removedSessions: 0
│     preservedSessions: 0
│     serverPid: 3532729
│ [04:38:58.033] INFO: Database connection closed
│     service: "database"
│ 
│  66 pass
│  0 fail
│  346 expect() calls
│ Ran 66 tests across 23 files. [3.97s]
└─ Done in 4.00 s
@agent-console/server test $ bun test src/
│ [194706 lines elided]
│       "exitCode": 128,
│       "stderr": "fatal: not a git repository",
│       "name": "GitError"
│     }
│ 
│  3439 pass
│  1 skip
│  1 fail
│  9489 expect() calls
│ Ran 3441 tests across 153 files. [66.11s]
└─ Exited with code 1
^[[?2026lerror: script "test:only" exited with code 1
error: script "test" exited with code 1
TEST_EXIT: 1
```

## Notes
- CodeRabbit CLI (`coderabbit review --agent --base main`) could not authenticate in this headless delegated worktree session (known limitation — no interactive browser auth available).
- Scope limited to `packages/embedded-agent/src/providers/openai-chat-adapter.ts` and its sibling test file, per the issue's stated scope.

## Note on CodeRabbit
Local CodeRabbit CLI could not authenticate in this headless session. The GitHub-side bot also appears rate-limited: PR #1138 (opened 2026-07-16T04:15:32Z, same session window) received a bot comment at 04:15:40Z stating "Review limit reached ... Next review available in: 57 minutes" (≈05:12:40Z). This PR was opened at 04:41:28Z, inside that window, and has received no bot activity after 7+ minutes (no rate-limit notice, no review). Both CodeRabbit layers are effectively unavailable for this PR's review window — simultaneous rate-limit case per `coderabbit-ops` troubleshooting. An independent architect audit (embedded-agent domain, session 84a3a530) confirmed the change is clean and merge-OK. Disposition follows existing PR Merge Authority.

Closes #1020

