### PR TITLE
test: cover embedded-agent system-prompt non-ENOENT read error branch

### DIFF
--- a/packages/embedded-agent/src/__tests__/system-prompt.test.ts
+++ b/packages/embedded-agent/src/__tests__/system-prompt.test.ts
@@ -479,6 +479,85 @@ describe('loadInstructions — instructions[] confinement (h, i, j, k; A9)', () 
   });
 });
 
+describe('loadInstructions — non-ENOENT read error is warn-logged, not thrown (m)', () => {
+  function makeRejectingBunFile(errorCode: string, message: string) {
+    return {
+      text: () => {
+        const err = new Error(message) as NodeJS.ErrnoException;
+        err.code = errorCode;
+        return Promise.reject(err);
+      },
+    } as ReturnType<typeof Bun.file>;
+  }
+
+  it('(m1) warn-logs and skips the directory when AGENTS.md read fails with EACCES', async () => {
+    const cwd = await makeTempDir();
+    const agentsPath = join(cwd, 'AGENTS.md');
+    const originalBunFile = Bun.file.bind(Bun);
+
+    const fileSpy = spyOn(Bun, 'file').mockImplementation((filePath: unknown, ...rest: unknown[]) => {
+      if (filePath === agentsPath) {
+        return makeRejectingBunFile('EACCES', 'EACCES: permission denied, open ' + agentsPath);
+      }
+      return (originalBunFile as (...args: unknown[]) => ReturnType<typeof Bun.file>)(
+        filePath,
+        ...rest,
+      );
+    });
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await loadInstructions({
+        cwd,
+        xdgConfigHome: await isolatedXdgConfigHome(),
+      });
+
+      // The directory yields no segment -- the read error is non-fatal to
+      // the overall activation, not a thrown exception.
+      expect(result.segments).toEqual([]);
+      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy.mock.calls.some((call) => String(call[0]).includes(agentsPath))).toBe(true);
+      expect(warnSpy.mock.calls.some((call) => String(call[0]).includes('EACCES'))).toBe(true);
+    } finally {
+      fileSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('(m2) warn-logs and skips the directory when CLAUDE.md read fails with EACCES (AGENTS.md absent)', async () => {
+    const cwd = await makeTempDir();
+    const claudePath = join(cwd, 'CLAUDE.md');
+    const originalBunFile = Bun.file.bind(Bun);
+
+    const fileSpy = spyOn(Bun, 'file').mockImplementation((filePath: unknown, ...rest: unknown[]) => {
+      if (filePath === claudePath) {
+        return makeRejectingBunFile('EACCES', 'EACCES: permission denied, open ' + claudePath);
+      }
+      return (originalBunFile as (...args: unknown[]) => ReturnType<typeof Bun.file>)(
+        filePath,
+        ...rest,
+      );
+    });
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await loadInstructions({
+        cwd,
+        xdgConfigHome: await isolatedXdgConfigHome(),
+      });
+
+      // AGENTS.md is genuinely absent (real ENOENT via the unmocked path),
+      // so resolution falls through to CLAUDE.md, whose non-ENOENT failure
+      // must also be warn-logged rather than thrown.
+      expect(result.segments).toEqual([]);
+      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy.mock.calls.some((call) => String(call[0]).includes(claudePath))).toBe(true);
+      expect(warnSpy.mock.calls.some((call) => String(call[0]).includes('EACCES'))).toBe(true);
+    } finally {
+      fileSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+});
+
 describe('loadInstructions — routine absence is silent (l, anti-noise)', () => {
   it('emits no log at all when a directory has neither AGENTS.md nor CLAUDE.md', async () => {
     const cwd = await makeTempDir();


### PR DESCRIPTION
## Summary
- Adds test coverage for `resolveDirectoryInstructionFile`'s non-ENOENT read-failure branches in `packages/embedded-agent/src/system-prompt.ts` (lines 183-185 for AGENTS.md, 192-194 for CLAUDE.md).
- Both branches previously only had ENOENT (routine-absence) coverage; a real read failure (e.g. EACCES) is now verified to warn-log and return `null` rather than throw or crash activation.

## Approach
- Mocks `Bun.file` at the call site (`spyOn(Bun, 'file')`), matching the "mock at the lowest level" rule and existing precedent (`spyOn(Bun, 'spawn')` in `user-mode.test.ts`). Only the target path (`AGENTS.md` or `CLAUDE.md`) is intercepted; all other paths fall through to the real `Bun.file`, so existing chain/global/instructions[] resolution is untouched.
- Two cases added, per `.claude/rules/test-trigger.md` sibling-test convention (same file, `packages/embedded-agent/src/__tests__/system-prompt.test.ts`):
  1. AGENTS.md read fails with EACCES -> directory yields no segment, `console.warn` called with the failing path and error text.
  2. AGENTS.md is genuinely absent (real ENOENT) and CLAUDE.md read fails with EACCES -> same assertions on the fallback path.

## Verification
- `bun run typecheck`: exit 0 (all packages).
- `bun run test:only`: `packages/embedded-agent` — 210 pass / 0 fail (target package, includes the 2 new cases).
- Two unrelated failures observed in the full-suite run, both confirmed pre-existing and environment-specific (not caused by this change):
  - `packages/integration` `message-template-boundary.test.ts` "POST with empty title/content returns validation error" timed out in the full parallel run but passes cleanly in isolation (970ms) — resource-contention flake under parallel load, not scoped to this diff.
  - `packages/server` `multi-user-mode.test.ts` "Issue #918: elevation-skip (direct) path ignores sshAuthSockFallback" fails because this dev environment has `SSH_AUTH_SOCK` set (`/home/*/.1password/agent.sock`), which the test does not isolate against. This is a separate observation (SSH_AUTH_SOCK environment leak, currently deprioritized by the owner) and is not tracked as an Issue at this time.

## Test plan
- [x] `bun run typecheck` exit 0
- [x] `bun run test:only` — `packages/embedded-agent` 210 pass / 0 fail
- [x] Preflight check clean
- [ ] CI green
- [ ] CodeRabbit review clean

Closes #1147


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of instruction-file read errors so non-critical failures no longer interrupt processing.
  * Added warning messages that identify the affected file and error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->