### PR TITLE
test(server): pin SSH_AUTH_SOCK to controlled state in multi-user-mode.test.ts

### DIFF
--- a/packages/server/src/services/__tests__/multi-user-mode.test.ts
+++ b/packages/server/src/services/__tests__/multi-user-mode.test.ts
@@ -1058,6 +1058,28 @@ describe('MultiUserMode', () => {
   // via `sh -c <unsetPrefix><command>` with env passed via opts.env, not via
   // an exported sudo-wrapped script).
   describe('Issue #918: sudo-skip (direct) path ignores sshAuthSockFallback', () => {
+    // Issue #952: the direct (sudo-skip) spawn path inherits process.env into
+    // opts.env, so SSH_AUTH_SOCK ends up on opts.env whenever the host/shell
+    // already has it set (true for every delegated agent-console session
+    // since PR #925). Pin the env var to a known, controlled (absent) state
+    // for the duration of this test so the assertion below exercises "the
+    // direct path does not inject a socket path when there wasn't one to
+    // begin with" instead of accidentally depending on the runner's env.
+    let originalSshAuthSock: string | undefined;
+
+    beforeEach(() => {
+      originalSshAuthSock = process.env.SSH_AUTH_SOCK;
+      delete process.env.SSH_AUTH_SOCK;
+    });
+
+    afterEach(() => {
+      if (originalSshAuthSock === undefined) {
+        delete process.env.SSH_AUTH_SOCK;
+      } else {
+        process.env.SSH_AUTH_SOCK = originalSshAuthSock;
+      }
+    });
+
     async function createMode(): Promise<MultiUserMode> {
       return MultiUserMode.create(ptyFactory.provider, userRepository);
     }


### PR DESCRIPTION
## Summary
- The Issue #918 test "does NOT inject any SSH_AUTH_SOCK shell snippet in the direct path even when sshAuthSockFallback is provided" asserted `opts.env?.SSH_AUTH_SOCK` is `undefined`, but the direct (elevation-skip) spawn path inherits `process.env` into `opts.env`. Since PR #925, delegated agent-console sessions inherit `SSH_AUTH_SOCK` by design, so every delegated full-suite run hit this failure while CI (clean env) stayed green.
- Fixed by pinning `SSH_AUTH_SOCK` to a known, controlled (absent) state via `beforeEach`/`afterEach` scoped to that one `describe` block — save the original value, delete it before the test, restore it after. This makes the assertion exercise the code's actual behavior (no injection when nothing was there to begin with) instead of the host's ambient environment.
- Test-only change; no production code touched.

## Test plan
- [x] `bun run typecheck` — exit 0
- [x] `bun run test` (normal env, `SSH_AUTH_SOCK` present) — exit 0, all packages pass
- [x] `env -u SSH_AUTH_SOCK bun run test` — exit 0, all packages pass
- [x] Polarity check: reverted only this test file's diff via `git diff > patch` + `git checkout --`, then ran `SSH_AUTH_SOCK=/tmp/fake-check.sock bun test packages/server/src/services/__tests__/multi-user-mode.test.ts` → **fails** (1 fail) without the fix. Re-applied the patch, re-ran the same forced-env command → **passes** (37 pass / 0 fail).
- [x] `node .claude/skills/orchestrator/preflight-check.js` — exit 0 (no production files changed, no coverage gap)

Closes #952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of SSH authentication settings when using the direct execution path.
  * Ensured fallback SSH socket settings are not applied unexpectedly during command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->