### PR TITLE
fix: sweep SESSION_ID-marked orphan processes tree-wide on restart (#1197 Part B)

### DIFF
--- a/.claude/rules/elevation-helpers.md
+++ b/.claude/rules/elevation-helpers.md
@@ -132,6 +132,26 @@ The reciprocal cost of preserving two branches is a small per-caller `if (should
 - Any caller currently doing `Bun.spawn(['sh','-c', cmd], { env: getCleanChildProcessEnv() })` (or analogous env-shape transformation) that is about to gain a multi-user elevation path. Check `getCleanChildProcessEnv` usage in `packages/server/src/`.
 - Any caller doing pre-spawn arg sanitization (path normalization, secret stripping, etc.) where the sanitization is not encoded in the spawn primitive.
 
+### Multi-line elevated commands: deliver via stdin, not argv
+
+When `runAsUser`'s elevated branch runs (`shouldElevateForUser` true), the argv it constructs is `['sudo', '-u', <user>, --preserve-env=..., '-i', 'sh', '-c', <innerCommand>]`. The target user's login shell (invoked via `-i` with trailing arguments) reconstructs its own command line by joining those trailing arguments with spaces before re-parsing them -- this collapses any literal newline characters embedded inside `innerCommand` into plain whitespace. A multi-statement shell script that relies on newlines as statement separators (e.g. a `for ... do ... done` loop written across multiple lines) breaks with a syntax error once every line lands on one collapsed line (observed on a real host: `sh: 1: Syntax error: "do" unexpected`). The non-elevated branch (`['sh', '-c', command]`, executed directly via `execve`, no intermediate login-shell re-join) does not have this problem -- the bug is specific to the elevated path.
+
+**Rule**: a `command` string passed to `runAsUser` / `spawnAsUser` must stay single-line whenever the caller cannot guarantee it will only ever run non-elevated. If the actual payload is a multi-line script, keep `command` fixed to the single-line `'sh -s'` (POSIX `sh`'s "read the script from stdin" invocation) and deliver the script's bytes via `opts.stdin` instead of embedding them in `command`. `opts.stdin` travels as a separate pipe, never touches argv, and is therefore immune to the elevated login shell's argv-join.
+
+```ts
+// Wrong: a multi-line command breaks once elevated (newlines collapse).
+await runAsUser({ username, command: multiLineScript, cwd: '/' });
+
+// Right: single-line command, script delivered over stdin.
+await runAsUser({ username, command: 'sh -s', stdin: multiLineScript, cwd: '/' });
+```
+
+This is safe for the non-elevated (or bypassed-elevation, e.g. `username` equals the server-process user) branch too -- `sh -c "sh -s"` with the script piped on stdin behaves identically to running the script directly, just through one extra layer of `sh`. No branching is needed between elevated and non-elevated cases; always use the `command: 'sh -s'` + `stdin: <script>` shape once the payload is multi-line.
+
+**Worked example**: `packages/server/src/services/orphan-process-sweeper.ts`'s `sweepOrphanProcesses` composes a multi-line POSIX `sh` script (`buildSweepScript`) to scan+match+kill orphan processes in one elevated invocation. The Issue #1197 Part B owner smoke on a real multi-user host caught the argv-join collapsing the script's `for` loop; the fix switched `command` from the raw multi-line script to `'sh -s'` with the script delivered via `stdin`, with no change to the script's own content.
+
+**Proactive audit candidates** (the bug shape, not current sites): any future caller that composes a multi-statement shell script (more than a single `cmd1 && cmd2` chain) and passes it directly as `command` to `runAsUser` / `spawnAsUser`. Single-line `command` strings (the overwhelming majority of existing call sites: `rm -rf --`, `kill -s`, `gh ...`, `git ...`) are unaffected and need no change.
+
 ## How this rule is expected to evolve
 
 As the helper family grows (`chmodAsUser`, `lstatAsUser`, etc. are plausible future additions when fs operations on cross-user paths come up), the naming pattern (`<verb>AsUser`) and the strict-thin-wrapper contract self-extend. This rule's body should not need to change; the glossary entry's enumeration of helpers should be updated in the same PR that adds the new primitive.
@@ -149,6 +169,7 @@ If a consumer surfaces a recurring need for semantic layering (e.g. "every calle
   - [PR #881](https://github.com/ms2sato/agent-console/pull/881) (Issues #869 / #870) — `lib/git.ts` consolidation; `gitExec`-routed helpers accept `requestUser`.
   - [PR #877](https://github.com/ms2sato/agent-console/pull/877) (Issue #876) — `delegate_to_worktree` resolves `parentSession.createdBy → osUsername`, hoist pattern.
   - [PR #880](https://github.com/ms2sato/agent-console/pull/880) (Issue #879) — `run_process` elevated via `spawnAsUser`.
+  - [PR #1219](https://github.com/ms2sato/agent-console/pull/1219) (Issue #1197 Part B) — `orphan-process-sweeper.ts`'s multi-line sweep script; discovered and fixed the argv-join-collapses-newlines bug this rule's "Multi-line elevated commands" subsection documents.
 - **Related Issues** (multi-PR convergence drivers):
   - [#871](https://github.com/ms2sato/agent-console/issues/871) — unregister-repository error surfacing (separate identity audit).
   - [#878](https://github.com/ms2sato/agent-console/issues/878) — MCP auth-boundary (caller-claimed `sessionId` verification); explicit out-of-scope for elevation PRs, addressed horizontally.

--- a/.github/workflows/language-lint.yml
+++ b/.github/workflows/language-lint.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           bun-version: "1.3.5"
 
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Run language check
         run: bun run check:lang
 

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -1155,6 +1155,61 @@ smokes above, this degenerate mode does not require `AUTH_MODE=multi-user`
 to be meaningful — the elevation bypass is evaluated independently of it,
 based solely on whether `<target-user>` equals the server-process user.
 
+### SESSION_ID marker orphan-process sweep
+
+Run after every deploy that touches
+`packages/server/src/services/orphan-process-sweeper.ts` or
+`SessionInitializationService.sweepSessionProcesses` (Issue #1197 Part B).
+`killOrphanWorkers` (Part A, checked above) only kills processes tracked via
+a session's persisted `worker.pid` — the direct PTY wrapper process. A
+worker's detached descendant processes (a `bun run dev` child, an MCP
+subprocess, ...) are never in that PID set and leak forever across server
+restarts. Every worker process already carries
+`AGENT_CONSOLE_SESSION_ID=<sessionId>` in its environment, inherited by
+every descendant; the sweep scans `/proc/[pid]/environ` for that marker,
+tree-wide, and kills anything matching regardless of whether it was ever
+tracked as a `worker.pid`:
+
+```bash
+sudo -u agentconsole bun scripts/smoke/check-orphan-sweep.ts <target-user>
+```
+
+What it verifies (against the **real** machine — real `sudo`, real
+`/proc/<pid>/environ` read permissions, real target processes):
+
+- `spawnAsUser` launches a real, long-lived `sleep` as `<target-user>` with
+  `AGENT_CONSOLE_SESSION_ID=<generated-session-id>` set in its environment
+  (the same marker every real worker process carries in production).
+- `sweepOrphanProcesses` runs the marker-scan-and-kill script AS
+  `<target-user>` — a real cross-user `/proc/<pid>/environ` read, which the
+  server process itself cannot do directly — and actually terminates the
+  marked process (polled via `/proc/<pid>` existence, bounded to 8s).
+- Negative: a second, real process spawned as the same target user WITHOUT
+  the marker survives the sweep — proof the sweep matches on the exact
+  `SESSION_ID` record, not a broader name-based or substring match.
+
+This smoke's distinct value versus Part A's `check-kill-as-user.ts` is
+proving the marker-based **discovery** mechanism works end-to-end against
+real `sudo` / real `/proc` read permissions — Part A never reads `environ`,
+it only signals an already-known pid. This smoke does NOT exercise the
+TERM → SIGKILL escalation path for a marked process that ignores SIGTERM
+(covered by the real-process tests in
+`packages/server/src/services/__tests__/orphan-process-sweeper.test.ts`,
+which drive the sweep script directly via `Bun.spawn`, same-user, no
+elevation needed to exercise the script's own grace/escalation logic) or
+`SessionInitializationService.sweepSessionProcesses`'s best-effort
+wrapping (covered by unit tests with an injected fake).
+
+Exit codes: `0` all assertions passed, `1` an assertion failed (the system
+is wrong), `2` bad usage or the smoke could not run (missing target-user
+argument, spawn-launch failure, or a bounded phase exceeding its deadline).
+
+Passing the current process user as `<target-user>` runs in a degenerate
+same-user mode where `spawnAsUser` / `sweepOrphanProcesses` bypass
+elevation — this still exercises the full mechanism (spawn, marker match,
+kill, negative assertion) except the actual `sudo` OS-user-boundary
+crossing and the cross-user `/proc/<pid>/environ` read permission.
+
 ### PTY master fd leak check
 
 Run after every deploy that touches `packages/server/src/lib/pty-provider.ts`

--- a/packages/server/src/services/__tests__/orphan-process-sweeper.test.ts
+++ b/packages/server/src/services/__tests__/orphan-process-sweeper.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { shellEscape, type RunAsUserResult, type runAsUser } from '../privilege-elevation.js';
+import {
+  buildSweepScript,
+  parseSweptCount,
+  sweepOrphanProcesses,
+} from '../orphan-process-sweeper.js';
+
+function okResult(overrides: Partial<RunAsUserResult> = {}): RunAsUserResult {
+  return { stdout: '', stderr: '', exitCode: 0, timedOut: false, ...overrides };
+}
+
+// ============================================================
+// Tier A — pure / fast (no real spawning, no elevation)
+// ============================================================
+
+describe('buildSweepScript', () => {
+  it('embeds the session ID via shellEscape (single-quote-safe)', () => {
+    const sessionId = "sess'id";
+    const script = buildSweepScript(sessionId, { killGraceMs: 2000 });
+    const expectedMarker = shellEscape(`AGENT_CONSOLE_SESSION_ID=${sessionId}`);
+    expect(script).toContain(`marker=${expectedMarker}`);
+  });
+
+  it('does not embed a session ID containing a single quote unescaped (injection safety)', () => {
+    const sessionId = "sess'; rm -rf /tmp/whatever; echo pwned '";
+    const script = buildSweepScript(sessionId, { killGraceMs: 2000 });
+    // The naive, unescaped form (bare single quote breaking out of the
+    // quoted shell literal) must never appear -- shellEscape must have
+    // converted each embedded quote into the '\'' escape sequence.
+    expect(script).not.toContain(`marker='AGENT_CONSOLE_SESSION_ID=${sessionId}'`);
+    // The properly-escaped form (produced by the same shellEscape helper
+    // the production code calls) must be present.
+    const expectedMarker = shellEscape(`AGENT_CONSOLE_SESSION_ID=${sessionId}`);
+    expect(script).toContain(`marker=${expectedMarker}`);
+  });
+
+  it('issues SIGTERM before SIGKILL', () => {
+    const script = buildSweepScript('sess-1', { killGraceMs: 2000 });
+    const termIdx = script.indexOf('kill -s TERM');
+    const killIdx = script.indexOf('kill -s KILL');
+    expect(termIdx).toBeGreaterThan(-1);
+    expect(killIdx).toBeGreaterThan(-1);
+    expect(termIdx).toBeLessThan(killIdx);
+  });
+
+  it('references SWEEP_PROC_ROOT with a /proc fallback', () => {
+    const script = buildSweepScript('sess-1', { killGraceMs: 2000 });
+    expect(script).toContain('proc_root="${SWEEP_PROC_ROOT:-/proc}"');
+  });
+
+  it('excludes its own pid ($$) from candidates', () => {
+    const script = buildSweepScript('sess-1', { killGraceMs: 2000 });
+    expect(script).toContain('self_pid=$$');
+    expect(script).toContain('[ "$pid" = "$self_pid" ] && continue');
+  });
+
+  it('embeds the requested grace period as fractional seconds for sleep', () => {
+    const script = buildSweepScript('sess-1', { killGraceMs: 500 });
+    expect(script).toContain('sleep 0.5');
+  });
+});
+
+describe('parseSweptCount', () => {
+  it('parses "SWEPT=0" as 0', () => {
+    expect(parseSweptCount('SWEPT=0\n')).toBe(0);
+  });
+
+  it('parses "SWEPT=5" as 5', () => {
+    expect(parseSweptCount('SWEPT=5\n')).toBe(5);
+  });
+
+  it('returns 0 for empty stdout', () => {
+    expect(parseSweptCount('')).toBe(0);
+  });
+
+  it('returns 0 for garbage / no matching line', () => {
+    expect(parseSweptCount('not well formed output\nnothing here\n')).toBe(0);
+  });
+
+  it('parses the correct line out of noise (embedded near-matches do not count)', () => {
+    const stdout = 'some log line\nNOISE SWEPT=999 trailing noise\nSWEPT=3\nmore junk\n';
+    expect(parseSweptCount(stdout)).toBe(3);
+  });
+});
+
+describe('sweepOrphanProcesses (unit, injected runAsUserImpl fake)', () => {
+  it('forwards username, cwd, and timeoutMs to runAsUserImpl', async () => {
+    const calls: Array<Parameters<typeof runAsUser>[0]> = [];
+    const fake: typeof runAsUser = async (opts) => {
+      calls.push(opts);
+      return okResult({ stdout: 'SWEPT=0\n' });
+    };
+
+    await sweepOrphanProcesses('sess-1', 'target-user', {
+      runAsUserImpl: fake,
+      timeoutMs: 12345,
+    });
+
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.username).toBe('target-user');
+    expect(calls[0]?.cwd).toBe('/');
+    expect(calls[0]?.timeoutMs).toBe(12345);
+  });
+
+  it('forwards procRootOverride as a SWEEP_PROC_ROOT env var', async () => {
+    const calls: Array<Parameters<typeof runAsUser>[0]> = [];
+    const fake: typeof runAsUser = async (opts) => {
+      calls.push(opts);
+      return okResult({ stdout: 'SWEPT=0\n' });
+    };
+
+    await sweepOrphanProcesses('sess-1', null, {
+      runAsUserImpl: fake,
+      procRootOverride: '/tmp/scratch-root',
+    });
+
+    expect(calls[0]?.env).toEqual({ SWEEP_PROC_ROOT: '/tmp/scratch-root' });
+  });
+
+  it('omits env entirely when procRootOverride is not provided', async () => {
+    const calls: Array<Parameters<typeof runAsUser>[0]> = [];
+    const fake: typeof runAsUser = async (opts) => {
+      calls.push(opts);
+      return okResult({ stdout: 'SWEPT=0\n' });
+    };
+
+    await sweepOrphanProcesses('sess-1', null, { runAsUserImpl: fake });
+
+    expect(calls[0]?.env).toBeUndefined();
+  });
+
+  it('killedCount reflects the parsed SWEPT count from stdout', async () => {
+    const fake: typeof runAsUser = async () => okResult({ stdout: 'SWEPT=7\n' });
+
+    const result = await sweepOrphanProcesses('sess-1', null, { runAsUserImpl: fake });
+
+    expect(result.killedCount).toBe(7);
+    expect(result.raw.stdout).toBe('SWEPT=7\n');
+  });
+
+  it('does not throw on a non-zero exit code -- returns the raw result unchanged', async () => {
+    const fake: typeof runAsUser = async () =>
+      okResult({ exitCode: 1, stderr: 'boom', stdout: '' });
+
+    let thrown: unknown;
+    let result: Awaited<ReturnType<typeof sweepOrphanProcesses>> | undefined;
+    try {
+      result = await sweepOrphanProcesses('sess-1', null, { runAsUserImpl: fake });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeUndefined();
+    expect(result?.killedCount).toBe(0);
+    expect(result?.raw.exitCode).toBe(1);
+    expect(result?.raw.stderr).toBe('boom');
+  });
+
+  it('does not throw on a timed-out result -- returns the raw result unchanged', async () => {
+    const fake: typeof runAsUser = async () =>
+      okResult({ timedOut: true, exitCode: 137, stdout: '' });
+
+    let thrown: unknown;
+    let result: Awaited<ReturnType<typeof sweepOrphanProcesses>> | undefined;
+    try {
+      result = await sweepOrphanProcesses('sess-1', null, { runAsUserImpl: fake });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeUndefined();
+    expect(result?.killedCount).toBe(0);
+    expect(result?.raw.timedOut).toBe(true);
+  });
+
+  it('does not throw on malformed stdout and returns killedCount 0', async () => {
+    const fake: typeof runAsUser = async () => okResult({ stdout: 'not-well-formed' });
+
+    const result = await sweepOrphanProcesses('sess-1', null, { runAsUserImpl: fake });
+
+    expect(result.killedCount).toBe(0);
+  });
+
+  it('throws synchronously on an empty sessionId without invoking runAsUserImpl', async () => {
+    let called = false;
+    const fake: typeof runAsUser = async () => {
+      called = true;
+      return okResult();
+    };
+
+    let thrown: unknown;
+    try {
+      await sweepOrphanProcesses('', 'target-user', { runAsUserImpl: fake });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(called).toBe(false);
+  });
+});
+
+// ============================================================
+// Tier B — real-process (Bun.spawn directly against real /proc, bypassing
+// runAsUser/elevation entirely -- same-user only, exactly like
+// packages/embedded-agent/src/tools/__tests__/bash.test.ts's trap-TERM
+// test). These tests exercise buildSweepScript's actual shell-script
+// behavior in isolation from the runAsUser plumbing, which Tier A already
+// covers via injected fakes.
+// ============================================================
+
+describe('buildSweepScript (real-process, same-user)', () => {
+  // Short grace period keeps the suite fast; still non-zero so the
+  // grace-then-escalate behavior is actually exercised (see the trap-TERM
+  // test below), matching the "no partial polarity" spirit -- a zero grace
+  // period would make the escalation branch untestable.
+  const TEST_KILL_GRACE_MS = 300;
+
+  const spawnedPids: number[] = [];
+
+  afterEach(async () => {
+    // Best-effort cleanup: kill anything this test spawned and did not
+    // already reap, so a failed assertion never leaks a real process from
+    // the CI runner. Verified, not assumed -- matches
+    // scripts/smoke/check-kill-as-user.ts's cleanup discipline.
+    const pending = spawnedPids.splice(0, spawnedPids.length);
+    for (const pid of pending) {
+      if (await procAlive(pid)) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // best-effort
+        }
+      }
+    }
+  });
+
+  function uniqueSessionId(label: string): string {
+    return `sweep-test-${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+
+  /**
+   * Liveness check via `Bun.file(...).exists()` on `/proc/<pid>/environ`,
+   * NOT `node:fs`'s `existsSync`. `packages/server/src/__tests__/utils/mock-fs-helper.ts`
+   * performs a process-global `mock.module('node:fs', ...)` (memfs) at
+   * import time; once ANY test file in this bun:test process imports it
+   * (many do), every OTHER test file's `node:fs` / `node:fs/promises`
+   * calls silently redirect to the fake in-memory filesystem for the rest
+   * of the process's lifetime -- see `.claude/rules/testing.md` Anti-Pattern
+   * #2. `Bun.file()` is a Bun-native API outside that module namespace and
+   * stays backed by the real OS filesystem regardless of what other test
+   * files in this run have mocked. `environ` (rather than the bare `/proc/<pid>`
+   * directory) is used because `Bun.file()` is file-oriented -- `.exists()`
+   * on a directory path always resolves `false` even when the directory is
+   * real, but the environ file reliably exists exactly while the process
+   * is alive and disappears immediately (no zombie-lag) once it exits.
+   */
+  async function procAlive(pid: number): Promise<boolean> {
+    return Bun.file(`/proc/${pid}/environ`).exists();
+  }
+
+  async function waitUntilGone(pid: number, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (!(await procAlive(pid))) return true;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    return !(await procAlive(pid));
+  }
+
+  /** Real `mkdir -p` via a subprocess -- immune to `node:fs` mock pollution (see `procAlive` docs above). */
+  async function mkdirReal(dir: string): Promise<void> {
+    const proc = Bun.spawn(['mkdir', '-p', dir]);
+    const code = await proc.exited;
+    if (code !== 0) throw new Error(`mkdir -p ${dir} failed (exit ${code})`);
+  }
+
+  /** Real `chmod` via a subprocess -- immune to `node:fs` mock pollution. */
+  async function chmodReal(target: string, mode: string): Promise<void> {
+    const proc = Bun.spawn(['chmod', mode, target]);
+    await proc.exited;
+  }
+
+  /** Real `rm -rf` via a subprocess -- immune to `node:fs` mock pollution. */
+  async function rmRecursiveReal(target: string): Promise<void> {
+    const proc = Bun.spawn(['rm', '-rf', target]);
+    await proc.exited;
+  }
+
+  /**
+   * Spawns a real, trackable `sleep` process directly (no shell wrapper --
+   * `Bun.spawn(['sleep', ...])` execs the binary in place, producing
+   * exactly one OS process with no forked child, unlike
+   * `Bun.spawn(['sh', '-c', 'sleep ...'])` which dash forks a child for).
+   * `env` is layered over the current process env when provided; omitting
+   * it produces an intentionally UNMARKED control process.
+   */
+  function spawnMarked(env: Record<string, string> | undefined, seconds = 300): number {
+    const proc = Bun.spawn(['sleep', String(seconds)], {
+      env: env ? { ...process.env, ...env } : { ...process.env },
+    });
+    spawnedPids.push(proc.pid);
+    return proc.pid;
+  }
+
+  async function runSweepScript(
+    sessionId: string,
+    opts: { killGraceMs?: number; procRootOverride?: string; extraEnv?: Record<string, string> } = {},
+  ): Promise<{ exitCode: number; stdout: string; stderr: string; killedCount: number }> {
+    const script = buildSweepScript(sessionId, { killGraceMs: opts.killGraceMs ?? TEST_KILL_GRACE_MS });
+    const env: Record<string, string> = { ...process.env } as Record<string, string>;
+    if (opts.procRootOverride) env.SWEEP_PROC_ROOT = opts.procRootOverride;
+    if (opts.extraEnv) Object.assign(env, opts.extraEnv);
+
+    const proc = Bun.spawn(['sh', '-c', script, 'sh'], { stdout: 'pipe', stderr: 'pipe', env });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { exitCode, stdout, stderr, killedCount: parseSweptCount(stdout) };
+  }
+
+  it('0 candidates: sweeps nothing and completes cleanly', async () => {
+    const sessionId = uniqueSessionId('zero');
+
+    const result = await runSweepScript(sessionId);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.killedCount).toBe(0);
+  });
+
+  it('1 candidate: the marked process is killed', async () => {
+    const sessionId = uniqueSessionId('one');
+    const pid = spawnMarked({ AGENT_CONSOLE_SESSION_ID: sessionId });
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await procAlive(pid)).toBe(true);
+
+    const result = await runSweepScript(sessionId);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.killedCount).toBe(1);
+    expect(await waitUntilGone(pid, 3000)).toBe(true);
+  });
+
+  it('N candidates: all marked processes are killed', async () => {
+    const sessionId = uniqueSessionId('many');
+    const pids = [
+      spawnMarked({ AGENT_CONSOLE_SESSION_ID: sessionId }),
+      spawnMarked({ AGENT_CONSOLE_SESSION_ID: sessionId }),
+      spawnMarked({ AGENT_CONSOLE_SESSION_ID: sessionId }),
+    ];
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = await runSweepScript(sessionId);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.killedCount).toBe(3);
+    for (const pid of pids) {
+      expect(await waitUntilGone(pid, 3000)).toBe(true);
+    }
+  });
+
+  it('negative: an unmarked control process survives the sweep', async () => {
+    const sessionId = uniqueSessionId('neg-unmarked');
+    const controlPid = spawnMarked(undefined);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = await runSweepScript(sessionId);
+
+    expect(result.killedCount).toBe(0);
+    expect(await procAlive(controlPid)).toBe(true);
+  });
+
+  it('negative: a process marked with a DIFFERENT session ID survives the sweep', async () => {
+    const targetSessionId = uniqueSessionId('neg-diff-target');
+    const otherSessionId = uniqueSessionId('neg-diff-other');
+    const controlPid = spawnMarked({ AGENT_CONSOLE_SESSION_ID: otherSessionId });
+    await new Promise((r) => setTimeout(r, 200));
+
+    const result = await runSweepScript(targetSessionId);
+
+    expect(result.killedCount).toBe(0);
+    expect(await procAlive(controlPid)).toBe(true);
+  });
+
+  it('escalates to SIGKILL for a marked process that ignores SIGTERM (trap TERM)', async () => {
+    const sessionId = uniqueSessionId('trap-term');
+    const trapProc = Bun.spawn(['sh', '-c', "trap '' TERM; while :; do :; done"], {
+      env: { ...process.env, AGENT_CONSOLE_SESSION_ID: sessionId },
+    });
+    spawnedPids.push(trapProc.pid);
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await procAlive(trapProc.pid)).toBe(true);
+
+    const sweepPromise = runSweepScript(sessionId);
+
+    // Mid-grace-window assertion: SIGTERM was sent and ignored, so the
+    // process must still be alive shortly before the grace period elapses.
+    // This proves the process survives the TERM-only window rather than
+    // just happening to die at some point during the whole sweep call.
+    await new Promise((r) => setTimeout(r, TEST_KILL_GRACE_MS - 100));
+    expect(await procAlive(trapProc.pid)).toBe(true);
+
+    const result = await sweepPromise;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.killedCount).toBe(1);
+    expect(await waitUntilGone(trapProc.pid, 3000)).toBe(true);
+  });
+
+  it('self-exclusion: the sweep script never signals its own pid, even when its own env matches the marker it is searching for', async () => {
+    const sessionId = uniqueSessionId('self');
+
+    // The sweep script's OWN process legitimately carries the very marker
+    // it is searching for (AGENT_CONSOLE_SESSION_ID=sessionId is set on
+    // this spawn's own env). If self-exclusion were broken, the script
+    // would send itself SIGTERM mid-loop and die before ever printing
+    // SWEPT= -- a strong, deterministic proof of self-exclusion.
+    const result = await runSweepScript(sessionId, {
+      extraEnv: { AGENT_CONSOLE_SESSION_ID: sessionId },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('SWEPT=');
+    expect(result.killedCount).toBe(0);
+  });
+
+  it('environ read failures (ENOENT/EACCES) in the scan do not crash the loop, and a real matching entry later in glob order is still killed', async () => {
+    const sessionId = uniqueSessionId('scratch');
+    // Manually-constructed unique path (not `fsPromises.mkdtemp`) + real
+    // `mkdir`/`Bun.write` primitives below -- see `procAlive`'s doc comment
+    // above for why `node:fs`/`node:fs/promises` are avoided in this file.
+    const scratchDir = path.join(tmpdir(), `orphan-sweep-test-${randomUUID()}`);
+    const badEnviron = path.join(scratchDir, '888888', 'environ');
+
+    // Real process to be discovered via the scratch override root. Its own
+    // real /proc/<pid>/environ is irrelevant to this test -- only the
+    // constructed override entry (below) needs to match, since the scan
+    // phase reads from SWEEP_PROC_ROOT, not the real /proc.
+    const realPid = spawnMarked(undefined);
+    await new Promise((r) => setTimeout(r, 200));
+
+    try {
+      // (a) ENOENT/race simulation: a numeric pid directory with no
+      // `environ` file. The glob itself will not produce this path (no
+      // file exists there), so this entry is silently absent from
+      // iteration -- documents the expected shape rather than exercising
+      // a distinct code branch.
+      await mkdirReal(path.join(scratchDir, '999999'));
+
+      // (b) EACCES simulation: an `environ` file that exists but is
+      // unreadable by this test process. `Bun.write` auto-creates parent
+      // directories, so no separate mkdir call is needed here.
+      await Bun.write(badEnviron, `AGENT_CONSOLE_SESSION_ID=${sessionId}\0`);
+      await chmodReal(badEnviron, '000');
+
+      // (c) a real running process's pid, with a constructed matching
+      // `environ` file at the override root -- NUL-separated KEY=VALUE
+      // records, mirroring the real /proc/<pid>/environ format.
+      const realEnviron = path.join(scratchDir, String(realPid), 'environ');
+      await Bun.write(realEnviron, `AGENT_CONSOLE_SESSION_ID=${sessionId}\0OTHER=1\0`);
+
+      const result = await runSweepScript(sessionId, { procRootOverride: scratchDir });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.killedCount).toBe(1);
+      expect(await waitUntilGone(realPid, 3000)).toBe(true);
+    } finally {
+      await chmodReal(badEnviron, '600');
+      await rmRecursiveReal(scratchDir);
+    }
+  });
+});

--- a/packages/server/src/services/__tests__/orphan-process-sweeper.test.ts
+++ b/packages/server/src/services/__tests__/orphan-process-sweeper.test.ts
@@ -106,6 +106,31 @@ describe('sweepOrphanProcesses (unit, injected runAsUserImpl fake)', () => {
     expect(calls[0]?.timeoutMs).toBe(12345);
   });
 
+  it('delivers the multi-line sweep script via stdin, with command fixed to the single-line "sh -s" (never embeds the script in argv/command)', async () => {
+    // Regression test: the elevated `sudo -u <user> --preserve-env=... -i sh
+    // -c <command>` path re-joins its trailing argv into a single command
+    // line for the target login shell, collapsing embedded newlines in a
+    // multi-line `command` string -- this broke `for ... do ... done` on a
+    // real dogfood host (observed: `sh: 1: Syntax error: "do" unexpected`).
+    // `command` must therefore stay single-line ("sh -s", which reads its
+    // script from stdin); the actual multi-line script travels over
+    // `stdin`, a channel immune to the argv-join.
+    const calls: Array<Parameters<typeof runAsUser>[0]> = [];
+    const fake: typeof runAsUser = async (opts) => {
+      calls.push(opts);
+      return okResult({ stdout: 'SWEPT=0\n' });
+    };
+
+    await sweepOrphanProcesses('sess-1', 'target-user', {
+      runAsUserImpl: fake,
+      killGraceMs: 2000,
+    });
+
+    expect(calls[0]?.command).toBe('sh -s');
+    expect(calls[0]?.command).not.toContain('\n');
+    expect(calls[0]?.stdin).toBe(buildSweepScript('sess-1', { killGraceMs: 2000 }));
+  });
+
   it('forwards procRootOverride as a SWEEP_PROC_ROOT env var', async () => {
     const calls: Array<Parameters<typeof runAsUser>[0]> = [];
     const fake: typeof runAsUser = async (opts) => {

--- a/packages/server/src/services/__tests__/session-initialization-service.test.ts
+++ b/packages/server/src/services/__tests__/session-initialization-service.test.ts
@@ -14,6 +14,7 @@ import { InvalidSessionDataScopeError } from '../../lib/session-data-path.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { SessionInitializationService } from '../session-initialization-service.js';
 import type { killAsUser, RunAsUserResult } from '../privilege-elevation.js';
+import type { sweepOrphanProcesses } from '../orphan-process-sweeper.js';
 import {
   buildPersistedQuickSession,
   buildPersistedAgentWorker,
@@ -29,6 +30,18 @@ const ELEVATED_TEST_USERNAME = `not-${os.userInfo().username}`;
 function okResult(overrides: Partial<RunAsUserResult> = {}): RunAsUserResult {
   return { stdout: '', stderr: '', exitCode: 0, timedOut: false, ...overrides };
 }
+
+// The real `sweepOrphanProcesses` spawns a real elevated-shell subprocess
+// that scans /proc. Tests exercising `initialize()` / `initializeSessions()`
+// / `cleanupOrphanProcesses()` do not want that side effect by default (it
+// would slow down and pollute otherwise-fast, isolated unit tests) --
+// `createService()` and the integration-describe factories below default to
+// this no-op fake unless a test explicitly overrides `sweepOrphanProcessesImpl`
+// to assert on the wiring itself.
+const noopSweepOrphanProcessesImpl: typeof sweepOrphanProcesses = async () => ({
+  killedCount: 0,
+  raw: okResult(),
+});
 
 const TEST_SERVER_PID = 99999;
 
@@ -102,6 +115,7 @@ describe('SessionInitializationService', () => {
     inMemorySessionIds?: Set<string>;
     jobQueue?: JobQueue | null;
     resolveSpawnUsername?: (createdBy?: string) => Promise<string>;
+    sweepOrphanProcessesImpl?: typeof sweepOrphanProcesses;
   }) {
     const sessionRepository = createMockSessionRepository(options.sessions);
     const workerOutputFileManager = createMockWorkerOutputFileManager();
@@ -118,6 +132,7 @@ describe('SessionInitializationService', () => {
       baseDirForPersistedSession: () => '/test/config/_quick',
       getServerPid: () => TEST_SERVER_PID,
       resolveSpawnUsername: options.resolveSpawnUsername ?? defaultResolveSpawnUsername,
+      sweepOrphanProcessesImpl: options.sweepOrphanProcessesImpl ?? noopSweepOrphanProcessesImpl,
     });
 
     return { service, sessionRepository, workerOutputFileManager, jobQueue };
@@ -665,6 +680,291 @@ describe('SessionInitializationService', () => {
     });
   });
 
+  // ============================================================
+  // sweepSessionProcesses (static) — Issue #1197 Part B
+  // ============================================================
+  describe('sweepSessionProcesses (static)', () => {
+    it('resolves the spawn username and calls sweepImpl with (session.id, resolvedUsername)', async () => {
+      const session = buildPersistedQuickSession({
+        id: 'session-1',
+        locationPath: '/some/path',
+        createdBy: 'user-1',
+      });
+
+      const calls: Array<[string, string | null | undefined]> = [];
+      const fakeSweep: typeof sweepOrphanProcesses = async (
+        sessionId,
+        username,
+      ) => {
+        calls.push([sessionId, username]);
+        return { killedCount: 0, raw: okResult() };
+      };
+
+      const count = await SessionInitializationService.sweepSessionProcesses(
+        session,
+        async (createdBy) => createdBy ?? 'server-user',
+        { sweepImpl: fakeSweep },
+      );
+
+      expect(count).toBe(0);
+      expect(calls).toEqual([['session-1', 'user-1']]);
+    });
+
+    it('returns killedCount from a successful sweep', async () => {
+      const session = buildPersistedQuickSession({ id: 'session-1', locationPath: '/some/path' });
+      const fakeSweep: typeof sweepOrphanProcesses = async () => ({
+        killedCount: 3,
+        raw: okResult(),
+      });
+
+      const count = await SessionInitializationService.sweepSessionProcesses(
+        session,
+        async () => 'user',
+        { sweepImpl: fakeSweep },
+      );
+
+      expect(count).toBe(3);
+    });
+
+    it('returns 0 and does not throw when the sweep reports a non-zero exit code', async () => {
+      const session = buildPersistedQuickSession({ id: 'session-1', locationPath: '/some/path' });
+      const fakeSweep: typeof sweepOrphanProcesses = async () => ({
+        killedCount: 0,
+        raw: okResult({ exitCode: 1, stderr: 'boom' }),
+      });
+
+      let thrown: unknown;
+      let count = -1;
+      try {
+        count = await SessionInitializationService.sweepSessionProcesses(
+          session,
+          async () => 'user',
+          { sweepImpl: fakeSweep },
+        );
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeUndefined();
+      expect(count).toBe(0);
+    });
+
+    it('returns 0 and does not throw when the sweep times out (timedOut takes precedence over a non-zero killedCount)', async () => {
+      const session = buildPersistedQuickSession({ id: 'session-1', locationPath: '/some/path' });
+      // killedCount:5 alongside timedOut:true is intentionally
+      // contradictory-looking input -- proves the timedOut check is
+      // consulted rather than blindly trusting a parsed killedCount,
+      // mirroring killOrphanWorkers's analogous timedOut-polarity test.
+      const fakeSweep: typeof sweepOrphanProcesses = async () => ({
+        killedCount: 5,
+        raw: okResult({ timedOut: true, exitCode: 0 }),
+      });
+
+      const count = await SessionInitializationService.sweepSessionProcesses(
+        session,
+        async () => 'user',
+        { sweepImpl: fakeSweep },
+      );
+
+      expect(count).toBe(0);
+    });
+
+    it('returns 0 and does not throw when sweepImpl itself throws', async () => {
+      const session = buildPersistedQuickSession({ id: 'session-1', locationPath: '/some/path' });
+      const fakeSweep: typeof sweepOrphanProcesses = async () => {
+        throw new Error('spawn failed');
+      };
+
+      let thrown: unknown;
+      let count = -1;
+      try {
+        count = await SessionInitializationService.sweepSessionProcesses(
+          session,
+          async () => 'user',
+          { sweepImpl: fakeSweep },
+        );
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeUndefined();
+      expect(count).toBe(0);
+    });
+
+    it('defaults to the real sweepOrphanProcesses when sweepImpl is not provided', async () => {
+      // Sanity check that the default wiring (opts.sweepImpl ?? sweepOrphanProcesses)
+      // is actually in place -- exercised with a username equal to the
+      // server-process user so `shouldElevateForUser` bypasses elevation and
+      // this stays a fast, local `sh -c` invocation with no real orphan
+      // candidates (a fresh random sessionId matches nothing in /proc).
+      const session = buildPersistedQuickSession({
+        id: `sweep-default-${Date.now()}`,
+        locationPath: '/some/path',
+      });
+
+      const count = await SessionInitializationService.sweepSessionProcesses(
+        session,
+        async () => os.userInfo().username,
+      );
+
+      expect(count).toBe(0);
+    });
+  });
+
+  // ============================================================
+  // sweepSessionProcesses wiring at the initializeSessions /
+  // cleanupOrphanProcesses call sites — Issue #1197 Part B
+  // ============================================================
+  describe('sweepSessionProcesses wiring (via initialize)', () => {
+    it('calls sweepImpl once for a session with a dead serverPid (initializeSessions path)', async () => {
+      const session = buildPersistedQuickSession({
+        id: 'session-1',
+        locationPath: '/some/path',
+        serverPid: 12345,
+        createdBy: 'user-1',
+      });
+      // serverPid 12345 is dead (not marked alive)
+
+      const calls: Array<[string, string | null | undefined]> = [];
+      const fakeSweep: typeof sweepOrphanProcesses = async (
+        sessionId,
+        username,
+      ) => {
+        calls.push([sessionId, username]);
+        return { killedCount: 0, raw: okResult() };
+      };
+
+      const { service } = createService({ sessions: [session], sweepOrphanProcessesImpl: fakeSweep });
+      await service.initialize();
+
+      expect(calls).toEqual([['session-1', 'user-1']]);
+    });
+
+    it('calls sweepImpl once for an orphan session with a dead serverPid (cleanupOrphanProcesses path)', async () => {
+      const orphanSession: PersistedSession = {
+        id: 'orphan-1',
+        type: 'worktree',
+        locationPath: '/some/path',
+        repositoryId: 'repo-1',
+        worktreeId: 'main',
+        serverPid: 88888, // dead pid (not marked alive)
+        pausedAt: '2024-01-01T01:00:00.000Z', // paused -> preserved by initializeSessions
+        createdAt: '2026-01-01T00:00:00.000Z',
+        workers: [],
+        createdBy: 'user-2',
+      };
+
+      const calls: Array<[string, string | null | undefined]> = [];
+      const fakeSweep: typeof sweepOrphanProcesses = async (
+        sessionId,
+        username,
+      ) => {
+        calls.push([sessionId, username]);
+        return { killedCount: 0, raw: okResult() };
+      };
+
+      const { service } = createService({ sessions: [orphanSession], sweepOrphanProcessesImpl: fakeSweep });
+      await service.initialize();
+
+      expect(calls).toEqual([['orphan-1', 'user-2']]);
+    });
+
+    it('boundary: an empty session list results in zero sweepImpl calls', async () => {
+      const calls: unknown[] = [];
+      const fakeSweep: typeof sweepOrphanProcesses = async (...args) => {
+        calls.push(args);
+        return { killedCount: 0, raw: okResult() };
+      };
+
+      const { service } = createService({ sessions: [], sweepOrphanProcessesImpl: fakeSweep });
+      await service.initialize();
+
+      expect(calls).toEqual([]);
+    });
+
+    it('boundary: sessions that never reach the orphan-worker-kill branch (live server, paused) result in zero sweepImpl calls', async () => {
+      const liveSession = buildPersistedQuickSession({
+        id: 'live-session',
+        locationPath: '/some/path',
+        serverPid: 55555,
+      });
+      mockProcess.markAlive(55555);
+
+      const pausedSession = buildPersistedQuickSession({
+        id: 'paused-session',
+        locationPath: '/some/path',
+        serverPid: null,
+        pausedAt: '2024-01-01T01:00:00.000Z',
+      });
+
+      const calls: unknown[] = [];
+      const fakeSweep: typeof sweepOrphanProcesses = async (...args) => {
+        calls.push(args);
+        return { killedCount: 0, raw: okResult() };
+      };
+
+      const { service } = createService({
+        sessions: [liveSession, pausedSession],
+        sweepOrphanProcessesImpl: fakeSweep,
+      });
+      await service.initialize();
+
+      expect(calls).toEqual([]);
+    });
+
+    it('a non-zero-exit sweep result does not throw and does not abort session initialization', async () => {
+      const session = buildPersistedQuickSession({
+        id: 'session-1',
+        locationPath: '/some/path',
+        serverPid: 12345,
+      });
+
+      const fakeSweep: typeof sweepOrphanProcesses = async () => ({
+        killedCount: 0,
+        raw: okResult({ exitCode: 1, stderr: 'sweep failed' }),
+      });
+
+      const { service } = createService({ sessions: [session], sweepOrphanProcessesImpl: fakeSweep });
+
+      let thrown: unknown;
+      let autoResumeIds: string[] = [];
+      try {
+        autoResumeIds = await service.initialize();
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeUndefined();
+      expect(autoResumeIds).toContain('session-1');
+    });
+
+    it('a timed-out sweep result does not throw and does not abort session initialization', async () => {
+      const session = buildPersistedQuickSession({
+        id: 'session-1',
+        locationPath: '/some/path',
+        serverPid: 12345,
+      });
+
+      const fakeSweep: typeof sweepOrphanProcesses = async () => ({
+        killedCount: 0,
+        raw: okResult({ timedOut: true, exitCode: 137 }),
+      });
+
+      const { service } = createService({ sessions: [session], sweepOrphanProcessesImpl: fakeSweep });
+
+      let thrown: unknown;
+      let autoResumeIds: string[] = [];
+      try {
+        autoResumeIds = await service.initialize();
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeUndefined();
+      expect(autoResumeIds).toContain('session-1');
+    });
+  });
+
   describe('initialize with empty data', () => {
     it('should handle empty session list without errors and return empty array', async () => {
       const { service } = createService({ sessions: [] });
@@ -792,6 +1092,7 @@ describe('SessionInitializationService integration (real DB → mapper → servi
       baseDirForPersistedSession: () => '/test/config/_quick',
       getServerPid: () => TEST_SERVER_PID,
       resolveSpawnUsername: async (createdBy) => createdBy ?? 'test-server-user',
+      sweepOrphanProcessesImpl: noopSweepOrphanProcessesImpl,
     });
 
     return { service };
@@ -871,6 +1172,7 @@ describe('SessionInitializationService integration (real DB → mapper → servi
         },
         getServerPid: () => TEST_SERVER_PID,
         resolveSpawnUsername: async (createdBy) => createdBy ?? 'test-server-user',
+      sweepOrphanProcessesImpl: noopSweepOrphanProcessesImpl,
       });
       return { service };
     }

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -21,6 +21,7 @@ import { UsernameLookupService } from '../username-lookup.js';
 import type { UserRepository } from '../../repositories/user-repository.js';
 import type { AuthUser } from '@agent-console/shared';
 import type { SpawnAsUserFn } from '../privilege-elevation.js';
+import type { sweepOrphanProcesses } from '../orphan-process-sweeper.js';
 import { McpTokenRegistry } from '../../mcp/mcp-auth.js';
 
 // Test config directory
@@ -4621,10 +4622,18 @@ describe('SessionManager', () => {
     // since it is also never loaded into `this.sessions`, it is picked up by
     // the LATER `cleanupOrphanProcesses()` pass instead (dead serverPid +
     // not in-memory -- no comparison to the new server's own pid is
-    // involved), which is the ONLY caller of
+    // involved), which is the ONLY code path calling
     // `resolveSpawnUsername(session.createdBy)` for this session. This
     // isolates the assertion to precisely the SessionInitializationService
     // wiring this PR adds, with no auto-resume confound.
+    //
+    // Issue #1197 Part B added a second, independent caller at the exact
+    // same call site: `sweepSessionProcesses` (the SESSION_ID marker sweep)
+    // also resolves `session.createdBy` via the same injected
+    // `resolveSpawnUsername`, immediately after `killOrphanWorkers` does.
+    // Both helpers resolve independently rather than sharing one resolved
+    // value, so this test now expects the SAME username resolved TWICE
+    // during restart-triggered orphan cleanup for this one session.
     it('resolves session.createdBy via the injected userRepository during restart-triggered orphan cleanup', async () => {
       const findByIdCalls: string[] = [];
       const stubUserRepo: UserRepository = {
@@ -4640,6 +4649,16 @@ describe('SessionManager', () => {
         },
       };
 
+      // This test's purpose is exclusively to verify resolveSpawnUsername's
+      // call count/args, not the sweep's own behavior -- inject a no-op fake
+      // so it doesn't also spawn a real subprocess (`sweepOrphanProcesses`
+      // always spawns one regardless of AUTH_MODE, unlike killOrphanWorkers's
+      // cheap in-process non-elevated fallback).
+      const noopSweepOrphanProcessesImpl: typeof sweepOrphanProcesses = async () => ({
+        killedCount: 0,
+        raw: { stdout: '', stderr: '', exitCode: 0, timedOut: false },
+      });
+
       const module1 = await import(`../session-manager.js?v=${++importCounter}`);
       const manager = await module1.SessionManager.create({
         userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
@@ -4650,6 +4669,7 @@ describe('SessionManager', () => {
         repositoryLookup: defaultRepositoryLookup,
         repositoryEnvLookup: defaultRepositoryEnvLookup,
         userRepository: stubUserRepo,
+        sweepOrphanProcessesImpl: noopSweepOrphanProcessesImpl,
       });
 
       const session = await manager.createSession(
@@ -4686,9 +4706,10 @@ describe('SessionManager', () => {
       const callsBeforeRestart = findByIdCalls.length;
 
       // Simulate server restart with the SAME stub userRepository injected.
-      // cleanupOrphanProcesses() -> killOrphanWorkers() calls
-      // resolveSpawnUsername(session.createdBy) once for this session, which
-      // must route through this repository.
+      // cleanupOrphanProcesses() calls resolveSpawnUsername(session.createdBy)
+      // TWICE for this session -- once via killOrphanWorkers, once via
+      // sweepSessionProcesses (Issue #1197 Part B) -- both of which must
+      // route through this repository.
       mockProcess.markDead(process.pid);
       const module2 = await import(`../session-manager.js?v=${++importCounter}`);
       await module2.SessionManager.create({
@@ -4700,10 +4721,11 @@ describe('SessionManager', () => {
         repositoryLookup: defaultRepositoryLookup,
         repositoryEnvLookup: defaultRepositoryEnvLookup,
         userRepository: stubUserRepo,
+        sweepOrphanProcessesImpl: noopSweepOrphanProcessesImpl,
       });
 
       const callsDuringRestart = findByIdCalls.slice(callsBeforeRestart);
-      expect(callsDuringRestart).toEqual(['user-alice-uuid']);
+      expect(callsDuringRestart).toEqual(['user-alice-uuid', 'user-alice-uuid']);
     });
   });
 

--- a/packages/server/src/services/orphan-process-sweeper.ts
+++ b/packages/server/src/services/orphan-process-sweeper.ts
@@ -19,7 +19,11 @@
  * This module composes a single POSIX `sh` script that does scan + match +
  * kill in one invocation and hands it to `runAsUser` so the whole thing
  * executes as the resolved session owner, mirroring the elevation semantics
- * of `killAsUser` / `rmRecursiveAsUser`.
+ * of `killAsUser` / `rmRecursiveAsUser`. The script is delivered over
+ * `runAsUser`'s stdin channel (`command: 'sh -s'`), not embedded in the
+ * elevated command line -- see `sweepOrphanProcesses`'s inline comment and
+ * `.claude/rules/elevation-helpers.md` "Multi-line elevated commands" for
+ * why.
  *
  * Strict-thin-wrapper contract (`.claude/rules/elevation-helpers.md`):
  * `sweepOrphanProcesses` does not throw on a non-zero exit code or a
@@ -189,9 +193,21 @@ export async function sweepOrphanProcesses(
   const killGraceMs = opts.killGraceMs ?? DEFAULT_KILL_GRACE_MS;
   const script = buildSweepScript(sessionId, { killGraceMs });
 
+  // The elevated `sudo -u <user> --preserve-env=... -i sh -c <innerCommand>`
+  // path re-joins its trailing argv into a single command line for the
+  // target login shell -- a multi-line `command` string embedded directly
+  // in argv gets its internal newlines collapsed, breaking multi-statement
+  // shell constructs (e.g. `for ... do ... done` loses the newline that
+  // separates `do` from the previous statement, producing a syntax error).
+  // Deliver the (multi-line) sweep script over stdin instead: `command` is
+  // the single-line `sh -s` (reads its script from stdin), which is immune
+  // to the argv-join because it never contains an embedded newline itself.
+  // See ".claude/rules/elevation-helpers.md" "Multi-line elevated commands"
+  // for the general pattern this establishes.
   const raw = await impl({
     username,
-    command: script,
+    command: 'sh -s',
+    stdin: script,
     cwd: '/',
     timeoutMs: opts.timeoutMs,
     env: opts.procRootOverride ? { SWEEP_PROC_ROOT: opts.procRootOverride } : undefined,

--- a/packages/server/src/services/orphan-process-sweeper.ts
+++ b/packages/server/src/services/orphan-process-sweeper.ts
@@ -1,5 +1,5 @@
 /**
- * Tree-wide orphan-process sweep by SESSION_ID env marker (Issue #1197 Part B).
+ * Tree-wide orphan-process sweep by SESSION_ID env marker.
  *
  * `SessionInitializationService.killOrphanWorkers` only kills processes
  * tracked via a session's persisted `worker.pid` -- the direct PTY wrapper

--- a/packages/server/src/services/orphan-process-sweeper.ts
+++ b/packages/server/src/services/orphan-process-sweeper.ts
@@ -1,0 +1,209 @@
+/**
+ * Tree-wide orphan-process sweep by SESSION_ID env marker (Issue #1197 Part B).
+ *
+ * `SessionInitializationService.killOrphanWorkers` only kills processes
+ * tracked via a session's persisted `worker.pid` -- the direct PTY wrapper
+ * process. Detached / background descendant processes spawned by a worker
+ * (e.g. a worker's `bun run dev` child, an MCP subprocess) are never in that
+ * PID set and leak forever across server restarts. Every worker process in
+ * this codebase already carries `AGENT_CONSOLE_SESSION_ID=<sessionId>` in its
+ * environment (set at PTY spawn time in `user-mode.ts`, inherited by every
+ * descendant process). This module scans `/proc/[pid]/environ` for that
+ * marker, tree-wide, regardless of whether a pid was ever recorded as a
+ * `worker.pid`.
+ *
+ * Multi-user constraint: `/proc/<pid>/environ` for another OS user's process
+ * is not readable by the server process (EACCES). The scan (which requires
+ * reading `environ` to match) MUST therefore run AS the target user -- a
+ * "scan as server, then kill as elevated user" two-step is not possible.
+ * This module composes a single POSIX `sh` script that does scan + match +
+ * kill in one invocation and hands it to `runAsUser` so the whole thing
+ * executes as the resolved session owner, mirroring the elevation semantics
+ * of `killAsUser` / `rmRecursiveAsUser`.
+ *
+ * Strict-thin-wrapper contract (`.claude/rules/elevation-helpers.md`):
+ * `sweepOrphanProcesses` does not throw on a non-zero exit code or a
+ * timeout -- it returns the underlying `RunAsUserResult` unchanged so the
+ * caller decides what a failure means. This module's own caller,
+ * `SessionInitializationService`, treats a failed sweep as best-effort and
+ * only logs a warn (the already-tested `killOrphanWorkers` path remains the
+ * primary cleanup mechanism; this sweep is a broader net on top of it).
+ */
+import { runAsUser, shellEscape, type RunAsUserResult } from './privilege-elevation.js';
+import { createLogger } from '../lib/logger.js';
+
+const logger = createLogger('service:orphan-process-sweeper');
+
+/**
+ * Grace period between sending SIGTERM to a matched candidate and
+ * escalating to SIGKILL if it is still alive. Mirrors
+ * `packages/embedded-agent/src/tools/bash.ts`'s `KILL_GRACE_MS`.
+ */
+const DEFAULT_KILL_GRACE_MS = 2_000;
+
+export interface SweepOrphanProcessesOpts {
+  timeoutMs?: number;
+  /** DI seam mirroring `rmRecursiveAsUser` / `killAsUser`. */
+  runAsUserImpl?: typeof runAsUser;
+  /** Grace period (ms) between SIGTERM and SIGKILL escalation. Default 2000ms. */
+  killGraceMs?: number;
+  /**
+   * Test-only override for the `/proc` root used during the SCAN phase
+   * (candidate discovery + marker matching). Production always omits this
+   * (defaults to real `/proc`). Liveness checks and the post-TERM re-match
+   * during the escalation phase always use the real `/proc`, independent of
+   * this override -- liveness is a kernel fact, not a function of where the
+   * scan looked for markers.
+   */
+  procRootOverride?: string;
+}
+
+export interface SweepOrphanProcessesResult {
+  killedCount: number;
+  /** Unchanged `RunAsUserResult` -- see strict-thin-wrapper contract above. */
+  raw: RunAsUserResult;
+}
+
+/**
+ * Build the POSIX `sh` sweep script for `sessionId`.
+ *
+ * Phases:
+ * 1. Scan each numeric pid directory's `environ` file under
+ *    `$SWEEP_PROC_ROOT` (default `/proc`), excluding the script's own pid
+ *    (`$$`). For each candidate whose `environ` file
+ *    contains an EXACT `AGENT_CONSOLE_SESSION_ID=<id>` record (matched via
+ *    `grep -Fxz`, i.e. a fixed-string whole-record match under NUL-delimited
+ *    "lines" -- not a substring match, and not vulnerable to regex
+ *    metacharacters in `sessionId`), send SIGTERM immediately in the same
+ *    loop iteration (minimizing the PID-reuse race window per candidate) and
+ *    remember the pid.
+ * 2. After a `killGraceMs` grace period, for each SIGTERM'd pid that is
+ *    still alive (checked against the REAL `/proc`, never the scan-phase
+ *    override), RE-READ and RE-MATCH its `environ` (defense against PID
+ *    reuse: a different process may have taken that pid number during the
+ *    grace window and must not be blindly killed) before sending SIGKILL.
+ *    A race remains possible inside this re-check window itself; that
+ *    residual risk is accepted, same class as a pkill-by-attribute race.
+ *    `kill(2)` only sends the signal -- termination is asynchronous -- so a
+ *    bounded poll (up to ~1s, in 100ms steps) follows the SIGKILL pass
+ *    before tallying, to avoid undercounting a kill that has been sent but
+ *    has not yet landed under host scheduling load.
+ * 3. Print exactly one `SWEPT=<n>` line: the number of SIGTERM'd pids that
+ *    are confirmed gone (real `/proc/$pid` no longer exists) after the
+ *    escalation pass.
+ *
+ * A permission-denied or vanished `environ` read never aborts the loop (no
+ * `set -e`; grep's stderr is discarded and a non-zero exit is treated as
+ * "no match, move on").
+ *
+ * @internal Exported for testing.
+ */
+export function buildSweepScript(sessionId: string, opts: { killGraceMs: number }): string {
+  const marker = shellEscape(`AGENT_CONSOLE_SESSION_ID=${sessionId}`);
+  const graceSeconds = (opts.killGraceMs / 1000).toString();
+
+  return [
+    'set -u',
+    'self_pid=$$',
+    `marker=${marker}`,
+    'proc_root="${SWEEP_PROC_ROOT:-/proc}"',
+    'term_pids=""',
+    'for envfile in "$proc_root"/[0-9]*/environ; do',
+    '  [ -e "$envfile" ] || continue',
+    '  pid=${envfile%/environ}',
+    '  pid=${pid##*/}',
+    '  [ "$pid" = "$self_pid" ] && continue',
+    '  if grep -Fxzq -- "$marker" "$envfile" 2>/dev/null; then',
+    '    kill -s TERM -- "$pid" 2>/dev/null',
+    '    term_pids="$term_pids $pid"',
+    '  fi',
+    'done',
+    'if [ -n "$term_pids" ]; then',
+    `  sleep ${graceSeconds}`,
+    '  for pid in $term_pids; do',
+    '    if [ -d "/proc/$pid" ]; then',
+    '      if grep -Fxzq -- "$marker" "/proc/$pid/environ" 2>/dev/null; then',
+    '        kill -s KILL -- "$pid" 2>/dev/null',
+    '      fi',
+    '    fi',
+    '  done',
+    '  # kill(2) only sends the signal -- SIGKILL termination is asynchronous',
+    '  # and, under host scheduling load, can lag the kill() call by up to',
+    '  # roughly a second for a CPU-spinning target. Poll briefly (bounded)',
+    '  # instead of tallying immediately, so the SWEPT count below does not',
+    '  # undercount a kill that has been sent but has not yet landed.',
+    '  poll_i=0',
+    '  while [ "$poll_i" -lt 10 ]; do',
+    '    any_alive=0',
+    '    for pid in $term_pids; do',
+    '      [ -d "/proc/$pid" ] && any_alive=1',
+    '    done',
+    '    [ "$any_alive" -eq 0 ] && break',
+    '    sleep 0.1',
+    '    poll_i=$((poll_i + 1))',
+    '  done',
+    'fi',
+    'killed=0',
+    'for pid in $term_pids; do',
+    '  [ -d "/proc/$pid" ] || killed=$((killed + 1))',
+    'done',
+    'echo "SWEPT=$killed"',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Parse the `SWEPT=<n>` line printed by {@link buildSweepScript}'s output.
+ * Returns 0 on missing or malformed output. Pure -- does not log; callers
+ * that want to distinguish "genuinely 0" from "could not parse" should
+ * inspect the raw stdout themselves (see {@link sweepOrphanProcesses}).
+ *
+ * @internal Exported for testing.
+ */
+export function parseSweptCount(stdout: string): number {
+  const matches = [...stdout.matchAll(/^SWEPT=(\d+)\s*$/gm)];
+  if (matches.length === 0) return 0;
+  const last = matches[matches.length - 1];
+  const n = Number(last[1]);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Sweep every process (tree-wide, not limited to tracked `worker.pid`
+ * values) whose environment carries `AGENT_CONSOLE_SESSION_ID=<sessionId>`,
+ * as `username` (elevating via `runAsUser` when necessary).
+ *
+ * Does NOT throw on a non-zero exit code or a timeout -- see the
+ * strict-thin-wrapper contract in the module docs above.
+ */
+export async function sweepOrphanProcesses(
+  sessionId: string,
+  username: string | null | undefined,
+  opts: SweepOrphanProcessesOpts = {},
+): Promise<SweepOrphanProcessesResult> {
+  if (sessionId.length === 0) {
+    throw new Error('sweepOrphanProcesses: sessionId must be a non-empty string');
+  }
+
+  const impl = opts.runAsUserImpl ?? runAsUser;
+  const killGraceMs = opts.killGraceMs ?? DEFAULT_KILL_GRACE_MS;
+  const script = buildSweepScript(sessionId, { killGraceMs });
+
+  const raw = await impl({
+    username,
+    command: script,
+    cwd: '/',
+    timeoutMs: opts.timeoutMs,
+    env: opts.procRootOverride ? { SWEEP_PROC_ROOT: opts.procRootOverride } : undefined,
+  });
+
+  const killedCount = parseSweptCount(raw.stdout);
+  if (killedCount === 0 && !/^SWEPT=\d+\s*$/m.test(raw.stdout)) {
+    logger.warn(
+      { sessionId, exitCode: raw.exitCode, timedOut: raw.timedOut, stdout: raw.stdout, stderr: raw.stderr },
+      'sweepOrphanProcesses: could not find a well-formed SWEPT=<n> line in script output',
+    );
+  }
+
+  return { killedCount, raw };
+}

--- a/packages/server/src/services/session-initialization-service.ts
+++ b/packages/server/src/services/session-initialization-service.ts
@@ -12,6 +12,7 @@ import { isProcessAlive, processKill } from '../lib/process-utils.js';
 import { createLogger } from '../lib/logger.js';
 import { isErrnoException } from '../lib/type-guards.js';
 import { killAsUser, shouldElevateForUser } from './privilege-elevation.js';
+import { sweepOrphanProcesses } from './orphan-process-sweeper.js';
 
 const logger = createLogger('session-initialization');
 
@@ -23,6 +24,15 @@ const logger = createLogger('session-initialization');
  * command while still bounding the worst case.
  */
 const KILL_AS_USER_TIMEOUT_MS = 10_000;
+
+/**
+ * Generous bound for the SESSION_ID marker sweep script (Issue #1197 Part
+ * B). Unlike a single `kill -s <SIG> -- <pid>` command, the sweep script
+ * scans every numeric `/proc` entry, waits out a grace period (default
+ * 2s), then polls (up to ~1s) for the SIGKILL escalation to land -- so it
+ * needs materially more headroom than `KILL_AS_USER_TIMEOUT_MS`.
+ */
+const SWEEP_ORPHAN_PROCESSES_TIMEOUT_MS = 20_000;
 
 /** Callback to check if a session is already loaded in memory. */
 type SessionInMemoryChecker = (id: string) => boolean;
@@ -53,8 +63,33 @@ interface SessionInitializationDeps {
    * mode).
    */
   resolveSpawnUsername: (createdBy?: string) => Promise<string>;
+  /**
+   * Optional injection point for the SESSION_ID marker sweep (Issue #1197
+   * Part B). Defaults to the real `sweepOrphanProcesses` when omitted.
+   * Threaded through to `sweepSessionProcesses`'s own `sweepImpl` opt --
+   * exposed at the deps level (rather than only reachable via the static
+   * method's own opts) because `initializeSessions` / `cleanupOrphanProcesses`
+   * call `sweepSessionProcesses` through the instance, not directly, so
+   * tests exercising those instance methods need a seam here to avoid
+   * spawning real elevated-shell subprocesses.
+   */
+  sweepOrphanProcessesImpl?: typeof sweepOrphanProcesses;
 }
 
+/**
+ * Startup-only scope note (Issue #1197 Part B): `sweepSessionProcesses` is
+ * invoked from `initializeSessions` / `cleanupOrphanProcesses` ONLY --
+ * i.e. only at server-startup orphan recovery, alongside the existing
+ * `killOrphanWorkers` calls. It is deliberately NOT wired into
+ * `deleteSession`-time cleanup or `shutdownAppContext`: both of those
+ * paths already know precisely which pids/workers they are tearing down
+ * (no discovery problem to solve), and running a tree-wide `/proc` scan on
+ * every session delete or server shutdown would add elevated-shell latency
+ * to hot paths for no corresponding benefit. The marker sweep exists to
+ * catch processes that a normal (non-crash) teardown never loses track of
+ * in the first place -- it is a startup recovery mechanism, not a
+ * steady-state cleanup mechanism.
+ */
 export class SessionInitializationService {
   constructor(private readonly deps: SessionInitializationDeps) {}
 
@@ -199,6 +234,7 @@ export class SessionInitializationService {
     const orphanSessions: PersistedSession[] = [];
     const autoResumeSessionIds: string[] = [];
     let killedWorkerCount = 0;
+    let sweptProcessCount = 0;
     let pathNotFoundCount = 0;
 
     for (const session of persistedSessions) {
@@ -242,6 +278,17 @@ export class SessionInitializationService {
 
       // Kill any orphan worker processes first
       killedWorkerCount += await SessionInitializationService.killOrphanWorkers(session, this.deps.resolveSpawnUsername);
+
+      // Broader net: sweep any SESSION_ID-marked descendant processes that
+      // were never tracked as a `worker.pid` (Issue #1197 Part B). Runs
+      // unconditionally for every session reaching this point, regardless
+      // of whether killOrphanWorkers found anything -- that is the whole
+      // point of the sweep.
+      sweptProcessCount += await SessionInitializationService.sweepSessionProcesses(
+        session,
+        this.deps.resolveSpawnUsername,
+        { sweepImpl: this.deps.sweepOrphanProcessesImpl },
+      );
 
       // Save with serverPid=null but pausedAt=undefined to indicate auto-resume target
       const { pausedAt: _removed, ...sessionWithoutPausedAt } = session;
@@ -290,6 +337,7 @@ export class SessionInitializationService {
     logger.info({
       autoResumeSessions: autoResumeSessionIds.length,
       killedWorkerProcesses: killedWorkerCount,
+      sweptOrphanProcesses: sweptProcessCount,
       removedOrphanSessions: pathNotFoundCount,
       serverPid: currentServerPid,
     }, 'Initialized sessions from persistence');
@@ -306,6 +354,7 @@ export class SessionInitializationService {
     const persistedSessions = await this.deps.sessionRepository.findAll();
     const currentServerPid = this.deps.getServerPid();
     let killedCount = 0;
+    let sweptProcessCount = 0;
     let preservedCount = 0;
     const orphanSessions: PersistedSession[] = [];
 
@@ -332,6 +381,15 @@ export class SessionInitializationService {
 
       // Kill all workers in this session (only PTY workers have pid)
       killedCount += await SessionInitializationService.killOrphanWorkers(session, this.deps.resolveSpawnUsername);
+
+      // Broader net: sweep any SESSION_ID-marked descendant processes that
+      // were never tracked as a `worker.pid` (Issue #1197 Part B). Runs
+      // unconditionally for every orphan session reaching this point.
+      sweptProcessCount += await SessionInitializationService.sweepSessionProcesses(
+        session,
+        this.deps.resolveSpawnUsername,
+        { sweepImpl: this.deps.sweepOrphanProcessesImpl },
+      );
     }
 
     // Remove orphan sessions from persistence and delete output files
@@ -359,6 +417,7 @@ export class SessionInitializationService {
 
     logger.info({
       killedProcesses: killedCount,
+      sweptOrphanProcesses: sweptProcessCount,
       removedSessions: orphanSessions.length,
       preservedSessions: preservedCount,
       serverPid: currentServerPid,
@@ -443,5 +502,65 @@ export class SessionInitializationService {
       }
     }
     return killedCount;
+  }
+
+  /**
+   * Sweep any SESSION_ID-marked processes for a session, tree-wide -- not
+   * limited to the pids tracked as `worker.pid` (that narrower path is
+   * `killOrphanWorkers`, called immediately before this at both call
+   * sites). See `orphan-process-sweeper.ts`'s module docs for the full
+   * rationale and the scope-boundary note at the top of this file for why
+   * this is startup-only.
+   *
+   * Resolves the session's spawn username the same way `killOrphanWorkers`
+   * does (all workers in a session share the same spawn user) and always
+   * calls `sweepImpl` with that resolved username -- `sweepOrphanProcesses`
+   * / `runAsUser` handle the non-elevated bypass themselves when the
+   * resolved username equals the server-process user.
+   *
+   * Best-effort: never throws. A non-success result (non-zero exit code or
+   * a timeout) or a thrown error from `sweepImpl` is logged as a warn and
+   * treated as "swept 0" -- this sweep is a broader net layered on top of
+   * the already-tested `killOrphanWorkers` path, not the primary cleanup
+   * mechanism, so a failure here must not abort session initialization.
+   *
+   * @returns The number of processes actually swept (0 on any failure).
+   */
+  static async sweepSessionProcesses(
+    session: PersistedSession,
+    resolveSpawnUsername: (createdBy?: string) => Promise<string>,
+    opts: { sweepImpl?: typeof sweepOrphanProcesses } = {},
+  ): Promise<number> {
+    const sweep = opts.sweepImpl ?? sweepOrphanProcesses;
+    const username = await resolveSpawnUsername(session.createdBy);
+
+    try {
+      const result = await sweep(session.id, username, { timeoutMs: SWEEP_ORPHAN_PROCESSES_TIMEOUT_MS });
+      if (result.raw.timedOut || result.raw.exitCode !== 0) {
+        logger.warn(
+          {
+            sessionId: session.id,
+            exitCode: result.raw.exitCode,
+            timedOut: result.raw.timedOut,
+            stderr: result.raw.stderr,
+          },
+          'sweepSessionProcesses: sweep script reported a non-success result (best-effort, continuing)',
+        );
+        return 0;
+      }
+      if (result.killedCount > 0) {
+        logger.info(
+          { sessionId: session.id, killedCount: result.killedCount },
+          'sweepSessionProcesses: swept marker-tagged orphan processes not tracked by killOrphanWorkers',
+        );
+      }
+      return result.killedCount;
+    } catch (error) {
+      logger.warn(
+        { sessionId: session.id, err: error },
+        'sweepSessionProcesses: sweep threw (best-effort, continuing)',
+      );
+      return 0;
+    }
   }
 }

--- a/packages/server/src/services/session-initialization-service.ts
+++ b/packages/server/src/services/session-initialization-service.ts
@@ -26,8 +26,8 @@ const logger = createLogger('session-initialization');
 const KILL_AS_USER_TIMEOUT_MS = 10_000;
 
 /**
- * Generous bound for the SESSION_ID marker sweep script (Issue #1197 Part
- * B). Unlike a single `kill -s <SIG> -- <pid>` command, the sweep script
+ * Generous bound for the SESSION_ID marker sweep script. Unlike a single
+ * `kill -s <SIG> -- <pid>` command, the sweep script
  * scans every numeric `/proc` entry, waits out a grace period (default
  * 2s), then polls (up to ~1s) for the SIGKILL escalation to land -- so it
  * needs materially more headroom than `KILL_AS_USER_TIMEOUT_MS`.
@@ -64,8 +64,8 @@ interface SessionInitializationDeps {
    */
   resolveSpawnUsername: (createdBy?: string) => Promise<string>;
   /**
-   * Optional injection point for the SESSION_ID marker sweep (Issue #1197
-   * Part B). Defaults to the real `sweepOrphanProcesses` when omitted.
+   * Optional injection point for the SESSION_ID marker sweep. Defaults to
+   * the real `sweepOrphanProcesses` when omitted.
    * Threaded through to `sweepSessionProcesses`'s own `sweepImpl` opt --
    * exposed at the deps level (rather than only reachable via the static
    * method's own opts) because `initializeSessions` / `cleanupOrphanProcesses`
@@ -77,8 +77,8 @@ interface SessionInitializationDeps {
 }
 
 /**
- * Startup-only scope note (Issue #1197 Part B): `sweepSessionProcesses` is
- * invoked from `initializeSessions` / `cleanupOrphanProcesses` ONLY --
+ * Startup-only scope note: `sweepSessionProcesses` is invoked from
+ * `initializeSessions` / `cleanupOrphanProcesses` ONLY --
  * i.e. only at server-startup orphan recovery, alongside the existing
  * `killOrphanWorkers` calls. It is deliberately NOT wired into
  * `deleteSession`-time cleanup or `shutdownAppContext`: both of those
@@ -280,10 +280,10 @@ export class SessionInitializationService {
       killedWorkerCount += await SessionInitializationService.killOrphanWorkers(session, this.deps.resolveSpawnUsername);
 
       // Broader net: sweep any SESSION_ID-marked descendant processes that
-      // were never tracked as a `worker.pid` (Issue #1197 Part B). Runs
-      // unconditionally for every session reaching this point, regardless
-      // of whether killOrphanWorkers found anything -- that is the whole
-      // point of the sweep.
+      // were never tracked as a `worker.pid`. Runs unconditionally for
+      // every session reaching this point, regardless of whether
+      // killOrphanWorkers found anything -- that is the whole point of the
+      // sweep.
       sweptProcessCount += await SessionInitializationService.sweepSessionProcesses(
         session,
         this.deps.resolveSpawnUsername,
@@ -383,8 +383,8 @@ export class SessionInitializationService {
       killedCount += await SessionInitializationService.killOrphanWorkers(session, this.deps.resolveSpawnUsername);
 
       // Broader net: sweep any SESSION_ID-marked descendant processes that
-      // were never tracked as a `worker.pid` (Issue #1197 Part B). Runs
-      // unconditionally for every orphan session reaching this point.
+      // were never tracked as a `worker.pid`. Runs unconditionally for
+      // every orphan session reaching this point.
       sweptProcessCount += await SessionInitializationService.sweepSessionProcesses(
         session,
         this.deps.resolveSpawnUsername,

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -27,6 +27,7 @@ import {
   type TriggerHandoffResult,
 } from './embedded-agent-worker-service.js';
 import type { SpawnAsUserFn } from './privilege-elevation.js';
+import type { sweepOrphanProcesses } from './orphan-process-sweeper.js';
 import { CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
 import type { AgentManager } from './agent-manager.js';
 import type { EmbeddedAgentManager } from './embedded-agent-manager.js';
@@ -144,6 +145,16 @@ interface SessionManagerOptions {
    * `EmbeddedAgentWorkerService` test seam.
    */
   spawnAsUserFn?: SpawnAsUserFn;
+  /**
+   * Test seam for the SESSION_ID marker orphan-process sweep (Issue #1197
+   * Part B). Defaults to the real `sweepOrphanProcesses`. Threaded through
+   * to `SessionInitializationService`, mirroring `spawnAsUserFn` above --
+   * unlike `killOrphanWorkers`'s non-elevated fallback (a cheap in-process
+   * `process.kill`), `sweepOrphanProcesses` always spawns a real subprocess
+   * regardless of `AUTH_MODE`, so tests exercising restart-triggered orphan
+   * cleanup that want to avoid that real spawn should inject a fake here.
+   */
+  sweepOrphanProcessesImpl?: typeof sweepOrphanProcesses;
   /** User repository for resolving createdBy → username for PTY spawning */
   userRepository?: UserRepository;
   notificationManager?: NotificationManager | null;
@@ -376,6 +387,7 @@ export class SessionManager {
       baseDirForPersistedSession: (persisted) => this.baseDirForPersistedSession(persisted),
       getServerPid,
       resolveSpawnUsername: (createdBy) => resolveSpawnUsername(createdBy, this.userRepository),
+      sweepOrphanProcessesImpl: options.sweepOrphanProcessesImpl,
     });
 
     this.sessionDeletionService = new SessionDeletionService({

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -146,8 +146,8 @@ interface SessionManagerOptions {
    */
   spawnAsUserFn?: SpawnAsUserFn;
   /**
-   * Test seam for the SESSION_ID marker orphan-process sweep (Issue #1197
-   * Part B). Defaults to the real `sweepOrphanProcesses`. Threaded through
+   * Test seam for the SESSION_ID marker orphan-process sweep. Defaults to
+   * the real `sweepOrphanProcesses`. Threaded through
    * to `SessionInitializationService`, mirroring `spawnAsUserFn` above --
    * unlike `killOrphanWorkers`'s non-elevated fallback (a cheap in-process
    * `process.kill`), `sweepOrphanProcesses` always spawns a real subprocess

--- a/scripts/smoke/check-orphan-sweep.ts
+++ b/scripts/smoke/check-orphan-sweep.ts
@@ -1,0 +1,332 @@
+#!/usr/bin/env bun
+/**
+ * Post-deploy smoke test for the SESSION_ID marker orphan-process sweep
+ * (Issue #1197 Part B).
+ *
+ * Drives the REAL production `spawnAsUser` / `sweepOrphanProcesses` helpers
+ * (`packages/server/src/services/privilege-elevation.ts` /
+ * `packages/server/src/services/orphan-process-sweeper.ts`) against REAL
+ * long-lived processes, with `AUTH_MODE=multi-user` forced on so the
+ * elevated `sudo -u <target-user> ... sh -c <sweep script>` argv actually
+ * runs.
+ *
+ * What this smoke exercises:
+ *   - `spawnAsUser` launching a real `sleep` as `<target-user>` with
+ *     `AGENT_CONSOLE_SESSION_ID=<generated-session-id>` set in its
+ *     environment -- the same env marker every real worker process carries
+ *     in production (`user-mode.ts`).
+ *   - `sweepOrphanProcesses` running the marker-scan-and-kill script AS
+ *     `<target-user>` (a real cross-user `/proc/<pid>/environ` read, which
+ *     the server process itself cannot do directly -- that permission
+ *     boundary is the entire reason the scan has to run elevated) and
+ *     actually terminating the marked process.
+ *   - Negative assertion: a second, real process spawned as the same
+ *     target user WITHOUT the marker survives the sweep -- proof the sweep
+ *     matches on the exact SESSION_ID record, not a broader name-based or
+ *     substring match.
+ *   - Every subprocess-facing phase is bounded so a stalled sudo/NSS/
+ *     login-shell chain, or a stuck sweep script, surfaces as a clear
+ *     timeout rather than hanging the deploy.
+ *   - Cleanup verification: leftover tracked pids are force-killed via
+ *     `killAsUser` in a `finally` block and re-checked, not assumed gone.
+ *
+ * What this smoke does NOT exercise:
+ *   - The TERM -> KILL escalation path for a marked process that ignores
+ *     SIGTERM (`trap '' TERM`). That is covered by the real-process Tier B
+ *     tests in
+ *     `packages/server/src/services/__tests__/orphan-process-sweeper.test.ts`,
+ *     which drive `buildSweepScript`'s output directly via `Bun.spawn`
+ *     (same-user, no elevation needed to exercise the shell script's own
+ *     grace/escalation logic).
+ *   - `SessionInitializationService.sweepSessionProcesses`'s best-effort
+ *     wrapping (non-throw on failure, logging) -- covered by unit tests
+ *     with an injected fake in
+ *     `packages/server/src/services/__tests__/session-initialization-service.test.ts`.
+ *   - What Part A's smoke (`check-kill-as-user.ts`) already proves: that a
+ *     single tracked pid can be elevated-signalled at all. This smoke's
+ *     distinct value is proving the marker-based DISCOVERY mechanism
+ *     itself works end-to-end against real `sudo` / real `/proc` read
+ *     permissions -- Part A never reads `environ`, it only signals an
+ *     already-known pid.
+ *
+ * Usage:
+ *   bun scripts/smoke/check-orphan-sweep.ts <target-user>
+ *
+ * Requirements:
+ *   - Run as a user with elevation privilege for <target-user> (a working,
+ *     non-interactive `sudo -u <target-user> -i ...` path). On the dogfood
+ *     host this typically means running as the agentconsole service user
+ *     (sudoers rules from scripts/setup-multiuser-for-ubuntu.sh).
+ *   - <target-user> must be a real OS user with a login shell.
+ *   - Degenerate mode: passing the CURRENT process user as <target-user>
+ *     exercises the entire mechanism (spawn, marker match, kill, negative
+ *     assertion) EXCEPT the actual cross-user `sudo` boundary and the
+ *     cross-user `/proc/<pid>/environ` read permission, since
+ *     `spawnAsUser` / `sweepOrphanProcesses` (via `runAsUser`) bypass
+ *     elevation whenever the target user equals the server-process user.
+ *     Useful when no second OS user + configured elevation is available.
+ *
+ * Exit codes:
+ *   0  all assertions passed
+ *   1  one or more assertions failed (system is wrong)
+ *   2  bad usage / cannot run (missing target user, spawn launch failure,
+ *      or any phase (PID read, the sweep call) exceeding its bounded
+ *      deadline -- treated as an environment problem, not a system-under-
+ *      test assertion failure)
+ *
+ * Sync contract: `spawnAsUser`, `killAsUser`, and `sweepOrphanProcesses`
+ * are imported directly from their production modules -- no replication.
+ */
+
+// Ad-hoc invocation inherits cwd from the caller (often /root or an
+// interactive user's home, neither readable by an elevation-target service
+// account). Neutralize at script start -- same root cause documented in
+// check-multiuser-pty-env.ts / check-kill-as-user.ts.
+process.chdir('/');
+
+const targetUsername = process.argv[2];
+if (!targetUsername) {
+  console.error('usage: bun scripts/smoke/check-orphan-sweep.ts <target-user>');
+  process.exit(2);
+}
+
+// privilege-elevation.ts reads `process.env.AUTH_MODE` at CALL time inside
+// `runAsUser` / `spawnAsUser` (not via a module-load-time IIFE), so a plain
+// static import + setting this env var beforehand is sufficient.
+process.env.AUTH_MODE = 'multi-user';
+
+import { existsSync } from 'node:fs';
+import * as os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { spawnAsUser, killAsUser } from '../../packages/server/src/services/privilege-elevation.js';
+import { sweepOrphanProcesses } from '../../packages/server/src/services/orphan-process-sweeper.js';
+
+/** Deadline for reading a tracked process's first stdout line (its own PID). */
+const PID_READ_TIMEOUT_MS = 15_000;
+
+/**
+ * `sweepOrphanProcesses` forwards `timeoutMs` straight to `runAsUser`,
+ * which sets no timer at all when it is omitted. The sweep script itself
+ * waits out a grace period (default 2s) plus a bounded escalation poll (up
+ * to ~1s) on top of the scan -- so this needs materially more headroom
+ * than a single `kill -s <SIG> -- <pid>` call. Mirrors
+ * `SWEEP_ORPHAN_PROCESSES_TIMEOUT_MS` in `session-initialization-service.ts`.
+ */
+const SWEEP_TIMEOUT_MS = 20_000;
+
+/** Deadline for the cleanup-pass `killAsUser` fallback. */
+const CLEANUP_KILL_TIMEOUT_MS = 10_000;
+
+/**
+ * Distinguishes "a phase of this probe hung past its deadline" from a
+ * normal assertion failure. Caught at the top level and mapped to exit
+ * code 2 (probe-cannot-run / environment problem), not exit code 1
+ * (assertion failed).
+ */
+class ProbeTimeoutError extends Error {}
+
+const failures: string[] = [];
+let passes = 0;
+const expect = (cond: boolean, label: string, detail?: string): void => {
+  if (cond) {
+    console.log(`  OK    ${label}`);
+    passes++;
+  } else {
+    console.error(`  FAIL  ${label}${detail ? ` -- ${detail}` : ''}`);
+    failures.push(label);
+  }
+};
+
+// Directory-existence check on /proc/<pid> works regardless of which OS
+// user owns the target process -- see check-kill-as-user.ts's identical
+// rationale for why this is preferred over `kill -0 <pid>` as the smoke's
+// own (possibly non-elevated) user.
+function procAlive(pid: number): boolean {
+  return existsSync(`/proc/${pid}`);
+}
+
+async function waitUntilGone(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!procAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return !procAlive(pid);
+}
+
+/**
+ * Spawn `sleep <seconds>` as `username`, optionally carrying
+ * `AGENT_CONSOLE_SESSION_ID=<sessionId>` in its environment, printing its
+ * own PID on the first stdout line before `exec`'ing into sleep (mirrors
+ * `check-kill-as-user.ts`'s `spawnTrackedSleep`: `exec` replaces the shell
+ * process image in place, so the printed PID is the actual long-lived
+ * process's PID, not an outer sudo/sh wrapper's).
+ */
+async function spawnTrackedMarked(
+  username: string,
+  sessionId: string | undefined,
+  seconds: number,
+): Promise<number> {
+  const { subprocess, stdin } = spawnAsUser({
+    username,
+    command: `echo $$; exec sleep ${seconds}`,
+    env: sessionId !== undefined ? { AGENT_CONSOLE_SESSION_ID: sessionId } : undefined,
+  });
+  // Fire-and-forget spawn: nothing is fed to stdin. Mandatory per
+  // `.claude/rules/elevation-helpers.md` "spawnAsUser: close stdin when
+  // not feeding input".
+  stdin.end();
+
+  const reader = subprocess.stdout.getReader();
+  const decoder = new TextDecoder();
+  let buffered = '';
+  const deadline = Date.now() + PID_READ_TIMEOUT_MS;
+  try {
+    while (!buffered.includes('\n')) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        throw new ProbeTimeoutError(
+          `reading tracked PID line timed out after ${PID_READ_TIMEOUT_MS}ms (stalled sudo/NSS/login-shell path?)`,
+        );
+      }
+      let timer: ReturnType<typeof setTimeout>;
+      const readOrTimeout = Promise.race([
+        reader.read(),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new ProbeTimeoutError(`reader.read() timed out after ${remainingMs}ms`)),
+            remainingMs,
+          );
+        }),
+      ]);
+      let readResult: ReadableStreamReadResult<Uint8Array>;
+      try {
+        readResult = await readOrTimeout;
+      } finally {
+        clearTimeout(timer!);
+      }
+      const { value, done } = readResult;
+      if (done) break;
+      buffered += decoder.decode(value, { stream: true });
+    }
+  } catch (err) {
+    await reader.cancel('PID read deadline exceeded').catch(() => {});
+    throw err;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // Best-effort: cancel() above may have already settled the lock.
+    }
+  }
+
+  const firstLine = buffered.split('\n')[0]?.trim();
+  const pid = firstLine ? Number(firstLine) : NaN;
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error(`PROBE FAILED: could not parse tracked PID from output: ${JSON.stringify(buffered)}`);
+  }
+  return pid;
+}
+
+async function main(): Promise<void> {
+  const serverUsername = os.userInfo().username;
+  const degenerate = targetUsername === serverUsername;
+  if (degenerate) {
+    console.warn(
+      `  WARN  target user '${targetUsername}' equals the server-process user; sweepOrphanProcesses` +
+        ' will bypass elevation for both the scan and the spawn (degenerate same-user mode). This' +
+        ' still exercises the full mechanism except the actual sudo OS-user-boundary crossing and' +
+        ' the cross-user /proc/<pid>/environ read permission.',
+    );
+  }
+
+  const sessionId = `smoke-orphan-sweep-${randomUUID()}`;
+  let markedPid: number | undefined;
+  let controlPid: number | undefined;
+  let timedOut = false;
+
+  try {
+    console.log(`==> spawning MARKED tracked sleep as '${targetUsername}' (sessionId=${sessionId})`);
+    markedPid = await spawnTrackedMarked(targetUsername, sessionId, 300);
+    console.log(`  marked sleep pid: ${markedPid}`);
+
+    console.log(`==> spawning UNMARKED control sleep as '${targetUsername}' (no AGENT_CONSOLE_SESSION_ID)`);
+    controlPid = await spawnTrackedMarked(targetUsername, undefined, 300);
+    console.log(`  control sleep pid: ${controlPid}`);
+
+    console.log('==> sanity: both pids alive before sweepOrphanProcesses');
+    expect(procAlive(markedPid), 'marked pid is alive before sweep', `pid=${markedPid}`);
+    expect(procAlive(controlPid), 'control pid is alive before sweep', `pid=${controlPid}`);
+
+    console.log(`==> sweepOrphanProcesses('${sessionId}', '${targetUsername}')`);
+    const result = await sweepOrphanProcesses(sessionId, targetUsername, { timeoutMs: SWEEP_TIMEOUT_MS });
+    if (result.raw.timedOut) {
+      throw new ProbeTimeoutError(`sweepOrphanProcesses timed out after ${SWEEP_TIMEOUT_MS}ms`);
+    }
+    expect(
+      result.raw.exitCode === 0,
+      'sweepOrphanProcesses script exitCode === 0',
+      `got exitCode=${result.raw.exitCode} stderr=${result.raw.stderr}`,
+    );
+    expect(result.killedCount === 1, 'sweepOrphanProcesses reports exactly 1 killed', `got killedCount=${result.killedCount}`);
+
+    console.log('==> waiting for marked pid to exit (bounded poll, up to 8s)');
+    const markedGone = await waitUntilGone(markedPid, 8_000);
+    expect(markedGone, 'marked pid is gone after sweepOrphanProcesses', `pid=${markedPid} still present in /proc`);
+
+    console.log('==> negative assertion: control pid must still be alive (sweep matched only the marked SESSION_ID)');
+    expect(procAlive(controlPid), 'control pid is still alive after sweeping the marked session', `pid=${controlPid}`);
+  } catch (err) {
+    if (err instanceof ProbeTimeoutError) {
+      timedOut = true;
+      console.error('PROBE TIMEOUT:', err.message);
+    } else {
+      console.error('PROBE ERROR:', err instanceof Error ? (err.stack ?? err.message) : String(err));
+      failures.push('unexpected exception during smoke run');
+    }
+  } finally {
+    console.log('==> cleanup (best-effort elevated SIGKILL of any surviving tracked pids, verified)');
+    for (const pid of [markedPid, controlPid]) {
+      if (pid === undefined) continue;
+      if (!procAlive(pid)) continue;
+      // `killAsUser` resolves normally even on a non-zero exit code or a
+      // timeout -- it does NOT reject the promise in either case. Inspect
+      // the result explicitly and re-check actual PID survival afterward
+      // rather than assuming a clean call means the process is gone.
+      try {
+        const cleanupResult = await killAsUser(pid, 'SIGKILL', targetUsername, { timeoutMs: CLEANUP_KILL_TIMEOUT_MS });
+        if (cleanupResult.timedOut || cleanupResult.exitCode !== 0) {
+          console.warn(
+            `  cleanup: killAsUser SIGKILL non-success for pid=${pid}` +
+              ` (timedOut=${cleanupResult.timedOut}, exitCode=${cleanupResult.exitCode}, stderr=${cleanupResult.stderr})`,
+          );
+        }
+      } catch (err) {
+        console.warn(`  cleanup: killAsUser SIGKILL threw for pid=${pid} (best-effort):`, err);
+      }
+      const goneAfterCleanup = await waitUntilGone(pid, 3_000);
+      expect(goneAfterCleanup, `cleanup left no surviving process for pid=${pid}`, `pid=${pid} still present in /proc after SIGKILL + wait`);
+    }
+  }
+
+  console.log();
+  if (timedOut) {
+    console.error('PROBE TIMED OUT: a phase of this smoke exceeded its deadline (environment problem, not an assertion failure)');
+    process.exit(2);
+  }
+  if (failures.length > 0) {
+    console.error(`FAILED: ${failures.length} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log(`PASSED: ${passes} assertion(s) passed`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  if (err instanceof ProbeTimeoutError) {
+    console.error('PROBE TIMEOUT (uncaught):', err.message);
+    process.exit(2);
+  }
+  console.error('PROBE FAILED (uncaught):', err instanceof Error ? (err.stack ?? err.message) : String(err));
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Issue #1197 Part B (follow-up to Part A, PR #1207 / merged 410dcd0): adds a tree-wide SESSION_ID env-marker sweep that catches orphan processes `SessionInitializationService.killOrphanWorkers` cannot see.

**Scope note (owner-approved)**: This PR incidentally includes a 1-line `.github/workflows/language-lint.yml` fix (adding a `bun install --frozen-lockfile` step). This is unrelated to the #1197 sweep logic — it addresses a CI regression PR #1220 introduced when `scripts/schema-source-normalize.mjs` started depending on the `typescript` package in a workflow that never installed devDeps in the first place (confirmed by reproducing the exact CI failure against a clean `origin/main` checkout with no dependency on this PR's own diff). Same-PR inclusion approved by the owner to avoid a separate infra-fix round-trip; see the "CI Language Lint infra fix" commit for the isolated change.

- `killOrphanWorkers` only kills processes tracked via a session's persisted `worker.pid` — the direct PTY wrapper process. Detached/background descendant processes (a worker's `bun run dev` child, an MCP subprocess, ...) are never in that PID set and leak forever across server restarts.
- Every worker process already carries `AGENT_CONSOLE_SESSION_ID=<sessionId>` in its environment (set at PTY spawn time in `user-mode.ts`, inherited by every descendant). New module `packages/server/src/services/orphan-process-sweeper.ts` scans `/proc/[pid]/environ` for that marker, tree-wide, and kills anything matching, regardless of whether it was ever tracked as a `worker.pid`.
- **Multi-user constraint**: `/proc/<pid>/environ` for another OS user's process is not readable by the server process (EACCES) — the scan (which requires reading `environ` to match) cannot be split into "scan as server, then kill as elevated user". A single POSIX `sh` script does scan + match + kill in one invocation, executed via `runAsUser` as the resolved session owner (same elevation pattern as `killAsUser` / `rmRecursiveAsUser`, i.e. an elevated login shell via the existing elevation helper).
- Wired into `SessionInitializationService.sweepSessionProcesses` (new static method), called unconditionally at both existing `killOrphanWorkers` call sites (`initializeSessions()`, `cleanupOrphanProcesses()`) — startup-only, best-effort (never throws, logs a warn on failure since `killOrphanWorkers` remains the primary, already-tested cleanup mechanism).

**Explicitly out of scope** (per Architect AC): `deleteSession`-time cleanup and `shutdownAppContext` are NOT wired to this sweep — both already know precisely which pids they're tearing down (no discovery problem to solve).

## `trap '' TERM` polarity case (Architect audit amend)

`packages/server/src/services/__tests__/orphan-process-sweeper.test.ts` includes a required real-process test (`escalates to SIGKILL for a marked process that ignores SIGTERM (trap TERM)`) that spawns a real `sh -c "trap '' TERM; while :; do :; done"` process with the marker set, runs the sweep script directly via `Bun.spawn` (same-user, no elevation needed to exercise the shell logic itself), asserts the process survives the TERM-only grace window, then is reaped by the SIGKILL escalation. This proves the escalation branch actually fires against a SIGTERM-immune target, not just that SIGTERM alone happens to work.

## Test coverage

- **Tier A (pure/fast)**: `buildSweepScript` script-shape assertions (shell-escaping/injection safety, TERM-before-KILL ordering, `SWEEP_PROC_ROOT` override, self-pid exclusion), `parseSweptCount` boundary matrix, `sweepOrphanProcesses` via injected `runAsUserImpl` fake (forwarding, non-throw on non-zero exit/timeout, empty-sessionId guard).
- **Tier B (real-process, same-user, no elevation)**: 0/1/N candidates, unmarked-process survives, different-session-id survives, `trap '' TERM` escalation (above), self-exclusion (script's own env legitimately carries the marker it searches for — a broken self-exclusion would self-SIGTERM and never print output), environ-unreadable/vanished entries don't crash the scan (via a `SWEEP_PROC_ROOT` override pointed at a scratch dir with ENOENT/EACCES fixtures alongside one real matching entry).
- `SessionInitializationService` gains `sweepSessionProcesses` unit tests: called once per session at both call sites with the resolved username, **0-sessions → 0 sweep-elevation calls** boundary, non-throw on sweep failure.
- Smoke: `scripts/smoke/check-orphan-sweep.ts` (real machine, real elevated login shell, real cross-user `/proc/<pid>/environ` read) — new marker-discovery smoke distinct from Part A's `check-kill-as-user.ts` (which only signals an already-known pid and never reads `environ`). Ran locally in degenerate same-user mode: 7/7 assertions passed, exit 0.

## Q10 (schema-type parallel maintenance) — N/A

No wire/shared-type change. This is a pure server-internal mechanism (no client-facing schema, no new shared type crossing the server/client boundary). Confirmed no `packages/shared/src/schemas/` or `packages/shared/src/types/` touched.

## Glossary trigger check

Walked `.claude/rules/glossary-maintenance.md`'s trigger list: no new design doc, no new type/interface crossing a wire boundary, no new DB field, no new API/MCP param, no Terminology-section edit. `orphan-process-sweeper.ts` is an internal helper extension within the already-documented elevation-helper family — same judgment as Part A's `killAsUser`, which also did not touch the glossary. Not a glossary trigger.

## Merge disposition note (2026-07-19)

**CR state**: local CLI hit the known headless-worktree auth failure (`automatic_login_failed` — a structural limitation of a delegated worktree session with no browser, not a rate-limit; same shape as PRs #1204/#1207/#1208/#1209/#1212 this sprint). The GitHub-side bot's initial walkthrough at 03:27 UTC was a rate-limit warning (next review in 44 min), and a manual `@coderabbitai review` retrigger at 03:33 UTC got the "Review finished... does not re-review already reviewed commits" quirk reply with no actual code review content — i.e. the only "walkthrough" for this commit is the rate-limit message itself (the rate-limit-only-walkthrough case, not the walkthrough-exists clean-equivalent case). inline comments: 0, reviewDecision: empty.

**Fallback disposition applied** (`coderabbit-ops` skill, headless-auth-unavailable + GitHub-bot-rate-limited-with-quirk): both CodeRabbit channels are unavailable for this commit. Substituting Architect independent audit + Orchestrator acceptance as the dual-clean gate. Architect audit verdict: **CLEAN-WITH-FOLLOWUPS** — no blocking findings; confirmed the single-elevated-invocation design, the strict-thin-wrapper contract, the PID-reuse mitigation, the required `trap '' TERM` escalation test, the startup-only wiring scope, and the smoke script's cross-user `/proc/<pid>/environ` read-permission coverage all match the AC. One non-blocking follow-up noted: `resolveSpawnUsername` is resolved independently by `killOrphanWorkers` and `sweepSessionProcesses` at the same call site (2 DB lookups instead of 1 per dead-server session at startup) — acceptable since it's a cold startup path, not a hot path, and the duplication is deliberately tested rather than accidental; worth a low-priority follow-up Issue if it's ever found to matter at scale.

All CI checks green (test, CodeQL x2, blame-shift lint, language-lint, preflight, structural metrics).

**Owner-run real multi-user smoke on the dogfood host remains a merge precondition** for this specific PR (per `.claude/rules/os-environment-coupling.md` pre-merge discipline, same as Part A) — requesting this explicitly; merging is deferred until that positive+negative result is confirmed.

## Update (2026-07-22): owner smoke found a real bug, fixed

The owner's real multi-user smoke on the dogfood host FAILED with `sh: 1: Syntax error: "do" unexpected`. Root cause: the elevated `sudo -u <user> ... -i sh -c <command>` path re-joins its trailing argv into a single line before the target login shell re-parses it, collapsing the sweep script's embedded newlines and breaking its `for ... do ... done` loop. This never surfaced in local/degenerate-mode testing because the non-elevated path execs directly (no re-join). Fix (Architect-directed): keep the elevated `command` fixed to the single-line `sh -s` and deliver the actual multi-line script over `stdin` instead — a channel immune to the argv re-join. New TDD-polarity unit test added; `.claude/rules/elevation-helpers.md` gained a new "Multi-line elevated commands" subsection documenting the general pattern. Re-requesting the owner smoke against this fix.

Separately, pushing this fix surfaced an unrelated main-side CI regression (`.github/workflows/language-lint.yml` never had a `bun install` step; PR #1220 added a script dependency on the `typescript` package that only that workflow's test suite exercises) — see the Scope note above for the 1-line fix included in this PR.

## CodeRabbit finding disposition (2026-07-22, commit 75b207cc)

CodeRabbit's GitHub-side bot successfully reviewed this commit (not rate-limited this time) and posted 1 Trivial/Nitpick finding: sequential per-session elevated `/proc` scans in `sweepSessionProcesses` could add latency after a crash with many dead sessions (one `sudo` spawn + full-`/proc` scan per session, serialized). **Deferring, not fixing** — same disposition class as the already-noted `resolveSpawnUsername` double-lookup: this is a startup-only, best-effort, cold path (not a hot path), and batching would add real complexity (multi-ID `grep -F -f`) for a scenario (many simultaneous dead sessions after a crash) that is itself already a rare, degraded-startup case where a few extra seconds of sequential sweeping is an acceptable trade-off against the correctness this sweep buys. Worth reconsidering only if this is ever observed to matter in practice.

All CI checks green (test, CodeQL x2, blame-shift lint, language-lint, preflight, structural metrics) as of commit `dd87528d`.

## Test plan

- [x] `bun run typecheck` — exit 0
- [x] `bun run test` (full monorepo suite) — all packages pass; server package's only failure is the pre-existing, environment-specific `Issue #918: elevation-skip (direct) path ... SSH_AUTH_SOCK` test (confirmed identical on unmodified `origin/main` via `git stash` baseline comparison — unrelated to this diff)
- [x] `node .claude/skills/orchestrator/preflight-check.js` — all checks green (coverage, rule/skill duplication, language, blame-shift)
- [x] `bun run check:lang` — exit 0
- [x] `bun scripts/smoke/check-orphan-sweep.ts "$(whoami)"` (degenerate same-user mode) — exit 0, 7/7 assertions
- [ ] Real multi-user smoke on dogfood host (owner-run, merge precondition — see above)

Closes #1197



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added startup and cleanup sweeps to find and terminate orphaned descendant processes associated with sessions.
  - Added safeguards to avoid affecting unrelated processes and to escalate termination when needed.
  - Added a post-deployment smoke test for cross-user orphan-process cleanup.

- **Documentation**
  - Documented elevated command execution requirements and the new orphan-process smoke test.

- **Tests**
  - Added comprehensive unit, integration, error-handling, and process-cleanup coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

