### PR TITLE
test: cover untested bash tool paths (closes #1145)

### DIFF
--- a/packages/embedded-agent/src/tools/__tests__/bash.test.ts
+++ b/packages/embedded-agent/src/tools/__tests__/bash.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { bashTool, runBash } from '../bash.js';
+import { bashTool, runBash, formatBashResult } from '../bash.js';
 import { buildBashEnv } from '../env-cleaner.js';
 
 describe('bashTool', () => {
@@ -218,5 +218,95 @@ describe('bashTool', () => {
         process.env.AGENT_CONSOLE_MCP_TOKEN = previous;
       }
     }
+  });
+
+  it('formats an aborted result with the abort marker, independent of exit code', () => {
+    const output = formatBashResult(
+      { ok: false, exitCode: null, stdout: 'partial output', stderr: '', timedOut: false, aborted: true },
+      5000,
+    );
+
+    expect(output).toContain('partial output');
+    expect(output).toContain('[Command aborted and its process group was terminated.]');
+    // aborted takes priority over the exitCode===null branch in the else-if chain.
+    expect(output).not.toContain('[Killed by signal]');
+  });
+
+  it('formats stderr output alongside the exit-code / signal-kill marker', () => {
+    const withExitCode = formatBashResult(
+      { ok: true, exitCode: 3, stdout: '', stderr: 'boom', timedOut: false, aborted: false },
+      5000,
+    );
+    expect(withExitCode).toContain('[stderr]\nboom');
+    expect(withExitCode).toContain('[Exit code: 3]');
+
+    const withoutExitCode = formatBashResult(
+      { ok: false, exitCode: null, stdout: '', stderr: 'boom', timedOut: false, aborted: false },
+      5000,
+    );
+    expect(withoutExitCode).toContain('[stderr]\nboom');
+    expect(withoutExitCode).toContain('[Killed by signal]');
+  });
+
+  it('escalates to SIGKILL after the grace period when the process ignores SIGTERM', async () => {
+    const pidFile = path.join(locationPath, 'ignore-term.pid');
+    const start = Date.now();
+
+    const result = await runBash(`trap '' TERM; echo $$ > ${pidFile}; while :; do :; done`, {
+      cwd: locationPath,
+      env: buildBashEnv(),
+      timeoutMs: 500,
+    });
+    const elapsedMs = Date.now() - start;
+
+    expect(result.timedOut).toBe(true);
+    expect(result.ok).toBe(false);
+    // The process ignores SIGTERM (trap '' TERM), so it can only have died via
+    // the SIGKILL escalation fired KILL_GRACE_MS after the SIGTERM -- proves
+    // the escalation branch actually ran, not just that SIGTERM alone worked.
+    // Bounds are widened (vs. the raw ~2500ms expectation) to tolerate CI
+    // scheduling jitter around the real setTimeout-driven grace window.
+    expect(elapsedMs).toBeGreaterThanOrEqual(2000);
+    expect(elapsedMs).toBeLessThan(6000);
+
+    // Brief grace window for signal delivery to actually land.
+    await new Promise((r) => setTimeout(r, 300));
+
+    const pid = parseInt((await fsPromises.readFile(pidFile, 'utf-8')).trim(), 10);
+    let alive = true;
+    try {
+      process.kill(pid, 0);
+    } catch {
+      alive = false;
+    }
+    expect(alive).toBe(false);
+  });
+
+  it('surfaces a spawn failure (e.g. ENOENT from a nonexistent cwd) as {ok:false} instead of throwing', async () => {
+    // Exercises the real `child.on('error', ...)` path via an actual spawn
+    // failure (nonexistent cwd) rather than mocking `spawn`, per this repo's
+    // "mock at the lowest level" testing rule -- a real OS-level failure is
+    // lower-level than mocking the child_process module.
+    const result = await runBash('echo hi', {
+      cwd: path.join(locationPath, 'this-directory-does-not-exist'),
+      env: buildBashEnv(),
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBeNull();
+    expect(result.timedOut).toBe(false);
+    expect(result.aborted).toBe(false);
+    expect(result.stderr).toContain('Failed to spawn command');
+  });
+
+  it('rejects non-string/non-number typed timeout and description arguments', async () => {
+    const badTimeout = await bashTool.execute({ command: 'echo hi', timeout: 'not-a-number' }, { locationPath });
+    expect(badTimeout.ok).toBe(false);
+    expect(badTimeout.result).toBe('timeout must be a number');
+
+    const badDescription = await bashTool.execute({ command: 'echo hi', description: 42 }, { locationPath });
+    expect(badDescription.ok).toBe(false);
+    expect(badDescription.result).toBe('description must be a string');
   });
 });

--- a/packages/embedded-agent/src/tools/__tests__/bash.test.ts
+++ b/packages/embedded-agent/src/tools/__tests__/bash.test.ts
@@ -68,6 +68,11 @@ describe('bashTool', () => {
     await new Promise((r) => setTimeout(r, 300));
 
     const pid = parseInt((await fsPromises.readFile(pidFile, 'utf-8')).trim(), 10);
+    // Guard against a NaN pid (e.g. an empty pidFile read on a timing fluke)
+    // silently turning into a false-positive pass: process.kill(NaN, 0) throws
+    // a TypeError, which the catch block below would otherwise mistake for
+    // "process not alive".
+    expect(pid).toBeGreaterThan(0);
     let alive = true;
     try {
       process.kill(pid, 0);
@@ -133,13 +138,21 @@ describe('bashTool', () => {
     let pid: number | undefined;
     for (let i = 0; i < 50; i++) {
       try {
-        pid = parseInt((await fsPromises.readFile(pidFile, 'utf-8')).trim(), 10);
+        const parsed = parseInt((await fsPromises.readFile(pidFile, 'utf-8')).trim(), 10);
+        // A read that races the writer's open()-before-write can observe an
+        // empty file (NaN here) rather than ENOENT -- retry instead of
+        // accepting a NaN pid, which would otherwise make process.kill(pid, 0)
+        // below throw and silently pass as "process not alive".
+        if (Number.isNaN(parsed)) {
+          throw new Error('pid file read before it was written');
+        }
+        pid = parsed;
         break;
       } catch {
         await new Promise((r) => setTimeout(r, 50));
       }
     }
-    expect(pid).toBeDefined();
+    expect(pid).toBeGreaterThan(0);
 
     const start = Date.now();
     controller.abort();
@@ -273,6 +286,11 @@ describe('bashTool', () => {
     await new Promise((r) => setTimeout(r, 300));
 
     const pid = parseInt((await fsPromises.readFile(pidFile, 'utf-8')).trim(), 10);
+    // Guard against a NaN pid (e.g. an empty pidFile read on a timing fluke)
+    // silently turning into a false-positive pass: process.kill(NaN, 0) throws
+    // a TypeError, which the catch block below would otherwise mistake for
+    // "process not alive".
+    expect(pid).toBeGreaterThan(0);
     let alive = true;
     try {
       process.kill(pid, 0);


### PR DESCRIPTION
## Summary
- Adds 5 test cases to `packages/embedded-agent/src/tools/__tests__/bash.test.ts` covering the 4 previously-uncovered paths in `packages/embedded-agent/src/tools/bash.ts` identified by the Sprint 2026-07-16 test-coverage audit (P1 findings):
  1. `formatBashResult()` aborted-result formatting (independent of exit code)
  2. `formatBashResult()` stderr formatting alongside the exit-code / signal-kill marker
  3. SIGKILL escalation when the spawned process ignores SIGTERM (`trap '' TERM`)
  4. The real spawn-error path (`child.on('error', ...)`), exercised via an actual ENOENT (nonexistent cwd) rather than mocking `spawn`
  5. `parseArgs` type-rejection for a non-number `timeout` and a non-string `description`
- **Test-only PR.** No production code (`bash.ts`) changes.

## Design notes
- The spawn-error test uses a real nonexistent `cwd` to trigger `child.on('error', ...)` (`ENOENT`) instead of mocking `node:child_process.spawn`, per this repo's testing rule to mock at the lowest level / prefer real integration over module mocking -- no DI seam exists for `spawn` in `bash.ts` and this is a test-only PR, so no production code was touched to add one.
- The SIGKILL escalation test spawns a process that ignores SIGTERM (`trap '' TERM; ...; while :; do :; done`) with a short outer `timeoutMs` (500ms), so the only way it terminates is via the `KILL_GRACE_MS`-later SIGKILL. Assertion bounds are widened (`elapsedMs` in `[2000, 6000)`ms) to tolerate CI scheduling jitter around the real `setTimeout`-driven grace window, per the Issue's flake-avoidance note.

## Independent architect audit
An independent embedded-agent architect (separate session) reviewed the diff directly and confirmed: clean, merge OK. Both design choices above (real-spawn-error over mocking, and the SIGKILL escalation test's polarity via `trap '' TERM`) were specifically checked and confirmed sound.

## CodeRabbit findings addressed
The GitHub-side bot posted one Minor/Quick-win finding on the first push: an empty `pidFile` read on a timing fluke can produce a NaN pid, and `process.kill(NaN, 0)` throws a `TypeError` that the test's `catch` block would mistake for "process not alive" -- a false-positive-pass risk. Fixed in commit `62dc65b`, bundled across all three sibling `parseInt(pidFile)` call sites in this file (not just the newly added test that was flagged), per this repo's sibling-call-site grep discipline.

## Note on CodeRabbit
Local CodeRabbit CLI requires an interactive browser auth flow unavailable in this headless delegated worktree session. The GitHub-side bot reviewed the first commit and posted the Minor finding above (now fixed); on the follow-up push it returned "Review limit reached, next review available in 51 minutes" -- both the local CLI and the GitHub bot are now unavailable simultaneously. Per the documented simultaneous-rate-limit disposition, CodeRabbit's clean verdict is unavailable for the latest commit; proceeding under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority) (test-only PR, embedded-agent area, independent architect audit already clean).

## Test plan
- [x] `bun run typecheck` -- all packages pass
- [x] `bun run test` (full suite) -- see output below. **1 pre-existing failure unrelated to this change**: the direct (non-elevated) path's SSH_AUTH_SOCK-forwarding test in `packages/server/src/services/__tests__/multi-user-mode.test.ts` (`MultiUserMode` describe block, Issue #918), caused by an ambient `SSH_AUTH_SOCK` env var on this host leaking into the test's env assertion. Verified pre-existing by stashing this PR's diff and re-running the same test file against unmodified `main` -- same failure. `packages/embedded-agent` itself: 208 pass / 0 fail (including all 5 new tests, after the NaN-pid fixup).

```
@agent-console/embedded-agent test $ bun test src/
bun test v1.3.10 (30e609e0)

 208 pass
 0 fail
 461 expect() calls
Ran 208 tests across 19 files. [8.33s]
Done in 8.34 s
@agent-console/client test $ bun test --preload ./src/test/setup.ts src/
[964 lines elided]

 1935 pass
 0 fail
 4027 expect() calls
Ran 1935 tests across 134 files. [50.92s]
Done in 51.00 s
@agent-console/shared test $ bun test src/
bun test v1.3.10 (30e609e0)

 523 pass
 0 fail
 794 expect() calls
Ran 523 tests across 20 files. [326.00ms]
Done in 335 ms
@agent-console/integration test $ bun test --preload ./src/setup.ts src/
[13125 lines elided]

 67 pass
 0 fail
 349 expect() calls
Ran 67 tests across 23 files. [3.39s]
Done in 3.41 s
@agent-console/server test $ bun test src/
[195140 lines elided]
      "exitCode": 128,
      "stderr": "fatal: not a git repository",
      "name": "GitError"
    }

 3449 pass
 1 skip
 1 fail
 9524 expect() calls
Ran 3451 tests across 153 files. [62.82s]
Exited with code 1

error: script "test:only" exited with code 1
error: script "test" exited with code 1
TEST_EXIT: 1
```

Closes #1145
