### PR TITLE
feat: agent operation exposure tables + phase-decomposition rule (#1160 PR-D)

### DIFF
--- a/.claude/rules/pre-pr-completeness.md
+++ b/.claude/rules/pre-pr-completeness.md
@@ -96,7 +96,7 @@ Before opening a PR that introduces a **new skill, script, rule, file type, or c
 
     (Lesson: Sprint 2026-06-30 PR #926 — backend correctly populated `Session.createdByUsername`, the WebSocket message carried it, but `SessionBaseSchema` in `packages/shared/src/schemas/app-server-message.ts` was not updated. valibot stripped the unknown field; the frontend received `undefined`. All unit tests passed because the frontend tests injected the field directly via a mock factory, bypassing the parse path entirely. The bug surfaced only when the owner ran manual Browser QA and noticed the sidebar label was absent. Three hours of cross-layer debugging followed before the schema gap was identified. The agent and the Orchestrator both had approved skipping integration tests with the rationale "derived field, simple shape, unit tests suffice" — a joint judgment failure that this question is meant to prevent. The deeper structural fix is tracked in Issue #927 — `v.strictObject` migration plus server/client schema version handshake.)
 
-11. **Tool surface symmetry check — for PRs that introduce a new worker / agent / execution surface analogous to an existing one:**
+11. **Tool surface symmetry check — for PRs that introduce a new worker / agent / execution surface analogous to an existing one, OR add/change a cross-surface agent operation:**
 
     When this PR introduces a new worker kind, agent kind, or execution surface that is architecturally analogous to an existing one (e.g., a new agent kind alongside terminal-agent / Claude Code), answer these four questions before the design's initial phase merges:
 
@@ -109,6 +109,17 @@ Before opening a PR that introduces a **new skill, script, rule, file type, or c
 
     (Lesson: Sprint 2026-07-11/12 — Embedded Agent Worker v1 (umbrella [#1004](https://github.com/ms2sato/agent-console/issues/1004)) shipped without built-in tools (`Read` / `Write` / `Edit` / `Bash` / `Glob` / `Grep`), the largest gap identified in the post-v1 dogfood retro. The tools were not deferred by a documented decision — the spec review simply never asked whether the new surface matched terminal-agent's tool set. Three fast-follow PRs closed the gap after the fact: [#1042](https://github.com/ms2sato/agent-console/issues/1042) (FF-1a, Read/Glob/Grep), [#1043](https://github.com/ms2sato/agent-console/issues/1043) (FF-1b, Bash), and [#1044](https://github.com/ms2sato/agent-console/issues/1044) (FF-1c, Write/Edit). Asking Q11 during the original phase-decomposition review would have surfaced the gap and let the fast-follows be filed and scheduled before v1 shipped, instead of after dogfood found the hole. See [Issue #1046](https://github.com/ms2sato/agent-console/issues/1046).)
 
+    **5. Operation exposure tables (Issue #1160 PR-D extension):** the four questions above cover *tool-level* symmetry (what can this agent kind invoke?). A structurally different question is *operation-level* symmetry across consumer surfaces (UI, MCP, embedded-visible): does every surface that lets a caller act on "an agent" (list, resolve, create a session with one, add one to a session, manage its definition) expose the same set of operations, or record an explicit reason when it doesn't?
+
+    That second question is now type-enforced, not just reviewed by hand: `AGENT_OPERATIONS` (`packages/shared/src/types/agent-operations.ts`) is the single writer of every cross-surface agent operation, and each surface owns a table typed `satisfies Record<AgentOperation, SurfaceExposure>` — `packages/client/src/lib/agent-operations-ui.ts` (UI), `packages/server/src/mcp/agent-operations-mcp.ts` (MCP), `packages/server/src/mcp/agent-operations-embedded.ts` (embedded-visible). Apply this sub-check whenever a PR does either of the following:
+
+    - **Adds a new entry to `AGENT_OPERATIONS`** — the `satisfies` typing already makes an omission a compile error in all three tables, so this case cannot silently merge with an incomplete table. The human judgment this sub-check adds: confirm each table's new entry has an *accurate* `via` (a real, human-locatable entry point) or `reason` (a real rationale, not a placeholder), not just a value that satisfies the type.
+    - **Adds a new consumer surface** analogous to UI / MCP / embedded-visible (e.g., a future CLI or webhook surface that lets a caller act on agents) — add a fourth exposure table for it in the same PR, covering all of `AGENT_OPERATIONS`, following the same `satisfies Record<AgentOperation, SurfaceExposure>` pattern and co-located with that surface's own code.
+
+    Where a table's `via` claim is mechanically checkable (e.g., the MCP table's `via` naming a tool that must actually be registered in `packages/server/src/mcp/mcp-server.ts`), add or extend the corresponding test (see `packages/server/src/mcp/__tests__/agent-operations-mcp.test.ts` for the pattern) instead of relying on review alone. Where it is not mechanically checkable (UI `via` claims naming a component/page), accuracy stays a review-time judgment call — this residue is the same "process rule as the residual net" pattern documented in `docs/design/agent-surface.md` Mechanism 3.
+
+    (Lesson: this rule itself — Issue [#1160](https://github.com/ms2sato/agent-console/issues/1160) PR-D built the exposure-table mechanism specifically because Q11's original four questions catch tool-level gaps like the embedded-agent-v1 case above, but had no equivalent for operation-level gaps like `list_agents` silently excluding embedded agents while `delegate_to_worktree` accepted them — see `docs/design/agent-surface.md` §0 "Verified current state" for that concrete parity bug.)
+
 ## When to apply
 
 - **Required** for PRs that introduce:
@@ -120,7 +131,7 @@ Before opening a PR that introduces a **new skill, script, rule, file type, or c
   - A cross-runtime spawn (Question 6) — required regardless of whether other criteria match
   - A shared / persistent artifact write (Question 7) — required regardless of whether other criteria match
   - A derived field added to a shared type that crosses the server/client wire (Question 10) — required regardless of whether other criteria match
-  - A new worker / agent / execution surface analogous to an existing one (Question 11) — required regardless of whether other criteria match
+  - A new worker / agent / execution surface analogous to an existing one, or a new entry in `AGENT_OPERATIONS` / a new agent-operations exposure table (Question 11) — required regardless of whether other criteria match
 - **Optional but encouraged** for any production code PR touching infrastructure or cross-cutting patterns
 - **Not required** for single-file bug fixes, typo corrections, or test-only additions
 

--- a/docs/design/agent-surface.md
+++ b/docs/design/agent-surface.md
@@ -40,9 +40,61 @@ Two new types in `packages/shared/src/types/agent-surface.ts`:
 
 Following the same strict-thin-wrapper discipline documented in [`elevation-helpers.md`](../../.claude/rules/elevation-helpers.md) for the privilege-elevation primitives: `AgentDirectory` owns no lifecycle, no caching, and no CRUD. It is constructed fresh (or once, at `AppContext` wiring time) over the live manager instances and reads through to them on every call. Suggestion policy (which agent generates a branch/title suggestion for a delegated worktree) and default-agent policy (`repository.defaultAgentId` fallback) are NOT absorbed into `AgentDirectory` — they stay at the caller (`delegate_to_worktree`'s handler), exactly as the elevation helpers keep ENOENT-tolerance and retry semantics at the caller rather than the primitive.
 
-## Mechanism 3: `AGENT_OPERATIONS` exposure table (planned, PR-D — not yet built)
+## Mechanism 3: `AGENT_OPERATIONS` exposure tables (implemented, PR-D)
 
-A future mechanism, out of scope for this PR, will let each MCP tool / REST route declare which `AgentKind`(s) it supports via a static exposure table (working name `AGENT_OPERATIONS`), so a tool surface's actual capability can be checked against the declared table mechanically (the same kind of structural check the tool-surface-symmetry review from Issue #1046 asks about by hand today). This is deferred to PR-D of the Issue #1160 migration; this document does not specify its shape, only reserves the concept so PR-A's audit is not mistaken for having built it.
+Mechanisms 1 and 2 answer "can a consumer query both registries uniformly, and does an omitted `AgentKind` fail the build?" They do **not** answer a structurally different question: does every consumer *surface* (UI, MCP, embedded-agent-visible) expose the *same set of operations* on agents, or does one surface silently drift ahead of or behind the others? That was the concrete symptom that opened Issue #1160: `list_agents` (MCP) listed terminal agents only while `delegate_to_worktree` (also MCP) already accepted embedded ids — a same-surface, cross-*operation* parity gap that Mechanisms 1/2 have no way to catch, because both operations query the same registries correctly in isolation.
+
+### The single-writer operation enum
+
+`AGENT_OPERATIONS` (`packages/shared/src/types/agent-operations.ts`) is the single writer of every cross-surface agent operation:
+
+```ts
+export const AGENT_OPERATIONS = [
+  'listAgents',             // enumerate selectable agents
+  'resolveAgent',           // ref (id/name) -> definition, incl. ambiguity handling
+  'createSessionWithAgent', // new worktree session with an initial agent worker
+  'addWorkerToSession',     // add an agent worker to an existing session
+  'manageDefinitions',      // CRUD on agent definitions
+] as const;
+export type AgentOperation = (typeof AGENT_OPERATIONS)[number];
+
+export type SurfaceExposure =
+  | { exposed: true; via: string }      // entry point, human-locatable
+  | { exposed: false; reason: string }; // explicit opt-out with rationale
+```
+
+An operation belongs in this enum when a user or agent can perform it against "an agent" through more than one surface, or when its absence from a surface must be an explicit recorded decision rather than silence.
+
+### One exposure table per surface, `satisfies Record<AgentOperation, SurfaceExposure>`
+
+Each surface owns its own table, colocated with that surface's code:
+
+| Table | File |
+|---|---|
+| UI | `packages/client/src/lib/agent-operations-ui.ts` |
+| MCP | `packages/server/src/mcp/agent-operations-mcp.ts` |
+| Embedded-visible | `packages/server/src/mcp/agent-operations-embedded.ts` |
+
+The `satisfies Record<AgentOperation, SurfaceExposure>` typing is the compile-time gate: adding a sixth operation to `AGENT_OPERATIONS` fails the build in every one of these tables until that table records an explicit `{ exposed: true; via }` or `{ exposed: false; reason }` entry for it. Types cannot force a UI affordance to exist -- they *can* force the omission to be a recorded decision instead of silence.
+
+### Initial content (verbatim from the architect's spec, Issue #1160)
+
+| Operation | UI | MCP | Embedded-visible |
+|---|---|---|---|
+| `listAgents` | pickers + /agents page | `list_agents` (both kinds after PR-A) | same MCP tool via /mcp endpoint |
+| `resolveAgent` | picker selection | `delegate_to_worktree` agentId/agentName | same |
+| `createSessionWithAgent` | CreateWorktreeForm | `delegate_to_worktree` | same |
+| `addWorkerToSession` | AddAgentWorkerMenu | `not-exposed`: delegate model is one-worktree-one-session; adding workers to foreign sessions crosses the #878 auth boundary | same |
+| `manageDefinitions` | /agents page + settings | `not-exposed`: definition CRUD is an owner/console concern, not a delegation concern | same |
+
+Two honesty notes, carried over from the spec:
+
+- **The embedded-visible surface is structurally identical to the MCP surface.** Embedded agents reach the same `/mcp` endpoint with a token; there is no caller-specific tool filter for these operations (the settled premise behind the embedded-agent-worker design's builtin-tool gating, which is a *separate*, already-solved concern via `EMBEDDED_AGENT_TOOL_NAMES`). `agent-operations-embedded.ts`'s table is therefore mostly `via: 'MCP endpoint (shared) — <tool name>'`, and its sibling test asserts `exposed` parity against the MCP table operation-by-operation -- a drift between the two tables is a bug, not a design choice, so it fails a test rather than requiring a reviewer to notice.
+- **Mechanical checking is applied where the claim is checkable, review where it is not.** The MCP and embedded-visible tables' `via` claims name a real registered MCP tool, so `packages/server/src/mcp/__tests__/agent-operations-mcp.test.ts` and `agent-operations-embedded.test.ts` parse `mcp-server.ts`'s actual tool registrations and assert every `exposed: true` claim names one that exists. The UI table's `via` claims name a component/page, which has no equivalent single source of truth to parse against without excessive coupling to file layout -- accuracy there stays a review-time judgment call. This division is the Option-D residue the process-rule extension below names explicitly: types and mechanical tests shrink what a reviewer must check by hand, they don't eliminate the need for judgment entirely.
+
+### Process-rule residue
+
+Whatever an exposure table's `satisfies` typing and mechanical tests cannot catch -- whether a `via`/`reason` claim is *accurate*, whether a newly-introduced surface remembered to add its own table at all -- is handled by `.claude/rules/pre-pr-completeness.md` Q11's extension (sub-question 5), which extends the pre-existing tool-surface-symmetry check from Issue #1046 to this operation-level parity. The goal, as with Mechanisms 1 and 2, is to shrink the review-by-convention surface to only what types and tests genuinely cannot enforce.
 
 ## Uniform listing principle (client convergence, PR-C)
 
@@ -75,7 +127,7 @@ Issue #1160 is decomposed into four PRs:
 - **PR-A** — shared types (`AgentKind`, `AgentDirectoryEntry`, `AgentSurface`, `AgentResolution`), `AgentManager` / `EmbeddedAgentManager` implementing `AgentSurface`, the new `AgentDirectory` service, and MCP wiring (`list_agents` gains embedded-agent parity; `delegate_to_worktree`'s inline resolution block is replaced by `AgentDirectory.resolve`).
 - **PR-B** — REST routes (`packages/server/src/routes/worktrees.ts`, `routes/workers.ts`) adopt `AgentDirectory` for any cross-registry agent listing/resolution currently duplicated there.
 - **PR-C (this PR)** — client-only convergence. `packages/client/src/hooks/useAgentDirectory.ts` merges the client's existing two per-registry queries (`useAgents` / `useEmbeddedAgents`) into one `AgentDirectoryEntry[]` (terminal first, then embedded -- mirroring the server's `AgentDirectory.listAll()` order). The non-discriminated `{ agentId?; embeddedAgentId? }` selection shape is replaced by a discriminated `AgentSelection` union (client-local UI state, not a wire type) so an invalid "both set" / "neither set" state is unrepresentable. `WorktreeAgentSelector` is renamed `UnifiedAgentSelector` and adopted uniformly by `QuickSessionForm` and (visible-but-disabled for embedded) `RestartSessionDialog`. A single-writer presentation table (`AGENT_KIND_PRESENTATION`) replaces per-component inline badge/optgroup markup. PR-C required **no wire or schema change**: `CreateQuickSessionRequestSchema` already carried `embeddedAgentId` (mutually exclusive with `agentId` via a `v.check`) since before this migration, so the client-side widening of `QuickSessionForm` to accept embedded selections needed only client code. This is a narrower mechanism than originally sketched ("consumes a unified agent list sourced from the REST/WebSocket surface PR-B exposes") -- PR-B's server-side `AgentDirectory` adoption did not add a new cross-registry REST/WS endpoint for the client to consume, so PR-C merges client-side instead, over the two endpoints that already existed.
-- **PR-D** — the `AGENT_OPERATIONS` exposure-table mechanism (Mechanism 3 above), giving each tool/route surface a declared, checkable capability set per `AgentKind`.
+- **PR-D (this PR)** — the `AGENT_OPERATIONS` exposure-table mechanism (Mechanism 3 above): the shared `AgentOperation` / `SurfaceExposure` types, the UI / MCP / embedded-visible tables, the MCP-table mechanical cross-check tests, and the `pre-pr-completeness.md` Q11 process-rule extension. Closes Issue #1160.
 
 ## Cross-references
 
@@ -83,6 +135,7 @@ Issue #1160 is decomposed into four PRs:
 - [`elevation-helpers.md`](../../.claude/rules/elevation-helpers.md) — the strict-thin-wrapper + "extract when two PRs converge" discipline this design's `AgentDirectory` follows.
 - Issue [#1160](https://github.com/ms2sato/agent-console/issues/1160) — umbrella tracking PR-A through PR-D.
 - Issue [#1161](https://github.com/ms2sato/agent-console/issues/1161) — the original `delegate_to_worktree` embedded-agent-selection gap that PR #1165's short-term facade fixed, and that `AgentDirectory.resolve` now formalizes.
-- Issue [#1046](https://github.com/ms2sato/agent-console/issues/1046) — the tool-surface-symmetry process check that Mechanism 3 (PR-D) will make structural.
+- Issue [#1046](https://github.com/ms2sato/agent-console/issues/1046) — the tool-surface-symmetry process check that Mechanism 3 (PR-D) extends from tool-level to operation-level parity.
+- [`pre-pr-completeness.md`](../../.claude/rules/pre-pr-completeness.md) Q11 sub-question 5 — the process-rule residue for exposure-table accuracy that Mechanism 3's types and mechanical tests cannot enforce.
 - PR [#1165](https://github.com/ms2sato/agent-console/pull/1165) — the short-term two-registry facade in `delegate_to_worktree` that this design's `AgentDirectory.resolve` absorbs verbatim.
 - Issue [#1171](https://github.com/ms2sato/agent-console/issues/1171) — server-side cross-type restart (embedded-agent restart support), the prerequisite for `RestartSessionDialog`'s embedded entries to become selectable instead of disabled-with-notice. Blocked on Issue #1123 (conversation transcript restore).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -28,6 +28,14 @@ The stored configuration for an AI agent, including command templates and activi
 **Implemented (Issue #1160 PR-A).** A stateless, policy-free composite (`packages/server/src/services/agent-directory.ts`) over the `terminal` and `embedded` [AgentSurface](#agentsurface) registries. Provides `listAll()` (used by the MCP `list_agents` tool) and `resolve({ agentId?, agentName? })` (used by `delegate_to_worktree`'s agent resolver, absorbing the short-term two-registry facade from PR #1165 verbatim — same terminal-first-by-id precedence and ambiguity error messages). Owns no lifecycle, no caching, no CRUD; suggestion policy and default-agent policy stay at callers, following the same strict-thin-wrapper discipline as [`privilege-elevation.ts`](../.claude/rules/elevation-helpers.md). Does NOT merge [AgentDefinition](#agentdefinition) and [EmbeddedAgentDefinition](#embeddedagentdefinition) — the two registries remain separate data models with separate id namespaces; `AgentDirectory` only unifies what their consumers can *query*.
 - **See:** [Agent Surface design](design/agent-surface.md)
 
+### AgentOperation
+**Implemented (Issue #1160 PR-D).** The discriminator naming a cross-surface action performable against "an agent" (`listAgents`, `resolveAgent`, `createSessionWithAgent`, `addWorkerToSession`, `manageDefinitions`). Single writer: the `AGENT_OPERATIONS` constant in [agent-operations.ts](../packages/shared/src/types/agent-operations.ts). Distinct from [AgentKind](#agentkind): `AgentKind` tags which registry an agent belongs to; `AgentOperation` names what a consumer surface (UI / MCP / embedded-visible) can do to an agent. Each surface owns an exposure table typed `satisfies Record<AgentOperation, SurfaceExposure>`, so adding a new operation is a compile error in every table until it records an explicit exposed/not-exposed decision.
+- **See:** [Agent Surface design](design/agent-surface.md) Mechanism 3
+
+### SurfaceExposure
+**Implemented (Issue #1160 PR-D).** The value type of an exposure-table entry: `{ exposed: true; via: string } | { exposed: false; reason: string }`. `via` names a human-locatable entry point (a component, a page, an MCP tool name); `reason` is the rationale for an intentional omission. Defined alongside [AgentOperation](#agentoperation) in `agent-operations.ts`.
+- **See:** [Agent Surface design](design/agent-surface.md) Mechanism 3
+
 ### Repository
 A registered Git repository available for session creation. Code reference: `repositoryId` (UUID).
 - **See:** [Core concepts in session-worker-design.md](design/session-worker-design.md#key-concepts)

--- a/packages/client/src/lib/__tests__/agent-operations-ui.test.ts
+++ b/packages/client/src/lib/__tests__/agent-operations-ui.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { AGENT_OPERATIONS } from '@agent-console/shared';
+import { UI_AGENT_OPERATIONS } from '../agent-operations-ui';
+
+const COMPONENTS_DIR = fileURLToPath(new URL('../../components', import.meta.url));
+
+/** Coarse recursive existence check: does any file named `fileName` exist
+ *  somewhere under packages/client/src/components? Intentionally loose
+ *  (name match, not exact path) so a future directory move doesn't make
+ *  this test fragile. */
+function componentFileExists(fileName: string, dir: string = COMPONENTS_DIR): boolean {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (componentFileExists(fileName, `${dir}/${entry.name}`)) return true;
+    } else if (entry.name === fileName) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe('UI_AGENT_OPERATIONS', () => {
+  test('covers exactly the members of AGENT_OPERATIONS (no missing/extra)', () => {
+    // Redundant with the `satisfies Record<AgentOperation, SurfaceExposure>`
+    // compile-time gate on the production table -- this is a runtime
+    // regression guard documenting the same intent.
+    const actualKeys = Object.keys(UI_AGENT_OPERATIONS).sort();
+    const expectedKeys = [...AGENT_OPERATIONS].sort();
+    expect(actualKeys).toEqual(expectedKeys);
+  });
+
+  test('all entries are currently exposed (matches the spec table)', () => {
+    // NOTE: if this test starts failing because an entry became
+    // `exposed: false`, that is likely an INTENTIONAL table update (a new
+    // recorded not-exposed decision for the UI surface), not a bug. Update
+    // this test's expectation to match the new table -- do not just delete
+    // the assertion.
+    for (const operation of AGENT_OPERATIONS) {
+      expect(UI_AGENT_OPERATIONS[operation].exposed).toBe(true);
+    }
+  });
+
+  test('exposed entries referencing a specific component file point at a file that actually exists', () => {
+    // Cross-check for `via` claims that name a specific component file, so
+    // a future rename doesn't silently leave a stale claim. Only checks
+    // entries whose `via` string looks like a bare component name.
+    const componentFileClaims: Partial<Record<keyof typeof UI_AGENT_OPERATIONS, string>> = {
+      createSessionWithAgent: 'CreateWorktreeForm.tsx',
+      addWorkerToSession: 'AddAgentWorkerMenu.tsx',
+    };
+
+    for (const [operation, fileName] of Object.entries(componentFileClaims)) {
+      expect(UI_AGENT_OPERATIONS[operation as keyof typeof UI_AGENT_OPERATIONS].via).toContain(
+        fileName.replace('.tsx', ''),
+      );
+      expect(componentFileExists(fileName)).toBe(true);
+    }
+  });
+});

--- a/packages/client/src/lib/agent-operations-ui.ts
+++ b/packages/client/src/lib/agent-operations-ui.ts
@@ -1,0 +1,26 @@
+import type { AgentOperation, SurfaceExposure } from '@agent-console/shared';
+
+/**
+ * SINGLE WRITER of the UI surface's cross-surface agent operation exposure
+ * table (agent-surface migration PR-D).
+ *
+ * `satisfies Record<AgentOperation, SurfaceExposure>` is the compile-time
+ * exhaustiveness gate: adding a 6th `AgentOperation` to
+ * `packages/shared/src/types/agent-operations.ts` fails the build here
+ * until this table records an explicit exposed/not-exposed decision for it.
+ *
+ * The `via` strings name real component/page locations for each exposed
+ * operation. Unlike the MCP surface's table (server-side sibling of this
+ * PR), which is cross-checked against the real MCP tool registry, these
+ * claims are checked by review rather than mechanically -- keep them
+ * accurate, but a rename elsewhere in the tree will not fail CI here.
+ *
+ * See docs/design/agent-surface.md "Mechanism 3" for the normative spec.
+ */
+export const UI_AGENT_OPERATIONS = {
+  listAgents: { exposed: true, via: 'pickers + /agents page' },
+  resolveAgent: { exposed: true, via: 'picker selection' },
+  createSessionWithAgent: { exposed: true, via: 'CreateWorktreeForm' },
+  addWorkerToSession: { exposed: true, via: 'AddAgentWorkerMenu' },
+  manageDefinitions: { exposed: true, via: '/agents page + settings' },
+} satisfies Record<AgentOperation, SurfaceExposure>;

--- a/packages/server/src/__tests__/utils/__tests__/mcp-tool-names-helper.test.ts
+++ b/packages/server/src/__tests__/utils/__tests__/mcp-tool-names-helper.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'bun:test';
+import { getRegisteredMcpToolNames } from '../mcp-tool-names-helper.js';
+
+describe('getRegisteredMcpToolNames', () => {
+  it('finds real tool registrations in the actual mcp-server.ts source', async () => {
+    const names = await getRegisteredMcpToolNames();
+
+    expect(names.has('list_agents')).toBe(true);
+    expect(names.has('delegate_to_worktree')).toBe(true);
+  });
+
+  it('does not vacuously match a name that is not registered', async () => {
+    const names = await getRegisteredMcpToolNames();
+
+    expect(names.has('this_tool_does_not_exist')).toBe(false);
+  });
+});

--- a/packages/server/src/__tests__/utils/mcp-tool-names-helper.ts
+++ b/packages/server/src/__tests__/utils/mcp-tool-names-helper.ts
@@ -1,0 +1,45 @@
+/**
+ * Statically parses `mcp-server.ts` for every `mcpServer.tool('name', ...)`
+ * registration. Used by `agent-operations-mcp.test.ts` /
+ * `agent-operations-embedded.test.ts` to verify exposure-table `via` claims
+ * name a tool that actually exists, instead of trusting a hand-maintained
+ * duplicate list that could silently drift when a tool is renamed or
+ * removed.
+ *
+ * Reads via `Bun.file()` rather than `node:fs` deliberately: sibling test
+ * files in this package register process-global `mock.module('node:fs', …)`
+ * memfs mocks (see `mock-fs-helper.ts`) that persist across test files
+ * within the same `bun test` run. `Bun.file()` bypasses the `node:fs`
+ * module entirely, so this helper reliably reads the real filesystem
+ * regardless of test execution order.
+ *
+ * @example
+ * ```typescript
+ * import { getRegisteredMcpToolNames } from '../../__tests__/utils/mcp-tool-names-helper.js';
+ *
+ * const registeredNames = await getRegisteredMcpToolNames();
+ * expect(registeredNames.has('list_agents')).toBe(true);
+ * ```
+ */
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const MCP_SERVER_SOURCE_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../mcp/mcp-server.ts',
+);
+
+const TOOL_REGISTRATION_RE = /mcpServer\.tool\(\s*'([a-zA-Z_][a-zA-Z0-9_]*)'/g;
+
+/**
+ * Reads the actual current source of `mcp-server.ts` and extracts every
+ * literal MCP tool name registered via `mcpServer.tool('name', ...)`.
+ */
+export async function getRegisteredMcpToolNames(): Promise<Set<string>> {
+  const source = await Bun.file(MCP_SERVER_SOURCE_PATH).text();
+  const names = new Set<string>();
+  for (const match of source.matchAll(TOOL_REGISTRATION_RE)) {
+    names.add(match[1]);
+  }
+  return names;
+}

--- a/packages/server/src/mcp/__tests__/agent-operations-embedded.test.ts
+++ b/packages/server/src/mcp/__tests__/agent-operations-embedded.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'bun:test';
+import { AGENT_OPERATIONS } from '@agent-console/shared';
+import { MCP_AGENT_OPERATIONS } from '../agent-operations-mcp.js';
+import { EMBEDDED_AGENT_OPERATIONS } from '../agent-operations-embedded.js';
+import { getRegisteredMcpToolNames } from '../../__tests__/utils/mcp-tool-names-helper.js';
+
+describe('EMBEDDED_AGENT_OPERATIONS', () => {
+  it('covers exactly AGENT_OPERATIONS (no missing/extra keys)', () => {
+    expect(Object.keys(EMBEDDED_AGENT_OPERATIONS).sort()).toEqual([...AGENT_OPERATIONS].sort());
+  });
+
+  it('every exposed `via` claim names a currently-registered MCP tool', async () => {
+    const registeredNames = await getRegisteredMcpToolNames();
+
+    for (const operation of AGENT_OPERATIONS) {
+      const entry = EMBEDDED_AGENT_OPERATIONS[operation];
+      if (!entry.exposed) continue;
+
+      const tokens = entry.via.match(/[a-zA-Z_][a-zA-Z0-9_]*/g) ?? [];
+      const matchesRegisteredTool = tokens.some((token) => registeredNames.has(token));
+
+      if (!matchesRegisteredTool) {
+        throw new Error(
+          `expected via="${entry.via}" for "${operation}" to reference a registered MCP tool`,
+        );
+      }
+      expect(matchesRegisteredTool).toBe(true);
+    }
+  });
+
+  it('mirrors MCP_AGENT_OPERATIONS exposed/not-exposed flags exactly (structural identity)', () => {
+    for (const operation of AGENT_OPERATIONS) {
+      expect(EMBEDDED_AGENT_OPERATIONS[operation].exposed).toBe(
+        MCP_AGENT_OPERATIONS[operation].exposed,
+      );
+    }
+  });
+});

--- a/packages/server/src/mcp/__tests__/agent-operations-mcp.test.ts
+++ b/packages/server/src/mcp/__tests__/agent-operations-mcp.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'bun:test';
+import { AGENT_OPERATIONS } from '@agent-console/shared';
+import { MCP_AGENT_OPERATIONS } from '../agent-operations-mcp.js';
+import { getRegisteredMcpToolNames } from '../../__tests__/utils/mcp-tool-names-helper.js';
+
+describe('MCP_AGENT_OPERATIONS', () => {
+  it('covers exactly AGENT_OPERATIONS (no missing/extra keys)', () => {
+    expect(Object.keys(MCP_AGENT_OPERATIONS).sort()).toEqual([...AGENT_OPERATIONS].sort());
+  });
+
+  it('every exposed `via` claim names a currently-registered MCP tool', async () => {
+    const registeredNames = await getRegisteredMcpToolNames();
+
+    for (const operation of AGENT_OPERATIONS) {
+      const entry = MCP_AGENT_OPERATIONS[operation];
+      if (!entry.exposed) continue;
+
+      const tokens = entry.via.match(/[a-zA-Z_][a-zA-Z0-9_]*/g) ?? [];
+      const matchesRegisteredTool = tokens.some((token) => registeredNames.has(token));
+
+      if (!matchesRegisteredTool) {
+        throw new Error(
+          `expected via="${entry.via}" for "${operation}" to reference a registered MCP tool`,
+        );
+      }
+      expect(matchesRegisteredTool).toBe(true);
+    }
+  });
+
+  it('does not vacuously pass — a fabricated tool name is not in the registered set', async () => {
+    const registeredNames = await getRegisteredMcpToolNames();
+
+    expect(registeredNames.has('this_tool_does_not_exist')).toBe(false);
+  });
+});

--- a/packages/server/src/mcp/agent-operations-embedded.ts
+++ b/packages/server/src/mcp/agent-operations-embedded.ts
@@ -1,0 +1,32 @@
+import type { AgentOperation, SurfaceExposure } from '@agent-console/shared';
+
+/**
+ * Single-writer exposure table for the embedded-agent-visible surface
+ * (agent-surface migration PR-D).
+ *
+ * Embedded agents reach the same `/mcp` endpoint as any other MCP client
+ * (authenticated via token, per the embedded-agent-worker design) and there
+ * is no caller-specific tool filter applied to these operations. This
+ * table is therefore expected to mirror `MCP_AGENT_OPERATIONS` exactly on
+ * `exposed` -- the parity is structural, not coincidental. The sibling test
+ * `__tests__/agent-operations-embedded.test.ts` enforces this parity
+ * mechanically, so an edit to one table without the other fails the test.
+ */
+export const EMBEDDED_AGENT_OPERATIONS = {
+  listAgents: { exposed: true, via: 'MCP endpoint (shared) — list_agents' },
+  resolveAgent: { exposed: true, via: 'MCP endpoint (shared) — delegate_to_worktree' },
+  createSessionWithAgent: {
+    exposed: true,
+    via: 'MCP endpoint (shared) — delegate_to_worktree',
+  },
+  addWorkerToSession: {
+    exposed: false,
+    reason:
+      'not-exposed via MCP: delegate model is one-worktree-one-session; adding workers to foreign sessions crosses the #878 auth boundary (same MCP endpoint, same restriction)',
+  },
+  manageDefinitions: {
+    exposed: false,
+    reason:
+      'not-exposed via MCP: definition CRUD is an owner/console concern, not a delegation concern (same MCP endpoint, same restriction)',
+  },
+} satisfies Record<AgentOperation, SurfaceExposure>;

--- a/packages/server/src/mcp/agent-operations-mcp.ts
+++ b/packages/server/src/mcp/agent-operations-mcp.ts
@@ -1,0 +1,30 @@
+import type { AgentOperation, SurfaceExposure } from '@agent-console/shared';
+
+/**
+ * Single-writer exposure table for the MCP surface (agent-surface migration
+ * PR-D).
+ *
+ * Every `AgentOperation` must have an explicit exposed/not-exposed entry
+ * here -- the `satisfies Record<AgentOperation, SurfaceExposure>` clause
+ * makes adding a new operation to `AGENT_OPERATIONS` a compile error in
+ * this table until that decision is recorded.
+ *
+ * The `via` strings for exposed operations are cross-checked mechanically
+ * against the real registered MCP tool names in `mcp-server.ts` by the
+ * sibling test `__tests__/agent-operations-mcp.test.ts`, so a renamed or
+ * removed tool fails the test instead of silently drifting from reality.
+ */
+export const MCP_AGENT_OPERATIONS = {
+  listAgents: { exposed: true, via: 'list_agents (both kinds after PR-A)' },
+  resolveAgent: { exposed: true, via: 'delegate_to_worktree agentId/agentName' },
+  createSessionWithAgent: { exposed: true, via: 'delegate_to_worktree' },
+  addWorkerToSession: {
+    exposed: false,
+    reason:
+      'delegate model is one-worktree-one-session; adding workers to foreign sessions crosses the #878 auth boundary',
+  },
+  manageDefinitions: {
+    exposed: false,
+    reason: 'definition CRUD is an owner/console concern, not a delegation concern',
+  },
+} satisfies Record<AgentOperation, SurfaceExposure>;

--- a/packages/shared/src/__tests__/index.test.ts
+++ b/packages/shared/src/__tests__/index.test.ts
@@ -107,6 +107,22 @@ describe('shared index exports', () => {
     expect(mod.AGENT_KINDS).toEqual(['terminal', 'embedded']);
   });
 
+  it('should re-export AGENT_OPERATIONS as the single-writer cross-surface operation enum', async () => {
+    const mod = await import('../index.js');
+
+    // AGENT_OPERATIONS is the single writer consumed by the UI / MCP /
+    // embedded-visible exposure tables (packages/shared/src/types/agent-operations.ts)
+    // -- verify the runtime constant is actually re-exported through the
+    // barrel, not just the type-only AgentOperation/SurfaceExposure.
+    expect(mod.AGENT_OPERATIONS).toEqual([
+      'listAgents',
+      'resolveAgent',
+      'createSessionWithAgent',
+      'addWorkerToSession',
+      'manageDefinitions',
+    ]);
+  });
+
   it('should export ConditionalWakeupInfo type', async () => {
     const mod = await import('../index.js');
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from './types/agent.js';
 export * from './types/worker.js';
 export * from './types/embedded-agent.js';
 export * from './types/agent-surface.js';
+export * from './types/agent-operations.js';
 export * from './types/session.js';
 export * from './types/repository.js';
 export * from './types/worktree-creation.js';

--- a/packages/shared/src/types/__tests__/agent-operations.test.ts
+++ b/packages/shared/src/types/__tests__/agent-operations.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'bun:test';
+import { AGENT_OPERATIONS } from '../agent-operations.js';
+
+describe('AGENT_OPERATIONS', () => {
+  it('contains exactly the five operations named in the Issue #1160 PR-D spec', () => {
+    expect(AGENT_OPERATIONS).toEqual([
+      'listAgents',
+      'resolveAgent',
+      'createSessionWithAgent',
+      'addWorkerToSession',
+      'manageDefinitions',
+    ]);
+  });
+
+  it('has no duplicate entries', () => {
+    expect(new Set(AGENT_OPERATIONS).size).toBe(AGENT_OPERATIONS.length);
+  });
+});

--- a/packages/shared/src/types/agent-operations.ts
+++ b/packages/shared/src/types/agent-operations.ts
@@ -1,0 +1,28 @@
+/**
+ * Cross-surface agent operation parity types (agent-surface migration PR-D).
+ *
+ * AGENT_OPERATIONS is the single writer of every cross-surface agent
+ * operation: an operation belongs here when a user or agent can perform it
+ * against "an agent" through more than one surface, or when its absence
+ * from a surface must be an explicit recorded decision rather than silence.
+ *
+ * Each surface (UI, MCP, embedded-visible) owns one exposure table keyed by
+ * AgentOperation and typed `satisfies Record<AgentOperation, SurfaceExposure>`
+ * -- adding a new operation here is a compile error in every surface's table
+ * until that table records an explicit exposed/not-exposed decision for it.
+ *
+ * See docs/design/agent-surface.md "Mechanism 3" for the normative spec.
+ */
+
+export const AGENT_OPERATIONS = [
+  'listAgents', // enumerate selectable agents
+  'resolveAgent', // ref (id/name) -> definition, incl. ambiguity handling
+  'createSessionWithAgent', // new worktree session with an initial agent worker
+  'addWorkerToSession', // add an agent worker to an existing session
+  'manageDefinitions', // CRUD on agent definitions
+] as const;
+export type AgentOperation = (typeof AGENT_OPERATIONS)[number];
+
+export type SurfaceExposure =
+  | { exposed: true; via: string } // entry point, human-locatable
+  | { exposed: false; reason: string }; // explicit opt-out with rationale


### PR DESCRIPTION
## Summary

Issue #1160 (owner ask: make UI / MCP / EmbeddedAgent-exposed agent operations structurally consistent) is decomposed into four PRs; this is **PR-D, the last one**. PR-A (#1167), PR-B (#1168), and PR-C (#1177) are already merged.

PR-A/B/C gave every surface a uniform way to *query* agents (`AgentSurface` / `AgentDirectory` / `AgentKind`). This PR closes the remaining gap: whether every surface *exposes the same set of operations* on agents (list / resolve / create-session / add-worker / manage-definitions), or records an explicit reason when it doesn't.

## What changed

- `packages/shared/src/types/agent-operations.ts` — single-writer `AGENT_OPERATIONS` const array + `AgentOperation` type + `SurfaceExposure` union (`{exposed:true; via} | {exposed:false; reason}`).
- Three exposure tables, each `satisfies Record<AgentOperation, SurfaceExposure>` (verbatim content per the architect's spec table in the Issue):
  - `packages/client/src/lib/agent-operations-ui.ts` (UI)
  - `packages/server/src/mcp/agent-operations-mcp.ts` (MCP)
  - `packages/server/src/mcp/agent-operations-embedded.ts` (embedded-agent-visible)
- Mechanical cross-check tests: `packages/server/src/mcp/__tests__/agent-operations-mcp.test.ts` / `agent-operations-embedded.test.ts` statically parse the real `mcp-server.ts` tool registrations (via `packages/server/src/__tests__/utils/mcp-tool-names-helper.ts`) and assert every `exposed:true` claim names a tool that actually exists — a renamed/removed tool fails the test instead of the table silently drifting. The embedded table is additionally asserted to mirror the MCP table's `exposed` flags exactly (the two surfaces are structurally identical: same `/mcp` endpoint, no caller-specific filter for these operations).
- `.claude/rules/pre-pr-completeness.md` Q11 (tool-surface-symmetry check) extended with a 5th sub-question: adding a new `AgentOperation` or a new consumer surface requires updating/adding the exposure tables in the same PR.
- `docs/design/agent-surface.md` — replaced the PR-A placeholder "Mechanism 3 (planned, not yet built)" section with the real spec, updated the migration-order PR-D line, added cross-references.
- `docs/glossary.md` — new `AgentOperation` / `SurfaceExposure` entries.

## Compile-time gate, verified

Both the frontend and backend implementers independently verified the `satisfies Record<AgentOperation, SurfaceExposure>` exhaustiveness gate is real: temporarily removing an entry from a table produces `TS1360` (missing property), confirmed via `tsc --noEmit`, then restored.

## Note on integration-test coverage (preflight `⚠` — explicit judgment call, not a silent skip)

`node .claude/skills/orchestrator/preflight-check.js` flags this as a cross-package shared-type change and recommends an integration test. This PR's shared type (`AGENT_OPERATIONS` / `AgentOperation` / `SurfaceExposure`) is **compile-time-only and never crosses a runtime wire boundary** — no valibot schema, no WebSocket/REST payload carries these values. Each of the three exposure tables is a static, in-process literal object built independently in its own package; there is nothing for a client↔server integration test to exercise at runtime. This is a materially different shape from the Q10 "derived field on a shared wire type" case the strong-recommend heuristic is calibrated for (Issue #927 / PR #926). The properties an integration test would otherwise target (does every table cover every operation; does the MCP claim match reality; does embedded mirror MCP) are instead asserted by the mechanical unit tests in this PR (`satisfies` + `mcp-server.ts` source cross-check + MCP/embedded parity test). Flagging this explicitly per `workflow.md`'s "joint decision" requirement rather than silently skipping — architect audit (spec §8) and CodeRabbit will get a second look at this reasoning.

## Test plan

- [x] `bun run typecheck` — all 4 packages clean
- [x] `bun run test:only` — full suite green (client 2059, server 3515, shared 573, embedded-agent 247, integration 72, scripts/hooks 434 — all pass, 0 fail)
- [x] `bun scripts/check-source-comment-blame-shift.mjs` — 0 new violations
- [x] `bun run check:lang` — clean
- [x] `node .claude/skills/orchestrator/check-mirror-drift.js` — in sync
- [x] Compile-time exhaustiveness gate manually verified (see above)
- [ ] Architect audit (session 84a3a530, spec §8 — pre-announced "light")

Closes #1160 (PR-D)
Refs #1167 #1168 #1177 #1046


## Note on CodeRabbit
Both local CodeRabbit CLI and GitHub-side bot were rate-limited at this PR's review window (CLI: headless-worktree auth timeout; bot: "Review limit reached, next review available in 41 minutes"). No CodeRabbit feedback obtainable from either source at PR-open time. Merging under existing PR Merge Authority.
