### PR TITLE
test: remove duplicate resolveTargets describe from inbound-integration.test.ts

### DIFF
--- a/packages/server/src/services/__tests__/inbound-integration.test.ts
+++ b/packages/server/src/services/__tests__/inbound-integration.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { createHmac } from 'node:crypto';
-import type { Repository, Session, InboundSystemEvent } from '@agent-console/shared';
 import { GitHubServiceParser } from '../inbound/github-service-parser.js';
-import { resolveTargets } from '../inbound/resolve-targets.js';
-import { buildWorktreeSession, buildPersistedRepository } from '../../__tests__/utils/build-test-data.js';
 
 describe('GitHubServiceParser', () => {
   const parser = new GitHubServiceParser('secret-token');
@@ -510,87 +507,5 @@ describe('GitHubServiceParser', () => {
       expect(event).not.toBeNull();
       expect(event!.metadata.url).toBeUndefined();
     });
-  });
-});
-
-describe('resolveTargets', () => {
-  const defaultRepo = buildPersistedRepository({ id: 'repo-1', name: 'repo', path: '/worktrees/repo' });
-  const defaultRepositories = new Map<string, Repository>([[defaultRepo.id, defaultRepo]]);
-
-  function createEvent(branch: string): InboundSystemEvent {
-    return {
-      type: 'ci:completed',
-      source: 'github',
-      timestamp: '2024-01-01T00:00:00Z',
-      metadata: { repositoryName: 'owner/repo', branch },
-      payload: { ok: true },
-      summary: 'CI success',
-    };
-  }
-
-  function createDeps(sessions: Session[], repositories = defaultRepositories) {
-    return {
-      getSessions: () => sessions,
-      getRepository: (repositoryId: string) => repositories.get(repositoryId),
-      getOrgRepoFromPath: async () => 'owner/repo',
-    };
-  }
-
-  it('matches worktree sessions by repository and branch', async () => {
-    const sessions = [buildWorktreeSession({ id: 'session-1', repositoryId: 'repo-1', worktreeId: 'main' })];
-    const targets = await resolveTargets(createEvent('main'), createDeps(sessions));
-    expect(targets).toEqual([{ sessionId: 'session-1' }]);
-  });
-
-  it('returns no targets for branch mismatch', async () => {
-    const sessions = [buildWorktreeSession({ id: 'session-1', repositoryId: 'repo-1', worktreeId: 'develop' })];
-    const targets = await resolveTargets(createEvent('main'), createDeps(sessions));
-    expect(targets).toEqual([]);
-  });
-
-  it('includes parent session when child matches', async () => {
-    const sessions = [
-      buildWorktreeSession({ id: 'child-1', repositoryId: 'repo-1', worktreeId: 'feature', parentSessionId: 'parent-1' }),
-    ];
-    const targets = await resolveTargets(createEvent('feature'), createDeps(sessions));
-    expect(targets).toEqual([
-      { sessionId: 'child-1' },
-      { sessionId: 'parent-1' },
-    ]);
-  });
-
-  it('does not include parent when parentSessionId is absent', async () => {
-    const sessions = [
-      buildWorktreeSession({ id: 'child-1', repositoryId: 'repo-1', worktreeId: 'feature' }),
-    ];
-    const targets = await resolveTargets(createEvent('feature'), createDeps(sessions));
-    expect(targets).toEqual([{ sessionId: 'child-1' }]);
-  });
-
-  it('deduplicates parent when multiple children match', async () => {
-    const sessions = [
-      buildWorktreeSession({ id: 'child-1', repositoryId: 'repo-1', worktreeId: 'main', parentSessionId: 'parent-1' }),
-      buildWorktreeSession({ id: 'child-2', repositoryId: 'repo-1', worktreeId: 'main', parentSessionId: 'parent-1' }),
-    ];
-    const targets = await resolveTargets(createEvent('main'), createDeps(sessions));
-    // parent-1 is added after child-1, then child-2 is added, then parent-1 again (deduped)
-    expect(targets).toEqual([
-      { sessionId: 'child-1' },
-      { sessionId: 'parent-1' },
-      { sessionId: 'child-2' },
-    ]);
-  });
-
-  it('does not duplicate parent that is also a direct match', async () => {
-    const sessions = [
-      buildWorktreeSession({ id: 'parent-1', repositoryId: 'repo-1', worktreeId: 'main' }),
-      buildWorktreeSession({ id: 'child-1', repositoryId: 'repo-1', worktreeId: 'main', parentSessionId: 'parent-1' }),
-    ];
-    const targets = await resolveTargets(createEvent('main'), createDeps(sessions));
-    // parent-1 matches directly AND is referenced as parent — should appear only once
-    expect(targets).toEqual([
-      { sessionId: 'parent-1' },
-      { sessionId: 'child-1' },
-    ]);
   });
 });


### PR DESCRIPTION
## Summary

Refs #1150 (partial improvement — see Investigation Status below; this PR does not close the Issue).

- Removes a fully duplicated `describe('resolveTargets', ...)` block (6 test cases) from `packages/server/src/services/__tests__/inbound-integration.test.ts`. All 6 cases were an exact subset of the 9 cases already covered by `packages/server/src/services/inbound/__tests__/resolve-targets.test.ts`.
- Per `.claude/rules/testing.md` ("Test Strategy: Unit vs Integration"): integration tests should verify pipeline connectivity with 1-2 representative events, not re-exercise exhaustive coverage that is the unit test's job. This duplicate block tested `resolveTargets` directly with hand-built deps — the same shape as the unit test file — with zero actual pipeline/integration value.
- Removed the now-unused imports (`resolveTargets`, `buildWorktreeSession`, `buildPersistedRepository`, and the `Repository` / `Session` / `InboundSystemEvent` types) that were only referenced inside the removed block.

## Investigation status (Issue #1150)

This PR was produced while investigating #1150 (intermittent `resolve-targets.test.ts` failures observed across 3 delegate sessions in Sprint 2026-07-16). Summary of the investigation:

- **Could not reproduce deterministically.** 19 full `packages/server` suite runs (`bun test src/`, 3479 tests / 154 files) plus 20 standalone runs of `resolve-targets.test.ts` alone — zero `resolveTargets`-related failures. The only failure observed across all runs was the known pre-existing elevation-skip (direct) path SSH_AUTH_SOCK baseline failure in `multi-user-mode.test.ts` (unrelated, tracked separately).
- **The Issue's 4 candidate hypotheses were reviewed and do not hold up:**
  1. `mock()` `callCount` state — local to each `it()` closure, not shared across tests.
  2. `new Date().toISOString()` timestamp — never asserted on (`targets` only contains `sessionId`).
  3. `defaultRepository` module-scope fixture — read-only, never mutated by production code.
  4. Sibling `diff-worker-handler.test.ts`'s `mock.module` — targets `../../git-diff-service.js`, a module `resolve-targets.ts` does not import; confirmed no shared resolved path.
- **This duplicate `describe` block was the one concrete "sibling test interference" candidate found** (per the Issue's own suggested repro method: "or by identifying the interfering sibling test"). Its removal is independently justified by `testing.md` regardless of whether it was contributing to flakiness, and it does remove one of two places in the suite that exercise `resolveTargets` (and its logger side effects) per run.
- **A deeper candidate theory was investigated and retracted:** `resolveTargets` (and `lib/git.ts`, transitively via `privilege-elevation.ts`) both instantiate the real pino logger with a `pino-pretty` worker-thread transport (since `NODE_ENV` is unset during `bun test`, `isDev` is `true`). This is the only unmocked OS-resource dependency in the test file. A file-local `mock.module('.../lib/logger.js', ...)` fix was attempted (matching the existing precedent in `worktree-creation-service.test.ts` / `worktree-deletion-service.test.ts`), but was empirically confirmed ineffective in the full-suite context: an earlier-loaded file (`app-context.ts`, pulled in via `services/inbound/index.ts`) already caches the real, unmocked module before this file's registration runs. A real fix would require either a production-code DI change to `resolveTargets`'s logger (out of this PR's test-only scope) or a repo-wide test-environment change (e.g. `NODE_ENV=test` for `bun test`, disabling the pretty-print transport suite-wide). Neither was applied here; a follow-up Issue is being filed separately for the repo-wide option.

Issue #1150 remains **open** pending a deterministic reproduction or the next real-world occurrence (at which point capturing the actual CI failure log is the recommended next step, per this repo's `.claude/rules/workflow.md` "Inference vs Verification" — no primary failure artifact was available for this investigation).

## Test plan

- [x] `bun run typecheck` — green across all packages
- [x] `bun run test` (full monorepo suite) — green except the known pre-existing elevation-skip SSH_AUTH_SOCK baseline failure in `multi-user-mode.test.ts` (unrelated to this change, tracked separately; same failure reproduces on `main`/unmodified code)
- [x] `resolve-targets.test.ts` + `inbound-integration.test.ts` run together, 20 consecutive times — 20/20 pass
- [x] No production code changes; test-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note on CodeRabbit
Both local CodeRabbit CLI (not authenticated in this delegated worktree session) and the GitHub-side bot ("Review limit reached") were unavailable at this PR's review window. No CodeRabbit feedback obtainable from either source. Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority) (test-only change).
