### PR TITLE
fix(embedded-agent-store): reorder history-fold reject AFTER flushResyncQueue

### DIFF
--- a/packages/client/src/components/workers/__tests__/embedded-agent-store.test.ts
+++ b/packages/client/src/components/workers/__tests__/embedded-agent-store.test.ts
@@ -829,6 +829,40 @@ describe('embedded-agent-store', () => {
     expect(finalEntries[1]).toMatchObject({ kind: 'user-message', text: 'after failure' });
   });
 
+  it('resolves a pending send whose confirming echo is still queued when the epoch-2 history response lands (#1120: flush-before-reject ordering)', async () => {
+    // Edge-of-edge race from the #1120 architect audit: a send is issued
+    // while an epoch resync is outstanding, and its confirming echo arrives
+    // as live output DURING the resync -- so it lands in the resync queue,
+    // not folded yet. If the history response that completes the resync
+    // rejects the pending send BEFORE flushing that queue, the reject fires
+    // even though the very next step would have resolved it via the queued
+    // echo.
+    const { instance, ws } = connectAndBumpEpoch('s21', 'w21');
+    await flush();
+    expect(instance.getSnapshot().entries).toHaveLength(0);
+
+    const sendPromise = instance.sendUserMessage('hello agent');
+
+    // The confirming echo arrives as live output for the new epoch while
+    // still resyncing -- queued, not folded yet (resolvePendingSend has NOT
+    // run at this point).
+    const echoData = ndjson({ v: 1, type: 'user-message', id: 'echo', text: 'hello agent' });
+    ws.simulateMessage(outputMessage(echoData, 50, 2));
+    await flush();
+    expect(instance.getSnapshot().entries).toHaveLength(0); // queued, not folded
+
+    // The epoch-2 history response lands, at an offset strictly BEFORE the
+    // queued echo's offset (so the echo is not covered/dropped by the flush
+    // -- it is genuinely newer and gets folded), and its own payload does
+    // not itself contain a confirming user-message (empty).
+    ws.simulateMessage(historyMessage('', 20, 0, 2));
+
+    await expect(sendPromise).resolves.toBeUndefined();
+    const entries = instance.getSnapshot().entries;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: 'user-message', text: 'hello agent' });
+  });
+
   it('disposes and re-subscribes to app-ws session-deleted', () => {
     const bus = makeAppBus();
     _setAppSubscribe(bus.subscribe);

--- a/packages/client/src/components/workers/embedded-agent-store.ts
+++ b/packages/client/src/components/workers/embedded-agent-store.ts
@@ -531,22 +531,28 @@ class EmbeddedAgentController implements EmbeddedAgentInstance {
     } else {
       this.patch({ loadingHistory: false });
     }
-    // A history response (startOffset is only ever set for those, never for
-    // live `output`) covers everything the server has from `requestedFromOffset`
-    // onward. If a send confirmation is still pending after folding it, the
-    // write must have been lost when the connection dropped before the
-    // server received it (an accepted send's echo would already have
-    // resolved it via foldEvent's user-message case above) -- reject so the
-    // caller doesn't hang waiting for a confirmation that will never arrive.
-    if (typeof startOffset === 'number') {
-      this.rejectPendingSend('Reconnected but the message was not confirmed');
-    }
     // A `history` response that lands while an epoch resync is outstanding
     // completes that resync: replay whatever output arrived and was queued
     // in the meantime, now that we know exactly what this history payload
-    // already covers.
+    // already covers. This MUST run before the reject check below -- a
+    // pending send's confirming echo can be sitting in the resync queue
+    // (not yet folded) at the moment this history response arrives, and
+    // flushing gives it a chance to resolve the pending send before the
+    // reject below would otherwise fire and kill it (#1120).
     if (typeof startOffset === 'number' && this.resyncing) {
       this.flushResyncQueue(offset);
+    }
+    // A history response (startOffset is only ever set for those, never for
+    // live `output`) covers everything the server has from `requestedFromOffset`
+    // onward. If a send confirmation is still pending after folding it AND
+    // after the resync-queue flush above, the write must have been lost when
+    // the connection dropped before the server received it (an accepted
+    // send's echo would already have resolved it via foldEvent's
+    // user-message case, either during this fold or during the flush above)
+    // -- reject so the caller doesn't hang waiting for a confirmation that
+    // will never arrive.
+    if (typeof startOffset === 'number' && this.pendingSend !== null) {
+      this.rejectPendingSend('Reconnected but the message was not confirmed');
     }
   }
 


### PR DESCRIPTION
## Summary

Architect audit follow-up from PR #1111 (Issue #1024). In `EmbeddedAgentController.applyBytes`, a `history` response's pending-send reject ran BEFORE `flushResyncQueue`. In the edge-of-edge race where a pending send's confirming echo is sitting in the resync queue (queued during an epoch resync, not yet folded) at the moment the history response arrives, the reject fired first and permanently killed the pending send — even though the very next statement (`flushResyncQueue`) would have folded the echo and resolved it correctly via `foldLine`'s `user-message` case.

- Swapped the two `if` blocks so `flushResyncQueue(offset)` runs before the reject check.
- Added an explicit `this.pendingSend !== null` guard to the reject condition, and updated the surrounding comments to explain the new ordering rationale.

## Test plan

- Added a new test (`embedded-agent-store.test.ts`) reproducing the exact race: bump to epoch 2 via `connectAndBumpEpoch`, issue `sendUserMessage`, queue the confirming echo as live output during resync, then deliver the epoch-2 history response (at an offset strictly before the queued echo, containing no echo itself). Asserts the send resolves and the entry folds exactly once.
- **TDD polarity verified in both directions** (independently re-verified, not just the implementing subagent's report):
  - Production fix reverted, test kept: **FAILS** with `Expected promise that resolves, Received promise that rejected` — reproduces the false-reject.
  - Production fix restored: **PASSES**.
- `bun run typecheck`: exit 0.
- `bun run test:only`: client 1936/0 fail, shared 523/0 fail, integration 67/0 fail, embedded-agent 208/0 fail. Server has 2 pre-existing failures in `git-diff-base-reresolve.test.ts` — a local 1Password/git-signing environment issue, confirmed reproducible even with this PR's diff stashed out (unrelated to this change).

Closes #1120