### PR TITLE
feat(server): route agent resolution via AgentDirectory (#1160 PR-B)

### DIFF
--- a/packages/server/src/routes/__tests__/workers.test.ts
+++ b/packages/server/src/routes/__tests__/workers.test.ts
@@ -21,6 +21,7 @@ import { SessionManager } from '../../services/session-manager.js';
 import { JsonSessionRepository } from '../../repositories/index.js';
 import { MAX_MESSAGE_FILES, MAX_TOTAL_FILE_SIZE } from '@agent-console/shared';
 import { McpTokenRegistry } from '../../mcp/mcp-auth.js';
+import { AgentDirectory } from '../../services/agent-directory.js';
 
 // Config dir is memfs-only; uploads target a per-uid /tmp dir by spec (see #821).
 // memfs hooks fs/promises so the route's mkdir lands in memfs, which we then
@@ -90,9 +91,23 @@ describe('Workers API', () => {
       },
     });
 
+    // Route-level appContext.agentDirectory needs both surfaces at
+    // construction (compile-time exhaustiveness gate). The workers.ts route
+    // only calls `.get('terminal', ...)`, so the embedded surface is a
+    // minimal stub -- this route never exercises embedded-agent lookups
+    // through agentDirectory (embedded-agent existence is validated deeper,
+    // in worker-lifecycle-manager.ts via the embeddedAgentManager above).
+    const emptyEmbeddedSurface = {
+      kind: 'embedded' as const,
+      list: () => [],
+      get: () => undefined,
+      findByName: () => [],
+    };
+    const agentDirectory = new AgentDirectory({ terminal: agentMgr, embedded: emptyEmbeddedSurface });
+
     app = new Hono<AppBindings>();
     app.use('*', async (c, next) => {
-      c.set('appContext', asAppContext({ sessionManager, agentManager: agentMgr }));
+      c.set('appContext', asAppContext({ sessionManager, agentManager: agentMgr, agentDirectory }));
       await next();
     });
     app.onError(onApiError);

--- a/packages/server/src/routes/__tests__/worktrees.test.ts
+++ b/packages/server/src/routes/__tests__/worktrees.test.ts
@@ -12,6 +12,7 @@ import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { _getPullsInProgress, _getDeletionsInProgress } from '../worktrees.js';
 import { CLAUDE_CODE_AGENT_ID } from '../../services/agent-manager.js';
+import { AgentDirectory } from '../../services/agent-directory.js';
 
 // ---------------------------------------------------------------------------
 // Test constants
@@ -314,16 +315,54 @@ describe('Worktrees API', () => {
   // =========================================================================
 
   describe('POST /api/repositories/:id/worktrees (Issue #1038 embedded-agent selection)', () => {
+    // Widened (agent-surface migration PR-B) so this mock can also serve as
+    // the `terminal` surface of a real `AgentDirectory` -- the route's
+    // embedded-agent validation now reads `agentDirectory.get('embedded', ...)`
+    // instead of `embeddedAgentManager.getEmbeddedAgent(...)`, and the
+    // `AgentDirectory` constructor requires a working `AgentSurface` for
+    // every kind at construction time (compile-time exhaustiveness gate).
+    const getAgent = mock(() => ({ id: 'claude-code-builtin', name: 'Claude Code' }));
     const mockAgentManager = {
-      getAgent: mock(() => ({ id: 'claude-code-builtin', name: 'Claude Code' })),
+      getAgent,
+      kind: 'terminal' as const,
+      list: () => [],
+      get: () => {
+        const agent = getAgent();
+        return agent ? { kind: 'terminal' as const, agent } : undefined;
+      },
+      findByName: () => [],
     } as unknown as Parameters<typeof asAppContext>[0]['agentManager'];
 
+    // Widened the same way as mockAgentManager above, so it can serve as the
+    // `embedded` surface of a real `AgentDirectory`.
     function createMockEmbeddedAgentManager(knownId: string) {
+      const getEmbeddedAgent = mock((id: string) =>
+        id === knownId ? { id: knownId, name: 'My Embedded Agent' } : undefined,
+      );
       return {
-        getEmbeddedAgent: mock((id: string) =>
-          id === knownId ? { id: knownId, name: 'My Embedded Agent' } : undefined,
-        ),
+        getEmbeddedAgent,
+        kind: 'embedded' as const,
+        list: () => [],
+        get: (id: string) => {
+          const agent = getEmbeddedAgent(id);
+          return agent ? { kind: 'embedded' as const, agent } : undefined;
+        },
+        findByName: () => [],
       } as unknown as Parameters<typeof asAppContext>[0]['embeddedAgentManager'];
+    }
+
+    // mockAgentManager / createMockEmbeddedAgentManager are cast to the real
+    // AgentManager / EmbeddedAgentManager classes above (both of which
+    // `implements AgentSurface<K>`, agent-surface migration PR-A), so they
+    // are directly assignable here without further casting. The trailing
+    // `!` strips the `| undefined` that `Parameters<typeof asAppContext>`
+    // widens to (asAppContext's param type is a Partial<AppContext>) -- the
+    // mocks above always construct a real object, never undefined.
+    function createAgentDirectory(knownEmbeddedId: string) {
+      return new AgentDirectory({
+        terminal: mockAgentManager!,
+        embedded: createMockEmbeddedAgentManager(knownEmbeddedId)!,
+      });
     }
 
     /**
@@ -352,6 +391,7 @@ describe('Worktrees API', () => {
           worktreeService: mockWorktreeService,
           agentManager: mockAgentManager,
           embeddedAgentManager: createMockEmbeddedAgentManager('known-embedded-agent'),
+          agentDirectory: createAgentDirectory('known-embedded-agent'),
           sessionManager: { createSession: mock() } as unknown as SessionManager,
           broadcastToApp: () => {},
           suggestSessionMetadata: mock(async () => ({ branch: '', title: '', error: 'unused' })),
@@ -395,6 +435,7 @@ describe('Worktrees API', () => {
           worktreeService: mockWorktreeService,
           agentManager: mockAgentManager,
           embeddedAgentManager: createMockEmbeddedAgentManager('known-embedded-agent'),
+          agentDirectory: createAgentDirectory('known-embedded-agent'),
           sessionManager: { createSession: createSessionMock } as unknown as SessionManager,
           broadcastToApp: () => {},
           suggestSessionMetadata: mock(async () => ({ branch: '', title: '', error: 'unused' })),
@@ -551,11 +592,22 @@ describe('Worktrees API', () => {
       return { mockFn };
     }
 
+    // Widened (agent-surface migration PR-B) so this mock can also serve as
+    // the `embedded` surface of a real `AgentDirectory` -- the route's
+    // embedded-agent validation now reads `agentDirectory.get('embedded', ...)`.
     function createMockEmbeddedAgentManager(knownId: string) {
+      const getEmbeddedAgent = mock((id: string) =>
+        id === knownId ? { id: knownId, name: 'My Embedded Agent' } : undefined,
+      );
       return {
-        getEmbeddedAgent: mock((id: string) =>
-          id === knownId ? { id: knownId, name: 'My Embedded Agent' } : undefined,
-        ),
+        getEmbeddedAgent,
+        kind: 'embedded' as const,
+        list: () => [],
+        get: (id: string) => {
+          const agent = getEmbeddedAgent(id);
+          return agent ? { kind: 'embedded' as const, agent } : undefined;
+        },
+        findByName: () => [],
       } as unknown as Parameters<typeof asAppContext>[0]['embeddedAgentManager'];
     }
 
@@ -571,6 +623,22 @@ describe('Worktrees API', () => {
         getAgent: mock((id: string) => ({ id, name: 'Mock Agent' })),
       } as unknown as Parameters<typeof asAppContext>[0]['agentManager'];
     }
+
+    /**
+     * The route's terminal-agent resolution (`agentManager.getAgent(...)`,
+     * feeding `suggestSessionMetadata`) is untouched by the agent-surface
+     * migration and still reads `createEchoingAgentManager()` directly, not
+     * `agentDirectory`. This test only needs `agentDirectory`'s `embedded`
+     * surface (for the `embeddedAgentId` existence check), so the `terminal`
+     * surface here is an unused stub satisfying the constructor's
+     * compile-time exhaustiveness gate.
+     */
+    const emptyTerminalSurface = {
+      kind: 'terminal' as const,
+      list: () => [],
+      get: () => undefined,
+      findByName: () => [],
+    };
 
     /**
      * Mirrors the capture helpers used elsewhere in this file: resolve a
@@ -603,6 +671,10 @@ describe('Worktrees API', () => {
           worktreeService: mockWorktreeService,
           agentManager: createEchoingAgentManager(),
           embeddedAgentManager: createMockEmbeddedAgentManager('known-embedded-agent'),
+          agentDirectory: new AgentDirectory({
+            terminal: emptyTerminalSurface,
+            embedded: createMockEmbeddedAgentManager('known-embedded-agent')!,
+          }),
           sessionManager: { createSession: mock() } as unknown as SessionManager,
           broadcastToApp: () => {},
           suggestSessionMetadata: suggestionMock as unknown as Parameters<typeof asAppContext>[0]['suggestSessionMetadata'],

--- a/packages/server/src/routes/workers.ts
+++ b/packages/server/src/routes/workers.ts
@@ -279,18 +279,18 @@ const workers = new Hono<AppBindings>()
     const sessionId = c.req.param('sessionId');
     const body = c.req.valid('json');
 
-    const { sessionManager, agentManager } = c.get('appContext');
+    const { sessionManager, agentDirectory } = c.get('appContext');
     const session = sessionManager.getSession(sessionId);
     if (!session) {
       throw new NotFoundError('Session');
     }
 
     // Fail-fast agent existence validation, mirroring worktrees.ts's
-    // `agentManager.getAgent()` check. Without this, an unknown agentId
+    // `agentDirectory.get()` check. Without this, an unknown agentId
     // silently falls back to the default agent at PTY activation instead
     // of surfacing an error to the caller.
     if (body.type === 'agent') {
-      const agent = agentManager.getAgent(body.agentId);
+      const agent = agentDirectory.get('terminal', body.agentId)?.agent;
       if (!agent) {
         throw new ValidationError(`Agent not found: ${body.agentId}`);
       }

--- a/packages/server/src/routes/worktrees.ts
+++ b/packages/server/src/routes/worktrees.ts
@@ -48,7 +48,7 @@ const worktrees = new Hono<AppBindings>()
   // Create a worktree (async - returns immediately and broadcasts result via WebSocket)
   .post('/:id/worktrees', vValidator(CreateWorktreeRequestSchema), async (c) => {
     const repoId = c.req.param('id');
-    const { repositoryManager, sessionManager, agentManager, embeddedAgentManager, worktreeService, broadcastToApp, suggestSessionMetadata } = c.get('appContext');
+    const { repositoryManager, sessionManager, agentManager, agentDirectory, worktreeService, broadcastToApp, suggestSessionMetadata } = c.get('appContext');
     const repo = repositoryManager.getRepository(repoId);
 
     if (!repo) {
@@ -72,7 +72,7 @@ const worktrees = new Hono<AppBindings>()
 
     // Validate the embedded agent exists before returning accepted.
     if (embeddedAgentId) {
-      const embeddedAgent = embeddedAgentManager.getEmbeddedAgent(embeddedAgentId);
+      const embeddedAgent = agentDirectory.get('embedded', embeddedAgentId)?.agent;
       if (!embeddedAgent) {
         throw new ValidationError(`Embedded agent not found: ${embeddedAgentId}`);
       }


### PR DESCRIPTION
## Summary

PR-B of the Issue #1160 agent-surface migration (design doc: `docs/design/agent-surface.md`, PR-A: #1167). `worktrees.ts` and `workers.ts` each had their own inline registry lookup for validating `agentId` / `embeddedAgentId` before accepting a request. Route the kind-known existence checks through `AgentDirectory.get(kind, id)` instead of calling `agentManager.getAgent` / `embeddedAgentManager.getEmbeddedAgent` directly.

## What changed

- **`packages/server/src/routes/worktrees.ts`**: the embedded-agent existence check (`if (embeddedAgentId) { ... }`) now reads `agentDirectory.get('embedded', embeddedAgentId)?.agent` instead of `embeddedAgentManager.getEmbeddedAgent(embeddedAgentId)`. Error message and control flow are unchanged.
- **`packages/server/src/routes/workers.ts`**: the `type === 'agent'` fail-fast existence check now reads `agentDirectory.get('terminal', body.agentId)?.agent` instead of `agentManager.getAgent(body.agentId)`. Error message and control flow are unchanged.
- Test mocks in `worktrees.test.ts` / `workers.test.ts` are widened to also implement `AgentSurface` (same pattern PR-A used in `mcp-server.test.ts`) so a real `AgentDirectory` can be constructed in tests. Existing test assertions, status codes, and error messages are unchanged.

## What deliberately did NOT change (architect direction)

- **`AgentDirectory.resolve()` is not used anywhere in this PR.** Both routes already know which registry to query from which request field is populated (`agentId` -> terminal, `embeddedAgentId` -> embedded) -- a kind-known `get()` avoids `resolve()`'s cross-registry fallback semantics, which exist only for MCP's ambiguous id-or-name refs. Using `resolve()` here would risk an `embeddedAgentId` incorrectly matching a same-id terminal agent.
- **`worktrees.ts`'s terminal-agent suggestion-resolution is untouched.** The `agentManager.getAgent(selectedAgentId)` call that resolves the terminal agent driving `suggestSessionMetadata`'s headless branch/title generation, and the `repo.defaultAgentId ?? CLAUDE_CODE_AGENT_ID` default-agent fallback, remain exactly as they were -- both are caller-resident suggestion *policy*, not a generic registry existence query, per `docs/design/agent-surface.md`.
- **No new embedded-agent existence check added to `workers.ts`.** `WorkerLifecycleManager.createWorker()` (`packages/server/src/services/worker-lifecycle-manager.ts`) already validates `type === 'embedded-agent'` via `embeddedAgentManager.getEmbeddedAgent(...)` and throws `ValidationError` on a dangling id, producing a 400 through the same error-handling path today. That's a service-layer concern outside PR-B's routes-only scope, and `workers.test.ts` already had both success (201) and dangling-id (400) boundary tests for this path before this PR -- no new test needed, only DI wiring confirmed to still pass.

## Semantic-preserving evidence

- `worktrees.test.ts` + `workers.test.ts`: 60/60 pass, unchanged assertions.
- Full suite: `bun run typecheck` exit 0; `bun run test` -- 3483 pass / 1 skip / 1 fail. The 1 failure (elevation-skip direct-path SSH_AUTH_SOCK-fallback test in `user-mode.test.ts`) is pre-existing and unrelated: reproduced identically with this PR's changes `git stash`ed (baseline comparison per `workflow.md`), and lives in `packages/server/src/services/__tests__/user-mode.test.ts`, a file this PR does not touch.

## CodeRabbit

Local CLI (`coderabbit review --agent --base main`) could not authenticate in this headless delegated worktree (known limitation, see `coderabbit-ops` skill). Relying on the GitHub-side bot review post-push.

Refs #1167 (PR-A), #1122

Closes #1160 (PR-B)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker creation validation to correctly recognize available terminal agents.
  * Improved worktree creation validation for embedded agents, including clearer handling when an agent cannot be found.

* **Tests**
  * Updated route tests to cover agent directory lookups and preserve existing agent selection and session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->