### PR TITLE
fix(client/mobile): left sidebar overflow scroll (#1170)

### DIFF
--- a/packages/client/src/components/sidebar/ActiveSessionsSidebar.tsx
+++ b/packages/client/src/components/sidebar/ActiveSessionsSidebar.tsx
@@ -559,7 +559,7 @@ export function ActiveSessionsSidebar({
     <aside
       ref={sidebarRef}
       aria-label="Active sessions"
-      className={`bg-slate-900 border-r border-slate-700 flex flex-col shrink-0 relative ${
+      className={`bg-slate-900 border-r border-slate-700 flex flex-col h-full shrink-0 relative ${
         isResizing ? '' : 'transition-all duration-200'
       }`}
       style={{ width: sidebarWidth }}

--- a/packages/client/src/components/sidebar/MobileSidebarDrawer.tsx
+++ b/packages/client/src/components/sidebar/MobileSidebarDrawer.tsx
@@ -61,7 +61,7 @@ export function MobileSidebarDrawer({ open, onClose, children }: MobileSidebarDr
         aria-modal={open || undefined}
         aria-hidden={!open}
         aria-label="Sessions drawer"
-        className={`fixed top-0 left-0 z-50 h-full w-72 bg-slate-900 transition-transform duration-300 ${
+        className={`fixed top-0 left-0 z-50 h-full w-72 flex flex-col overflow-hidden bg-slate-900 transition-transform duration-300 ${
           open ? 'translate-x-0' : '-translate-x-full'
         }`}
       >

--- a/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
+++ b/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
@@ -279,6 +279,18 @@ describe('ActiveSessionsSidebar', () => {
       const sidebar = screen.getByRole('complementary', { name: 'Active sessions' });
       expect(sidebar.style.width).toBe(`${customWidth}px`);
     });
+
+    it('should have an explicit h-full class on the <aside> so it gets a bounded height even without a flex-row parent (Issue #1170)', async () => {
+      // On desktop, the aside's height comes from `align-items: stretch` in
+      // the parent flex row. On mobile, the aside is rendered inside a
+      // non-flex-row drawer wrapper, so it needs its own explicit height to
+      // bound the internal `overflow-y-auto` session list — otherwise the
+      // list grows unbounded and long session lists get cut off.
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} />);
+
+      const sidebar = screen.getByRole('complementary', { name: 'Active sessions' });
+      expect(sidebar.className.split(' ')).toContain('h-full');
+    });
   });
 
   describe('Navigation', () => {

--- a/packages/client/src/components/sidebar/__tests__/MobileSidebarDrawer.test.tsx
+++ b/packages/client/src/components/sidebar/__tests__/MobileSidebarDrawer.test.tsx
@@ -64,6 +64,24 @@ describe('MobileSidebarDrawer', () => {
       expect(dialog!.className).toContain('-translate-x-full');
       expect(dialog!.className).not.toContain('translate-x-0');
     });
+
+    it('should make the drawer wrapper a bounded-height flex container so children can be stretched to fill it (Issue #1170)', () => {
+      // The drawer wrapper is `h-full` but must also establish a flex
+      // column context so its child (the sidebar `<aside>`) is stretched to
+      // fill the drawer's bounded height. Without `flex flex-col`, the
+      // aside grows with its content on mobile and long session lists get
+      // cut off with no way to scroll to the overflow.
+      render(
+        <MobileSidebarDrawer open={true} onClose={() => {}}>
+          <div>Content</div>
+        </MobileSidebarDrawer>
+      );
+      const dialog = screen.getByRole('dialog');
+      const classList = dialog.className.split(' ');
+      expect(classList).toContain('flex');
+      expect(classList).toContain('flex-col');
+      expect(classList).toContain('h-full');
+    });
   });
 
   describe('Interactions', () => {


### PR DESCRIPTION
## Summary

- Mobile sidebar drawer's outer wrapper was not a flex container, so its child (the sessions `<aside>`, which on desktop relies on the parent flex-row's `align-items: stretch` for a bounded height) had no explicit height inside it.
- With many sessions, the `<aside>` grew past the drawer's fixed viewport-height box (confirmed via DOM measurement: `aside.scrollHeight` = 761px vs. drawer box = 667px), and the internal `overflow-y-auto` session list had no bounded parent to actually scroll within — content below the fold was simply clipped, with no scroll affordance.
- Fix: give the `<aside>` an explicit `h-full` (safe on desktop too — the flex-row parent already had a definite height, so `height: 100%` computes to the same value `align-items: stretch` produced) and make the drawer wrapper a bounded `flex flex-col` (+ `overflow-hidden` as a safety net) so the aside is stretched to the drawer's full height. The existing `overflow-y-auto` session list section then correctly becomes the scrollable region, while the header stays pinned (`shrink-0`, unchanged).

## Root cause verification

Confirmed via `evaluate_script` DOM measurement in a real mobile-viewport browser session (375×667):

| | Before fix | After fix |
|---|---|---|
| `aside` height | 761px (unbounded, overflows drawer) | 667px (bounded to drawer) |
| session list `clientHeight` vs `scrollHeight` | 720 vs 720 (no scroll region) | 626 vs 720 (scrollable) |

## Test plan

- [x] `packages/client/src/components/sidebar/__tests__/MobileSidebarDrawer.test.tsx` — new test asserting the drawer wrapper has `flex`, `flex-col`, `h-full` classes. TDD-polarity confirmed (failed before the fix, passes after).
- [x] `packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx` — new test asserting the `<aside>` has `h-full`. TDD-polarity confirmed.
- [x] `bun run typecheck && bun run test:only` — full monorepo suite green (see below).
- [x] Manual Browser QA via Chrome DevTools MCP, mobile viewport (375×667) with 12 active sessions:
  - Before/after screenshots showing the cut-off list vs. the scrollable list (screenshots to follow in a PR comment).
  - Verified landscape orientation (667×375) — header stays pinned, list scrolls, no console errors.
  - Verified via `list_console_messages` — no console errors in either viewport.

### Full suite result

```
bun run typecheck: TYPECHECK_EXIT: 0
bun run test:only: TEST_EXIT: 0
(client: 1951 pass / 0 fail, server: 3481 pass / 1 skip / 0 fail,
 shared: 527 pass / 0 fail, integration: 70 pass / 0 fail,
 embedded-agent: 217 pass / 0 fail, scripts/hooks: 434 pass / 0 fail)
```

Note: one server test (`multi-user-mode.test.ts` Issue #918 SSH_AUTH_SOCK direct-path assertion) fails locally only when `SSH_AUTH_SOCK` is exported in the shell environment (a workaround this delegate session uses for commit signing) — that failure is an environment-coupling gap unrelated to this diff (verified: passes identically with `env -u SSH_AUTH_SOCK`, and this PR touches only `packages/client/src/components/sidebar/`). Full suite above was run with `SSH_AUTH_SOCK` unset for a clean baseline.

Closes #1170

## Note on CodeRabbit
Local CodeRabbit CLI could not authenticate in this headless worktree environment (no browser available for the interactive login flow). Attempted to rely on the GitHub-side CodeRabbit bot review instead, but the bot returned a "Review limit reached" rate-limit warning at PR open, and a manual `@coderabbitai review` re-trigger returned the same rate-limit warning (next review window: 52 minutes). Both local CLI and GitHub-side bot are simultaneously unavailable for this PR. No CodeRabbit feedback obtainable from either source. Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority).