### PR TITLE
refactor(client): IPv4-literal vite proxy targets + /ws observability (Refs #1211)

### DIFF
--- a/.claude/skills/dev-environment-quirks/SKILL.md
+++ b/.claude/skills/dev-environment-quirks/SKILL.md
@@ -26,6 +26,7 @@ Operational facts that differ from the host-side scripts:
 - **It does NOT exercise host OS quirks.** sudoers drift, PAM config, PATH/login-shell issues on the real host still need `dev-multiuser.sh` or the production instance.
 - **Coexists with the verification stack** (`docker/docker-compose.verification.yml`, host port 8080 — which on the dogfood host is also the production port, so give the verification stack a different `PORT` when production is running).
 - Logs / restart / shell: `docker compose -f docker/docker-compose.yml logs --tail 100 -f`, `... restart agent-console-dev`, `... exec -u agentconsole agent-console-dev sh`.
+- **Known limitation: the vite `/ws` proxy is currently unreliable in this stack** (Issue #1211 — the Dashboard can hang forever on "Loading sessions..." with no client-side error). Root cause is unresolved as of this writing (ruled out: `changeOrigin`, IPv6/DNS fallback asymmetry, vite's upgrade-dispatch registration, a Bun 1.3.8→1.3.10 bump). For WS-dependent QA, prefer `scripts/dev-multiuser.sh` or `docker/docker-compose.verification.yml` until #1211 is resolved.
 
 ## Multi-user dev: source propagation is rsync, not live
 

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
         target: `ws://127.0.0.1:${serverPort}`,
         ws: true,
         configure: (proxy) => {
+          proxy.on('proxyReqWs', (_proxyReq, req) => {
+            console.log('[vite proxy /ws] upgrade dispatched:', req?.url);
+          });
           proxy.on('error', (err) => {
             console.error('[vite proxy /ws] error:', err);
           });

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -21,12 +21,23 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: `http://localhost:${serverPort}`,
+        target: `http://127.0.0.1:${serverPort}`,
         changeOrigin: true,
       },
       '/ws': {
-        target: `ws://localhost:${serverPort}`,
+        target: `ws://127.0.0.1:${serverPort}`,
         ws: true,
+        configure: (proxy) => {
+          proxy.on('error', (err) => {
+            console.error('[vite proxy /ws] error:', err);
+          });
+          proxy.on('open', () => {
+            console.log('[vite proxy /ws] upstream socket open');
+          });
+          proxy.on('close', () => {
+            console.log('[vite proxy /ws] proxy close event');
+          });
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

This PR ships the symptom-independent hygiene/observability improvements from a deep investigation into #1211 (Docker dev stack's vite `/ws` proxy hangs, Dashboard stuck on "Loading sessions..."). **It does not fix that hang** — the root cause remains open and deferred (see the evidence bundle in the issue comments). It ships only what has standalone value regardless of the eventual root-cause fix.

- `/api` and `/ws` proxy targets changed from `localhost` to `127.0.0.1` literals. The Docker dev stack's backend binds IPv4-only; `localhost` resolves to `::1` first inside the container (confirmed via probe: `curl http://[::1]:3457/...` -> connection refused, `127.0.0.1` -> 200), so only HTTP's implicit fallback behavior was masking the ambiguity for `/api`. The literal removes the DNS/IPv6 resolution step entirely, giving deterministic proxy behavior in both Docker and non-Docker dev environments.
- Permanent `proxyReqWs`/`error`/`open`/`close` logging on the `/ws` proxy's `configure` hook, so a future connection failure (this one or a different one) surfaces a console signal instead of a silent, undiagnoseable hang — the single biggest time-sink during the #1211 investigation. `proxyReqWs` specifically logs the moment vite dispatches the upgrade to `http-proxy`, which is the only signal that distinguishes "never dispatched" from "dispatched but stalled downstream" — exactly the ambiguity that cost an extra investigation round on #1211 (added per architect review feedback on this PR).
- `dev-environment-quirks` skill gains a one-line known-limitation note pointing WS-dependent QA at `scripts/dev-multiuser.sh` / `docker/docker-compose.verification.yml` until #1211 is resolved.

## Investigation trail (for context, not required reading to review this PR)

Full evidence bundle, ruled-out hypotheses, and probe data: https://github.com/ms2sato/agent-console/issues/1211#issuecomment-5013888055 and the follow-up comment. Ruled out: `changeOrigin: true` alone, IPv6/DNS fallback asymmetry (real, not causal), vite's upgrade-dispatch registration (confirmed working), a Bun 1.3.8 to 1.3.10 version bump (tested, no effect). Confirmed root-cause layer: the WS upgrade request is dispatched to `http-proxy`'s `.ws()` call, a TCP connection to the backend is established, but the upgrade bytes never reach the backend (zero request-log evidence) and no `error`/`open`/`close` event fires — non-deterministic (worked once out of many attempts). Deferred to a separate track per architect + orchestrator agreement.

## CodeRabbit

Local CLI hit the headless-worktree auth failure (`authentication_failed` / `automatic_login_failed` from `coderabbit review --agent --base main`), not a rate-limit — this is a structural limitation of a delegated worktree session (no browser for the interactive login), not a quota condition. Relying on the GitHub-side bot review per `coderabbit-ops` skill's documented disposition for this failure shape.

## Test plan

- [x] `bun run typecheck` — exit 0
- [x] `bun run test` (full monorepo suite) — exit 0: client 2075 pass, shared 595 pass, integration 73 pass, embedded-agent 287 pass, server 3608 pass/1 skip, scripts/hooks/skills 457 pass
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (no coverage gaps: `vite.config.ts` is a build/dev-server config file, outside `test-trigger.md`'s patterns; skill doc change passed the language check)
- [x] `bun run check:lang` — clean
- [x] Docker QA on the exact committed branch state (rebuilt image, fresh container): confirmed the `/ws` hang from #1211 is **not** fixed by this change (expected — logging does not fire during that specific silent-hang failure mode either, consistent with the investigation's finding that no `error`/`open`/`close` event fires during the hang). **Separately confirmed the logging hook does work correctly for a different, real failure mode**: stopping the backend process to force `ECONNREFUSED` produced `[vite proxy /ws] error: ... ECONNREFUSED` in the vite console and a client-side `close:1006` — proving the instrumentation fires when the proxy has *any* signal to report. The #1211 hang is unusual specifically because it gives the proxy no signal at all to log, not because the logging is broken.
- [x] R1 (architect review): re-ran `bun run typecheck` and the full suite after adding the missing `proxyReqWs` handler — both green (identical pass counts as above).

Refs #1211 (does not close it)
