### PR TITLE
test: cover embedded-agent tools parseArgs error branches (closes #1146)

### DIFF
--- a/packages/embedded-agent/src/tools/__tests__/edit.test.ts
+++ b/packages/embedded-agent/src/tools/__tests__/edit.test.ts
@@ -144,6 +144,16 @@ describe('editTool', () => {
     expect(result.result).toBe('new_string is required and must be a string');
   });
 
+  it('rejects a non-boolean replace_all argument', async () => {
+    const result = await editTool.execute(
+      { file_path: 'a.txt', old_string: 'a', new_string: 'b', replace_all: 'yes' },
+      { locationPath },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.result).toBe('replace_all must be a boolean');
+  });
+
   it('rejects an empty old_string instead of hanging (regression: countOccurrences infinite loop)', async () => {
     const target = path.join(locationPath, 'a.txt');
     await fsPromises.writeFile(target, 'hello world');
@@ -165,6 +175,27 @@ describe('editTool', () => {
 
     expect(result.ok).toBe(false);
     expect(result.result).toMatch(/^Failed to read file: /);
+  });
+
+  it('formats a "Failed to write file" message when the write-back fails', async () => {
+    const target = path.join(locationPath, 'a.txt');
+    await fsPromises.writeFile(target, 'hello world');
+    // Read succeeds (file itself keeps its own permissions), but the directory
+    // loses write permission, so atomicWrite's temp-file creation fails --
+    // exercising the write-back catch branch distinct from the read-failure one.
+    await fsPromises.chmod(locationPath, 0o555);
+
+    try {
+      const result = await editTool.execute(
+        { file_path: target, old_string: 'world', new_string: 'there' },
+        { locationPath },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.result).toMatch(/^Failed to write file: /);
+    } finally {
+      await fsPromises.chmod(locationPath, 0o755);
+    }
   });
 
   it('returns {ok:false, result:"aborted"} without editing when the signal is already aborted', async () => {

--- a/packages/embedded-agent/src/tools/__tests__/glob.test.ts
+++ b/packages/embedded-agent/src/tools/__tests__/glob.test.ts
@@ -73,6 +73,13 @@ describe('globTool', () => {
     expect(result.result).toBe('pattern is required and must be a string');
   });
 
+  it('rejects a non-string path argument', async () => {
+    const result = await globTool.execute({ pattern: '*.ts', path: 42 }, { locationPath });
+
+    expect(result.ok).toBe(false);
+    expect(result.result).toBe('path must be a string');
+  });
+
   it('returns {ok:false, result:"aborted"} without completing the scan when the signal is already aborted', async () => {
     for (let i = 0; i < 20; i++) {
       await touch(path.join(locationPath, `f${i}.ts`));

--- a/packages/embedded-agent/src/tools/__tests__/grep.test.ts
+++ b/packages/embedded-agent/src/tools/__tests__/grep.test.ts
@@ -111,6 +111,27 @@ describe('grepTool', () => {
     expect(result.result).toBe('pattern is required and must be a string');
   });
 
+  it('rejects a non-string path argument', async () => {
+    const result = await grepTool.execute({ pattern: 'x', path: 42 }, { locationPath });
+
+    expect(result.ok).toBe(false);
+    expect(result.result).toBe('path must be a string');
+  });
+
+  it('rejects a non-string glob argument', async () => {
+    const result = await grepTool.execute({ pattern: 'x', glob: 42 }, { locationPath });
+
+    expect(result.ok).toBe(false);
+    expect(result.result).toBe('glob must be a string');
+  });
+
+  it('rejects a non-boolean caseInsensitive argument', async () => {
+    const result = await grepTool.execute({ pattern: 'x', caseInsensitive: 'yes' }, { locationPath });
+
+    expect(result.ok).toBe(false);
+    expect(result.result).toBe('caseInsensitive must be a boolean');
+  });
+
   it('rejects an invalid outputMode', async () => {
     const result = await grepTool.execute({ pattern: 'x', outputMode: 'bogus' }, { locationPath });
 

--- a/packages/embedded-agent/src/tools/__tests__/write.test.ts
+++ b/packages/embedded-agent/src/tools/__tests__/write.test.ts
@@ -68,6 +68,19 @@ describe('writeTool', () => {
     expect(result.result).toBe('content is required and must be a string');
   });
 
+  it('formats a "Failed to write file" message when atomicWrite fails', async () => {
+    // A directory already exists at the target path, so atomicWrite's final
+    // rename fails with EISDIR -- exercising the write tool's catch branch
+    // that formats atomicWrite's rejection into a result message.
+    const target = path.join(locationPath, 'blocked-dir');
+    await fsPromises.mkdir(target);
+
+    const result = await writeTool.execute({ file_path: target, content: 'new content' }, { locationPath });
+
+    expect(result.ok).toBe(false);
+    expect(result.result).toMatch(/^Failed to write file: /);
+  });
+
   it('leaves no stray temp file behind after a successful write (atomic write verification)', async () => {
     const target = path.join(locationPath, 'atomic.txt');
 


### PR DESCRIPTION
## Summary

Adds test coverage for the argument-validation error branches in the embedded-agent builtin tools' `parseArgs` functions, flagged as a P2 gap by the Sprint 2026-07-16 test-coverage audit. The happy paths were already covered; only the type-check reject branches and the `atomicWrite` failure catch were missing.

- `packages/embedded-agent/src/tools/edit.ts` — `replace_all must be a boolean` branch; `atomicWrite` failure catch (write-back error formatting)
- `packages/embedded-agent/src/tools/grep.ts` — `path must be a string` / `glob must be a string` / `caseInsensitive must be a boolean` branches
- `packages/embedded-agent/src/tools/glob.ts` — `path must be a string` branch
- `packages/embedded-agent/src/tools/write.ts` — `atomicWrite` failure catch (write-back error formatting)

No production code changed — tests only, added to the existing sibling `__tests__/*.test.ts` files.

### Implementation notes

- `write.ts`'s `atomicWrite` failure branch is exercised the same way `atomic-write.test.ts` already does: pre-creating a directory at the target path so the final rename fails with `EISDIR`.
- `edit.ts`'s `atomicWrite` failure branch needed a different technique, since Edit reads the target file's content *before* writing it back. The test writes a normal file, then removes write permission from the containing directory (`chmod 0o555`) so the initial read still succeeds but `atomicWrite`'s temp-file creation fails — isolating the write-back catch branch from the read-failure catch branch. Permissions are restored in a `finally` block before the directory is cleaned up in `afterEach`.

## Test plan

- [x] `bun run test` (full suite, typecheck + all packages) — 3450 pass / 1 skip / 0 fail
- [x] `node .claude/skills/orchestrator/preflight-check.js` — all checks pass (no missing coverage, no language violations, no blame-shift references)

**Pre-existing failure note (unrelated to this PR):** one server-package test (the elevation-skip direct-path test in `multi-user-mode.test.ts` covering Issue #918) fails when the local shell environment has `SSH_AUTH_SOCK` set (e.g. via a 1Password agent), because the value leaks into the test process. Confirmed reproducible on `origin/main` with the same environment, and passes cleanly with `SSH_AUTH_SOCK` unset. This is an environment-only issue, not tracked as an Issue at this time, and out of scope for this PR.

Closes #1146
