### PR TITLE
fix: JsonSessionRepository.update() drops recoveryState/orphanedAt/orphanedReason (closes #1210)

### DIFF
--- a/packages/server/src/repositories/__tests__/json-session-repository.test.ts
+++ b/packages/server/src/repositories/__tests__/json-session-repository.test.ts
@@ -223,6 +223,165 @@ describe('JsonSessionRepository', () => {
     });
   });
 
+  describe('update', () => {
+    it('should return false when session does not exist', async () => {
+      const testSessions = [buildPersistedQuickSession({ id: 'session-1' })];
+      fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
+
+      const result = await repository.update('non-existent', { title: 'New Title' });
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when file does not exist', async () => {
+      const result = await repository.update('any-id', { title: 'New Title' });
+
+      expect(result).toBe(false);
+    });
+
+    it('should persist recoveryState, orphanedAt, and orphanedReason (Issue #1210)', async () => {
+      // These three fields were silently dropped by update() — the write
+      // reported success but the JSON file never reflected the change.
+      const testSessions = [
+        buildPersistedQuickSession({ id: 'session-1', locationPath: '/some/path' }),
+      ];
+      fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
+
+      const result = await repository.update('session-1', {
+        recoveryState: 'orphaned',
+        orphanedAt: 1700000000000,
+        orphanedReason: 'path_resolution_failed',
+      });
+
+      expect(result).toBe(true);
+
+      const reloaded = await repository.findById('session-1');
+      expect(reloaded?.recoveryState).toBe('orphaned');
+      expect(reloaded?.orphanedAt).toBe(1700000000000);
+      expect(reloaded?.orphanedReason).toBe('path_resolution_failed');
+    });
+
+    it('should clear orphanedAt and orphanedReason when explicitly set to null', async () => {
+      const testSessions = [
+        buildPersistedWorktreeSession({
+          id: 'session-1',
+          recoveryState: 'orphaned',
+          orphanedAt: 1700000000000,
+          orphanedReason: 'path_resolution_failed',
+        }),
+      ];
+      fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
+
+      await repository.update('session-1', {
+        recoveryState: 'healthy',
+        orphanedAt: null,
+        orphanedReason: null,
+      });
+
+      const reloaded = await repository.findById('session-1');
+      expect(reloaded?.recoveryState).toBe('healthy');
+      expect(reloaded?.orphanedAt).toBeUndefined();
+      expect(reloaded?.orphanedReason).toBeUndefined();
+    });
+
+    it('should not modify recoveryState/orphanedAt/orphanedReason when not provided', async () => {
+      const testSessions = [
+        buildPersistedWorktreeSession({
+          id: 'session-1',
+          recoveryState: 'orphaned',
+          orphanedAt: 1700000000000,
+          orphanedReason: 'path_resolution_failed',
+        }),
+      ];
+      fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
+
+      await repository.update('session-1', { title: 'New Title' });
+
+      const reloaded = await repository.findById('session-1');
+      expect(reloaded?.title).toBe('New Title');
+      expect(reloaded?.recoveryState).toBe('orphaned');
+      expect(reloaded?.orphanedAt).toBe(1700000000000);
+      expect(reloaded?.orphanedReason).toBe('path_resolution_failed');
+    });
+
+    it('should update pre-existing supported fields (non-regression)', async () => {
+      const testSessions = [
+        buildPersistedWorktreeSession({
+          id: 'session-1',
+          title: 'Original Title',
+          initialPrompt: 'Original Prompt',
+          locationPath: '/original/path',
+          serverPid: 1000,
+          worktreeId: 'main',
+          pausedAt: undefined,
+        }),
+      ];
+      fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
+
+      const result = await repository.update('session-1', {
+        serverPid: null,
+        title: 'Updated Title',
+        initialPrompt: 'Updated Prompt',
+        locationPath: '/updated/path',
+        worktreeId: 'feature-branch',
+        pausedAt: '2024-01-01T00:00:00.000Z',
+      });
+
+      expect(result).toBe(true);
+      const reloaded = await repository.findById('session-1');
+      expect(reloaded?.serverPid).toBeUndefined();
+      expect(reloaded?.title).toBe('Updated Title');
+      expect(reloaded?.initialPrompt).toBe('Updated Prompt');
+      expect(reloaded?.locationPath).toBe('/updated/path');
+      expect(reloaded?.pausedAt).toBe('2024-01-01T00:00:00.000Z');
+      if (reloaded?.type === 'worktree') {
+        expect(reloaded.worktreeId).toBe('feature-branch');
+      }
+    });
+
+    it('should not set worktreeId on a quick session', async () => {
+      const testSessions = [buildPersistedQuickSession({ id: 'session-1' })];
+      fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
+
+      await repository.update('session-1', { worktreeId: 'ignored' });
+
+      const reloaded = await repository.findById('session-1');
+      expect(reloaded && 'worktreeId' in reloaded).toBe(false);
+    });
+
+    it('should reproduce the detectOrphans() write shape end-to-end via re-read', async () => {
+      // Mirrors the exact update() call shape used by
+      // SessionInitializationService.detectOrphans() in
+      // session-initialization-service.ts, so a regression in the allowlist
+      // used by that production call site is caught here too.
+      const testSessions = [
+        buildPersistedWorktreeSession({
+          id: 'orphan-candidate',
+          locationPath: '/some/path',
+          serverPid: undefined,
+        }),
+      ];
+      fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
+
+      const now = 1700000000000;
+      const result = await repository.update('orphan-candidate', {
+        recoveryState: 'orphaned',
+        orphanedAt: now,
+        orphanedReason: 'path_resolution_failed',
+      });
+      expect(result).toBe(true);
+
+      // Re-read from a fresh findAll() call (new file read), not the same
+      // in-memory reference, to confirm the write actually landed on disk.
+      const all = await repository.findAll();
+      const persisted = all.find((s) => s.id === 'orphan-candidate');
+      expect(persisted).toBeDefined();
+      expect(persisted?.recoveryState).toBe('orphaned');
+      expect(persisted?.orphanedAt).toBe(now);
+      expect(persisted?.orphanedReason).toBe('path_resolution_failed');
+    });
+  });
+
   describe('save', () => {
     it("should create new session when it doesn't exist", async () => {
       const newSession = buildPersistedQuickSession({ id: 'new-session' });

--- a/packages/server/src/repositories/__tests__/json-session-repository.test.ts
+++ b/packages/server/src/repositories/__tests__/json-session-repository.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { PersistedSession } from '../../services/persistence-service.js';
+import type { SessionUpdateFields } from '../session-repository.js';
 import { JsonSessionRepository } from '../json-session-repository.js';
 import {
   setupTestConfigDir,
@@ -379,6 +380,37 @@ describe('JsonSessionRepository', () => {
       expect(persisted?.recoveryState).toBe('orphaned');
       expect(persisted?.orphanedAt).toBe(now);
       expect(persisted?.orphanedReason).toBe('path_resolution_failed');
+    });
+
+    it('should persist every field declared in SessionUpdateFields (compile-enforced full coverage)', async () => {
+      // `satisfies Required<SessionUpdateFields>` forces this fixture to name
+      // every field in the interface. Adding a field to SessionUpdateFields
+      // without adding it here is a TS compile error — a structural guard
+      // (not just review discipline) against a future field silently
+      // landing in one backend's update() allowlist but not another's.
+      const FULL_UPDATE = {
+        serverPid: 424242,
+        title: 'Full Update Title',
+        initialPrompt: 'Full Update Prompt',
+        locationPath: '/full/update/path',
+        worktreeId: 'full-update-worktree',
+        pausedAt: '2025-01-01T00:00:00.000Z',
+        recoveryState: 'orphaned',
+        orphanedAt: 1700000000000,
+        orphanedReason: 'full_update_test',
+      } satisfies Required<SessionUpdateFields>;
+
+      const testSessions = [buildPersistedWorktreeSession({ id: 'full-coverage-session' })];
+      fs.writeFileSync(sessionsFilePath, JSON.stringify(testSessions, null, 2));
+
+      const result = await repository.update('full-coverage-session', FULL_UPDATE);
+      expect(result).toBe(true);
+
+      const reloaded = await repository.findById('full-coverage-session');
+      expect(reloaded).not.toBeNull();
+      for (const [key, value] of Object.entries(FULL_UPDATE)) {
+        expect((reloaded as unknown as Record<string, unknown>)[key]).toBe(value);
+      }
     });
   });
 

--- a/packages/server/src/repositories/__tests__/sqlite-session-repository.test.ts
+++ b/packages/server/src/repositories/__tests__/sqlite-session-repository.test.ts
@@ -4,6 +4,7 @@ import { BunSqliteDialect } from 'kysely-bun-sqlite';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { SqliteSessionRepository } from '../sqlite-session-repository.js';
 import type { Database } from '../../database/schema.js';
+import type { SessionUpdateFields } from '../session-repository.js';
 import {
   buildPersistedQuickSession,
   buildPersistedWorktreeSession,
@@ -1150,6 +1151,37 @@ describe('SqliteSessionRepository', () => {
       });
 
       expect(result).toBe(false);
+    });
+
+    it('should persist every field declared in SessionUpdateFields (compile-enforced full coverage)', async () => {
+      // `satisfies Required<SessionUpdateFields>` forces this fixture to name
+      // every field in the interface. Adding a field to SessionUpdateFields
+      // without adding it here is a TS compile error — a structural guard
+      // (not just review discipline) against a future field silently
+      // landing in one backend's update() allowlist but not another's.
+      const FULL_UPDATE = {
+        serverPid: 424242,
+        title: 'Full Update Title',
+        initialPrompt: 'Full Update Prompt',
+        locationPath: '/full/update/path',
+        worktreeId: 'full-update-worktree',
+        pausedAt: '2025-01-01T00:00:00.000Z',
+        recoveryState: 'orphaned',
+        orphanedAt: 1700000000000,
+        orphanedReason: 'full_update_test',
+      } satisfies Required<SessionUpdateFields>;
+
+      const session = buildPersistedWorktreeSession({ id: 'full-coverage-session' });
+      await repository.save(session);
+
+      const result = await repository.update('full-coverage-session', FULL_UPDATE);
+      expect(result).toBe(true);
+
+      const reloaded = await repository.findById('full-coverage-session');
+      expect(reloaded).not.toBeNull();
+      for (const [key, value] of Object.entries(FULL_UPDATE)) {
+        expect((reloaded as unknown as Record<string, unknown>)[key]).toBe(value);
+      }
     });
   });
 

--- a/packages/server/src/repositories/json-session-repository.ts
+++ b/packages/server/src/repositories/json-session-repository.ts
@@ -121,6 +121,15 @@ export class JsonSessionRepository implements SessionRepository {
     if (updates.pausedAt !== undefined) {
       updated.pausedAt = updates.pausedAt ?? undefined;
     }
+    if (updates.recoveryState !== undefined) {
+      updated.recoveryState = updates.recoveryState;
+    }
+    if (updates.orphanedAt !== undefined) {
+      updated.orphanedAt = updates.orphanedAt ?? undefined;
+    }
+    if (updates.orphanedReason !== undefined) {
+      updated.orphanedReason = updates.orphanedReason ?? undefined;
+    }
 
     sessions[index] = updated;
     await atomicWrite(this.filePath, JSON.stringify(sessions, null, 2));

--- a/packages/server/src/repositories/session-repository.ts
+++ b/packages/server/src/repositories/session-repository.ts
@@ -16,7 +16,7 @@ import type { PersistedSession } from '../services/persistence-service.js';
  *
  * Every implementation of SessionRepository.update() must handle every field
  * in this interface. Adding a field here without updating each implementation
- * causes a silent no-op on backends that were not updated (see Issue #1210).
+ * causes a silent no-op on backends that were not updated.
  */
 export interface SessionUpdateFields {
   serverPid?: number | null;

--- a/packages/server/src/repositories/session-repository.ts
+++ b/packages/server/src/repositories/session-repository.ts
@@ -15,8 +15,11 @@ import type { PersistedSession } from '../services/persistence-service.js';
  * - orphanedReason: Update orphaned reason code
  *
  * Every implementation of SessionRepository.update() must handle every field
- * in this interface. Adding a field here without updating each implementation
- * causes a silent no-op on backends that were not updated.
+ * in this interface. Each repository's test suite includes a fixture typed
+ * `satisfies Required<SessionUpdateFields>` that fails to compile when a
+ * field is added here without also updating the fixture — a structural
+ * guard (not just this comment) against a field silently landing in one
+ * backend's update() but not another's.
  */
 export interface SessionUpdateFields {
   serverPid?: number | null;

--- a/packages/server/src/repositories/session-repository.ts
+++ b/packages/server/src/repositories/session-repository.ts
@@ -9,6 +9,14 @@ import type { PersistedSession } from '../services/persistence-service.js';
  * - initialPrompt: Update initial prompt
  * - locationPath: Update session location path
  * - worktreeId: Update worktree ID (only valid for worktree sessions)
+ * - pausedAt: Update paused timestamp
+ * - recoveryState: Update session recovery state
+ * - orphanedAt: Update orphaned timestamp
+ * - orphanedReason: Update orphaned reason code
+ *
+ * Every implementation of SessionRepository.update() must handle every field
+ * in this interface. Adding a field here without updating each implementation
+ * causes a silent no-op on backends that were not updated (see Issue #1210).
  */
 export interface SessionUpdateFields {
   serverPid?: number | null;


### PR DESCRIPTION
## Summary

`JsonSessionRepository.update()` silently dropped `recoveryState`, `orphanedAt`, and `orphanedReason` — the call reported `true` (success) but the JSON file on disk never reflected the change. `SqliteSessionRepository.update()` already handled these three fields correctly, so the two backends had diverged.

This matters because `SessionInitializationService.detectOrphans()` writes exactly these fields via `sessionRepository.update()`. On a JSON-backend deployment, orphan marking would silently no-op. Production wiring today uses `SqliteSessionRepository` as primary, but `session-manager.ts` has a latent fallback to `new JsonSessionRepository(...)` when `sessionRepository` is not explicitly passed to `SessionManager` — a real code path that would hit this bug the moment anyone constructs `SessionManager` without wiring the repository.

## Fix

**Path A (allowlist inclusion)** — extend `JsonSessionRepository.update()`'s explicit field allowlist to include `recoveryState`, `orphanedAt`, `orphanedReason`, mirroring `SqliteSessionRepository.update()`'s existing handling of the same three fields (null → clear, no null-coalescing for the non-nullable `recoveryState`).

Chosen over Path B (throw-on-unknown-field) because it's the safer default with minimal impact to existing callers, and the allowlist stays trivially in sync with `SessionUpdateFields` by inspection (both implementations list the same fields side by side).

Also corrected the `SessionUpdateFields` JSDoc in `session-repository.ts`, which predated `pausedAt`/`recoveryState`/`orphanedAt`/`orphanedReason` being added to the interface and only documented the original 5 fields.

`SqliteSessionRepository` is unchanged — it already handled these fields correctly.

## Test plan

- [x] **Polarity-verified TDD**: stashed the fix (keeping the new tests), confirmed the 3 targeted tests fail against unmodified `update()` (`recoveryState`/`orphanedAt`/`orphanedReason` read back as `undefined` / unchanged), restored the fix, confirmed all pass.
- [x] New `describe('update', ...)` block in `json-session-repository.test.ts` (this method had zero prior test coverage):
  - not-found / no-file → `false`
  - round-trip persistence of `recoveryState`/`orphanedAt`/`orphanedReason` (the bug)
  - explicit-`null` clears `orphanedAt`/`orphanedReason`
  - fields untouched when not provided in the update call
  - non-regression: all pre-existing supported fields (`serverPid`, `title`, `initialPrompt`, `locationPath`, `worktreeId`, `pausedAt`) still update correctly
  - `worktreeId` is not set on a quick session
  - end-to-end reproduction of the exact `detectOrphans()` write shape, re-read via a fresh `findAll()`
- [x] `bun run typecheck` — clean
- [x] `bun run test` (full suite) — all pass except one pre-existing, unrelated failure in `multi-user-mode.test.ts` (`SSH_AUTH_SOCK` env-coupling to the local dev machine's 1Password agent socket); verified pre-existing by reproducing the same failure with this PR's changes stashed.
- [x] `bun run check:lang` — clean
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (coverage, rule/skill duplication, language, blame-shift all pass)
- [x] CodeRabbit CLI: not usable in this headless worktree (non-interactive auth unavailable); relying on the GitHub-side CodeRabbit review after this PR opens.

Closes #1210
Refs #1197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session updates now correctly persist recovery status and orphan-session details.
  - Clearing orphan information is handled consistently when values are removed.
  - Updates preserve existing recovery and orphan details when those fields are not changed.
  - Session updates continue to handle supported fields, including nullable server information and quick-session behavior.

- **Tests**
  - Added coverage for session update persistence, missing sessions, missing storage files, and recovery-related scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Note on CodeRabbit (GitHub-side)

Local CLI unusable (headless worktree, non-interactive auth unavailable). GitHub-side bot completed a review of the current HEAD (commit range ends at 1606db0, matching this PR's tip): pre-merge checks 5/5 SUCCESS, no actionable comments generated. No formal APPROVED/CHANGES_REQUESTED review event was submitted (reviewDecision reads empty) — this is CodeRabbit's known behavior when there are zero findings to flag, not an unreviewed state. 0 inline comments outstanding.

---

## Note on CodeRabbit (R1 delta review)

GitHub-side bot hit its PR review rate limit reviewing the R1 delta (commit range 1606db0..c83b1ed): "Review limit reached ... Next review available in: 51 minutes." Local CLI remains unusable in this headless worktree (non-interactive auth). The original fix commit range (410dcd0..1606db0) was already reviewed clean (pre-merge 5/5, no actionable comments) before this R1 delta. R1's diff is additive test-only (compile-enforced fixture + JSDoc note), no production logic changed. Deferring the merge/rate-limit disposition to the architect/Orchestrator per existing PR Merge Authority.

**Disposition (Orchestrator, 2026-07-19):** R1 delta (commit c83b1ed) is test-only additive — no production behavior change beyond JSDoc wording. The original fix (production code + initial test suite, commit range 410dcd0..1606db0) already completed a clean CodeRabbit walkthrough (pre-merge 5/5, no actionable comments). Given the GitHub-side bot's 51-minute rate-limit window on the R1 delta specifically, not waiting: R1's structural-guard correctness is verified by the architect's independent audit rather than re-running CodeRabbit on test-only code. Merging once the architect confirms the R1 fixture satisfies the required follow-up, per existing PR Merge Authority (test-only category).
