### PR TITLE
fix(embedded-agent): copy-markdown button non-secure context fallback

### DIFF
--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -266,6 +266,30 @@ function PreviewablePre(props: JSX.IntrinsicElements['pre'] & ExtraProps) {
 const COPY_MARKDOWN_FEEDBACK_MS = 1500;
 
 /**
+ * Legacy clipboard-copy technique via a temporary hidden textarea + the
+ * deprecated `document.execCommand('copy')` API. Used as a fallback when
+ * `navigator.clipboard` is unavailable, which happens whenever the page is
+ * served from a non-secure context (plain HTTP, e.g. LAN dev-server access
+ * at http://192.168.x.x:5173/) -- `navigator.clipboard` is undefined outside
+ * HTTPS/localhost, so the modern API silently cannot be used there (#1159).
+ */
+function copyViaExecCommand(text: string): boolean {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  // Keep off-screen so it never affects layout or scroll position.
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  try {
+    textarea.focus();
+    textarea.select();
+    return document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+/**
  * Icon-only button pinned to the bottom-right of an assistant message
  * bubble. Copies the message's raw markdown SOURCE (the `text` prop, as
  * received from the agent) to the clipboard -- never the rendered HTML the
@@ -283,12 +307,35 @@ function CopyMarkdownButton({ text }: { text: string }) {
   }, []);
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(text);
-    } catch (err) {
-      logger.error('Failed to copy markdown:', err);
+    let ok = false;
+    let lastError: unknown;
+
+    if (navigator.clipboard && window.isSecureContext) {
+      try {
+        await navigator.clipboard.writeText(text);
+        ok = true;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+
+    // Fall back to the legacy execCommand('copy') technique when the
+    // Clipboard API is unavailable (non-secure context, e.g. LAN access
+    // over plain HTTP) or when it threw above.
+    if (!ok) {
+      try {
+        ok = copyViaExecCommand(text);
+        if (!ok) lastError = new Error('execCommand("copy") returned false');
+      } catch (err) {
+        lastError = err;
+      }
+    }
+
+    if (!ok) {
+      logger.error('Failed to copy markdown:', lastError);
       return;
     }
+
     setCopied(true);
     if (revertTimeoutRef.current !== null) clearTimeout(revertTimeoutRef.current);
     revertTimeoutRef.current = setTimeout(() => setCopied(false), COPY_MARKDOWN_FEEDBACK_MS);

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -1185,12 +1185,34 @@ describe('EmbeddedAgentWorkerView', () => {
       }
     }
 
+    // happy-dom does not implement `window.isSecureContext` (it is
+    // `undefined`, i.e. falsy) regardless of the mocked `http://localhost`
+    // location above. Real browsers treat `http://localhost` as a secure
+    // context, so we stub `true` here to match real-browser behavior for
+    // every test in this block except the #1159 non-secure-context tests,
+    // which explicitly override it back to a falsy value.
+    const originalIsSecureContextDescriptor = Object.getOwnPropertyDescriptor(window, 'isSecureContext');
+
+    function installSecureContext() {
+      Object.defineProperty(window, 'isSecureContext', { value: true, writable: true, configurable: true });
+    }
+
+    function restoreSecureContext() {
+      if (originalIsSecureContextDescriptor) {
+        Object.defineProperty(window, 'isSecureContext', originalIsSecureContextDescriptor);
+      } else {
+        Reflect.deleteProperty(window, 'isSecureContext');
+      }
+    }
+
     beforeEach(() => {
       installClipboardMock();
+      installSecureContext();
     });
 
     afterEach(() => {
       restoreClipboard();
+      restoreSecureContext();
     });
 
     async function renderWithAssistantMessage(sessionId: string, workerId: string, text: string) {
@@ -1379,6 +1401,69 @@ describe('EmbeddedAgentWorkerView', () => {
         expect(screen.getByRole('button', { name: 'Copy as markdown' })).toBeTruthy();
         expect(screen.queryByRole('button', { name: 'Copied!' })).toBeNull();
       } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    });
+
+    // navigator.clipboard is only defined in a secure context (HTTPS or
+    // localhost/127.0.0.1). Dev-server access over plain-HTTP LAN
+    // (e.g. http://192.168.1.12:5173/) leaves it undefined, so the
+    // primary path must fall back to the legacy execCommand('copy')
+    // technique instead of silently failing (#1159).
+    function installUndefinedClipboard() {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(window, 'isSecureContext', { value: false, writable: true, configurable: true });
+    }
+
+    it('falls back to document.execCommand("copy") and shows "Copied!" when navigator.clipboard is unavailable (non-secure context, #1159)', async () => {
+      installUndefinedClipboard();
+      const execCommandMock = mock(() => true);
+      // happy-dom does not implement execCommand, so assign it directly
+      // rather than spyOn-wrapping a nonexistent method.
+      (document as unknown as { execCommand: typeof execCommandMock }).execCommand = execCommandMock;
+      try {
+        await renderWithAssistantMessage('s37', 'w37', 'copy me via fallback');
+
+        const button = screen.getByRole('button', { name: 'Copy as markdown' });
+        await act(async () => {
+          fireEvent.click(button);
+          await Promise.resolve();
+        });
+
+        expect(execCommandMock).toHaveBeenCalledWith('copy');
+        expect(writeTextMock).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: 'Copied!' })).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Copy as markdown' })).toBeNull();
+      } finally {
+        Reflect.deleteProperty(document, 'execCommand');
+      }
+    });
+
+    it('logs and leaves the button in the idle "Copy as markdown" state when BOTH the clipboard API and the execCommand fallback fail (#1159)', async () => {
+      const consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+      installUndefinedClipboard();
+      const execCommandMock = mock(() => false);
+      (document as unknown as { execCommand: typeof execCommandMock }).execCommand = execCommandMock;
+      try {
+        await renderWithAssistantMessage('s38', 'w38', 'copy me but fail');
+
+        const button = screen.getByRole('button', { name: 'Copy as markdown' });
+        await act(async () => {
+          fireEvent.click(button);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+
+        expect(execCommandMock).toHaveBeenCalledWith('copy');
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: 'Copy as markdown' })).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Copied!' })).toBeNull();
+      } finally {
+        Reflect.deleteProperty(document, 'execCommand');
         consoleErrorSpy.mockRestore();
       }
     });

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -1424,7 +1424,10 @@ describe('EmbeddedAgentWorkerView', () => {
       const execCommandMock = mock(() => true);
       // happy-dom does not implement execCommand, so assign it directly
       // rather than spyOn-wrapping a nonexistent method.
-      (document as unknown as { execCommand: typeof execCommandMock }).execCommand = execCommandMock;
+      Object.defineProperty(document, 'execCommand', {
+        value: execCommandMock,
+        configurable: true,
+      });
       try {
         await renderWithAssistantMessage('s37', 'w37', 'copy me via fallback');
 
@@ -1447,7 +1450,10 @@ describe('EmbeddedAgentWorkerView', () => {
       const consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
       installUndefinedClipboard();
       const execCommandMock = mock(() => false);
-      (document as unknown as { execCommand: typeof execCommandMock }).execCommand = execCommandMock;
+      Object.defineProperty(document, 'execCommand', {
+        value: execCommandMock,
+        configurable: true,
+      });
       try {
         await renderWithAssistantMessage('s38', 'w38', 'copy me but fail');
 


### PR DESCRIPTION
## Summary

- `navigator.clipboard` requires a secure context (HTTPS or `localhost`/`127.0.0.1`). Accessing the dev server over plain HTTP on a LAN IP (e.g. `http://192.168.1.12:5173/`) leaves `navigator.clipboard` undefined, so the copy-markdown button's `handleCopy` threw, logged the error, and returned early — the "Copied!" state was never reached and the button silently did nothing from the user's perspective (owner dogfood report, 2026-07-17).
- Added a legacy `document.execCommand('copy')` fallback via a temporary hidden `<textarea>`, used when `navigator.clipboard`/`window.isSecureContext` is unavailable or when the modern API throws.
- Restructured `handleCopy` so success from either path converges on `setCopied(true)` + the revert timer, and failure from both paths converges on a logged error with no state change and no unhandled rejection.

## Test plan

- [x] `bun run typecheck && bun run test:only` — full monorepo suite green (pasted below)
- [x] TDD polarity verified: the new non-secure-context fallback test fails against the unmodified `handleCopy` (`TypeError: undefined is not an object (evaluating 'navigator.clipboard.writeText')`) and passes after the fix
- [x] 2 new tests added to `packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx`:
  - non-secure-context fallback succeeds → `execCommand('copy')` called, button reaches "Copied!"
  - both clipboard API and `execCommand` fallback fail → button stays "Copy as markdown", error logged, no unhandled rejection
- [x] All 9 pre-existing "Copy markdown button" tests still pass (secure-context path, rapid-click timer reset, unmount cleanup, rejected-clipboard error case)

```
@agent-console/shared:        523 pass, 0 fail
@agent-console/integration:    66 pass, 0 fail
@agent-console/server:       3439 pass, 1 skip, 0 fail
@agent-console/embedded-agent: 199 pass, 0 fail
@agent-console/client:       1932 pass, 0 fail
root scripts/hooks tests:      427 pass, 0 fail
TEST_EXIT: 0
```

## Browser QA — skip justification

This is a UI change, but manual Browser QA against a real LAN non-secure-context URL is not reproducible in the delegate environment (which serves over `localhost`, always a secure context). Per `.claude/rules/workflow.md` skip threshold guidance:

- No server-side contract is involved — the fix is entirely client-local browser API selection (Clipboard API vs. legacy `execCommand`), not a wire/server boundary. `preflight-check.js`'s integration-test-gap warning is consequently not applicable here (no shared type, no client-server message crosses this change).
- The client-side behavior change (both the fallback path and the both-fail path) is fully covered by the new unit tests above, including the actual pre/post-fix polarity flip that reproduces the reported bug.
- Owner dogfood verification against the actual LAN URL (`http://192.168.1.12:5173/`) is expected post-merge to close the loop on the original report.

## Closes

Closes #1159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the “Copy as markdown” button across secure and non-secure browsing contexts.
  * Added a fallback copy method when the modern clipboard feature is unavailable or fails.
  * Preserved clear success feedback and improved handling when copying cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->