### PR TITLE
docs: sprint retrospective improvements (2026-07-16)

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -251,7 +251,9 @@ Commit messages for PRs that introduce or modify privilege-elevation paths (the 
 
 **Why.** The orchestrator's sandbox guard scans tool inputs for `sudo` as a destructive-action precaution and blocks the entire invocation when it matches — including `gh issue create --body-file` / `git commit -m`-style usages where the literal is only narrative. Two attempts on PR #915 hit this trap before the agent paraphrased the body and the commit landed. Code comments are not scanned and can keep using `sudo` directly; only commit messages, PR bodies, and Issue bodies need the paraphrase.
 
-(Lesson: Sprint 2026-06-29 PR #915 — agent's first commit message body contained `sudo -i` in the elevation explanation; both attempts returned `sudo is denied` until the body was sanitized.)
+**Scope extension: the same trap fires on any tool input body, not only commit messages for elevation code.** PR bodies, Issue bodies, `gh api ... -X PATCH` heredoc contents, and any other narrative body containing the `sudo` substring — even inside a quoted test name (e.g. `describe('sudo-skip (direct) path')`) or narration referencing an existing identifier — will be blocked identically. The trap is content-based, not context-aware. When a public artifact needs to reference such an identifier, paraphrase the reference (`describe('elevation-skip (direct) path')` in the body reference, or `elevation-skip test in multi-user-mode.test.ts`), leaving the source file's actual name unchanged. This applies regardless of whether the PR itself touches elevation code — it triggers whenever the narrative substring appears.
+
+(Lessons: Sprint 2026-06-29 PR #915 — agent's first commit message body contained `sudo -i` in the elevation explanation; both attempts returned `sudo is denied` until the body was sanitized. Sprint 2026-07-16 — two independent delegates (PR #1143 delegate referencing `multi-user-mode.test.ts` describe titles, and PR #1148 delegate referencing an existing failing test name) hit the same trap in PR body / heredoc content unrelated to elevation-code PRs; both resolved with paraphrase.)
 
 ### Allowlist-baseline lint introduction template
 


### PR DESCRIPTION
## Summary

Sprint 2026-07-16 retrospective process improvements. Only one proposal was approved by the owner in the retro apply step; the others were deferred or marked as ignore.

## Proposal B (applied): extend privilege-elevation convention to cover PR body / heredoc trap

`.claude/rules/workflow.md` — the existing "Privilege-elevation commit message convention" section documented only commit messages for elevation-code PRs. The same sandbox guard trap fires on **any tool input body** (PR body, Issue body, `gh api ... -X PATCH` heredoc content), even when the PR itself doesn't touch elevation code, whenever the narrative substring appears — including inside quoted test names being referenced.

Extended the section to make the trap's true scope explicit and document paraphrasing the reference as the workaround (leaving source-file names unchanged; only the narrative reference needs to be re-worded).

## Evidence

Two independent delegates in Sprint 2026-07-16 hit this trap on unrelated PRs:
- PR #1143 delegate: PR body referenced `multi-user-mode.test.ts` describe titles containing the substring — required paraphrase to `elevation-skip (direct) path`.
- PR #1148 delegate: `gh pr create --body-file` heredoc referencing an existing failing test name — same trap, same workaround.

Both delegates recognized the pattern independently and resolved it via paraphrasing, but the extended convention makes the trap's scope explicit rather than relying on delegate re-discovery.

## Proposals deferred / ignored

Owner selected only Proposal B in the retro apply step. The following were marked ignore:
- Proposal A: coderabbit-ops skill walkthrough-only disposition documentation (6 consecutive uses this sprint)
- Proposal C: orchestrator skill embedded-agent merge policy explicit documentation
- Proposals D-H: sprint-retro.js Step 3a instruction / architect scope R1 labeling / metrics design PR flag / delegate prompt lint / pre-pr-completeness scope-expansion rule

## Test plan

- [x] `bun run check:lang` — clean (109 files scanned, exit 0)
- Documentation-only change; no runtime behavior impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)