### PR TITLE
test: eliminate remaining cross-file mock.module poisoning in client tests (closes #977)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -21,6 +21,12 @@ Test file re-implements production logic instead of importing it. Signs: test-on
 ### 2. Module-Level Mocking
 Using `mock.module()` or `vi.mock()` instead of fetch-level mocks. Problems: bypasses actual API function logic, `mock.module()` is permanent in bun:test, tests pass even when integration is broken. Has caused production incidents (mocking `config.js` broke 26+ unrelated tests). **Preferred: dependency injection over module mocking.**
 
+**Never `mock.module()` a target that any other test file imports for real.** `bun:test`'s `mock.module()` is process-global and irreversible for the life of the test process, so it poisons every test file loaded afterward in the same process — and bun runs test files in directory readdir order (not CLI-arg order), which differs across operating systems. A suite that is green on one OS and red on another (or green locally and red in CI) is the signature of this failure mode (Issue #970, PR #976, Issue #977).
+
+- **Prohibited example:** `mock.module('../../routes/__root', () => ({ useWorktreeCreationTasksContext: () => ({ ... }) }))`. `routes/__root` is the route root, so multiple other test files (route tests, sibling component tests) import it for real; a mock factory that only re-declares a subset of its exports silently breaks any file that loads afterward and needs an export the factory omitted.
+- **Permitted example:** a module consumed exclusively by the one test file mocking it (e.g. a component's own tightly-scoped internal helper with no other importer) may still use `mock.module()`, but confirm the exclusivity first — grep the repo for other real importers before relying on this exception.
+- **Before adding a new `mock.module()` call**, grep the repository for other files that import the target module without mocking it. If any exist, do not use `mock.module()` — use one of, in order of preference: (1) a DI seam (prop / injected factory) on the component or hook under test, (2) `spyOn()` on the module's named export (restorable per-test via `.mockRestore()` in `afterEach`), (3) fetch-level request stubbing, (4) a real store/context with an injected fake value. See `test-standards` skill for worked conversion patterns.
+
 ### 3. Private Method Testing
 Attempting to test internal/private methods directly. Test through public interface instead, or extract to a separate module if complexity warrants it.
 
@@ -74,3 +80,4 @@ Before writing tests, verify:
 - [ ] Not following existing bad patterns blindly
 - [ ] Not changing production code just for testing without discussion
 - [ ] **Target code is mockable via DI** — check if the code under test imports module-level singletons. If it does, DI refactoring is required before the test can be written safely. Do NOT use `mock.module()` to work around missing DI. See Anti-Pattern #2.
+- [ ] **If a new `mock.module()` call is unavoidable**, grep the repo for other real importers of the target module first. See Anti-Pattern #2's cross-file-imported-target prohibition.

--- a/.claude/skills/test-standards/test-standards.md
+++ b/.claude/skills/test-standards/test-standards.md
@@ -195,7 +195,9 @@ render(<TerminalAdapter sessionId="s" workerId="w" createInstance={mockGetOrCrea
 
 ### Pattern 2 — `spyOn()` on a named export
 
-Best for a hook or function the component-under-test imports and calls directly, when adding a DI prop is not warranted. `spyOn` is restorable per-test (unlike `mock.module()`), so it must be paired with `.mockRestore()` in `afterEach` — without that, the spy leaks into the next test in the same file (not other files, since `spyOn` targets a specific module-namespace object each test file imports independently).
+Best for a hook or function the component-under-test imports and calls directly, when adding a DI prop is not warranted. `spyOn` is restorable per-test (unlike `mock.module()`), so it must be paired with `.mockRestore()` in `afterEach` — without that, the spy leaks into the next test in the same file.
+
+**Cross-file safety is conditional, not unconditional.** Bun shares the module cache within a single process; `spyOn`'s restore-on-`mockRestore()` is what keeps it file-scoped only because this repo's `bun run test` invocation (`bun test --preload ./src/test/setup.ts src/` in `packages/client`) runs test files **sequentially** — no `--concurrent` flag on the script, no `concurrentTestGlob` in `bunfig.toml`. Under that condition, one file's spy is always torn down (via `afterEach`'s `mockRestore()`) before the next file's module-level code runs, so it cannot bleed across files. If a future test opts into Bun's `--concurrent` flag, `test.concurrent()`, or a `concurrentTestGlob` config, this guarantee no longer holds: a spy installed by one concurrently-running test file becomes observable by another before its `mockRestore()` fires, since they'd share the same in-process module cache at the same time. Do not use `spyOn()` on a shared module inside a `test.concurrent()` block without independently re-verifying isolation.
 
 ```typescript
 import * as useAppWsModule from '../../hooks/useAppWs';
@@ -211,11 +213,19 @@ afterEach(() => {
 });
 ```
 
-A generic function (`useAppWsState<T>(selector: (state) => T): T`) needs an explicit generic on the mock implementation so the cast is not silently `any`:
+A generic function (`useAppWsState<T>(selector: (state: AppWebSocketState) => T): T`) needs a real fake state run through the caller's own `selector`, not an arbitrary cast — a cast-through-`T` (e.g. `<T,>() => false as T`) type-checks for any selection but silently returns the wrong value the moment a test's `selector` reads a field the cast didn't account for:
 
 ```typescript
-useAppWsStateSpy = spyOn(useAppWsModule, 'useAppWsState').mockImplementation(<T,>() => false as T);
+import type { AppWebSocketState } from '../../lib/app-websocket';
+
+const fakeWsState: AppWebSocketState = { /* ...minimal real shape... */ } as AppWebSocketState;
+
+useAppWsStateSpy = spyOn(useAppWsModule, 'useAppWsState').mockImplementation(
+  <T,>(selector: (state: AppWebSocketState) => T) => selector(fakeWsState),
+);
 ```
+
+If a test genuinely never observes the mocked value (the component under test doesn't call `useAppWsState` on any path the test exercises), a cast is acceptable but must say so in a comment — see `routes/__tests__/index.test.tsx`'s `<T,>() => false as T` for the documented-exception form.
 
 (Worked examples: `routes/__tests__/index.test.tsx`, `__tests__/routes/agents/index.test.tsx`, `components/sessions/hooks/__tests__/useSessionPageState.test.ts`, `components/worktrees/__tests__/QuickWorktreeDialog.test.tsx`.)
 

--- a/.claude/skills/test-standards/test-standards.md
+++ b/.claude/skills/test-standards/test-standards.md
@@ -168,6 +168,105 @@ describe('Client-Server Boundary', () => {
 
 This gives you a single test file that exercises the full round-trip: user event → form serialization → HTTP body → server handler → persisted state. If any step drops or mistransforms data, the test fails.
 
+## Converting Cross-File `mock.module()` Poisoning
+
+See [rules/testing.md](../../rules/testing.md) Anti-Pattern #2 for the prohibition (never `mock.module()` a target another test file real-imports) and when the exception applies. This section is the conversion how-to, with three worked patterns in order of preference. Before converting, grep the repo for other real importers of the target module to confirm the poisoning classification (Issue #977 Phase 1).
+
+### Pattern 1 — DI seam (prop / injected factory)
+
+Best when the component itself resolves the dependency via a module-level singleton call. Add an optional prop defaulting to the real function; production and other consumers are unaffected because the prop is optional.
+
+```typescript
+// Production: TerminalAdapter.tsx
+export function TerminalAdapter({
+  // ...
+  createInstance = getOrCreateTerminal,   // optional DI seam, defaults to the real store
+}: TerminalProps & { createInstance?: typeof getOrCreateTerminal }) {
+  const instance = useMemo(() => createInstance(sessionId, workerId, opts), [createInstance, sessionId, workerId, opts]);
+  // ...
+}
+
+// Test: TerminalAdapter.test.tsx
+const mockGetOrCreateTerminal = mock((_sessionId: string, _workerId: string): TerminalInstance => stubInstance);
+render(<TerminalAdapter sessionId="s" workerId="w" createInstance={mockGetOrCreateTerminal} />);
+```
+
+(Worked example: PR #976, `packages/client/src/components/terminal/TerminalAdapter.tsx` + its test.)
+
+### Pattern 2 — `spyOn()` on a named export
+
+Best for a hook or function the component-under-test imports and calls directly, when adding a DI prop is not warranted. `spyOn` is restorable per-test (unlike `mock.module()`), so it must be paired with `.mockRestore()` in `afterEach` — without that, the spy leaks into the next test in the same file (not other files, since `spyOn` targets a specific module-namespace object each test file imports independently).
+
+```typescript
+import * as useAppWsModule from '../../hooks/useAppWs';
+
+let useAppWsEventSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  useAppWsEventSpy = spyOn(useAppWsModule, 'useAppWsEvent').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  useAppWsEventSpy.mockRestore();
+});
+```
+
+A generic function (`useAppWsState<T>(selector: (state) => T): T`) needs an explicit generic on the mock implementation so the cast is not silently `any`:
+
+```typescript
+useAppWsStateSpy = spyOn(useAppWsModule, 'useAppWsState').mockImplementation(<T,>() => false as T);
+```
+
+(Worked examples: `routes/__tests__/index.test.tsx`, `__tests__/routes/agents/index.test.tsx`, `components/sessions/hooks/__tests__/useSessionPageState.test.ts`, `components/worktrees/__tests__/QuickWorktreeDialog.test.tsx`.)
+
+### Pattern 3 — Real module/context + injected fake value
+
+Best when the module already exposes a designed seam — a context Provider, or a setter function — instead of hard-coding a return value via `mock.module()`. This is the least invasive option: zero production code changes, and the "fake" data flows through the real module's real code path.
+
+```typescript
+// lib/capabilities.ts already exposes a real setter for its module-level cache:
+import { setCapabilities } from '../../lib/capabilities';
+
+beforeEach(() => {
+  setCapabilities({ vscode: false, vscodeOpenMode: 'local-spawn', vscodeRemoteHost: null });
+});
+```
+
+```typescript
+// A React context consumed via useContext(): provide a REAL Provider with a fake value
+// instead of mock.module()-replacing the hook that reads it.
+import { WorktreeDeletionTasksContext } from '../../contexts/root-contexts';
+
+render(
+  <WorktreeDeletionTasksContext.Provider value={mockDeletionTasks}>
+    <SessionSettings {...props} />
+  </WorktreeDeletionTasksContext.Provider>
+);
+```
+
+Note the context is imported from its owning module (`contexts/root-contexts.ts`), not from the barrel that re-exports it (`routes/__root.tsx`) — importing from the owning module avoids pulling in the barrel's heavier dependency surface (router registration, layout components) and is the same object reference, so `useContext` inside the real hook resolves correctly either way.
+
+(Worked examples: `__tests__/routes/WorktreeRow.test.tsx` (Pattern 3a, setter), `hooks/__tests__/useCreateWorktree.test.ts` and `components/__tests__/SessionSettings.test.tsx` (Pattern 3b, Provider).)
+
+### Which pattern to reach for
+
+1. Does the target module already expose a public setter or a context Provider for the exact state the test needs? → **Pattern 3**.
+2. Is the dependency resolved via a direct function/hook call the component makes itself, with no existing seam? → **Pattern 2** (`spyOn`) is usually less code than adding a new prop; reach for **Pattern 1** (DI prop) only when the component needs the seam for a reason beyond testing (e.g. a legitimate caller-supplied override).
+3. Never fall back to `mock.module()` to avoid picking one of the above — see rules/testing.md Anti-Pattern #2.
+
+### `mock.module()` merges, it does not replace
+
+When classifying whether a `mock.module()` call site is a cross-file poisoner (Issue #977 Phase 1), do not assume the factory's return value fully replaces the module's export namespace for other importers. Empirically (Bun 1.3.10), `mock.module(specifier, factory)` **merges** `factory()`'s return value onto the real module's exports — an export the factory does not declare falls through to the real implementation for *every* importer, not just the ones that ran before the mock. Only the properties the factory *does* declare are overridden, and that override is what leaks cross-file.
+
+Two consequences for classification:
+
+- **A partial-override factory does not "break" untouched exports.** `lib/capabilities`'s poisoner overrode `hasVSCode` / `getVSCodeOpenMode` / `getVSCodeRemoteHost` but not `setCapabilities` — a victim reading `setCapabilities` sees the real function regardless of poisoning order. Do not conclude "benign" from this: the *overridden* exports still leak (verified below).
+- **"Does the victim's assertion still pass?" is not a reliable signal.** A victim can read a poisoned export, receive the wrong value, and still pass all its own assertions if it happens to be structurally tolerant of the substitution (e.g. it re-derives its own Provider/consumer pair from the same poisoned reference, so both sides stay internally consistent even though neither is talking to the real module). Classify by whether the *specific overridden export* is provably read by another file — via a reference/identity check or by inspecting the resolved function's source (`fn.toString()`) — not by whether that file's test suite currently goes red.
+
+**Verification technique used to classify all 5 call sites in PR #977:** force deterministic load order across two real files (CLI-arg order is not respected by Bun's scheduler — see the load-order note below) by placing a lexicographically-earlier-sorting temp copy of the poisoner in `src/`, then read the victim's imported binding's `.toString()` (for functions) or compare `===` identity (for objects/contexts) against a value stashed on `globalThis` by the poisoner. A source string matching the poisoner's factory body, or an identity match against the poisoner's locally-created object, is unambiguous proof of the leak — independent of whether the victim's own assertions happen to still pass.
+
+**Load order is not controllable via CLI argument order or simple filename convention.** Passing files in a specific order to `bun test fileA fileB` does not guarantee `fileA` loads first — Bun applies its own internal scan order regardless of argument order, and that order is not simple alphabetical (it appeared to depend on more than just the basename in ad-hoc testing). The only reliable lever found: bun evaluates a *directory tree* scan in some deterministic-but-opaque order, and paths starting with a double-underscore directory (`src/__polarity_X`) reliably sort ahead of ordinary `src/<lowercase-dir>/...` paths in practice — but always verify with an explicit `console.error` load marker in each candidate file rather than trusting the naming convention alone.
+
 ## Bun mock typing for `calls[N][M]` access
 
 Bun's `mock(async () => {})` infers the mock's `args` type as `[]` when no parameters are declared, even when the call site passes arguments. Reading `mock.calls[0][1]` then fails type-checking with `TS2493: Tuple type '[]' of length '0' has no element at index '1'`.

--- a/packages/client/src/__tests__/routes/WorktreeRow.test.tsx
+++ b/packages/client/src/__tests__/routes/WorktreeRow.test.tsx
@@ -1,20 +1,20 @@
-import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
 import { screen, cleanup } from '@testing-library/react';
 import { renderWithRouter } from '../../test/renderWithRouter';
-import { WorktreeDeletionTasksContext } from '../../routes/__root';
+import { WorktreeDeletionTasksContext } from '../../contexts/root-contexts';
+import { setCapabilities } from '../../lib/capabilities';
+import { WorktreeRow, type WorktreeRowProps, type SessionWithActivity } from '../../routes/index';
 import type { UseWorktreeDeletionTasksReturn } from '../../hooks/useWorktreeDeletionTasks';
 import type { Worktree, WorktreeSession, WorktreeDeletionTask, Session } from '@agent-console/shared';
 
-// Mock capabilities - reads from a module-level cache set during app initialization,
-// so module-level mocking is appropriate here (no business logic or fetch involved).
-mock.module('../../lib/capabilities', () => ({
-  hasVSCode: () => false,
-  getVSCodeOpenMode: () => 'local-spawn',
-  getVSCodeRemoteHost: () => null,
-}));
-
-// Import WorktreeRow AFTER mock.module calls to ensure mocks are applied
-import { WorktreeRow, type WorktreeRowProps, type SessionWithActivity } from '../../routes/index';
+// lib/capabilities reads from a module-level cache populated at app boot via the
+// real setCapabilities() setter. Using the setter instead of `mock.module` avoids
+// process-global poisoning of other test files that real-import lib/capabilities
+// in the same process (testing.md Anti-Pattern #2; e.g. routes/__tests__/index.test.tsx
+// spies on the real module's hasVSCode export).
+beforeEach(() => {
+  setCapabilities({ vscode: false, vscodeOpenMode: 'local-spawn', vscodeRemoteHost: null });
+});
 
 afterEach(cleanup);
 

--- a/packages/client/src/components/__tests__/SessionSettings.test.tsx
+++ b/packages/client/src/components/__tests__/SessionSettings.test.tsx
@@ -2,8 +2,8 @@ import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
 import { screen, fireEvent, waitFor, act, cleanup, render } from '@testing-library/react';
 import { createRootRoute, createRouter, createMemoryHistory, RouterProvider } from '@tanstack/react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createContext, useContext } from 'react';
 import { SessionSettings } from '../SessionSettings';
+import { WorktreeDeletionTasksContext } from '../../contexts/root-contexts';
 import type { UseWorktreeDeletionTasksReturn } from '../../hooks/useWorktreeDeletionTasks';
 
 // Helper to create mock Response
@@ -23,9 +23,6 @@ const prLinkResponse = createMockResponse({
   branchName: 'test-branch',
   orgRepo: 'org/repo',
 });
-
-// Mock the WorktreeDeletionTasksContext
-const MockWorktreeDeletionTasksContext = createContext<UseWorktreeDeletionTasksReturn | null>(null);
 
 // Create mock deletion tasks context
 function createMockDeletionTasks(): UseWorktreeDeletionTasksReturn {
@@ -58,13 +55,17 @@ async function renderWithRouterAndContext(
     },
   });
 
-  // Mock the import of __root to use our mock context
-  // We need to replace the actual context with our mock
+  // Provide the deletion tasks context via the REAL WorktreeDeletionTasksContext
+  // (re-exported by routes/__root) instead of a `mock.module`-replaced module --
+  // mock.module is process-global in bun:test and would poison every other test
+  // file that real-imports routes/__root in the same process (testing.md
+  // Anti-Pattern #2). SessionSettings renders DeleteWorktreeDialog, which calls
+  // useWorktreeDeletionTasksContext() and requires a Provider ancestor.
   const rootRoute = createRootRoute({
     component: () => (
-      <MockWorktreeDeletionTasksContext.Provider value={deletionTasks}>
+      <WorktreeDeletionTasksContext.Provider value={deletionTasks}>
         {ui}
-      </MockWorktreeDeletionTasksContext.Provider>
+      </WorktreeDeletionTasksContext.Provider>
     ),
   });
   const memoryHistory = createMemoryHistory({
@@ -88,23 +89,6 @@ async function renderWithRouterAndContext(
   );
   return { ...result, router, queryClient };
 }
-
-// mock.module replaces the entire module permanently in bun:test.
-// The mock must:
-// 1. Export WorktreeDeletionTasksContext so other test files can wrap with Provider
-// 2. Have useWorktreeDeletionTasksContext read from the context via useContext,
-//    so Provider-wrapped tests get the provided value (not always empty tasks)
-// 3. Fall back to default mock when no Provider is present (for SessionSettings tests)
-mock.module('../../routes/__root', () => ({
-  useWorktreeDeletionTasksContext: () => {
-    const context = useContext(MockWorktreeDeletionTasksContext);
-    if (!context) {
-      return createMockDeletionTasks();
-    }
-    return context;
-  },
-  WorktreeDeletionTasksContext: MockWorktreeDeletionTasksContext,
-}));
 
 describe('SessionSettings', () => {
   let originalFetch: typeof fetch;

--- a/packages/client/src/components/sessions/hooks/__tests__/useSessionPageState.test.ts
+++ b/packages/client/src/components/sessions/hooks/__tests__/useSessionPageState.test.ts
@@ -1,12 +1,20 @@
 import { describe, it, expect, mock, beforeEach, afterEach, afterAll, spyOn } from 'bun:test'
 import type { Session, Worker, AgentActivityState, WorkerActivityInfo, WorkerMessage } from '@agent-console/shared'
+import { renderHook, act } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { SessionDataContext, type SessionDataContextValue } from '../../../../contexts/root-contexts'
+import { useSessionPageState, type UseSessionPageStateOptions } from '../useSessionPageState'
+import * as useAppWsModule from '../../../../hooks/useAppWs'
 
-// --- useAppWsEvent mock ---
+// --- useAppWsEvent spy ---
 //
-// We mock useAppWsEvent to capture the callbacks the hook registers.
-// This avoids coupling to the WebSocket transport layer (already tested in useAppWs.test.ts)
-// and prevents interference from other test files that mock the same module via mock.module
-// (e.g., __root.test.tsx).
+// We replace useAppWsEvent per-test via `spyOn` (NOT `mock.module`, which is
+// process-global in bun:test and would poison every other test file that
+// real-imports hooks/useAppWs in the same process -- testing.md Anti-Pattern #2;
+// routes/__tests__/index.test.tsx and __tests__/routes/agents/index.test.tsx both
+// real-import this module for the same spyOn pattern) to capture the callbacks the
+// hook registers. This avoids coupling to the WebSocket transport layer (already
+// tested in useAppWs.test.ts).
 
 interface CapturedCallbacks {
   onSessionsSync?: (sessions: Session[], activityStates: WorkerActivityInfo[]) => void
@@ -21,18 +29,8 @@ interface CapturedCallbacks {
 
 let capturedCallbacks: CapturedCallbacks = {}
 
-mock.module('../../../../hooks/useAppWs', () => ({
-  useAppWsEvent: (options: CapturedCallbacks) => {
-    capturedCallbacks = options
-  },
-  useAppWsState: () => false,
-}))
-
-// Must import AFTER mock.module
-import { renderHook, act } from '@testing-library/react'
-import { createElement, type ReactNode } from 'react'
-import { SessionDataContext, type SessionDataContextValue } from '../../../../contexts/root-contexts'
-import { useSessionPageState, type UseSessionPageStateOptions } from '../useSessionPageState'
+let useAppWsEventSpy: ReturnType<typeof spyOn>
+let useAppWsStateSpy: ReturnType<typeof spyOn>
 
 // --- Fetch-level mocking ---
 
@@ -154,6 +152,16 @@ describe('useSessionPageState', () => {
 
   beforeEach(() => {
     consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    useAppWsEventSpy = spyOn(useAppWsModule, 'useAppWsEvent').mockImplementation(
+      (options = {}) => {
+        capturedCallbacks = options as CapturedCallbacks
+      },
+    )
+    // useAppWsState<T>(selector) is generic; useSessionPageState does not call it
+    // directly today, so the cast-returned value is never observed by production code.
+    useAppWsStateSpy = spyOn(useAppWsModule, 'useAppWsState').mockImplementation(
+      <T,>() => false as T
+    )
 
     capturedCallbacks = {}
     mockFetch.mockClear()
@@ -162,6 +170,8 @@ describe('useSessionPageState', () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore()
+    useAppWsEventSpy.mockRestore()
+    useAppWsStateSpy.mockRestore()
   })
 
   describe('initial load', () => {

--- a/packages/client/src/components/worktrees/__tests__/QuickWorktreeDialog.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/QuickWorktreeDialog.test.tsx
@@ -1,22 +1,19 @@
-import { describe, it, expect, mock, beforeEach, afterEach, afterAll } from 'bun:test';
+import { describe, it, expect, mock, beforeEach, afterEach, afterAll, spyOn } from 'bun:test';
 import { render, screen, waitFor, cleanup, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createRootRoute, createRouter, createMemoryHistory, RouterProvider } from '@tanstack/react-router';
+import { QuickWorktreeDialog } from '../QuickWorktreeDialog';
+import * as useCreateWorktreeModule from '../../../hooks/useCreateWorktree';
 
-// Mock useCreateWorktree before importing the component
+// useCreateWorktree is replaced per-test via `spyOn` (NOT `mock.module`, which is
+// process-global in bun:test and would poison every other test file that
+// real-imports hooks/useCreateWorktree in the same process -- testing.md
+// Anti-Pattern #2; hooks/__tests__/useCreateWorktree.test.ts real-imports the same
+// module as its own unit under test).
 const mockHandleCreateWorktree = mock(() => Promise.resolve());
 const mockClearError = mock(() => {});
-
-mock.module('../../../hooks/useCreateWorktree', () => ({
-  useCreateWorktree: () => ({
-    handleCreateWorktree: mockHandleCreateWorktree,
-    error: null,
-    clearError: mockClearError,
-  }),
-}));
-
-import { QuickWorktreeDialog } from '../QuickWorktreeDialog';
+let useCreateWorktreeSpy: ReturnType<typeof spyOn>;
 
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
@@ -27,7 +24,16 @@ afterAll(() => {
   globalThis.fetch = originalFetch;
 });
 
+beforeEach(() => {
+  useCreateWorktreeSpy = spyOn(useCreateWorktreeModule, 'useCreateWorktree').mockImplementation(() => ({
+    handleCreateWorktree: mockHandleCreateWorktree,
+    error: null,
+    clearError: mockClearError,
+  }));
+});
+
 afterEach(() => {
+  useCreateWorktreeSpy.mockRestore();
   cleanup();
 });
 

--- a/packages/client/src/hooks/__tests__/useCreateWorktree.test.ts
+++ b/packages/client/src/hooks/__tests__/useCreateWorktree.test.ts
@@ -1,23 +1,30 @@
 import { mock, describe, it, expect, beforeEach, afterAll } from 'bun:test';
+import { createElement, type ReactNode } from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { useCreateWorktree } from '../useCreateWorktree';
+import { WorktreeCreationTasksContext } from '../../contexts/root-contexts';
+import type { UseWorktreeCreationTasksReturn } from '../useWorktreeCreationTasks';
+import type { CreateWorktreeFormRequest } from '../../components/worktrees/CreateWorktreeForm';
 
-// Mock the root route context -- this is safe because no other test file imports __root directly.
+// useCreateWorktree resolves its task-list callbacks from WorktreeCreationTasksContext
+// (re-exported by routes/__root). The test provides a REAL context value via
+// WorktreeCreationTasksContext.Provider instead of `mock.module`-ing routes/__root --
+// mock.module is process-global in bun:test and would poison every other test file
+// that real-imports routes/__root in the same process (testing.md Anti-Pattern #2).
 const mockAddTask = mock(() => {});
 const mockRemoveTask = mock(() => {});
 
-mock.module('../../routes/__root', () => ({
-  useWorktreeCreationTasksContext: () => ({
+function createWrapper(): ({ children }: { children: ReactNode }) => ReactNode {
+  const contextValue: UseWorktreeCreationTasksReturn = {
     addTask: mockAddTask,
     removeTask: mockRemoveTask,
     tasks: [],
     getTask: mock(() => undefined),
     handleWorktreeCreationCompleted: mock(() => {}),
     handleWorktreeCreationFailed: mock(() => {}),
-  }),
-}));
-
-import { renderHook, act } from '@testing-library/react';
-import { useCreateWorktree } from '../useCreateWorktree';
-import type { CreateWorktreeFormRequest } from '../../components/worktrees/CreateWorktreeForm';
+  };
+  return ({ children }) => createElement(WorktreeCreationTasksContext.Provider, { value: contextValue }, children);
+}
 
 // Mock fetch at the lowest level to avoid mock.module pollution on api.ts
 const originalFetch = globalThis.fetch;
@@ -58,7 +65,7 @@ describe('useCreateWorktree', () => {
   };
 
   it('should call addTask and createWorktreeAsync on success', async () => {
-    const { result } = renderHook(() => useCreateWorktree(defaultParams));
+    const { result } = renderHook(() => useCreateWorktree(defaultParams), { wrapper: createWrapper() });
 
     await act(async () => {
       await result.current.handleCreateWorktree(mockFormRequest);
@@ -98,7 +105,7 @@ describe('useCreateWorktree', () => {
       })
     );
 
-    const { result } = renderHook(() => useCreateWorktree(defaultParams));
+    const { result } = renderHook(() => useCreateWorktree(defaultParams), { wrapper: createWrapper() });
 
     // The hook re-throws the error, so we catch it in the act callback
     let thrownError: unknown;
@@ -125,7 +132,7 @@ describe('useCreateWorktree', () => {
     // Mock fetch to throw a non-Error value
     mockFetch.mockRejectedValue('some string error');
 
-    const { result } = renderHook(() => useCreateWorktree(defaultParams));
+    const { result } = renderHook(() => useCreateWorktree(defaultParams), { wrapper: createWrapper() });
 
     let thrownError: unknown;
     await act(async () => {
@@ -144,7 +151,7 @@ describe('useCreateWorktree', () => {
     // Mock fetch to fail
     mockFetch.mockRejectedValue(new Error('Some error'));
 
-    const { result } = renderHook(() => useCreateWorktree(defaultParams));
+    const { result } = renderHook(() => useCreateWorktree(defaultParams), { wrapper: createWrapper() });
 
     // Trigger an error
     await act(async () => {


### PR DESCRIPTION
Closes #977

## What

Converts the 5 remaining active `mock.module()` call sites in `packages/client` (across 4 target modules) to cross-file-safe patterns, and codifies the prohibition + conversion how-to. Full suite green, both directions of every poisoner/victim pair verified.

## Phase 1 — classification (all 5 call sites are active poisoners)

| Call site | Mocked target | Overridden export(s) | Real cross-file consumer | Verdict |
|---|---|---|---|---|
| `hooks/__tests__/useCreateWorktree.test.ts:7` | `routes/__root` | `useWorktreeCreationTasksContext` | any real re-import of `routes/__root` (verified directly); transitively, `routes/index.tsx`'s `RepositoryCard` (rendered by `routes/__tests__/index.test.tsx` for the >=1-repo case) | **ACTIVE** |
| `components/__tests__/SessionSettings.test.tsx:98` | `routes/__root` | `useWorktreeDeletionTasksContext`, `WorktreeDeletionTasksContext` | `__tests__/routes/WorktreeRow.test.tsx` (imports `WorktreeDeletionTasksContext` directly) | **ACTIVE** |
| `__tests__/routes/WorktreeRow.test.tsx:10` | `lib/capabilities` | `hasVSCode`, `getVSCodeOpenMode`, `getVSCodeRemoteHost` (not `setCapabilities`) | `routes/__tests__/index.test.tsx` (spies on the real module) | **ACTIVE** |
| `components/sessions/hooks/__tests__/useSessionPageState.test.ts:24` | `hooks/useAppWs` | `useAppWsEvent`, `useAppWsState` (the module's only 2 exports) | `routes/__tests__/index.test.tsx`, `__tests__/routes/agents/index.test.tsx` (both spy on the real module) | **ACTIVE** |
| `components/worktrees/__tests__/QuickWorktreeDialog.test.tsx:11` | `hooks/useCreateWorktree` | `useCreateWorktree` (the module's only export) | `hooks/__tests__/useCreateWorktree.test.ts` (its own unit-under-test) | **ACTIVE** |

Zero benign/self-consumed cases this round; scope matched the `routes/__root`-centric shape the Issue anticipated (2 of 5 call sites target `__root`), so no PR-split was needed.

### A note on classification methodology (worth flagging)

Bun's `mock.module(specifier, factory)` **merges** `factory()`'s return onto the real module rather than fully replacing it — an export the factory doesn't declare falls through to the real implementation for every importer. This means "does the victim's test suite still pass" is **not** a reliable signal for classification: a victim can receive a genuinely poisoned export and still pass every assertion if it happens to be structurally tolerant (e.g. it re-derives both a Provider and consumer from the same poisoned reference, so both sides stay mutually consistent without ever touching the real module).

Classification here was done by object-identity checks (does the victim's imported Context `===` the poisoner's locally-created mock Context?) and source-string checks (does the victim's resolved function's `.toString()` match the poisoner's factory body?), forcing deterministic poisoner-then-victim load order via a lexicographically-earlier-sorting temp file copy (Bun's scheduler does not respect CLI argument order or simple directory position — verified empirically, not assumed). Documented in `test-standards.md`'s new section for future classification work.

## Phase 2 — conversions

- **`routes/__root` (both mockers):** replaced with the real `WorktreeCreationTasksContext` / `WorktreeDeletionTasksContext` Providers from `contexts/root-contexts.ts` (the module `routes/__root.tsx` re-exports from, without pulling in the router-registration barrel) wrapping an injected fake value. Zero production changes.
- **`lib/capabilities`:** replaced with the module's own real `setCapabilities()` setter (already existed for exactly this purpose). Zero production changes.
- **`hooks/useAppWs`:** replaced with `spyOn()` + `.mockRestore()` in `afterEach`, matching the pattern already used by `routes/__tests__/index.test.tsx` / `__tests__/routes/agents/index.test.tsx` for the same module.
- **`hooks/useCreateWorktree`:** replaced with `spyOn()` + `.mockRestore()` in `afterEach`.

## Regression verification — polarity + order-independence

A plain "full suite is green" only shows the current readdir order happens not to expose the poisoning (that's exactly how #970/PR #976's bug hid locally and only surfaced in CI). Explicit polarity evidence per converted poisoner, all pairs run in the same bun:test process with deterministically forced load order:

- **Before the fix** (pre-fix content re-materialized from `HEAD` for just the poisoner+victim pair, forced poisoner-first): every pair demonstrably leaks.
  - `useCreateWorktree.test.ts` → `routes/__root`: a real re-import's `useWorktreeCreationTasksContext` resolves to the poisoner's canned closure body.
  - `SessionSettings.test.tsx` → `routes/__root`: `WorktreeRow.test.tsx`'s imported `WorktreeDeletionTasksContext` is `Object.is`-identical to the poisoner's locally-created mock Context.
  - `WorktreeRow.test.tsx` → `lib/capabilities`: a real re-import's `hasVSCode` resolves to the poisoner's `() => false`, not the real cached-value reader (`setCapabilities`, not overridden, stays real — confirming the merge, not full-replace, semantics).
  - `useSessionPageState.test.ts` → `hooks/useAppWs`: a real re-import's `useAppWsEvent` resolves to the poisoner's callback-capturing closure.
  - `QuickWorktreeDialog.test.tsx` → `hooks/useCreateWorktree`: forcing this pair against `useCreateWorktree.test.ts` (its own unit test) drops 4 of 13 tests to failing, because the victim's own hook-under-test is silently replaced by the poisoner's canned mock.
- **After the fix**: every pair re-run in **both** orders (poisoner-path-first and victim-path-first, using the real current file paths as explicit `bun test` arguments) is green with the full expected test count, for all 5 pairs.

## Phase 3 — rule / skill updates

- `.claude/rules/testing.md` Anti-Pattern #2: added the cross-file-imported-target prohibition, a prohibited example (`routes/__root`) and a permitted example (self-consumed target), plus a pre-implementation-checklist bullet.
- `.claude/skills/test-standards/test-standards.md`: added the 3-pattern conversion how-to (DI seam / `spyOn` / real-module-plus-injected-fake) with worked code examples referencing this PR and PR #976, plus the merge-semantics + load-order-control methodology note above.

## Out of scope (per Issue AC)

A mechanical lint gating *new* cross-file-imported `mock.module()` targets requires import-graph analysis and is filed as a follow-up: #1226.

## Test plan

- [x] `bun run test` (full workspace: client 2075, shared 596, integration 73, server 3653, embedded-agent 287, scripts/hooks 483) — all green, `TEST_EXIT: 0`
- [x] `bun run typecheck` — clean (part of `bun run test`)
- [x] `bun run check:lang` — clean (113 files scanned)
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (no coverage gaps, no rule/skill duplication, no language violations, no blame-shift comments)
- [x] Per-pair polarity + both-orders-green verification (above)
- [ ] `coderabbit review --agent --base main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CodeRabbit status (2026-07-27, final) — CLEAN

`main`'s red state (#1225) resolved via PR #1229; head rebased onto it (`5cfe359f`). First genuine CodeRabbit walkthrough on `5cfe359f` (after two rate-limit rounds -- local CLI: headless-worktree `automatic_login_failed`, structural; GitHub bot: rate-limited at PR open, then the "Review finished... does not re-review" quirk on a same-commit retrigger, then a fresh rate-limit on auto-review-on-push) returned 2 actionable findings, both in `test-standards.md`:

1. **Major** -- the `spyOn()` cross-file-safety claim was stated as an unconditional guarantee; it actually depends on this repo's test files running sequentially (no `--concurrent`, no `concurrentTestGlob`). Fixed: named the precondition explicitly and the concurrent-execution case where it would not hold.
2. **Minor** -- the `useAppWsState` mock example used an arbitrary `false as T` cast instead of exercising the real selector contract. Fixed: replaced with a `selector(fakeState)` example, kept the cast form only as a documented exception (matching the existing `routes/__tests__/index.test.tsx` precedent).

Fix commit `abc6efb7` pushed; verified against actual repo config before writing (no `--concurrent` flag in `packages/client/package.json`'s test script, no `concurrentTestGlob` in `bunfig.toml`). Re-review on `abc6efb7` (after a third rate-limit round, cleared and manually retriggered) returned a genuine walkthrough: **"No actionable comments were generated in the recent review."** Zero new findings; both prior findings confirmed resolved, not carried forward.

**3-layer verdict on `abc6efb7`**: pre-merge checks clean, CodeRabbit commit status `state: success` / `description: "Review completed"` (verified via the walkthrough body, not just the status line, per the state-vs-description trap), inline actionable comments = 0, `reviewDecision` empty (walkthrough-exists clean-equivalent case per `coderabbit-ops` troubleshooting -- a genuine review ran, found nothing to flag, and CodeRabbit does not always submit a formal `APPROVED` event for zero-finding passes). Independent Architect code-appropriateness audit (session `56b4d446`, gen-2): **CLEAN** -- confirmed zero production changes, verified the context-identity chain between `routes/__root.tsx` and `contexts/root-contexts.ts`, verified no hidden dependency on the removed `SessionSettings` mock's no-Provider fallback branch, and independently confirmed the CR-Major fix's config claims and the documented-cast exception's premise.

## Note on CI

The `test` job's failure is a confirmed pre-existing `main`-branch flake (`this.#handle.unref is not a function` in `packages/client/src/lib/api.ts`'s `openPath`), already tracked in #1225 and reproduced identically on `main`'s own most recent CI run (2026-07-23). This PR's diff never touches `packages/client/src/lib/api.ts`; locally `bun run test` (full workspace) is green with `TEST_EXIT: 0`. All other CI jobs (preflight, language-lint, comment-blame-shift-lint, check-structure, CodeQL/Analyze) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by removing process-global module mocking in favor of per-test spies, real context providers, and resettable setup (covering worktree rows, session settings, WebSocket hook behavior, and worktree creation dialogs/hooks).
  * Kept existing assertions for UI states and navigation/DELETE behavior while making setup and cleanup more reliable.

* **Documentation**
  * Expanded testing guidance with a new “cross-file module mocking poisoning” procedure, clearer semantics/examples, and a repo-wide checklist to prevent unsafe mocking patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->