### PR TITLE
fix: restore register()-bound draft fields via setValue under shouldUnregister:true (#1187)

### DIFF
--- a/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
+++ b/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
@@ -127,8 +127,8 @@ export function CreateWorktreeForm({
         // shouldUnregister: true, reset(merged, { keepDefaultValues: true })
         // does not reliably populate react-hook-form's internal _formValues
         // for register()-bound fields (e.g. sessionTitle) -- reproducible
-        // independent of React StrictMode (Issue #1187). setValue is the
-        // mechanism already proven correct here for the non-register()-bound
+        // independent of React StrictMode. setValue is the mechanism already
+        // proven correct here for the non-register()-bound
         // agentId/embeddedAgentId fields, so it is used uniformly for every
         // draft key.
         for (const key of Object.keys(draft) as Array<keyof CreateWorktreeFormData>) {

--- a/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
+++ b/packages/client/src/components/worktrees/CreateWorktreeForm.tsx
@@ -71,7 +71,6 @@ export function CreateWorktreeForm({
     setError,
     watch,
     setValue,
-    reset,
     control,
     formState: { errors },
   } = useForm<CreateWorktreeFormData>({
@@ -124,23 +123,23 @@ export function CreateWorktreeForm({
       const saved = localStorage.getItem(draftKey);
       if (saved) {
         const draft = JSON.parse(saved) as Partial<CreateWorktreeFormData>;
-        // getValues() returns initial defaults (form just mounted).
-        // The draft overwrites them with previously saved user input.
-        reset({ ...getValues(), ...draft }, { keepDefaultValues: true });
-        // agentId/embeddedAgentId are never register()-bound (custom select, driven by
-        // watch/setValue), so reset()'s keepDefaultValues silently discards them; restore explicitly.
-        if ('agentId' in draft) {
-          setValue('agentId', draft.agentId, { shouldDirty: true });
-        }
-        if ('embeddedAgentId' in draft) {
-          setValue('embeddedAgentId', draft.embeddedAgentId, { shouldDirty: true });
+        // Restore every saved key via setValue rather than reset(): with
+        // shouldUnregister: true, reset(merged, { keepDefaultValues: true })
+        // does not reliably populate react-hook-form's internal _formValues
+        // for register()-bound fields (e.g. sessionTitle) -- reproducible
+        // independent of React StrictMode (Issue #1187). setValue is the
+        // mechanism already proven correct here for the non-register()-bound
+        // agentId/embeddedAgentId fields, so it is used uniformly for every
+        // draft key.
+        for (const key of Object.keys(draft) as Array<keyof CreateWorktreeFormData>) {
+          setValue(key, draft[key] as never, { shouldDirty: true });
         }
       }
     } catch {
       // Ignore corrupted drafts
     }
-    // reset, getValues and setValue are stable refs from react-hook-form
-  }, [draftKey, reset, getValues, setValue, prefillValues]);
+    // setValue is a stable ref from react-hook-form
+  }, [draftKey, setValue, prefillValues]);
 
 
 

--- a/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
@@ -900,6 +900,36 @@ describe('CreateWorktreeForm', () => {
       expect(localStorage.getItem('undefined')).toBeNull();
       expect(localStorage.getItem('null')).toBeNull();
     });
+
+    describe('register()-bound field restore (Issue #1187)', () => {
+      const draftKey = 'register-bound-restore-draft-key';
+
+      beforeEach(() => {
+        localStorage.removeItem(draftKey);
+      });
+
+      afterEach(() => {
+        localStorage.removeItem(draftKey);
+      });
+
+      it('should restore a register()-bound sessionTitle value from localStorage on mount', async () => {
+        localStorage.setItem(draftKey, JSON.stringify({ sessionTitle: 'Restored Title' }));
+
+        renderCreateWorktreeForm({ draftKey });
+
+        // Wait for agents to load
+        await waitFor(() => {
+          expect(screen.getByText('Claude Code (built-in)')).toBeTruthy();
+        });
+
+        // The regression-guarding assertion: the sessionTitle input (a
+        // register()-bound field) must reflect the restored draft value.
+        await waitFor(() => {
+          const titleInput = screen.getByPlaceholderText('Session title') as HTMLInputElement;
+          expect(titleInput.value).toBe('Restored Title');
+        });
+      });
+    });
   });
 
   describe('StrictMode double-invoke draft-restore race (Issue #1077)', () => {

--- a/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
@@ -943,20 +943,15 @@ describe('CreateWorktreeForm', () => {
       localStorage.removeItem(draftKey);
     });
 
-    // Note: `embeddedAgentId` is used here rather than `sessionTitle` (a
-    // register()-bound field). Investigation while writing this test found
-    // that restoring a register()-bound field's value via this form's
-    // `reset(merged, { keepDefaultValues: true })` call does not actually
-    // land in react-hook-form's internal `_formValues` when the form is also
-    // configured with `shouldUnregister: true` (a separate, pre-existing RHF
-    // interaction, reproducible with or without the Issue #1077 fix and
-    // without StrictMode at all -- see PR discussion). That gap makes
-    // `sessionTitle` unusable as a regression guard for *this* bug: its
-    // localStorage value never becomes the restored draft value either way,
-    // so an assertion on it would not polarity-flip. `embeddedAgentId` is
-    // restored via an explicit `setValue(..., { shouldDirty: true })` call
-    // (not `reset()`), which is unaffected by that quirk and does polarity-
-    // flip on the StrictMode double-invoke race this test targets.
+    // Note: `embeddedAgentId` is used here rather than `sessionTitle`, even
+    // though both are now restored correctly on mount. `embeddedAgentId` is
+    // restored via an explicit `setValue(..., { shouldDirty: true })` call,
+    // which is unaffected by React's StrictMode double-invoke timing and
+    // does polarity-flip on the race this test targets. This test's purpose
+    // is the StrictMode double-invoke race specifically, not draft-restore
+    // correctness in general (that is covered separately by the
+    // `register()-bound field restore` tests above), so `embeddedAgentId`
+    // remains the guard field here.
     it('should not clobber a restored draft in localStorage when effects double-invoke under StrictMode', async () => {
       localStorage.setItem(draftKey, JSON.stringify({ embeddedAgentId: 'embedded-1' }));
 


### PR DESCRIPTION
Closes #1187

## Root cause

`CreateWorktreeForm` restores a saved localStorage draft on mount via:

```ts
reset({ ...getValues(), ...draft }, { keepDefaultValues: true });
```

The form is configured with `shouldUnregister: true`. For fields wired via `{...register('fieldName')}` (e.g. `sessionTitle`, `initialPrompt`, `customBranch`, `baseBranch`, `branchNameMode`), `reset(merged, { keepDefaultValues: true })` does **not** reliably populate react-hook-form's internal `_formValues` for those fields when `shouldUnregister: true` is set. The restored value is silently dropped and the field falls back to its original default.

This is reproducible **independent of React StrictMode** — a pre-existing comment in `CreateWorktreeForm.test.tsx` (added while investigating PR #1186 / Issue #1077) already documented this exact gap and explained why that regression test uses `embeddedAgentId` (restored via explicit `setValue`, not `reset()`) rather than `sessionTitle` as its guard field, precisely because `sessionTitle` never became the restored value either way and would not polarity-flip.

The Issue's "ref callback runs after `reset()`" ordering theory was a plausible but essentially unverified hypothesis. The empirical finding (confirmed by a new failing test against unfixed code, and by the pre-existing test-file comment) is that the gap is an interaction between `register()`-bound fields, `reset(..., { keepDefaultValues: true })`, and `shouldUnregister: true` — not a StrictMode timing race.

## Fix strategy

Extended the mount-restore effect so that **every key present in the draft object** is restored via explicit `setValue(key, value, { shouldDirty: true })` — the same mechanism already proven correct for `agentId` / `embeddedAgentId`. The `reset()` call and its two special-cased `if ('agentId' in draft)` / `if ('embeddedAgentId' in draft)` branches were removed since the generic `setValue` loop now covers all draft keys uniformly, including those two.

```ts
for (const key of Object.keys(draft) as Array<keyof CreateWorktreeFormData>) {
  setValue(key, draft[key] as never, { shouldDirty: true });
}
```

### Rejected alternatives (from the Issue's fix candidates)

- **`shouldUnregister: false`** — rejected because it has broader implications (field registry no longer churns across conditional renders, e.g. the `customBranch` / `baseBranch` fields that only render in certain `branchNameMode` states), and the `setValue`-based fix is sufficient without touching that behavior.
- **`field.onChange(draftValue)` after `register()` completes** — rejected because it requires per-field wiring at each JSX callsite (more surface area, easier to miss a field) versus the single generic loop in the existing mount effect.

## Test

Added `describe('register()-bound field restore (Issue #1187)')` in `CreateWorktreeForm.test.tsx`: sets `sessionTitle` in a localStorage draft, renders the form (non-StrictMode, since the pre-existing comment confirms this bug reproduces without StrictMode), waits for agents to load, and asserts the rendered `sessionTitle` input's value equals the draft value.

**Polarity check:** `git diff` the production fix into a patch, reverted only `CreateWorktreeForm.tsx` to the pre-fix state while keeping the new test, and ran the suite:
- **Without the fix:** 39 pass / 1 fail — the new assertion `expect(titleInput.value).toBe('Restored Title')` fails (input value stays empty, the field's default).
- **With the fix restored:** 40 pass / 0 fail — the assertion passes.

The `#1077` fix (`control._formState.dirtyFields` live read in `pickDirtyValues`) is unchanged and its regression test (`StrictMode double-invoke draft-restore race (Issue #1077)`, `embeddedAgentId`-based) still passes.

## Verification

- `bun run typecheck`: exit 0
- `bun run test` (full monorepo suite): all packages pass. One pre-existing, unrelated failure was observed and root-caused to a local dev-environment `SSH_AUTH_SOCK` leak into `process.env` (a 1Password agent socket path) affecting an unrelated `MultiUserMode` test in `packages/server`; re-running with `env -u SSH_AUTH_SOCK` gives a fully clean run (2065+573+72+3528+257+2065... all packages 0 fail, exit 0). Two other transient failures (`terminal-store-paging.test.ts`, `terminal-store.test.ts`) were observed once under full-suite parallel load and confirmed as pre-existing flakes unrelated to this change — both pass in isolation and did not recur on a repeat full-suite run.
- `node .claude/skills/orchestrator/preflight-check.js`: exit 0 (coverage check covered, blame-shift check clean, language check clean).
- CodeRabbit CLI is installed locally but requires interactive browser auth, unavailable in this headless worktree; the CLI review step was skipped. GitHub-side CodeRabbit review will run on this PR as usual.

## Browser QA (StrictMode, `bun run dev`)

Verified end-to-end in a real browser against the running dev server (React `StrictMode` is always on in `main.tsx`, dev or prod), using the global "Create worktree" dialog (`QuickWorktreeDialog`, which passes `draftKey`):

1. **Fresh mount (no draft)** — `Title (optional)` field empty, as expected.
2. **Before fix** — temporarily checked out the pre-fix version of `CreateWorktreeForm.tsx` only (via `git checkout <parent-commit> -- <file>`, uncommitted, reverted immediately after; no commit history was altered) with a `sessionTitle` draft already saved in `localStorage`. Reloaded and reopened the dialog: `Title` field renders **empty** despite the saved draft — reproduces the reported bug.
3. **After fix** — restored the fixed file (`git checkout HEAD -- <file>`), reseeded the same draft, reloaded, reopened the dialog: `Title` field renders **"QA Draft Restore Test 1187"**, matching the saved draft.

Screenshots posted in https://github.com/ms2sato/agent-console/pull/1193#issuecomment-5010018010 (fresh mount / before-fix bug / after-fix restored, in that order).

Working tree was confirmed clean (`git status --porcelain` empty, `git diff HEAD` empty) after each revert step, before and after the temporary before/after comparison.


## Note on CodeRabbit

**Correction (per architect verdict, Sprint 2026-07-18)**: GitHub-side CodeRabbit bot did complete a review of this PR — walkthrough posted, and a manual `@coderabbitai review` re-trigger returned "Review finished" (indicating no un-reviewed commits remain, not a rate-limit block). Inline actionable comments = 0. `reviewDecision` remains empty per this repo's status-check-only CodeRabbit pattern (matches PR #1183, #1191, #1194 precedent). Local CodeRabbit CLI required interactive browser auth unavailable in this headless worktree; the GitHub-side review is the authoritative signal here.

Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority) with architect audit + Orchestrator gate satisfied.
