### PR TITLE
chore: silence pino-pretty transport during bun test (#1175)

### DIFF
--- a/packages/server/src/lib/__tests__/logger.test.ts
+++ b/packages/server/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'bun:test';
+import { resolveLoggerConfig } from '../logger.js';
+
+describe('resolveLoggerConfig', () => {
+  describe("NODE_ENV==='test' (Bun's bun test default)", () => {
+    it('does not construct the pino-pretty transport (no worker thread)', () => {
+      const config = resolveLoggerConfig('test');
+
+      expect(config.transport).toBeUndefined();
+    });
+
+    it('disables the logger to silence output during test runs', () => {
+      const config = resolveLoggerConfig('test');
+
+      expect(config.enabled).toBe(false);
+    });
+
+    it('is classified as isTest, not isDev or isProduction', () => {
+      const config = resolveLoggerConfig('test');
+
+      expect(config.isTest).toBe(true);
+      expect(config.isDev).toBe(false);
+      expect(config.isProduction).toBe(false);
+    });
+
+    it('uses the info level (matches non-dev level selection)', () => {
+      const config = resolveLoggerConfig('test');
+
+      expect(config.level).toBe('info');
+    });
+  });
+
+  describe("NODE_ENV==='production'", () => {
+    it('does not construct a transport (regression guard: unchanged behavior)', () => {
+      const config = resolveLoggerConfig('production');
+
+      expect(config.transport).toBeUndefined();
+    });
+
+    it('keeps the logger enabled (not silenced)', () => {
+      const config = resolveLoggerConfig('production');
+
+      expect(config.enabled).toBe(true);
+    });
+
+    it('is classified as isProduction, not isDev or isTest', () => {
+      const config = resolveLoggerConfig('production');
+
+      expect(config.isProduction).toBe(true);
+      expect(config.isDev).toBe(false);
+      expect(config.isTest).toBe(false);
+    });
+
+    it('uses the info level', () => {
+      const config = resolveLoggerConfig('production');
+
+      expect(config.level).toBe('info');
+    });
+  });
+
+  describe('NODE_ENV unset or development (regression guard for `bun run dev`)', () => {
+    it('constructs the pino-pretty transport when NODE_ENV is undefined', () => {
+      const config = resolveLoggerConfig(undefined);
+
+      expect(config.transport).toEqual({
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+          translateTime: 'HH:MM:ss.l',
+          ignore: 'pid,hostname',
+        },
+      });
+    });
+
+    it('constructs the pino-pretty transport when NODE_ENV is "development"', () => {
+      const config = resolveLoggerConfig('development');
+
+      expect(config.transport).toEqual({
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+          translateTime: 'HH:MM:ss.l',
+          ignore: 'pid,hostname',
+        },
+      });
+    });
+
+    it('keeps the logger enabled when NODE_ENV is unset', () => {
+      const config = resolveLoggerConfig(undefined);
+
+      expect(config.enabled).toBe(true);
+    });
+
+    it('is classified as isDev when NODE_ENV is unset', () => {
+      const config = resolveLoggerConfig(undefined);
+
+      expect(config.isDev).toBe(true);
+      expect(config.isProduction).toBe(false);
+      expect(config.isTest).toBe(false);
+    });
+
+    it('uses the debug level when NODE_ENV is unset', () => {
+      const config = resolveLoggerConfig(undefined);
+
+      expect(config.level).toBe('debug');
+    });
+
+    it('treats any other unrecognized value (e.g. "staging") as dev-like', () => {
+      const config = resolveLoggerConfig('staging');
+
+      expect(config.isDev).toBe(true);
+      expect(config.transport).toBeDefined();
+      expect(config.enabled).toBe(true);
+    });
+  });
+});

--- a/packages/server/src/lib/logger.ts
+++ b/packages/server/src/lib/logger.ts
@@ -1,25 +1,66 @@
 import pino from 'pino';
 import { serverConfig } from './server-config.js';
 
-const isDev = serverConfig.NODE_ENV !== 'production';
+/**
+ * Pure environment-branching decision for pino configuration.
+ *
+ * Extracted from `rootLogger`'s construction so the decision can be unit
+ * tested directly, without needing to introspect pino's internal transport
+ * worker-thread spawning (see `logger.test.ts`).
+ *
+ * - `production`: JSON output, no transport, logger enabled.
+ * - `test` (`NODE_ENV==='test'`, Bun's `bun test` default): the pino-pretty
+ *   transport is NOT constructed (no worker thread spawns) and the logger is
+ *   disabled entirely, minimizing log noise during test runs.
+ * - development (unset or any other value): pretty-printed transport,
+ *   logger enabled. Matches the original default `bun run dev` behavior.
+ *
+ * @internal Exported for testing
+ */
+export function resolveLoggerConfig(nodeEnv: string | undefined): {
+  isDev: boolean;
+  isTest: boolean;
+  isProduction: boolean;
+  enabled: boolean;
+  level: 'debug' | 'info';
+  transport: pino.TransportSingleOptions | undefined;
+} {
+  const isProduction = nodeEnv === 'production';
+  const isTest = nodeEnv === 'test';
+  const isDev = !isProduction && !isTest;
+
+  return {
+    isDev,
+    isTest,
+    isProduction,
+    enabled: !isTest,
+    level: isDev ? 'debug' : 'info',
+    transport: isDev
+      ? {
+          target: 'pino-pretty',
+          options: {
+            colorize: true,
+            translateTime: 'HH:MM:ss.l',
+            ignore: 'pid,hostname',
+          },
+        }
+      : undefined,
+  };
+}
+
+const loggerConfig = resolveLoggerConfig(serverConfig.NODE_ENV);
 
 /**
  * Root logger instance configured based on environment.
  * - Development: Pretty printed output with colors
+ * - Test: Disabled (no transport, no output) to avoid pino-pretty's
+ *   worker-thread spawn and log noise during `bun test` runs
  * - Production: JSON output for machine parsing
  */
 export const rootLogger = pino({
-  level: serverConfig.LOG_LEVEL || (isDev ? 'debug' : 'info'),
-  transport: isDev
-    ? {
-        target: 'pino-pretty',
-        options: {
-          colorize: true,
-          translateTime: 'HH:MM:ss.l',
-          ignore: 'pid,hostname',
-        },
-      }
-    : undefined,
+  level: serverConfig.LOG_LEVEL || loggerConfig.level,
+  enabled: loggerConfig.enabled,
+  transport: loggerConfig.transport,
 });
 
 /**


### PR DESCRIPTION
## Summary

- `Bun`'s `bun test` runner auto-sets `NODE_ENV=test` when unset (verified empirically: a throwaway test file printed `process.env.NODE_ENV === 'test'`). The previous `isDev = serverConfig.NODE_ENV !== 'production'` check therefore evaluated `true` during every `bun test` run, constructing the `pino-pretty` transport (and its worker thread) on module load.
- No `package.json` script changes were needed — the empirical NODE_ENV finding holds for all invocation paths verified (`bun run test`, `bun run test:only`, per-package `bun test src/`), since they all bottom out in a literal `bun test` invocation that Bun itself defaults `NODE_ENV` for.
- `packages/server/src/lib/logger.ts` now extracts the environment-branching decision into a pure `resolveLoggerConfig(nodeEnv)` function with three explicit branches:
  - `production`: unchanged (JSON output, no transport, enabled).
  - `test` (`NODE_ENV==='test'`): pino-pretty transport is NOT constructed (no worker thread), and the logger is disabled (`enabled: false`) to also cut stdout log noise during test runs.
  - unset / any other value (dev): unchanged (pretty transport active, enabled) — this is the `bun run dev` path.

## Why `enabled: false` for the test branch

Chosen over `level: 'silent'` because `enabled: false` is pino's documented no-op switch — it short-circuits log calls entirely rather than merely filtering by level, which cleanly satisfies "no worker thread + no stdout noise" in one setting without relying on level-ordering assumptions.

## AC / Definition of Done

- [x] `NODE_ENV=test` -> pino-pretty transport not constructed, no worker thread (verified via `resolveLoggerConfig('test').transport === undefined`, factored as a pure function since introspecting pino's internal worker-thread spawn directly is impractical in a unit test).
- [x] No behavioral change in production or dev-mode logger output/config (regression-guard tests for `'production'`, `undefined`, `'development'`, and an unrecognized value all assert the pre-existing shape).
- [x] TDD polarity verified: the new test file fails against the original `logger.ts` (import error — `resolveLoggerConfig` didn't exist) and passes after the fix (14/14).
- [x] Full test suite green (`bun run test`), full paste in this PR's description below.
- [x] `bun run typecheck` clean.
- [x] Flake verification: `resolve-targets.test.ts` run inside the full-suite parallel run (`bun test src/` in `packages/server`) 5 consecutive times — 0 failures each run (see evidence below).
- [x] `bun run scripts/check-source-comment-blame-shift.mjs` clean (0 new violations) — an earlier draft accidentally referenced "Issue #1175" inside a JSDoc comment and inside a test `describe` title; both were reworded to avoid the blame-shift lint trigger before this push.
- [x] Glossary check (`.claude/rules/glossary-maintenance.md` trigger scan): this change does NOT introduce a new domain concept, type, schema field, API/MCP param, or design-doc terminology — it's an internal logger-config branching refactor confined to `packages/server/src/lib/logger.ts`. No `docs/glossary.md` update required.
- [x] CodeRabbit: local CLI auth failed in this headless/delegated session (`automatic_login_failed` — no browser available to complete the OAuth flow; this is a known limitation of headless worktrees, not a rate-limit). Skipped per the `coderabbit-ops` skill's "CLI not installed/unavailable" fallback; relying on the GitHub-side bot review (`reviewDecision`) after this PR opens.
- [x] No files outside `packages/server/src/lib/logger.ts` and its new sibling test needed changes — confirms the NODE_ENV auto-set finding.

## Scope note (per Issue #1175's own comment thread)

This is a test-infra hygiene fix (`Low / chore` per the Issue), not a definitive flake fix. It removes the pino-pretty worker-thread hypothesis as a contributing factor to `resolve-targets.test.ts` flakiness. Later occurrences after PR #1184's hardening suggest the root flake cause may not be fully explained by this hypothesis alone (cross-test cwd contamination / concurrency race is also suspected) — **Issue #1150 remains open** to track any further recurrence.

## Flake verification evidence

Command run 5 consecutive times from `packages/server/`:

```
bun test src/
```

| Run | `resolve-targets.test.ts` result | Overall suite result |
|---|---|---|
| 1 | pass (no failures reported for this file) | 3599 tests, 1 fail (pre-existing, see below) |
| 2 | pass | 3599 tests, 1 fail (pre-existing, see below) |
| 3 | pass | 3599 tests, 1 fail (pre-existing, see below) |
| 4 | pass | 3599 tests, 1 fail (pre-existing, see below) |
| 5 | pass | 3599 tests, 1 fail (pre-existing, see below) |

`resolve-targets.test.ts` itself had zero failures across all 5 runs — the recurring 1-failure result in each run is a **pre-existing, unrelated** environment condition (see below), not resolve-targets flakiness and not caused by this PR.

## Pre-existing unrelated test failure noted (not caused by this PR)

`multi-user-mode.test.ts` — a test guarding the elevation-skip (direct) path's handling of `sshAuthSockFallback` (Issue #918) — fails deterministically in this local shell because `SSH_AUTH_SOCK` is set to a real 1Password agent socket (`/home/ms2sato/.1password/agent.sock`) in the ambient environment, and the test asserts `opts.env?.SSH_AUTH_SOCK` is `undefined`. This test file has no dependency on `logger.ts`. Confirmed unrelated by:
- The test file does not import `logger.ts` (`grep` confirms no reference).
- Running `env -u SSH_AUTH_SOCK bun run test` (unsetting the ambient var) yields **0 failures** across the entire monorepo suite (3598/3598 server tests pass, full paste below).

## Full test suite paste (env -u SSH_AUTH_SOCK bun run test, 0 failures)

```
@agent-console/client test $ bun test --preload ./src/test/setup.ts src/
 2075 pass
 0 fail
 4359 expect() calls
Ran 2075 tests across 142 files. [72.76s]

@agent-console/shared test $ bun test src/
 595 pass
 0 fail
 888 expect() calls
Ran 595 tests across 22 files. [552.00ms]

@agent-console/integration test $ bun test --preload ./src/setup.ts src/
 73 pass
 0 fail
 421 expect() calls
Ran 73 tests across 27 files. [6.71s]

@agent-console/server test $ bun test src/
 3598 pass
 1 skip
 0 fail
 9911 expect() calls
Ran 3599 tests across 163 files. [76.80s]

@agent-console/embedded-agent test $ bun test src/
 287 pass
 0 fail
 637 expect() calls
Ran 287 tests across 26 files. [9.11s]

$ bun test scripts/ ./.claude/hooks/__tests__/ ./.claude/skills/*/__tests__/
 457 pass
 0 fail
 1045 expect() calls
Ran 457 tests across 13 files. [5.97s]

TEST_EXIT: 0
```

## Test plan

- [x] `packages/server/src/lib/__tests__/logger.test.ts` — new sibling test file, 14 test cases covering `resolveLoggerConfig` for `test`, `production`, `undefined`, `'development'`, and an unrecognized value.
- [x] TDD polarity confirmed (fails against unmodified `logger.ts`, passes after the fix).
- [x] `bun run typecheck` — clean.
- [x] `bun run test` — full suite green (see paste above; 0 failures repo-wide with `SSH_AUTH_SOCK` unset).
- [x] Flake verification — `resolve-targets.test.ts` passed 5/5 consecutive full-suite parallel runs.
- [x] `bun run check:lang` — clean.
- [x] `bun run scripts/check-source-comment-blame-shift.mjs` — clean (0 new violations).
- [x] Conflict check against `origin/main` — clean (`git merge-tree`, no conflict markers).

Closes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)