### PR TITLE
test: assert warn-log payload shape in mcp-auth mode-matrix tests (closes #1035)

### DIFF
--- a/packages/server/src/mcp/__tests__/mcp-auth.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-auth.test.ts
@@ -185,6 +185,11 @@ describe('checkCallerOwnsSession', () => {
     expect(checkCallerOwnsSession(null, claimed, 'warn', ctx, { logger })).toBeNull();
     expect(calls).toHaveLength(1);
     expect(calls[0].message).toContain('AGENT_CONSOLE_MCP_AUTH=warn');
+    expect(calls[0].message).toContain('without bearer token');
+    expect(calls[0].payload).toEqual({
+      toolName: 'run_process',
+      claimedSessionId: 'session-a',
+    });
   });
 
   it('caller=null + enforce → error', () => {


### PR DESCRIPTION
## Summary

- `checkCallerOwnsSession`'s mode-matrix unit tests (`packages/server/src/mcp/__tests__/mcp-auth.test.ts`) covered the pass/reject **outcome** for the `warn`-mode tokenless-call case, but did not assert the recorded warn-log call itself. A future change to the log payload shape would only be observable in production logs, not caught by this test.
- Strengthens the existing `'caller=null + warn → null, warns once'` test with explicit assertions on the recorded log call:
  1. `calls[0].message` also contains `'without bearer token'` (in addition to the existing `'AGENT_CONSOLE_MCP_AUTH=warn'` check), guarding against a message rewrite that keeps the mode flag but drops the meaning.
  2. `calls[0].payload` is asserted via `toEqual({ toolName: 'run_process', claimedSessionId: 'session-a' })` — an exact-shape check so an added/renamed/dropped field is caught, not just a subset match.
- No production code changed. `packages/server/src/mcp/mcp-auth.ts` is untouched.
- No other test in the file was modified.

## Why this is a regression net (not vacuous)

Verified via polarity check against two independently-regressed production shapes (each reverted after verification, `git diff` on `mcp-auth.ts` confirmed empty):

1. Message-text regression (dropped `claimedSessionId` from the payload + reworded the message) → new assertion `toContain('without bearer token')` failed as expected.
2. Payload-only regression (kept message text identical, renamed `claimedSessionId` → `sessionId`) → the new `toEqual({...})` assertion independently failed with a field-level diff.

Both new assertions are load-bearing: each independently catches a distinct regression class (message-text drift vs. payload-field drift).

## Test plan

- `bun test packages/server/src/mcp/__tests__/mcp-auth.test.ts` — 29/29 pass.
- `bun run test` (full suite) — all packages pass except one pre-existing, environment-specific failure in `packages/server/src/services/__tests__/multi-user-mode.test.ts` (SSH_AUTH_SOCK from the local 1Password agent leaking into the test process env — unrelated to this change, not touched by this PR).
- `bun run typecheck` — exit 0, all packages clean.
- `node .claude/skills/orchestrator/preflight-check.js` — clean (no production files changed, no language violations, no rule/skill duplication, no blame-shift references).

Closes #1035