### PR TITLE
fix(client): make picker-added agent workers closeable (closes #1134)

### DIFF
--- a/packages/client/src/components/sessions/SessionPage.tsx
+++ b/packages/client/src/components/sessions/SessionPage.tsx
@@ -431,6 +431,8 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
   const statusColor = getConnectionStatusColor(connectionStatus, activityState, statusWorkerType);
   const statusText = getConnectionStatusText(connectionStatus, activityState, exitInfo ?? null, statusWorkerType);
 
+  const primaryAgentTabId = tabs.find(t => t.workerType === 'agent')?.id;
+
   const tabButtons = tabs.map(tab => (
     <button
       key={tab.id}
@@ -452,7 +454,7 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
         <span className={`inline-block w-2 h-2 rounded-full ${getTabDotColor(tab.workerType)}`} aria-hidden="true" />
       )}
       {tab.name}
-      {isCloseableTabType(tab.workerType) && (
+      {isCloseableTabType(tab.workerType, tab.id === primaryAgentTabId) && (
         <button
           type="button"
           aria-label="Close tab"

--- a/packages/client/src/components/sessions/__tests__/SessionPage.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/SessionPage.test.tsx
@@ -15,7 +15,7 @@ import {
 } from '../workerRestart';
 import { sessionToPageState } from '../SessionPage';
 import { getTabDotColor, isCloseableTabType, getWorkerTypeLabel, showsActivityBadge } from '../tabAppearance';
-import type { UseTabManagementResult, AddAgentWorkerParams } from '../hooks/useTabManagement';
+import type { UseTabManagementResult, AddAgentWorkerParams, Tab } from '../hooks/useTabManagement';
 import { AddAgentWorkerMenu } from '../AddAgentWorkerMenu';
 
 // Test helpers
@@ -457,6 +457,24 @@ describe('embedded-agent tab bar wiring (Phase 3, Issue #1021)', () => {
       updateTabsFromSession: () => {},
     };
     expect(typeof result.addAgentTab).toBe('function');
+  });
+});
+
+describe('primary agent tab close-button wiring (Issue #1134)', () => {
+  // Pins the primaryAgentTabId computation SessionPage.tsx's tab bar JSX
+  // relies on: the first 'agent'-type tab in array order stays fixed
+  // (non-closeable); any later 'agent'-type tab (added via the picker) is
+  // closeable. See tabAppearance.ts's isCloseableTabType for the full contract.
+  it('only the first agent-type tab in array order is treated as primary', () => {
+    const tabs: Tab[] = [
+      { id: 'agent-1', workerType: 'agent', name: 'Claude Code' },
+      { id: 'terminal-1', workerType: 'terminal', name: 'Shell' },
+      { id: 'agent-2', workerType: 'agent', name: 'Claude Code 2' },
+    ];
+    const primaryAgentTabId = tabs.find(t => t.workerType === 'agent')?.id;
+
+    expect(isCloseableTabType('agent', tabs[0].id === primaryAgentTabId)).toBe(false);
+    expect(isCloseableTabType('agent', tabs[2].id === primaryAgentTabId)).toBe(true);
   });
 });
 

--- a/packages/client/src/components/sessions/__tests__/tabAppearance.test.ts
+++ b/packages/client/src/components/sessions/__tests__/tabAppearance.test.ts
@@ -36,12 +36,20 @@ describe('isCloseableTabType', () => {
     expect(isCloseableTabType('embedded-agent')).toBe(true);
   });
 
-  it('agent tabs are fixed (not closeable)', () => {
+  it('agent tabs are fixed (not closeable) by default', () => {
     expect(isCloseableTabType('agent')).toBe(false);
   });
 
   it('git-diff tabs are fixed (not closeable)', () => {
     expect(isCloseableTabType('git-diff')).toBe(false);
+  });
+
+  it('non-primary agent tabs (picker-added) are closeable', () => {
+    expect(isCloseableTabType('agent', false)).toBe(true);
+  });
+
+  it('primary agent tabs are not closeable when explicitly marked', () => {
+    expect(isCloseableTabType('agent', true)).toBe(false);
   });
 });
 

--- a/packages/client/src/components/sessions/hooks/__tests__/useTabManagement.test.ts
+++ b/packages/client/src/components/sessions/hooks/__tests__/useTabManagement.test.ts
@@ -514,6 +514,53 @@ describe('useTabManagement', () => {
       expect(result.current.tabs).toHaveLength(1);
     });
 
+    it('closeTab deletes a second (non-primary) agent worker and removes tab (Issue #1134)', async () => {
+      const workers = [
+        createAgentWorker('agent-1'),
+        createTerminalWorker('terminal-1'),
+        createAgentWorker('agent-2', 'Claude Code 2'),
+      ];
+      const options = createDefaultOptions({
+        activeSession: { workers },
+        urlWorkerId: 'agent-1',
+      });
+
+      const { result } = renderHook(() => useTabManagement(options));
+
+      expect(result.current.tabs).toHaveLength(3);
+
+      await act(async () => {
+        await result.current.closeTab('agent-2');
+      });
+
+      const deleteCalls = findFetchCalls(/\/sessions\/session-1\/workers\/agent-2$/);
+      expect(deleteCalls).toHaveLength(1);
+      expect(result.current.tabs).toHaveLength(2);
+      expect(result.current.tabs.map(t => t.id)).toEqual(['agent-1', 'terminal-1']);
+    });
+
+    it('does not close the primary agent tab even when a second agent worker exists (Issue #1134)', async () => {
+      const workers = [
+        createAgentWorker('agent-1'),
+        createTerminalWorker('terminal-1'),
+        createAgentWorker('agent-2', 'Claude Code 2'),
+      ];
+      const options = createDefaultOptions({
+        activeSession: { workers },
+        urlWorkerId: 'agent-1',
+      });
+
+      const { result } = renderHook(() => useTabManagement(options));
+
+      await act(async () => {
+        await result.current.closeTab('agent-1');
+      });
+
+      const deleteCalls = findFetchCalls(/\/workers\//);
+      expect(deleteCalls).toHaveLength(0);
+      expect(result.current.tabs).toHaveLength(3);
+    });
+
     it('closeTab deletes an embedded-agent worker and removes tab', async () => {
       const workers = [createAgentWorker('agent-1'), createEmbeddedAgentWorker('embedded-1')];
       const options = createDefaultOptions({

--- a/packages/client/src/components/sessions/hooks/useTabManagement.ts
+++ b/packages/client/src/components/sessions/hooks/useTabManagement.ts
@@ -185,10 +185,13 @@ export function useTabManagement({
     const tab = tabs.find(t => t.id === tabId);
     if (!tab) return;
 
-    // Fixed tabs (agent, git-diff) cannot be closed -- only opt-in workers a
-    // user added to the running session (terminal, embedded-agent). Mirrors
-    // the tab bar's close-button visibility in `tabAppearance.ts`.
-    if (!isCloseableTabType(tab.workerType)) return;
+    // Fixed tabs (git-diff, and the session's primary agent worker) cannot be
+    // closed -- only opt-in workers a user added to the running session
+    // (terminal, embedded-agent, and any additional agent worker added via
+    // the picker). Mirrors the tab bar's close-button visibility in
+    // `tabAppearance.ts`.
+    const primaryAgentTabId = tabs.find(t => t.workerType === 'agent')?.id;
+    if (!isCloseableTabType(tab.workerType, tab.id === primaryAgentTabId)) return;
 
     try {
       await deleteWorker(sessionId, tabId);

--- a/packages/client/src/components/sessions/tabAppearance.ts
+++ b/packages/client/src/components/sessions/tabAppearance.ts
@@ -23,12 +23,16 @@ export function getTabDotColor(workerType: Worker['type']): string {
 
 /**
  * Worker types whose tab renders a close ("x") button: opt-in workers a user
- * added to a running session and can remove again. `agent` and `git-diff`
- * are fixed tabs (auto-created with the session) and are never closeable --
- * see `useTabManagement.ts`'s `closeTab` guard for the server-side mirror of
- * this rule.
+ * added to a running session and can remove again. `git-diff` is a fixed tab
+ * (auto-created with the session) and is never closeable -- see
+ * `useTabManagement.ts`'s `closeTab` guard for the server-side mirror of
+ * this rule. `agent` tabs are closeable EXCEPT for the session's primary
+ * agent worker (the one auto-created at session creation) -- callers pass
+ * `isPrimaryAgent` to distinguish that worker from any additional `agent`
+ * tabs added later via the picker.
  */
-export function isCloseableTabType(workerType: Worker['type']): boolean {
+export function isCloseableTabType(workerType: Worker['type'], isPrimaryAgent = true): boolean {
+  if (workerType === 'agent') return !isPrimaryAgent;
   return workerType === 'terminal' || workerType === 'embedded-agent';
 }
 


### PR DESCRIPTION
## Summary

`isCloseableTabType()` in `packages/client/src/components/sessions/tabAppearance.ts` blanket-denied a close button for every `type: 'agent'` tab. That was correct back when a session could only ever have exactly one `'agent'`-type worker (the one auto-created with the session). PR #1132 (Issue #1023) enabled adding further `'agent'`-type workers to a running session via the unified add-agent picker, but the blanket rule left those opt-in workers with no way to be closed from the UI — the only workaround was calling the DELETE API directly (MCP tool / curl).

## Fix

- `isCloseableTabType(workerType, isPrimaryAgent = true)` now takes a second parameter. `'agent'` tabs are closeable unless `isPrimaryAgent` is true; `terminal` / `embedded-agent` / `git-diff` behavior is unchanged. The default (`true`) preserves prior behavior for any caller that doesn't pass the second argument.
- The session's primary agent worker is identified as **the first `'agent'`-type worker in the session's worker array** — the same convention `useTabManagement.ts`'s existing `findFirstAgentWorker` already uses for default-tab selection. The server only ever creates one `'agent'`-type worker at session-creation time; any further one can only be added afterwards via the picker, strictly later in the array, so this is a reliable signal without needing new server/wire state.
- `SessionPage.tsx` and `useTabManagement.ts`'s `closeTab` both compute `primaryAgentTabId = tabs.find(t => t.workerType === 'agent')?.id` and pass `tab.id === primaryAgentTabId` through.

### Design alternatives considered (per Issue #1134's own fix-design options)

The Issue suggested either `worker.metadata.isFixedInitial: boolean` or `session.initialWorkerId` as more "structural" alternatives to client-side runtime inference. Both were rejected for this fix: either would require a new DB migration, wire-schema (valibot) changes, and server-side population logic purely to answer a client-only rendering question, which is disproportionate for a UX bug fix. The array-order convention this PR uses is not a new invention — it already backs `findFirstAgentWorker` elsewhere in the same file for the exact same "which agent worker is the fixed one" question, so this fix stays consistent with existing precedent rather than introducing a second, redundant way to answer the same question.

## Test plan

- `packages/client/src/components/sessions/__tests__/tabAppearance.test.ts` — added cases for `isCloseableTabType('agent', false)` (closeable) and `isCloseableTabType('agent', true)` (not closeable).
- `packages/client/src/components/sessions/hooks/__tests__/useTabManagement.test.ts` — added: closing a second (non-primary) agent worker succeeds (DELETE fires, tab removed); closing the primary agent tab still no-ops even when a second agent worker exists alongside it (the regression guard).
- `packages/client/src/components/sessions/__tests__/SessionPage.test.tsx` — added a test pinning the `primaryAgentTabId` computation SessionPage's tab-bar JSX relies on, following the same non-full-render pattern already used by the neighboring `embedded-agent tab bar wiring` test block.
- No integration test added: this is a pure client-side rendering/gating change with no server, wire-schema, or persisted-type changes (Q10 does not apply).

### Full suite (`bun run test`)

```
[@agent-console/client] test $ bun test --preload ./src/test/setup.ts src/
 1935 pass
 0 fail
 4026 expect() calls
Ran 1935 tests across 134 files. [52.35s]

[@agent-console/shared] test $ bun test src/
 523 pass
 0 fail
Ran 523 tests across 20 files. [414ms]

[@agent-console/integration] test $ bun test --preload ./src/setup.ts src/
 66 pass
 0 fail
Ran 66 tests across 23 files. [3.88s]

[@agent-console/embedded-agent] test $ bun test src/
 203 pass
 0 fail
Ran 203 tests across 19 files. [5.70s]

[@agent-console/server] test $ bun test src/
 3448 pass
 1 skip
 1 fail
Ran 3450 tests across 153 files. [64.16s]
error: script "test:only" exited with code 1
TEST_EXIT: 1
```

The one `server` failure is pre-existing and unrelated to this PR: `MultiUserMode > Issue #918: sudo-skip (direct) path ignores sshAuthSockFallback > does NOT inject any SSH_AUTH_SOCK shell snippet...` asserts `process.env.SSH_AUTH_SOCK` is `undefined`, but this dev machine has a 1Password SSH agent socket set in the environment, which leaks into the test process. No file under `packages/server` is touched by this PR (`git diff --stat` confirms only 5 files under `packages/client` changed) — confirmed as environment-caused, not a regression from this change.

`bun run typecheck`: all packages clean, exit 0.

## Browser QA

Verified end-to-end in a real browser via Chrome DevTools MCP, against a dedicated dev instance for this worktree (custom ports to avoid colliding with the already-running default-port dev instance) using a Quick Session with the built-in Claude Code agent. Screenshots posted as a follow-up PR comment (`qa-screenshots` upload flow):

1. **Initial state** — only the fixed primary agent tab + Diff tab, neither closeable.
2. **After adding a second agent-type worker** via the picker (Add agent worker → Claude Code Terminal) — the new tab shows a close (×) button, the primary tab still does not.

Clicking the × on the second tab fired the DELETE request and removed the tab, leaving only the primary Claude Code + Diff tabs — confirmed via snapshot after the click. Test artifacts (the Quick Session) were stopped/removed after verification.

## CodeRabbit review fallback disposition

CodeRabbit GitHub-side bot posted an explicit rate-limit warning at 06:10 UTC.
Local CodeRabbit CLI could not authenticate in the headless worktree.

Proceeding under the coderabbit-ops "rate-limit fallback" disposition:
- Pre-merge checks: all SUCCESS
- reviewDecision: empty (bot did not post any actionable review)
- Inline comments: none
- Architect audit (independent, embedded-agent-adjacent domain, session 84a3a530): clean on this diff (backward-compatible default direction correct, terminal/embedded-agent/git-diff behavior unchanged, both directions covered by tests). Two non-blocking observations recorded as owner-side consideration only (see Orchestrator memo).
- Merged by Orchestrator per owner directive (2026-07-16, embedded-agent domain architect+Orchestrator merge authority)

Closes #1134


