### PR TITLE
feat(embedded-agent): gate copy-markdown button on !entry.streaming

### DIFF
--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -340,9 +340,11 @@ function ChatEntryRow({ entry, onRestart }: ChatEntryRowProps) {
               {entry.text}
             </Markdown>
             {entry.streaming && <span className="inline-block w-1.5 h-3.5 ml-0.5 bg-gray-400 animate-pulse align-middle" aria-hidden="true" />}
-            <div className="flex justify-end mt-1">
-              <CopyMarkdownButton text={entry.text} />
-            </div>
+            {!entry.streaming && (
+              <div className="flex justify-end mt-1">
+                <CopyMarkdownButton text={entry.text} />
+              </div>
+            )}
           </div>
         </div>
       );

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -1231,6 +1231,51 @@ describe('EmbeddedAgentWorkerView', () => {
       expect(screen.queryByRole('button', { name: 'Copy as markdown' })).toBeNull();
     });
 
+    it('does NOT render a copy-markdown button for a STREAMING assistant-message (#1124)', async () => {
+      renderView({ sessionId: 's30b', workerId: 'w30b' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      // assistant-delta keeps the entry in the streaming state (no
+      // assistant-message finalize event sent), mirroring the Preview-toggle
+      // streaming test above (A1).
+      const chunk = ndjson({ v: 1, type: 'assistant-delta', turnId: 't1', text: 'partial mark' });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'output', data: chunk, offset: chunk.length, epoch: 1 }));
+      });
+      await flush();
+
+      expect(screen.getByText('partial mark')).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Copy as markdown' })).toBeNull();
+    });
+
+    it('renders a copy-markdown button once a STREAMING assistant-message finalizes (#1124)', async () => {
+      renderView({ sessionId: 's30c', workerId: 'w30c' });
+      const ws = MockWebSocket.getLastInstance();
+      act(() => {
+        ws?.simulateOpen();
+      });
+
+      const chunk = ndjson({ v: 1, type: 'assistant-delta', turnId: 't1', text: 'partial mark' });
+      act(() => {
+        ws?.simulateMessage(JSON.stringify({ type: 'output', data: chunk, offset: chunk.length, epoch: 1 }));
+      });
+      await flush();
+      expect(screen.queryByRole('button', { name: 'Copy as markdown' })).toBeNull();
+
+      const finalize = ndjson({ v: 1, type: 'assistant-message', turnId: 't1', text: 'partial mark done' });
+      act(() => {
+        ws?.simulateMessage(
+          JSON.stringify({ type: 'output', data: finalize, offset: chunk.length + finalize.length, epoch: 1 }),
+        );
+      });
+      await flush();
+
+      expect(screen.getByRole('button', { name: 'Copy as markdown' })).toBeTruthy();
+    });
+
     it('copies the raw markdown text (not rendered HTML) to the clipboard on click', async () => {
       const markdown = '# Heading\n\n**bold** and `code`';
       await renderWithAssistantMessage('s32', 'w32', markdown);


### PR DESCRIPTION
Closes #1124

## Summary

The copy-markdown button on an assistant message bubble was rendered
unconditionally, so a user could click "Copy as markdown" while the
message was still streaming and copy a partial/incomplete markdown
string. This gates the button on `!entry.streaming`.

## Gate option chosen: A (conditional render)

Chose conditional-render over a disabled-button state, matching the
existing precedent in the same file where the Markdown preview-toggle
is already gated the same way (`components={!entry.streaming ? { pre:
PreviewablePre } : undefined}`, `EmbeddedAgentWorkerView.tsx` ~L338).
Keeping both streaming-incompatible controls consistent (not rendered
at all while streaming) avoids introducing a new disabled-button
visual treatment for a single control.

## Browser QA

Skipped per `.claude/rules/workflow.md` Browser QA skip-threshold:
- Pure behavior subtraction — the button is hidden while streaming;
  no other rendering changes.
- No corresponding server-side contract to verify (client-only
  gating of an existing UI control).
- Fully covered by client unit tests (see Test plan below).

## Test plan

- [x] New test: copy-markdown button does NOT render while
      `entry.streaming === true`
- [x] New test: copy-markdown button renders once the
      assistant-message finalizes (`streaming: false`)
- [x] TDD polarity confirmed both directions (tests fail against
      un-gated code, pass with the gate)
- [x] Full existing `EmbeddedAgentWorkerView.test.tsx` suite passes
      (no regressions to rapid-click / unmount / clipboard-rejection
      tests)
- [x] `bun run typecheck` — 0 errors
- [x] `bun run test:only` — client package: 1937 pass / 0 fail

## Known pre-existing environment failures (unrelated to this diff)

`packages/server/src/services/__tests__/git-diff-base-reresolve.test.ts`
has 2 pre-existing failures in this environment
(`fatal: failed to write commit object`), caused by SSH_AUTH_SOCK /
GPG signing being unavailable at the time this diff was authored.
Unrelated to this diff (server-side git-repo test, no relation to
`EmbeddedAgentWorkerView`).

## Note on CodeRabbit
Local CodeRabbit CLI authentication failed in this headless delegated worktree (requires interactive browser auth, not available here). Relying on the GitHub-side CodeRabbit bot review before merge.
