### PR TITLE
refactor: codify lookupOsUserFn throw semantics per caller

### DIFF
--- a/packages/server/src/services/__tests__/os-user-lookup.test.ts
+++ b/packages/server/src/services/__tests__/os-user-lookup.test.ts
@@ -39,4 +39,15 @@ describe('lookupOsUser', () => {
     const result: OsUserInfo | null = await lookupOsUser(fakeUsername);
     expect(result).toBeNull();
   });
+
+  // Explicit contract check backing the "never rejects" claim documented on
+  // `LookupOsUserFn`'s JSDoc (Issue #1034): the built-in implementation
+  // resolves (never rejects) even for a username that resolves to no OS
+  // account. Callers accepting an injectable `LookupOsUserFn` must not
+  // assume this holds for OTHER implementations -- see that type's JSDoc.
+  it.skipIf(!isSupported)('resolves rather than rejects, even for an unknown user', async () => {
+    const fakeUsername = `nonexistent-user-${crypto.randomBytes(8).toString('hex')}-zzz`;
+
+    await expect(lookupOsUser(fakeUsername)).resolves.toBeNull();
+  });
 });

--- a/packages/server/src/services/__tests__/shared-account-registry.test.ts
+++ b/packages/server/src/services/__tests__/shared-account-registry.test.ts
@@ -158,4 +158,58 @@ describe('SharedAccountRegistry', () => {
       expect(userCount.count).toBe(0);
     });
   });
+
+  describe('lookup implementation throws (OS/exec error)', () => {
+    it('wraps the error with a distinguishing message and preserves the cause', async () => {
+      const userRepository = new SqliteUserRepository(db);
+      const underlyingError = new Error('getent: command not found');
+      const lookup: LookupOsUserFn = async () => {
+        throw underlyingError;
+      };
+
+      await expect(
+        SharedAccountRegistry.create({
+          username: 'shared-user',
+          userRepository,
+          lookupOsUser: lookup,
+        }),
+      ).rejects.toThrow(/failed unexpectedly/);
+
+      try {
+        await SharedAccountRegistry.create({
+          username: 'shared-user',
+          userRepository,
+          lookupOsUser: lookup,
+        });
+        throw new Error('expected SharedAccountRegistry.create to reject');
+      } catch (err) {
+        expect((err as Error).message).not.toMatch(/does not resolve/);
+        expect((err as Error).cause).toBeInstanceOf(Error);
+        expect(((err as Error).cause as Error).message).toBe('getent: command not found');
+      }
+    });
+
+    it('does not create a users row when the lookup throws', async () => {
+      const userRepository = new SqliteUserRepository(db);
+      const lookup: LookupOsUserFn = async () => {
+        throw new Error('getent: command not found');
+      };
+
+      try {
+        await SharedAccountRegistry.create({
+          username: 'shared-user',
+          userRepository,
+          lookupOsUser: lookup,
+        });
+      } catch {
+        // expected
+      }
+
+      const userCount = await db
+        .selectFrom('users')
+        .select(db.fn.count<number>('id').as('count'))
+        .executeTakeFirstOrThrow();
+      expect(userCount.count).toBe(0);
+    });
+  });
 });

--- a/packages/server/src/services/__tests__/shared-account-registry.test.ts
+++ b/packages/server/src/services/__tests__/shared-account-registry.test.ts
@@ -183,9 +183,12 @@ describe('SharedAccountRegistry', () => {
         });
         throw new Error('expected SharedAccountRegistry.create to reject');
       } catch (err) {
-        expect((err as Error).message).not.toMatch(/does not resolve/);
-        expect((err as Error).cause).toBeInstanceOf(Error);
-        expect(((err as Error).cause as Error).message).toBe('getent: command not found');
+        expect(err).toBeInstanceOf(Error);
+        if (!(err instanceof Error)) return;
+        expect(err.message).not.toMatch(/does not resolve/);
+        expect(err.cause).toBeInstanceOf(Error);
+        if (!(err.cause instanceof Error)) return;
+        expect(err.cause.message).toBe('getent: command not found');
       }
     });
 

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -1660,6 +1660,36 @@ describe('WorkerManager', () => {
       expect(worker.pty).not.toBeNull();
     });
 
+    it('multi-user + lookupOsUserFn throwing: skips minting without crashing activation', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const registry = createFakeMcpTokenRegistry();
+      const { fake: runAsUserImpl } = createCommandDiscriminatingRunAsUser();
+      const wm = buildManagerWithSeams({
+        mcpTokenRegistry: registry,
+        lookupOsUserFn: async () => {
+          throw new Error('boom: lookup implementation misbehaved');
+        },
+        runAsUserImpl,
+      });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'mcp-agent-6',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      await wm.activateAgentWorkerPty(worker, {
+        ...defaultAgentActivationParams,
+        username: 'alice',
+        createdByUserId: 'user-uuid-1',
+      });
+
+      expect(registry.mint).not.toHaveBeenCalled();
+      expect(worker.mcpToken).toBeNull();
+      expect(worker.pty).not.toBeNull();
+    });
+
     describe('cleanup on kill / exit', () => {
       async function activateWithToken(id: string): Promise<{
         wm: WorkerManager;

--- a/packages/server/src/services/os-user-lookup.ts
+++ b/packages/server/src/services/os-user-lookup.ts
@@ -20,12 +20,36 @@ export interface OsUserInfo {
 /**
  * Function shape for `lookupOsUser`. Exposed so consumers can inject a stub
  * in tests without monkey-patching `Bun.spawn`.
+ *
+ * Throw semantics are intentionally NOT part of this type's contract:
+ * `Promise<OsUserInfo | null>` cannot structurally forbid rejection, so
+ * nothing stops an injected implementation (a test stub, or a hypothetical
+ * future real implementation) from throwing, even though the built-in
+ * `lookupOsUser` below never does. Do not assume "never throws" just because
+ * the default implementation happens to hold that property.
+ *
+ * Each caller that accepts an injectable `LookupOsUserFn` MUST make an
+ * explicit decision about how to handle a rejection:
+ * - `worker-manager.ts` (`activateAgentWorkerPty`) folds a throw into its
+ *   existing "skip MCP token mint, don't fail activation" non-fatal path.
+ * - `shared-account-registry.ts` (`SharedAccountRegistry.create`) keeps its
+ *   fail-fast-at-startup behavior but wraps the error with a message that
+ *   distinguishes "OS lookup failed unexpectedly" from "account genuinely
+ *   missing".
+ * - `user-mode.ts` calls the concrete `lookupOsUser` function directly (not
+ *   through this injectable type), so it is exempt: `lookupOsUser` is
+ *   contractually never-throwing, and there is no DI seam through which a
+ *   throwing implementation could be substituted.
  */
 export type LookupOsUserFn = (username: string) => Promise<OsUserInfo | null>;
 
 /**
  * Look up the OS user (uid + home directory) for the given username.
  * Returns null when the user does not exist or the platform is unsupported.
+ * Never rejects: all internal failure modes (unsupported platform, `dscl` /
+ * `id` / `getent` failures) are caught and folded into a `null` result. This
+ * is a property of THIS implementation, not something the `LookupOsUserFn`
+ * type enforces for other implementations -- see that type's JSDoc.
  */
 export async function lookupOsUser(username: string): Promise<OsUserInfo | null> {
   const platform = os.platform();

--- a/packages/server/src/services/shared-account-registry.ts
+++ b/packages/server/src/services/shared-account-registry.ts
@@ -71,7 +71,23 @@ export class SharedAccountRegistry {
       return new SharedAccountRegistry([]);
     }
 
-    const osInfo = await lookup(username);
+    let osInfo: Awaited<ReturnType<LookupOsUserFn>>;
+    try {
+      osInfo = await lookup(username);
+    } catch (err) {
+      // lookup is an injectable LookupOsUserFn seam; the built-in
+      // implementation never rejects, but an injected implementation is not
+      // contractually guaranteed not to throw (see os-user-lookup.ts's
+      // LookupOsUserFn JSDoc). Distinguish this from the "genuinely
+      // unresolved" case below with a distinct message + `cause` so an
+      // operator does not mistake a transient OS/exec error for a missing
+      // account.
+      throw new Error(
+        `shared account: OS lookup for username '${username}' failed unexpectedly (see cause); ` +
+          `this may indicate a transient OS/exec error rather than a missing account.`,
+        { cause: err },
+      );
+    }
     if (!osInfo) {
       throw new Error(
         `shared account: configured username '${username}' does not resolve to an OS account. ` +

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -484,7 +484,20 @@ export class WorkerManager {
           'Agent worker activated without session.createdBy; skipping MCP token mint (MCP calls from this worker will be rejected if AGENT_CONSOLE_MCP_AUTH=enforce is set; see Issue #1107)',
         );
       } else if (this.mcpTokenRegistry) {
-        const osUser = await this.lookupOsUserFn(params.username);
+        // lookupOsUserFn is an injectable seam (LookupOsUserFn); the built-in
+        // implementation never rejects, but an injected implementation (test
+        // stub, future variant) is not contractually guaranteed not to throw
+        // -- see os-user-lookup.ts's LookupOsUserFn JSDoc. Fold a throw into
+        // the same "skip mint, don't fail activation" path as a null result,
+        // distinguished by `logger.error` (implementation misbehaved) vs the
+        // `logger.warn` below (genuinely unresolved).
+        const osUser = await this.lookupOsUserFn(params.username).catch((err: unknown) => {
+          logger.error(
+            { workerId: worker.id, username: params.username, err },
+            'lookupOsUserFn threw unexpectedly during MCP token mint; skipping mint',
+          );
+          return null;
+        });
         if (!osUser) {
           logger.warn(
             { workerId: worker.id, username: params.username },


### PR DESCRIPTION
## Summary

Codifies previously-undefined throw-case semantics for the `LookupOsUserFn` injectable DI seam. This is a hardening task -- there is no live production bug, because the built-in `lookupOsUser` implementation already internally try/catches everything and never rejects. The gap is structural: `Promise<OsUserInfo | null>` cannot forbid rejection, so an injected implementation (a test stub, or a hypothetical future real implementation) is not contractually guaranteed not to throw, and neither of the two injectable call sites previously handled that case.

## Why not a single global option

The two injectable callers have deliberately different, pre-existing fail philosophies, so no single global policy fits both:

- **`worker-manager.ts` (`activateAgentWorkerPty`)** treats a `null` lookup result as a **non-fatal skip** -- the surrounding code's own comment calls PTY activation "a long-established availability-critical path" (create / revive / restart / restore) that must not be blocked by an optional MCP-token-mint sub-step. Today, an uncaught throw from `lookupOsUserFn` would propagate all the way out of `activateAgentWorkerPty` -- which is called with no try/catch from `worker-lifecycle-manager.ts` and `session-pause-resume-service.ts` -- aborting the entire worker/session creation flow. That breaks the documented non-fatal philosophy for this sub-step.
- **`shared-account-registry.ts` (`SharedAccountRegistry.create`)** is explicitly **fail-fast at startup** by design (JSDoc: `@throws Error when the configured username does not resolve to an OS account`; module doc: "the server fails fast at startup"). Today, a throw would still fail startup (correct), but the operator would see a raw, possibly-cryptic underlying error instead of the actionable message reserved for the "genuinely missing account" case -- misleading if the real cause was a transient OS/exec error.

Given these predate this PR and are each independently correct for their caller, the fix is per-caller rather than a shared wrapper.

## Per-caller changes

| Call site | Injectable? | Change |
|---|---|---|
| `worker-manager.ts:487` (`this.lookupOsUserFn(...)`, constructor DI seam) | Yes | **Option B**: wrap in try/catch (via `.catch()`); on throw, `logger.error` (distinguished from the existing `logger.warn` for the genuinely-unresolved `null` case) and fold into the same "skip mint, don't fail activation" control-flow path as `osUser === null`. |
| `shared-account-registry.ts:74` (`lookup(username)`, options seam) | Yes | **Option A**: wrap in try/catch; on throw, wrap in a new `Error` whose message does NOT match `/does not resolve/` (distinct from the missing-account message) and carries `{ cause: err }` (native ES2022 `Error.cause`, new pattern for this file only). Still throws -- fail-fast-at-startup behavior is unchanged, only the message/cause improve. |
| `user-mode.ts:326` (`lookupOsUser(username)`, direct import) | **No** -- out of scope | Not modified. `lookupOsUser` itself is contractually never-throwing (it internally try/catches everything), and this call site is bound to the concrete implementation, not the injectable `LookupOsUserFn` type, so there is no DI seam through which a throwing implementation could be substituted. Adding a defensive try/catch here would be "error handling for a scenario that can't happen." |
| `os-user-lookup.ts` | N/A (defines the type) | No behavior change. Extended JSDoc on `LookupOsUserFn` documents the throw-contract gap explicitly and states each injectable caller's decision; briefly notes on `lookupOsUser`'s own doc that never-rejecting is a property of that implementation, not the type. |

## Tests + polarity verification

- `packages/server/src/services/__tests__/worker-manager.test.ts`: new test `'multi-user + lookupOsUserFn throwing: skips minting without crashing activation'`, sibling to the existing null-case test. Asserts `activateAgentWorkerPty(...)` resolves (does not throw), `registry.mint` was not called, `worker.mcpToken` is `null`, `worker.pty` is not `null`.
  - **Polarity**: pre-fix, `await wm.activateAgentWorkerPty(...)` rejects with the injected stub's error, propagating out of the test; post-fix it resolves cleanly. Verified via `git stash` of the production-only files (keeping the new tests) -- confirmed failure pre-fix (uncaught rejection at `worker-manager.ts:487`), pass post-fix.
- `packages/server/src/services/__tests__/shared-account-registry.test.ts`: new `describe('lookup implementation throws (OS/exec error)', ...)` block with two tests: (1) asserts the rejection message does NOT match `/does not resolve/` and DOES match `/failed unexpectedly/`, and that `.cause` is an `Error` whose message equals the original underlying error's message; (2) asserts no `users` row is created when the lookup throws.
  - **Polarity**: pre-fix, the raw underlying error message (`'getent: command not found'`) propagates unwrapped with no `cause`, so the message-pattern and `cause` assertions fail pre-fix (confirmed via `git stash`) and pass post-fix.
- `packages/server/src/services/__tests__/os-user-lookup.test.ts`: added an explicit "resolves rather than rejects" contract test, backing the new JSDoc claim on `lookupOsUser` (this file's only diff was JSDoc/comment-only, but the mechanical comment-only-diff detector in `preflight-check.js` has a documented conservative limitation for hunks with `--unified=0` that don't include the block-comment opener -- see that function's own JSDoc -- so a sibling-test touch was still required and is a genuinely useful addition regardless).

## Verification

- `bun run typecheck` -- clean across all packages.
- `bun run test` -- full suite green (server 3611 pass / 0 fail, client 2075 pass, shared 595 pass, integration 73 pass, embedded-agent 287 pass, scripts/hooks 457 pass). One unrelated pre-existing failure was observed in `multi-user-mode.test.ts` (`Issue #918` SSH_AUTH_SOCK direct-path test) caused by this dev environment's real `SSH_AUTH_SOCK` (a 1Password agent socket) leaking into the test process -- reproduced identically with this PR's changes stashed out, confirming it predates and is unrelated to this change. Full suite is clean with `SSH_AUTH_SOCK` unset.
- `node .claude/skills/orchestrator/preflight-check.js` (run after commit) -- all production files covered, no rule/skill duplication, language check clean, no blame-shift violations.
- `coderabbit review --agent --base main` -- CLI installed but authentication failed in this headless worktree (known limitation, not a rate-limit). Relying on the GitHub-side CodeRabbit bot review post-PR-open per the `coderabbit-ops` skill disposition.
- Duplication check: grepped for `lookupOsUserFn(`/`lookupOsUser(`/`lookup(` call sites -- confirmed exactly the 3 known call sites, no pre-existing similar wrapper to reuse.

## Merge authority

Per delegating orchestrator instructions, this is a **reversible category** change (semantics codification, no live bug) and merges on **architect + Orchestrator dual-clean** review, not a unilateral merge by this agent.

Closes #1034
Refs #1030 #1032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Worker activation now succeeds even when operating-system account lookup fails; MCP token creation is skipped safely.
  - Shared account creation now reports unexpected account lookup failures clearly while preserving the underlying error.
  - Unresolved operating-system usernames continue to be handled without throwing.
- **Documentation**
  - Clarified account lookup behavior for unsupported platforms and lookup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->