### PR TITLE
refactor(client): AddAgentWorkerMenu useAgentDirectory unification (#1179)

### DIFF
--- a/packages/client/src/components/sessions/AddAgentWorkerMenu.tsx
+++ b/packages/client/src/components/sessions/AddAgentWorkerMenu.tsx
@@ -1,7 +1,6 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { Link } from '@tanstack/react-router';
-import { useAgents } from '../../hooks/useAgents';
-import { useEmbeddedAgents } from '../../hooks/useEmbeddedAgents';
+import { useAgentDirectory } from '../../hooks/useAgentDirectory';
 import { AGENT_KIND_PRESENTATION } from '../agents';
 import type { AddAgentWorkerParams } from './hooks/useTabManagement';
 
@@ -30,8 +29,15 @@ interface AddAgentWorkerMenuProps {
  */
 export function AddAgentWorkerMenu({ onSelect, onSelectShell }: AddAgentWorkerMenuProps) {
   const [open, setOpen] = useState(false);
-  const { agents, isLoading: agentsLoading } = useAgents();
-  const { embeddedAgents, isLoading: embeddedLoading } = useEmbeddedAgents();
+  const { entries, isLoading } = useAgentDirectory();
+  const agents = useMemo(
+    () => entries.filter((entry) => entry.kind === 'terminal').map((entry) => entry.agent),
+    [entries]
+  );
+  const embeddedAgents = useMemo(
+    () => entries.filter((entry) => entry.kind === 'embedded').map((entry) => entry.agent),
+    [entries]
+  );
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -60,7 +66,6 @@ export function AddAgentWorkerMenu({ onSelect, onSelectShell }: AddAgentWorkerMe
     await onSelectShell();
   };
 
-  const isLoading = agentsLoading || embeddedLoading;
   const isEmpty = !isLoading && agents.length === 0 && embeddedAgents.length === 0;
 
   return (
@@ -122,7 +127,7 @@ export function AddAgentWorkerMenu({ onSelect, onSelectShell }: AddAgentWorkerMe
               </span>
             </button>
           ))}
-          {!embeddedLoading && embeddedAgents.length === 0 && (
+          {!isLoading && embeddedAgents.length === 0 && (
             <div className="border-t border-slate-700 px-3 py-2 text-xs text-gray-500">
               No embedded agents are registered yet.{' '}
               <Link

--- a/packages/client/src/components/sessions/__tests__/AddAgentWorkerMenu.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/AddAgentWorkerMenu.test.tsx
@@ -86,6 +86,42 @@ describe('AddAgentWorkerMenu', () => {
     expect(embeddedBadge.className).toContain(AGENT_KIND_PRESENTATION.embedded.badgeClassName);
   });
 
+  it('renders terminal entries before embedded entries (useAgentDirectory merge order)', async () => {
+    agentsResponse = {
+      agents: [{ id: 'claude-code', name: 'Claude Code', isBuiltIn: true }],
+    };
+    embeddedAgentsResponse = {
+      embeddedAgents: [
+        {
+          id: 'embedded-1',
+          name: 'Ollama qwen3',
+          provider: { baseUrl: 'http://localhost:11434/v1', model: 'qwen3' },
+          createdBy: 'user-1',
+          createdAt: '',
+          updatedAt: '',
+        },
+      ],
+    };
+
+    await renderWithRouter(
+      <AddAgentWorkerMenu onSelect={async () => {}} onSelectShell={async () => {}} />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Add agent worker' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Ollama qwen3')).toBeTruthy();
+    });
+
+    const menu = screen.getByRole('menu');
+    const menuItems = within(menu).getAllByRole('menuitem');
+    const terminalIndex = menuItems.findIndex((item) => item.textContent?.includes('Claude Code'));
+    const embeddedIndex = menuItems.findIndex((item) => item.textContent?.includes('Ollama qwen3'));
+    expect(terminalIndex).toBeGreaterThan(-1);
+    expect(embeddedIndex).toBeGreaterThan(-1);
+    expect(terminalIndex).toBeLessThan(embeddedIndex);
+  });
+
   it('empty embedded registry still shows terminal agents plus a link to create one', async () => {
     agentsResponse = {
       agents: [{ id: 'claude-code', name: 'Claude Code', isBuiltIn: true }],

--- a/packages/client/src/components/sessions/__tests__/AddAgentWorkerMenu.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/AddAgentWorkerMenu.test.tsx
@@ -86,7 +86,7 @@ describe('AddAgentWorkerMenu', () => {
     expect(embeddedBadge.className).toContain(AGENT_KIND_PRESENTATION.embedded.badgeClassName);
   });
 
-  it('renders terminal entries before embedded entries (useAgentDirectory merge order)', async () => {
+  it('preserves item order: Shell, then terminal entries, then embedded entries (useAgentDirectory merge order)', async () => {
     agentsResponse = {
       agents: [{ id: 'claude-code', name: 'Claude Code', isBuiltIn: true }],
     };
@@ -115,11 +115,12 @@ describe('AddAgentWorkerMenu', () => {
 
     const menu = screen.getByRole('menu');
     const menuItems = within(menu).getAllByRole('menuitem');
+    const shellIndex = menuItems.findIndex((item) => item.textContent?.includes('Shell'));
     const terminalIndex = menuItems.findIndex((item) => item.textContent?.includes('Claude Code'));
     const embeddedIndex = menuItems.findIndex((item) => item.textContent?.includes('Ollama qwen3'));
-    expect(terminalIndex).toBeGreaterThan(-1);
-    expect(embeddedIndex).toBeGreaterThan(-1);
-    expect(terminalIndex).toBeLessThan(embeddedIndex);
+    expect(shellIndex).toBe(0);
+    expect(terminalIndex).toBeGreaterThan(shellIndex);
+    expect(embeddedIndex).toBeGreaterThan(terminalIndex);
   });
 
   it('empty embedded registry still shows terminal agents plus a link to create one', async () => {


### PR DESCRIPTION
## Summary
- Replaces `AddAgentWorkerMenu`'s `useAgents + useEmbeddedAgents` juxtaposition with the single `useAgentDirectory` merge hook introduced in PR #1177 (PR-C), matching the pattern already used by `UnifiedAgentSelector`.
- Kind-based menu grouping (Terminal / Embedded sections, badges) is unchanged; terminal and embedded entries are now filtered client-side from the merged `AgentDirectoryEntry[]` instead of coming from two separate hook calls.
- Removes the last ad-hoc two-registry holdout identified in the #1160 concept audit ([comment](https://github.com/ms2sato/agent-console/issues/1160#issuecomment-5008492559)).
- No user-facing behavior change: loading state, empty state, badges, disabled entries, and the empty-embedded-registry footer link all render identically.

## Test plan
- [x] `bun run typecheck` — all packages green
- [x] `bun run test` — full suite green (see below)
- [x] `AddAgentWorkerMenu.test.tsx` — all 11 existing tests pass with **zero assertion changes** (semantic-preserving; tests mock at the `fetch` layer, not the hook layer, so no mock updates were needed either)
- [x] `bun run lint:deps` — no new dependency-cruiser violations
- [x] `bun run check:lang` — clean

```
@agent-console/client test $ bun test --preload ./src/test/setup.ts src/
 2056 pass
 0 fail
 4315 expect() calls
Ran 2056 tests across 140 files. [57.33s]

@agent-console/server test $ bun test src/
 3506 pass
 1 skip
 0 fail
 9718 expect() calls
Ran 3507 tests across 156 files. [65.71s]
TEST_EXIT: 0
```

Closes #1179
Refs #1160 #1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)