### PR TITLE
test: add countPtmxFds() self-check to guard against vacuous fd-leak pass

### DIFF
--- a/packages/server/src/lib/__tests__/pty-provider-fd-leak.test.ts
+++ b/packages/server/src/lib/__tests__/pty-provider-fd-leak.test.ts
@@ -131,6 +131,22 @@ describe.skipIf(process.platform !== 'linux')('bunTerminalProvider ptmx fd leak 
     // See the sibling test above for why this force-collect is needed.
     Bun.gc(true);
     const baseline = countPtmxFds();
+
+    // Self-check: prove countPtmxFds() can actually detect a live ptmx fd
+    // before trusting it for the regression assertion below. If the
+    // counting mechanism itself is broken (sh missing, /proc unreadable,
+    // readlink absent), before/after would both silently read 0 and the
+    // assertion below would vacuously pass without verifying anything
+    // (Issue #1200).
+    const selfCheckPty = bunTerminalProvider.spawn('sleep', ['5'], {});
+    const selfCheckExited = waitForExit(selfCheckPty);
+    const selfCheckCount = countPtmxFds();
+    selfCheckPty.kill('SIGTERM');
+    await selfCheckExited;
+    if (!(selfCheckCount > baseline)) {
+      throw new Error('countPtmxFds() self-check failed — infrastructure broken, cannot verify');
+    }
+
     const retained: PtyInstance[] = [];
 
     for (let i = 0; i < SPAWN_COUNT; i++) {

--- a/scripts/smoke/check-pty-fd-leak.ts
+++ b/scripts/smoke/check-pty-fd-leak.ts
@@ -91,6 +91,29 @@ function readKernelPtyCount(): number {
   return parsed;
 }
 
+/**
+ * Prove countPtmxFds() can actually detect a live ptmx fd before trusting it
+ * for the regression assertions below. If the counting mechanism itself is
+ * broken (sh missing, /proc unreadable, readlink absent), before/after would
+ * both silently read 0 and the assertions below would vacuously pass without
+ * verifying anything (Issue #1200).
+ */
+async function selfCheck(baseline: number): Promise<void> {
+  const pty = bunTerminalProvider.spawn('sleep', ['5'], {});
+  const exited = new Promise<void>((resolve) => {
+    pty.onExit(() => resolve());
+  });
+  const count = countPtmxFds();
+  pty.kill('SIGTERM');
+  await exited;
+  if (!(count > baseline)) {
+    console.error(
+      `Self-check failed: countPtmxFds() reported ${count} with a live PTY held open (baseline=${baseline}) -- counting infrastructure is broken, cannot verify`,
+    );
+    process.exit(2);
+  }
+}
+
 async function runCycle(retained: PtyInstance[]): Promise<void> {
   const pty = bunTerminalProvider.spawn('sleep', ['3'], {});
   retained.push(pty);
@@ -119,6 +142,8 @@ async function waitUntil<T>(read: () => T, isDone: (value: T) => boolean, timeou
 
 const beforeFds = countPtmxFds();
 const beforeKernelCount = readKernelPtyCount();
+
+await selfCheck(beforeFds);
 
 // Retained for the assertion's lifetime -- see file header. Without this, an
 // unreachable adapter can be GC-finalized mid-run, masking a regression.


### PR DESCRIPTION
## Summary

- Adds a one-time self-check to `countPtmxFds()`'s consumers (the kill()-path regression test and the deploy smoke) that proves the counting mechanism can actually detect a live `/dev/ptmx` fd before trusting it for the leak-regression comparison.
- Without this, a host where the counting infrastructure itself is broken (`sh` missing, `/proc` unreadable, `readlink` absent, etc.) would have both the "before" and "after" measurements silently read `0`, and the assertion would vacuously pass without verifying anything.

## Details

- `packages/server/src/lib/__tests__/pty-provider-fd-leak.test.ts` — inside the `kill() path` test only (not the `natural exit` test), spawn one `sleep` PTY, measure `countPtmxFds()` while it's alive, and throw a clear error if the count did not increase over baseline. The self-check PTY is killed via the same `kill()` -> `dispose()` path the main loop uses, before the existing `SPAWN_COUNT` loop runs.
- `scripts/smoke/check-pty-fd-leak.ts` — same self-check pattern as an async helper, called right after `beforeFds`/`beforeKernelCount` are captured and before the main `CYCLE_COUNT` loop. On failure it exits `2` (probe-cannot-run), matching this script's existing exit-code convention (0 = pass, 1 = regression detected, 2 = probe could not run) and its other `process.exit(2)` paths (non-Linux platform, unparseable kernel counter).
- No changes to the existing N-cycle regression assertions in either file.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` (full suite) — server: 3558 pass / 1 skip / 1 fail. The 1 failure (a multi-user elevation-skip direct-path env test in `multi-user-mode.test.ts`) is pre-existing and unrelated: confirmed via `git stash` that it reproduces identically on the unmodified tree, caused by this sandbox having a real `SSH_AUTH_SOCK` (1Password agent socket) set in the environment. All other packages (client, shared, integration, embedded-agent) are fully green.
- [x] `bun scripts/smoke/check-pty-fd-leak.ts` — exit 0, self-check passes silently, 100-cycle run reports `PASSED: 2 assertion(s) passed`.
- [x] `bun test packages/server/src/lib/__tests__/pty-provider-fd-leak.test.ts` — 2 pass, 0 fail (Linux-gated, ran for real on this host).
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (test-only/script-only change, no new production files).
- [x] `bun run check:lang` — clean.
- [ ] CodeRabbit CLI review — could not complete locally; automatic browser-based login timed out in this sandbox (`coderabbit review --agent --base main` returned `authentication_failed`). Relying on the GitHub-side bot review post-PR per the 3-layer verdict process.

Closes #1200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure PTY file-descriptor counting detects active terminal descriptors before running leak regression checks.
  * Improved failure reporting by stopping tests early when the counting mechanism cannot observe expected descriptors.
  * Preserved existing process lifecycle, leak detection, and assertion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->