### PR TITLE
refactor(test): extract createMockSystemCapabilities helper (#996)

### DIFF
--- a/packages/integration/src/system-api-boundary.test.ts
+++ b/packages/integration/src/system-api-boundary.test.ts
@@ -22,6 +22,9 @@ import { SystemCapabilitiesService } from '@agent-console/server/src/services/sy
 // Import mock-fs-helper to add test paths
 import { setupMemfs } from '@agent-console/server/src/__tests__/utils/mock-fs-helper';
 
+// Import shared mock SystemCapabilitiesService factory
+import { createMockSystemCapabilities } from '@agent-console/server/src/__tests__/utils/mock-system-capabilities-helper';
+
 // Import client API functions
 import { openInVSCode, openPath } from '@agent-console/client/src/lib/api';
 
@@ -56,21 +59,6 @@ function setupSpawnMock() {
   }) as typeof Bun.spawn;
 }
 
-/**
- * Create mock system capabilities with VS Code enabled/disabled.
- */
-function createMockSystemCapabilities(vscodeAvailable: boolean = true): SystemCapabilitiesService {
-  const mockCapabilities = new SystemCapabilitiesService();
-  // Manually set capabilities to avoid running 'which' command
-  Reflect.set(mockCapabilities, 'capabilities', {
-    vscode: vscodeAvailable,
-    vscodeOpenMode: 'local-spawn',
-    vscodeRemoteHost: null,
-  });
-  Reflect.set(mockCapabilities, 'vscodeCommand', vscodeAvailable ? 'code' : null);
-  return mockCapabilities;
-}
-
 describe('Client-Server Boundary: System API', () => {
   let app: Hono;
   let bridge: ReturnType<typeof createFetchBridge>;
@@ -94,7 +82,7 @@ describe('Client-Server Boundary: System API', () => {
     process.env.AGENT_CONSOLE_HOME = '/test/config';
 
     // Create system capabilities and pass to app via AppContext
-    systemCapabilities = createMockSystemCapabilities(true);
+    systemCapabilities = createMockSystemCapabilities({ vscode: true });
 
     // Create test app with all routes, passing systemCapabilities via AppContext
     app = await createTestApp({ systemCapabilities });
@@ -128,7 +116,7 @@ describe('Client-Server Boundary: System API', () => {
 
     it('should return error when VS Code is not available', async () => {
       // Recreate app with VS Code disabled
-      const noVscodeCapabilities = createMockSystemCapabilities(false);
+      const noVscodeCapabilities = createMockSystemCapabilities({ vscode: false });
       app = await createTestApp({ systemCapabilities: noVscodeCapabilities });
       bridge.restore();
       bridge = createFetchBridge(app);

--- a/packages/server/src/__tests__/utils/__tests__/mock-system-capabilities-helper.test.ts
+++ b/packages/server/src/__tests__/utils/__tests__/mock-system-capabilities-helper.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'bun:test';
+import { createMockSystemCapabilities } from '../mock-system-capabilities-helper.js';
+
+describe('createMockSystemCapabilities', () => {
+  it('defaults to no capabilities detected', () => {
+    const service = createMockSystemCapabilities();
+
+    expect(service.getCapabilities()).toEqual({
+      vscode: false,
+      vscodeOpenMode: 'local-spawn',
+      vscodeRemoteHost: null,
+    });
+    expect(service.getVSCodeCommand()).toBeNull();
+    expect(Reflect.get(service, 'vscodeCommand')).toBeNull();
+  });
+
+  it('defaults vscodeCommand to "code" when vscode is enabled', () => {
+    const service = createMockSystemCapabilities({ vscode: true });
+
+    expect(service.getCapabilities()).toEqual({
+      vscode: true,
+      vscodeOpenMode: 'local-spawn',
+      vscodeRemoteHost: null,
+    });
+    expect(service.getVSCodeCommand()).toBe('code');
+    expect(Reflect.get(service, 'vscodeCommand')).toBe('code');
+  });
+
+  it('applies an explicit full override of all options', () => {
+    const service = createMockSystemCapabilities({
+      vscode: true,
+      vscodeOpenMode: 'remote-url-scheme',
+      vscodeRemoteHost: 'example.com',
+      vscodeCommand: 'code-insiders',
+    });
+
+    expect(service.getCapabilities()).toEqual({
+      vscode: true,
+      vscodeOpenMode: 'remote-url-scheme',
+      vscodeRemoteHost: 'example.com',
+    });
+    expect(service.getVSCodeCommand()).toBe('code-insiders');
+    expect(Reflect.get(service, 'vscodeCommand')).toBe('code-insiders');
+  });
+});

--- a/packages/server/src/__tests__/utils/mock-system-capabilities-helper.ts
+++ b/packages/server/src/__tests__/utils/mock-system-capabilities-helper.ts
@@ -1,0 +1,52 @@
+/**
+ * Centralized SystemCapabilitiesService mock factory for tests.
+ *
+ * IMPORTANT: Import this module in test files that need a mock
+ * SystemCapabilitiesService instance instead of running the underlying
+ * `which` shell-out.
+ *
+ * @example
+ * ```typescript
+ * import { createMockSystemCapabilities } from '../../__tests__/utils/mock-system-capabilities-helper.js';
+ *
+ * const systemCapabilities = createMockSystemCapabilities({ vscode: true });
+ * ```
+ */
+import { SystemCapabilitiesService } from '../../services/system-capabilities-service.js';
+
+export interface MockSystemCapabilitiesOptions {
+  vscode?: boolean;
+  vscodeOpenMode?: 'local-spawn' | 'remote-url-scheme';
+  vscodeRemoteHost?: string | null;
+  vscodeCommand?: 'code' | 'code-insiders' | null;
+}
+
+/**
+ * Create a mock SystemCapabilitiesService for testing.
+ *
+ * Constructs a real instance and seeds its private state via Reflect so
+ * tests avoid running the underlying `which` shell-out, while staying
+ * structurally honest without `as unknown as` casts.
+ *
+ * Defaults mirror "no capabilities detected" (vscode: false). Pass
+ * `{ vscode: true }` (or any subset of options) to override per call site.
+ */
+export function createMockSystemCapabilities(
+  options: MockSystemCapabilitiesOptions = {},
+): SystemCapabilitiesService {
+  const {
+    vscode = false,
+    vscodeOpenMode = 'local-spawn',
+    vscodeRemoteHost = null,
+    vscodeCommand = vscode ? 'code' : null,
+  } = options;
+
+  const service = new SystemCapabilitiesService();
+  Reflect.set(service, 'capabilities', {
+    vscode,
+    vscodeOpenMode,
+    vscodeRemoteHost,
+  });
+  Reflect.set(service, 'vscodeCommand', vscodeCommand);
+  return service;
+}

--- a/packages/server/src/routes/__tests__/api.test.ts
+++ b/packages/server/src/routes/__tests__/api.test.ts
@@ -7,27 +7,8 @@ import type { MessageTemplateRepository } from '../../repositories/message-templ
 import type { EmbeddedAgentManager } from '../../services/embedded-agent-manager.js';
 import type { UserRepository } from '../../repositories/user-repository.js';
 import { SharedAccountRegistry } from '../../services/shared-account-registry.js';
-import { SystemCapabilitiesService } from '../../services/system-capabilities-service.js';
 import { serverConfig } from '../../lib/server-config.js';
-
-/**
- * Minimal SystemCapabilitiesService mock that returns no detected capabilities.
- *
- * Constructs a real instance and seeds its private state via Reflect so we
- * avoid running the underlying `which` shell-out. Mirrors the pattern used in
- * `__tests__/system.test.ts`. Returning a real instance also lets the test
- * stay structurally honest without `as unknown as` casts.
- */
-function createMockSystemCapabilities(): SystemCapabilitiesService {
-  const service = new SystemCapabilitiesService();
-  Reflect.set(service, 'capabilities', {
-    vscode: false,
-    vscodeOpenMode: 'local-spawn',
-    vscodeRemoteHost: null,
-  });
-  Reflect.set(service, 'vscodeCommand', null);
-  return service;
-}
+import { createMockSystemCapabilities } from '../../__tests__/utils/mock-system-capabilities-helper.js';
 
 describe('API route mounting', () => {
   let app: Hono<AppBindings>;

--- a/packages/server/src/routes/__tests__/auth.test.ts
+++ b/packages/server/src/routes/__tests__/auth.test.ts
@@ -16,7 +16,7 @@ import type { UserMode, LoginResult } from '../../services/user-mode.js';
 import type { AuthUser } from '@agent-console/shared';
 import type { PtyInstance } from '../../lib/pty-provider.js';
 import type { PtySpawnRequest } from '../../services/user-mode.js';
-import { SystemCapabilitiesService } from '../../services/system-capabilities-service.js';
+import { createMockSystemCapabilities } from '../../__tests__/utils/mock-system-capabilities-helper.js';
 
 // ============================================================================
 // Mock UserMode implementations
@@ -445,20 +445,6 @@ describe('LoginRateLimiter', () => {
 // =========================================================================
 
 describe('GET /api/config (multi-user mode)', () => {
-  /**
-   * Create a mock SystemCapabilitiesService for testing.
-   */
-  function createMockSystemCapabilities(): SystemCapabilitiesService {
-    const service = new SystemCapabilitiesService();
-    Reflect.set(service, 'capabilities', {
-      vscode: false,
-      vscodeOpenMode: 'local-spawn',
-      vscodeRemoteHost: null,
-    });
-    Reflect.set(service, 'vscodeCommand', null);
-    return service;
-  }
-
   /**
    * Create a test app with the /api/config route that mirrors
    * the production setup in api.ts.

--- a/packages/server/src/routes/__tests__/system.test.ts
+++ b/packages/server/src/routes/__tests__/system.test.ts
@@ -12,7 +12,7 @@ mock.module('open', () => ({
 
 // Import mock-fs-helper to set up memfs mocks
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
-import { SystemCapabilitiesService } from '../../services/system-capabilities-service.js';
+import { createMockSystemCapabilities } from '../../__tests__/utils/mock-system-capabilities-helper.js';
 
 // Track Bun.spawn calls for VS Code
 const spawnCalls: Array<{ args: string[]; options: Record<string, unknown> }> = [];
@@ -75,14 +75,12 @@ describe('System API - open-in-vscode', () => {
     const suffix = `?v=${++importCounter}`;
 
     // Set up mock system capabilities
-    const mockCapabilities = new SystemCapabilitiesService();
-    // Manually set capabilities to avoid running which command
-    Reflect.set(mockCapabilities, 'capabilities', {
+    const mockCapabilities = createMockSystemCapabilities({
       vscode: vscodeAvailable,
-      vscodeOpenMode: options.vscodeOpenMode ?? 'local-spawn',
-      vscodeRemoteHost: options.vscodeRemoteHost ?? null,
+      vscodeOpenMode: options.vscodeOpenMode,
+      vscodeRemoteHost: options.vscodeRemoteHost,
+      vscodeCommand: vscodeAvailable ? vscodeCommand : null,
     });
-    Reflect.set(mockCapabilities, 'vscodeCommand', vscodeAvailable ? vscodeCommand : null);
     const { system } = await import(`../system.js${suffix}`);
     const { onApiError } = await import(`../../lib/error-handler.js${suffix}`);
 


### PR DESCRIPTION
## Summary
- Extract a single shared `createMockSystemCapabilities` factory (`packages/server/src/__tests__/utils/mock-system-capabilities-helper.ts`) to replace four independent local copies flagged by CodeRabbit on PR #989 as a drift risk (a new capability field would otherwise need lockstep edits across 4 files).
- Switch all four call sites to import the shared helper, preserving each site's exact prior behavior via a partial-override options argument (`{ vscode?, vscodeOpenMode?, vscodeRemoteHost?, vscodeCommand? }`).
- Pure test-only refactor: **no assertions changed**, only imports / construction code / call-site argument shapes.

## Call sites updated
- `packages/server/src/routes/__tests__/api.test.ts`
- `packages/server/src/routes/__tests__/auth.test.ts`
- `packages/server/src/routes/__tests__/system.test.ts`
- `packages/integration/src/system-api-boundary.test.ts`

## Test plan
- [x] Added sibling test `packages/server/src/__tests__/utils/__tests__/mock-system-capabilities-helper.test.ts` covering defaults, `{ vscode: true }` default-command derivation, and a full explicit override.
- [x] Verified via `git diff` that zero `expect(...)` lines changed across the four call-site files.
- [x] `bun run typecheck` — exit 0.
- [x] `bun run test` — full suite green (5384 tests across all packages, 0 fail).

Closes #996

## Note on CodeRabbit
Both local CodeRabbit CLI and GitHub-side bot were unavailable at this PR's review window: the local CLI could not complete browser auth in this headless worktree, and the GitHub-side bot posted a rate-limit warning ("Next review available in: 44 minutes") at PR open. No CodeRabbit feedback obtainable from either source at this time. This is a test-only refactor with zero production-code changes and zero assertion changes (see diff). Disposition (wait for bot recovery vs. proceed) follows existing PR Merge Authority.