### PR TITLE
feat(embedded-agent): extend Read tool truncation notice with next-step guidance

### DIFF
--- a/packages/embedded-agent/src/tools/__tests__/read.test.ts
+++ b/packages/embedded-agent/src/tools/__tests__/read.test.ts
@@ -95,6 +95,9 @@ describe('readTool', () => {
       expect(result.result).toContain(
         `[Read truncated: file is ${READ_MAX_BYTES + 1} bytes, exceeding the ${READ_MAX_BYTES}-byte read cap.`,
       );
+      expect(result.result).toContain(
+        'Use the Bash tool (e.g. `tail -c` or `sed -n`) to view content beyond this cap.',
+      );
     });
 
     it('truncates a file well over the cap to the cap size, plus a truncation notice', async () => {
@@ -108,6 +111,9 @@ describe('readTool', () => {
       const [body, ...rest] = result.result.split('\n\n[Read truncated');
       expect(body).toBe(`1\t${'b'.repeat(READ_MAX_BYTES)}`);
       expect(rest.join('')).toContain(`file is ${totalSize} bytes`);
+      expect(rest.join('')).toContain(
+        'Use the Bash tool (e.g. `tail -c` or `sed -n`) to view content beyond this cap.',
+      );
     });
 
     it('never splits a multibyte character at the truncation boundary', async () => {

--- a/packages/embedded-agent/src/tools/read.ts
+++ b/packages/embedded-agent/src/tools/read.ts
@@ -96,7 +96,8 @@ async function execute(args: unknown, ctx: BuiltinToolContext, signal?: AbortSig
       .join('\n');
     const notice = truncated
       ? `\n\n[Read truncated: file is ${stat.size} bytes, exceeding the ${READ_MAX_BYTES}-byte read cap. ` +
-        `Showing content from the first ${READ_MAX_BYTES} bytes only.]`
+        `Showing content from the first ${READ_MAX_BYTES} bytes only. ` +
+        `Use the Bash tool (e.g. \`tail -c\` or \`sed -n\`) to view content beyond this cap.]`
       : '';
     return { ok: true, result: formatted + notice };
   } catch (err) {


### PR DESCRIPTION
## Summary
- Extend the embedded-agent `Read` tool's per-file byte-cap truncation notice with a concrete next-step hint, instead of only stating that the file was truncated.
- Wording choice: appended `Use the Bash tool (e.g. \`tail -c\` or \`sed -n\`) to view content beyond this cap.` — kept generic (not prescribing a single command) since the model may want the tail of the file or an arbitrary byte range, and both are one Bash invocation away. Chose this over the Issue's literal suggestion because `Read`'s own offset/limit only slices the already-truncated (line-based) prefix, so a Bash-based workaround is the only way to actually reach bytes past the cap.
- Scope: production notice string in `packages/embedded-agent/src/tools/read.ts` + matching test assertions in `packages/embedded-agent/src/tools/__tests__/read.test.ts`. The Grep tool's parallel next-step guidance (mentioned as optional in the Issue) is deferred — out of scope for this PR, left for a follow-up if warranted.

## Approach
- TDD: added the new assertion text to the two truncation tests (`over-by-one`, `well-over-cap`) first, ran the suite to confirm it failed against the old notice text (red), then updated the production notice string and re-ran to confirm green.

## Test plan
- `bun run typecheck && bun run test:only` (full suite) — embedded-agent package: 208/208 pass.
- Overall suite: 3448 pass / 1 skip / 2 fail in `packages/server`. Both failures are in `git-diff-base-reresolve.test.ts` and are pre-existing, environment-only failures unrelated to this diff — the test performs a real `git commit` which requires 1Password SSH signing, and the SSH agent socket was unreachable at the time of that run. Not caused by this change.
- Note on a separate, unrelated pre-existing environment issue: with `SSH_AUTH_SOCK` set in some environments, one existing `multi-user-mode.test.ts` case (Issue #918 elevation-skip) fails — SSH_AUTH_SOCK environment leak, not tracked as an Issue at this time. Not observed in this run.

## Note on CodeRabbit
Local CodeRabbit CLI review requires interactive browser auth, which is unavailable in this headless worktree session — falls under the `coderabbit-ops` skill's rate-limited/unresponsive-bot fallback disposition. Proceeding without a local CLI pass; the GitHub-side bot review will run against the PR as usual.

Closes #1116
