### PR TITLE
test: cover prompt-mode + embedded-agent combination for branch-name suggestion

### DIFF
--- a/packages/server/src/routes/__tests__/worktrees.test.ts
+++ b/packages/server/src/routes/__tests__/worktrees.test.ts
@@ -11,6 +11,7 @@ import { asAppContext } from '../../__tests__/test-utils.js';
 import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { _getPullsInProgress, _getDeletionsInProgress } from '../worktrees.js';
+import { CLAUDE_CODE_AGENT_ID } from '../../services/agent-manager.js';
 
 // ---------------------------------------------------------------------------
 // Test constants
@@ -531,6 +532,154 @@ describe('Worktrees API', () => {
       // CLAUDE_CODE_AGENT_ID (route default), forwarded unchanged.
       expect(sessionRequest.agentId).toBe('claude-code-builtin');
       expect(sessionRequest.embeddedAgentId).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // POST /api/repositories/:id/worktrees (Issue #1061: prompt mode +
+  // embedded-agent combination)
+  // =========================================================================
+
+  describe('POST /api/repositories/:id/worktrees (Issue #1061 prompt mode + embedded-agent combination)', () => {
+    /**
+     * The route's worktree creation runs in a fire-and-forget background
+     * promise; short-circuit it with an error result so the test only
+     * needs to observe that the suggester ran, not the full success path.
+     */
+    function createCapturingWorktreeMock() {
+      const mockFn = mock(() => Promise.resolve({ worktreePath: '', error: 'short-circuit for test' }));
+      return { mockFn };
+    }
+
+    function createMockEmbeddedAgentManager(knownId: string) {
+      return {
+        getEmbeddedAgent: mock((id: string) =>
+          id === knownId ? { id: knownId, name: 'My Embedded Agent' } : undefined,
+        ),
+      } as unknown as Parameters<typeof asAppContext>[0]['embeddedAgentManager'];
+    }
+
+    /**
+     * Unlike the fixed-id mock used elsewhere in this file, this manager
+     * echoes back whatever id it was asked for. That distinguishes which
+     * terminal agent id the route actually resolved and forwarded to
+     * `suggestSessionMetadata`, rather than always observing a single
+     * hardcoded id regardless of the route's fallback logic.
+     */
+    function createEchoingAgentManager() {
+      return {
+        getAgent: mock((id: string) => ({ id, name: 'Mock Agent' })),
+      } as unknown as Parameters<typeof asAppContext>[0]['agentManager'];
+    }
+
+    /**
+     * Mirrors the capture helpers used elsewhere in this file: resolve a
+     * promise with the call args so the test can await the fire-and-forget
+     * IIFE deterministically, and short-circuit so the downstream success
+     * path does not need to be mocked further.
+     */
+    function createCapturingSuggestionMock() {
+      let resolveCall!: (args: unknown[]) => void;
+      const captured = new Promise<unknown[]>((resolve) => {
+        resolveCall = resolve;
+      });
+      const mockFn = mock((...args: unknown[]) => {
+        resolveCall(args);
+        return Promise.resolve({ branch: undefined, title: undefined, error: 'short-circuit for test' });
+      });
+      return { mockFn, captured };
+    }
+
+    it('resolves the terminal agent fallback for suggestSessionMetadata when the initial worker uses an embedded agent', async () => {
+      const { mockFn: suggestionMock, captured } = createCapturingSuggestionMock();
+
+      const { mockFn: createCapture } = createCapturingWorktreeMock();
+      (mockWorktreeService as unknown as { createWorktree: typeof createCapture }).createWorktree = createCapture;
+
+      app = new Hono<AppBindings>();
+      app.use('*', async (c, next) => {
+        c.set('appContext', asAppContext({
+          repositoryManager: mockRepositoryManager,
+          worktreeService: mockWorktreeService,
+          agentManager: createEchoingAgentManager(),
+          embeddedAgentManager: createMockEmbeddedAgentManager('known-embedded-agent'),
+          sessionManager: { createSession: mock() } as unknown as SessionManager,
+          broadcastToApp: () => {},
+          suggestSessionMetadata: suggestionMock as unknown as Parameters<typeof asAppContext>[0]['suggestSessionMetadata'],
+        }));
+        await next();
+      });
+      app.onError(onApiError);
+      app.route('/api', api);
+
+      const res = await app.request(
+        `/api/repositories/${TEST_REPO.id}/worktrees`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            taskId: 'task-issue-1061-embedded',
+            mode: 'prompt',
+            initialPrompt: 'Add a dark mode toggle',
+            baseBranch: 'main',
+            useRemote: false,
+            autoStartSession: false,
+            embeddedAgentId: 'known-embedded-agent',
+          }),
+        },
+      );
+
+      expect(res.status).toBe(202);
+
+      const args = await captured;
+      const req = args[0] as { agent: { id: string } };
+      expect(req.agent.id).toBe(CLAUDE_CODE_AGENT_ID);
+    });
+
+    it('regression: an explicit non-default agentId is still forwarded to suggestSessionMetadata unchanged', async () => {
+      const { mockFn: suggestionMock, captured } = createCapturingSuggestionMock();
+
+      const { mockFn: createCapture } = createCapturingWorktreeMock();
+      (mockWorktreeService as unknown as { createWorktree: typeof createCapture }).createWorktree = createCapture;
+
+      app = new Hono<AppBindings>();
+      app.use('*', async (c, next) => {
+        c.set('appContext', asAppContext({
+          repositoryManager: mockRepositoryManager,
+          worktreeService: mockWorktreeService,
+          agentManager: createEchoingAgentManager(),
+          sessionManager: { createSession: mock() } as unknown as SessionManager,
+          broadcastToApp: () => {},
+          suggestSessionMetadata: suggestionMock as unknown as Parameters<typeof asAppContext>[0]['suggestSessionMetadata'],
+        }));
+        await next();
+      });
+      app.onError(onApiError);
+      app.route('/api', api);
+
+      const res = await app.request(
+        `/api/repositories/${TEST_REPO.id}/worktrees`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            taskId: 'task-issue-1061-explicit',
+            mode: 'prompt',
+            initialPrompt: 'Add a dark mode toggle',
+            baseBranch: 'main',
+            useRemote: false,
+            autoStartSession: false,
+            agentId: 'custom-terminal-agent',
+          }),
+        },
+      );
+
+      expect(res.status).toBe(202);
+
+      const args = await captured;
+      const req = args[0] as { agent: { id: string } };
+      expect(req.agent.id).toBe('custom-terminal-agent');
+      expect(req.agent.id).not.toBe(CLAUDE_CODE_AGENT_ID);
     });
   });
 


### PR DESCRIPTION
## Summary

- Test-only change (no production code modified). Adds direct route-level coverage for the `prompt` mode + embedded-agent combination introduced by PR #1058.
- PR #1058 added a terminal-agent fallback in `packages/server/src/routes/worktrees.ts`: `const selectedAgentId = agentId || CLAUDE_CODE_AGENT_ID;`. This lets `suggestSessionMetadata` still resolve a headless-CLI-capable agent to drive branch-name/title suggestion in `'prompt'` mode even when the initial worker itself uses an embedded agent (embedded agents have no headless CLI template). No test exercised this exact combination directly, which was a silent-regression risk on an owner-facing feature.
- Adds two tests to `packages/server/src/routes/__tests__/worktrees.test.ts` under a new `describe('POST /api/repositories/:id/worktrees (Issue #1061 prompt mode + embedded-agent combination)')` block:
  1. `mode: 'prompt'` + `embeddedAgentId` set (no `agentId`) → asserts `suggestSessionMetadata` is called with `agent.id === CLAUDE_CODE_AGENT_ID`.
  2. Regression: `mode: 'prompt'` + an explicit non-default `agentId` (no `embeddedAgentId`) → asserts `suggestSessionMetadata` is called with that provided `agentId`, and explicitly not `CLAUDE_CODE_AGENT_ID`.

Closes #1061

## Polarity verification (TDD)

Confirmed both directions manually before committing:

1. `git diff packages/server/src/routes/worktrees.ts` was empty (no production changes staged).
2. Temporarily edited `packages/server/src/routes/worktrees.ts` line 67 from
   `const selectedAgentId = agentId || CLAUDE_CODE_AGENT_ID;` to
   `const selectedAgentId = agentId;` (removing the fallback).
3. `bun test packages/server/src/routes/__tests__/worktrees.test.ts -t "1061"` →
   **1 pass / 1 fail** — the fallback test failed with `Expected: "claude-code-builtin", Received: undefined`; the regression test (which doesn't rely on the fallback) still passed.
4. Reverted the temporary edit and confirmed `git diff packages/server/src/routes/worktrees.ts` was empty again.
5. Re-ran the same filter → **2 pass / 0 fail**.

This confirms the new fallback test actually regression-guards the `agentId || CLAUDE_CODE_AGENT_ID` line and isn't a vacuously-passing test.

## Test plan

- [x] `bun run typecheck` — 0 errors (all 4 packages)
- [x] `bun run check:lang` — clean (109 files scanned)
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (no coverage gaps, no rule/skill duplication, language clean, no new blame-shift comment references)
- [x] Polarity check (see above) — confirmed fail-without-fix / pass-with-fix
- [x] Full `bun run test` — see output below

```
│  0 fail
│  4016 expect() calls
│ Ran 1930 tests across 134 files. [54.36s]
└─ Running...
@agent-console/shared test $ bun test src/
│ bun test v1.3.10 (30e609e0)
│ 
│  523 pass
│  0 fail
│  794 expect() calls
│ Ran 523 tests across 20 files. [750.00ms]
└─ Done in 769 ms
@agent-console/integration test $ bun test --preload ./src/setup.ts src/
│ [12784 lines elided]
│     removedSessions: 0
│     preservedSessions: 0
│     serverPid: 3592033
│ [05:17:30.375] INFO: Database connection closed
│     service: "database"
│ 
│  66 pass
│  0 fail
│  346 expect() calls
│ Ran 66 tests across 23 files. [4.48s]
└─ Done in 4.51 s
@agent-console/server test $ bun test src/
│ [194703 lines elided]
│       "exitCode": 128,
│       "stderr": "fatal: not a git repository",
│       "name": "GitError"
│     }
│ 
│  3446 pass
│  1 skip
│  0 fail
│  9502 expect() calls
│ Ran 3447 tests across 153 files. [66.39s]
└─ Done in 66.56 s
@agent-console/embedded-agent test $ bun test src/
│ bun test v1.3.10 (30e609e0)
│ 
│  203 pass
│  0 fail
│  438 expect() calls
│ Ran 203 tests across 19 files. [5.84s]
└─ Done in 5.87 s
@agent-console/client test $ bun test --preload ./src/test/setup.ts src/
│ [964 lines elided]
│       at handleApiError (packages/client/src/lib/api.ts:78:9)
│       at async createWorker (packages/client/src/lib/api.ts:156:11)
│       at async <anonymous> (packages/client/src/components/sessions/hooks/useTabManagement.ts:166:32)
│       at async <anonymous> (packages/client/src/components/sessions/hooks/__tests__/useTabManagement.test.ts:510:30)
│ 
│ 
│  1930 pass
│  0 fail
│  4016 expect() calls
│ Ran 1930 tests across 134 files. [54.36s]
└─ Done in 54.43 s
@agent-console/shared test $ bun test src/
│ bun test v1.3.10 (30e609e0)
│ 
│  523 pass
│  0 fail
│  794 expect() calls
│ Ran 523 tests across 20 files. [750.00ms]
└─ Done in 769 ms
@agent-console/integration test $ bun test --preload ./src/setup.ts src/
│ [12784 lines elided]
│     removedSessions: 0
│     preservedSessions: 0
│     serverPid: 3592033
│ [05:17:30.375] INFO: Database connection closed
│     service: "database"
│ 
│  66 pass
│  0 fail
│  346 expect() calls
│ Ran 66 tests across 23 files. [4.48s]
└─ Done in 4.51 s
@agent-console/server test $ bun test src/
│ [194703 lines elided]
│       "exitCode": 128,
│       "stderr": "fatal: not a git repository",
│       "name": "GitError"
│     }
│ 
│  3446 pass
│  1 skip
│  0 fail
│  9502 expect() calls
│ Ran 3447 tests across 153 files. [66.39s]
└─ Done in 66.56 s
$ bun test scripts/ ./.claude/hooks/__tests__/ ./.claude/skills/*/__tests__/
bun test v1.3.10 (30e609e0)

 427 pass
 0 fail
 1180 expect() calls
Ran 427 tests across 12 files. [3.34s]
```

`TEST_EXIT: 0`

Note: the raw run is invoked with `env -u SSH_AUTH_SOCK` — this local dev machine's 1Password SSH agent socket otherwise leaks into an unrelated pre-existing `MultiUserMode` test assertion (`sshAuthSockFallback`) that expects the var to be absent; this is a local-environment artifact unrelated to this change (confirmed identical on the unmodified base branch), not something introduced here.

## Merge policy

Test-only + embedded-agent area: architect audit (session `84a3a530-86a8-4825-b103-bc3edfe764ee`) + Orchestrator acceptance is sufficient for merge, per current sprint delegation policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Note on CodeRabbit

Both local CodeRabbit CLI (headless worktree, cannot complete browser auth) and GitHub-side bot (rate limit, "Next review available in: 59 minutes" per PR comment) were unavailable at this PR's review window. No CodeRabbit feedback obtainable from either source. Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority) for this test-only change, pending architect audit + Orchestrator acceptance.