### PR TITLE
fix(docker-dev-stack): own soft-fail for git-absence in install-hooks.mjs + missing embedded-agent volume

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -89,8 +89,9 @@ and must never be reachable from the LAN.
 
 Named volumes (all under the `agent-console-dev` compose project):
 `root-node-modules`, `client-node-modules`, `server-node-modules`,
-`shared-node-modules`, `integration-node-modules`, `dev-data`. Remove them
-with `docker compose -f docker/docker-compose.yml down -v` for a from-scratch
+`shared-node-modules`, `integration-node-modules`,
+`embedded-agent-node-modules`, `dev-data`. Remove them with
+`docker compose -f docker/docker-compose.yml down -v` for a from-scratch
 start.
 
 ### Driving the stack as an AI agent

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -28,6 +28,7 @@ if [ "${1:-}" != "stage2" ]; then
     "$APP_DIR/packages/server/node_modules" \
     "$APP_DIR/packages/shared/node_modules" \
     "$APP_DIR/packages/integration/node_modules" \
+    "$APP_DIR/packages/embedded-agent/node_modules" \
     /var/lib/agent-console; do
     chown "$SERVICE_USER:$SERVICE_GROUP" "$dir"
     chmod 2775 "$dir"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - server-node-modules:/app/packages/server/node_modules
       - shared-node-modules:/app/packages/shared/node_modules
       - integration-node-modules:/app/packages/integration/node_modules
+      - embedded-agent-node-modules:/app/packages/embedded-agent/node_modules
       # Dev data root (DB, jwt-secret, worktrees) persists across
       # `docker compose down` / `up` cycles.
       - dev-data:/var/lib/agent-console
@@ -87,4 +88,5 @@ volumes:
   server-node-modules:
   shared-node-modules:
   integration-node-modules:
+  embedded-agent-node-modules:
   dev-data:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "check:pty-fd-leak": "bun scripts/smoke/check-pty-fd-leak.ts",
     "hooks:install": "bun scripts/install-hooks.mjs",
     "preinstall": "bun scripts/check-bun-version.mjs",
-    "postinstall": "bun scripts/install-hooks.mjs || echo 'hooks:install skipped (likely no git or non-interactive env)'",
+    "postinstall": "bun scripts/install-hooks.mjs",
     "lint": "bun run lint:structure",
     "lint:structure": "bun run lint:deps && bun run lint:cycles && bun run lint:unused",
     "lint:deps": "depcruise --config .dependency-cruiser.cjs --ignore-known .dependency-cruiser-known-violations.json packages",

--- a/scripts/__tests__/install-hooks.test.mjs
+++ b/scripts/__tests__/install-hooks.test.mjs
@@ -279,6 +279,46 @@ describe('scripts/install-hooks.mjs hard-failure polarity (Issue #1214)', () => 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('exists with different content');
   });
+
+  it('a `git rev-parse --git-path hooks` failure stays hard (exit 1) even though the repo itself resolved', () => {
+    // Stub `git` on PATH so `--git-common-dir` succeeds (as a real repo
+    // would) but `--git-path hooks` fails, simulating a corrupted /
+    // abnormal repo state distinct from "no git repo at all". Only
+    // resolveRepoRoot()'s git-absence branch is soft; a hooks-path failure
+    // AFTER the repo resolves must surface loudly, not be swallowed as if
+    // the repo were simply missing (that would silently skip installing
+    // the commit-msg language check — the #1210 silent-no-op class).
+    const stubBin = mkdtempSync(join(tmpdir(), 'install-hooks-stubgit-'));
+    const gitStub = join(stubBin, 'git');
+    writeFileSync(
+      gitStub,
+      [
+        '#!/bin/sh',
+        'if [ "$1" = "rev-parse" ] && [ "$2" = "--git-common-dir" ]; then',
+        '  echo "/tmp/fake-common-dir"',
+        '  exit 0',
+        'fi',
+        'if [ "$1" = "rev-parse" ] && [ "$2" = "--git-path" ]; then',
+        '  echo "simulated corrupted repo" 1>&2',
+        '  exit 1',
+        'fi',
+        'exit 1',
+        '',
+      ].join('\n'),
+    );
+    chmodSync(gitStub, 0o755);
+
+    try {
+      const result = spawnSync('bun', [INSTALL_SCRIPT], {
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${stubBin}:${process.env.PATH}` },
+      });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('git rev-parse --git-path hooks');
+    } finally {
+      rmSync(stubBin, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('scripts/install-hooks.mjs invoked via package.json#postinstall in a git repo (Issue #735)', () => {

--- a/scripts/__tests__/install-hooks.test.mjs
+++ b/scripts/__tests__/install-hooks.test.mjs
@@ -187,7 +187,7 @@ describe('scripts/install-hooks.mjs', () => {
   });
 });
 
-describe('scripts/install-hooks.mjs in a non-git environment (Issue #735)', () => {
+describe('scripts/install-hooks.mjs in a non-git environment (Issue #735, #1214)', () => {
   let nonGitSandbox;
 
   beforeEach(() => {
@@ -220,23 +220,22 @@ describe('scripts/install-hooks.mjs in a non-git environment (Issue #735)', () =
     return { ...process.env, GIT_CEILING_DIRECTORIES: nonGitSandbox };
   }
 
-  it('install-hooks.mjs exits non-zero when no .git is reachable', () => {
+  it('install-hooks.mjs exits 0 with a stderr warning when no .git is reachable (Issue #1214)', () => {
     const result = spawnSync(
       'bun',
       [join(nonGitSandbox, 'scripts/install-hooks.mjs')],
       { encoding: 'utf8', cwd: nonGitSandbox, env: envWithCeiling() },
     );
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain('git rev-parse');
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('not a git repository');
   });
 
-  it('package.json#scripts.postinstall fails soft (exit 0) when no .git is reachable', () => {
+  it('package.json#scripts.postinstall exits 0 with no shell `||` needed when no .git is reachable (Issue #1214)', () => {
     const pkg = JSON.parse(
       readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
     );
     const postinstallCmd = pkg.scripts.postinstall;
-    expect(postinstallCmd).toContain('bun scripts/install-hooks.mjs');
-    expect(postinstallCmd).toContain('||');
+    expect(postinstallCmd).toBe('bun scripts/install-hooks.mjs');
 
     const result = spawnSync('sh', ['-c', postinstallCmd], {
       encoding: 'utf8',
@@ -244,7 +243,41 @@ describe('scripts/install-hooks.mjs in a non-git environment (Issue #735)', () =
       env: envWithCeiling(),
     });
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('skipped');
+    expect(result.stderr).toContain('not a git repository');
+  });
+});
+
+describe('scripts/install-hooks.mjs hard-failure polarity (Issue #1214)', () => {
+  // Guards against a future regression to "everything soft": failures that
+  // occur AFTER git resolution succeeds must stay hard (non-zero exit).
+  // These scenarios are already covered above (symlink-elsewhere, different
+  // content, missing source) — this block exists to make the AC's mandatory
+  // hard-path polarity requirement explicit and separately named so a future
+  // reader sees it was intentionally verified, not just incidentally covered.
+  let sandbox;
+  let hooksDir;
+
+  beforeEach(() => {
+    sandbox = mkdtempSync(join(tmpdir(), 'install-hooks-hardfail-'));
+    mkdirSync(join(sandbox, 'scripts/git-hooks'), { recursive: true });
+    copyFileSync(SOURCE_HOOK, join(sandbox, 'scripts/git-hooks/commit-msg'));
+    chmodSync(join(sandbox, 'scripts/git-hooks/commit-msg'), 0o755);
+    spawnSync('git', ['init', '-q', '-b', 'main'], { cwd: sandbox });
+    hooksDir = join(sandbox, '.git', 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('a conflicting existing target still exits non-zero once git resolves', () => {
+    const target = join(hooksDir, 'commit-msg');
+    writeFileSync(target, '#!/bin/sh\necho different\n');
+    chmodSync(target, 0o755);
+    const result = runInstaller(sandbox);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('exists with different content');
   });
 });
 

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -14,16 +14,26 @@
  * installed" and exits 0. If it exists with different content, the script
  * refuses to overwrite and asks the user to remove it explicitly.
  *
- * Soft-fail ownership (Issue #1214): when git itself is unresolvable (no
- * `.git`, e.g. a Docker bind mount of a worktree without its main repo, or a
- * non-git checkout), this script exits 0 with a stderr warning rather than
- * exit 1. This is the same fact regardless of invocation context (postinstall
- * or a manual `bun run hooks:install`), so the exit-0 contract lives here
- * rather than in a shell `||` fallback at the call site — a shell `cmdA ||
- * cmdB` postinstall string was found to not reliably surface its final exit
- * status through Bun 1.3.8's lifecycle-script bookkeeping. Failures *after*
- * git resolves (symlink failure, copy failure, conflicting existing target)
- * stay hard failures — those mean the hook genuinely didn't install.
+ * Soft-fail ownership (Issue #1214): when no git repository is resolvable at
+ * all (`git rev-parse --git-common-dir` fails — no `.git`, e.g. a Docker bind
+ * mount of a worktree without its main repo, or a non-git checkout), this
+ * script exits 0 with a stderr warning rather than exit 1. This is the same
+ * fact regardless of invocation context (postinstall or a manual
+ * `bun run hooks:install`), so the exit-0 contract lives here rather than in
+ * a shell `||` fallback at the call site — a shell `cmdA || cmdB` postinstall
+ * string was found to not reliably surface its final exit status through Bun
+ * 1.3.8's lifecycle-script bookkeeping.
+ *
+ * This soft-fail is intentionally asymmetric: only `resolveRepoRoot()`'s
+ * `--git-common-dir` failure is soft. `resolveHooksDir()`'s
+ * `--git-path hooks` failure — which only runs after a repo was already
+ * found — stays a hard failure, because at that point "no repo" has already
+ * been ruled out; the failure means something is abnormal (a corrupted repo,
+ * a git internal error) that should surface loudly rather than silently skip
+ * installing the commit-msg language check (the same silent-no-op class as
+ * #1210). Likewise, failures after both resolve (symlink failure, copy
+ * failure, conflicting existing target) stay hard failures — those mean the
+ * hook genuinely didn't install.
  */
 
 import { spawnSync } from 'node:child_process';
@@ -62,9 +72,14 @@ function resolveHooksDir() {
     encoding: 'utf8',
   });
   if (result.status !== 0) {
-    console.error('hooks:install — not a git repository; skipping hook install.');
-    console.error(`\`git rev-parse --git-path hooks\` failed: ${result.stderr || '(no stderr)'}`);
-    return null;
+    // Reached only after resolveRepoRoot() already confirmed a git repo
+    // exists, so this is NOT the "no git repo" case — it stays a hard
+    // failure (see the module docstring for why).
+    console.error(
+      'hooks:install — `git rev-parse --git-path hooks` failed even though a git repository was found:',
+    );
+    console.error(result.stderr || '(no stderr)');
+    process.exit(1);
   }
   return resolve(result.stdout.trim());
 }
@@ -140,9 +155,6 @@ function main() {
     process.exit(0);
   }
   const hooksDir = resolveHooksDir();
-  if (hooksDir === null) {
-    process.exit(0);
-  }
   mkdirSync(hooksDir, { recursive: true });
   for (const hook of HOOKS) installOne(hook, hooksDir, repoRoot);
 }

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -13,6 +13,17 @@
  * identical, or file content identical), the script reports "already
  * installed" and exits 0. If it exists with different content, the script
  * refuses to overwrite and asks the user to remove it explicitly.
+ *
+ * Soft-fail ownership (Issue #1214): when git itself is unresolvable (no
+ * `.git`, e.g. a Docker bind mount of a worktree without its main repo, or a
+ * non-git checkout), this script exits 0 with a stderr warning rather than
+ * exit 1. This is the same fact regardless of invocation context (postinstall
+ * or a manual `bun run hooks:install`), so the exit-0 contract lives here
+ * rather than in a shell `||` fallback at the call site — a shell `cmdA ||
+ * cmdB` postinstall string was found to not reliably surface its final exit
+ * status through Bun 1.3.8's lifecycle-script bookkeeping. Failures *after*
+ * git resolves (symlink failure, copy failure, conflicting existing target)
+ * stay hard failures — those mean the hook genuinely didn't install.
  */
 
 import { spawnSync } from 'node:child_process';
@@ -35,11 +46,9 @@ function resolveRepoRoot() {
     encoding: 'utf8',
   });
   if (result.status !== 0) {
-    console.error(
-      'hooks:install — `git rev-parse --git-common-dir` failed:',
-    );
-    console.error(result.stderr || '(no stderr)');
-    process.exit(1);
+    console.error('hooks:install — not a git repository; skipping hook install.');
+    console.error(`\`git rev-parse --git-common-dir\` failed: ${result.stderr || '(no stderr)'}`);
+    return null;
   }
   // `.git` (relative) when run from the main worktree, absolute path to the
   // shared `.git` when run from a linked worktree. Either way the parent
@@ -53,9 +62,9 @@ function resolveHooksDir() {
     encoding: 'utf8',
   });
   if (result.status !== 0) {
-    console.error('hooks:install — `git rev-parse --git-path hooks` failed:');
-    console.error(result.stderr || '(no stderr)');
-    process.exit(1);
+    console.error('hooks:install — not a git repository; skipping hook install.');
+    console.error(`\`git rev-parse --git-path hooks\` failed: ${result.stderr || '(no stderr)'}`);
+    return null;
   }
   return resolve(result.stdout.trim());
 }
@@ -127,7 +136,13 @@ function installOne({ name, source }, hooksDir, repoRoot) {
 
 function main() {
   const repoRoot = resolveRepoRoot();
+  if (repoRoot === null) {
+    process.exit(0);
+  }
   const hooksDir = resolveHooksDir();
+  if (hooksDir === null) {
+    process.exit(0);
+  }
   mkdirSync(hooksDir, { recursive: true });
   for (const hook of HOOKS) installOne(hook, hooksDir, repoRoot);
 }


### PR DESCRIPTION
## Scope note (read this first)

This PR contains **two independent fixes**, bundled together because the second was needed to actually demonstrate the first. Issue #1214's acceptance criteria require a Docker smoke test proving `docker compose up` gets past `bun install` on a fresh checkout. While building that smoke, I hit a **second, unrelated defect** that also breaks `bun install` on a fresh checkout — without fixing it too, the smoke for #1214 cannot pass, so the PR's own verification would be unsatisfiable if split. Commits are kept separate for review clarity:

- Commit 1 (`3c4d8e19`) + commit 2 (`4e136971`): the actual #1214 fix — `install-hooks.mjs` soft-fail ownership.
- Commit 3 (`4e152d05`): the second, independent docker-compose.yml fix, needed only to make the smoke executable.

## Merge disposition note (2026-07-27, updated)

**CR state (initial)**: local CodeRabbit CLI returned `automatic_login_failed` (headless-worktree auth failure — needs interactive browser login, not available in this delegated session). GitHub-side bot posted a rate-limit warning at PR open ("Review limit reached... Next review available in: 15 minutes"). Both channels unavailable for this commit set at the time.

**Resolution**: per Orchestrator direction, waited out the bot's rate-limit countdown rather than using the documented fallback disposition (no urgency to spend the exception since `main` was independently red on unrelated Issue #1225 at the time). Retriggered with `@coderabbitai review` after the countdown; a genuine walkthrough landed (CodeRabbit status `SUCCESS` / "Review completed" at 02:13:40Z, accurately describing both fixes in this PR). Final state: inline actionable comments = 0, pre-merge checks 4/5 passed (1 non-blocking "Docstring Coverage" warning — not applicable to this repo's shell/JS utility script conventions, no actual finding), `reviewDecision` empty (known CodeRabbit behavior for a zero-finding pass — see the `coderabbit-ops` skill's "walkthrough-exists rubric," treated as clean-equivalent). A separate independent code-appropriateness audit from the Architect also returned CLEAN on this diff.

CodeRabbit + Architect layers are both clean. Per Orchestrator: this PR still requires **owner approval** before merge (touches `package.json`, `scripts/install-hooks.mjs`, and `docker/*` behavior — not test/docs-only), gated additionally on `main` going green (Issue #1225, unrelated, in progress).

## Summary

`docker/dev-entrypoint.sh`'s `bun install --frozen-lockfile` returned exit 1 on every fresh Docker dev-stack start, even though every dependency installed successfully, because `set -eu` then killed the container before the dev servers started.

### Fix 1: `scripts/install-hooks.mjs` soft-fail ownership (the #1214 fix)

`package.json`'s `postinstall` delegated soft-fail to a shell `bun scripts/install-hooks.mjs || echo '...'`. Under Bun 1.3.8, this does not reliably work: **minimal reproduction** —

```bash
# Standalone, the exact postinstall command string: exit 0, works fine.
$ bun scripts/install-hooks.mjs || echo done; echo $?
hooks:install — not a git repository; skipping hook install.
...
done
0

# But via `bun install` itself, inside a directory where git is unresolvable,
# the postinstall's own exit 0 does not stop bun from recording the
# left-hand script's exit 1 as a package failure:
$ bun install --frozen-lockfile
...
$ bun scripts/install-hooks.mjs || echo 'hooks:install skipped ...'
hooks:install — `git rev-parse --git-common-dir` failed: ...
hooks:install skipped ...
1318 packages installed [...]
Failed to install 1 package     # <- non-zero exit despite the compound's own exit 0
```

Per `design-principles.md` ("enforce constraints through structure, not convention"), the fix moves soft-fail ownership into the script itself rather than depending on Bun's compound-script exit-status bookkeeping:

- `resolveRepoRoot()`'s `git rev-parse --git-common-dir` failure (no git repo resolvable at all — e.g. a Docker bind mount of a worktree without its main repo, or a non-git checkout) now returns early and the script exits **0** with a stderr warning, instead of exit 1.
- `postinstall` simplified to `bun scripts/install-hooks.mjs` (the shell `||` removed entirely) — `bun install`'s exit code no longer depends on Bun's compound-script bookkeeping at all, so the fix holds regardless of whether the exact bookkeeping hypothesis above is the full story.
- **Asymmetric refinement** (post-review): only `resolveRepoRoot()`'s failure is soft. `resolveHooksDir()`'s `git rev-parse --git-path hooks` failure — reached only *after* a git repo was already confirmed to exist — stays a **hard failure** (exit 1). At that point "no repo" has already been ruled out, so a failure here means something abnormal (corrupted repo, git internal error), which should surface loudly rather than silently skip installing the commit-msg language check (the same silent-no-op class as #1210).
- All other failures (symlink failure, copy failure, conflicting existing target) are unchanged — still hard failures, since those mean the hook genuinely didn't install.

Filing the exact Bun 1.3.8 compound-script bookkeeping behavior upstream is out of scope for this PR (recorded above for a future reader; the fix does not depend on the hypothesis being correct).

### Fix 2: `docker-compose.yml` missing `packages/embedded-agent` volume (discovered by the smoke test)

Running the required Docker smoke against a **genuinely fresh checkout** (`git clone`, no pre-existing `node_modules` — exactly the "fresh container start" scenario in #1214) surfaced a second failure, independent of Fix 1:

```
ENOENT: No such file or directory: failed to symlink dependencies for package: @agent-console/embedded-agent@workspace:packages/embedded-agent (symlink)
...
Failed to install 1 package
```

Root cause: `docker/docker-compose.yml`'s dev-stack volumes list has named `node_modules` volumes for root/client/server/shared/integration, but not for `packages/embedded-agent` (a workspace member via `packages/*`, evidently added after this list was last updated). Without a dedicated volume, bun's workspace-symlink step for `@agent-console/embedded-agent` falls through to the bare bind mount and fails with `ENOENT` on a truly fresh checkout.

Confirmed fully independent of Fix 1 / git resolution:
- Reproduces with `--ignore-scripts` (all lifecycle scripts disabled).
- Reproduces with a fully resolvable git repo (`git clone --local`, not a broken worktree pointer).
- Does NOT reproduce when the same tree is copied to a container-native (non-bind-mounted) directory — only manifests over a bind mount + missing volume.
- My own dev worktree masked this bug because `packages/embedded-agent/node_modules` already existed there from an earlier host-side `bun install` — this is exactly the kind of state that let the defect survive undetected (see `os-environment-coupling.md`).

Fix: added `embedded-agent-node-modules` to both `docker-compose.yml`'s volumes list/mounts and `dev-entrypoint.sh`'s stage-1 `chown`/`chmod` loop (a named volume mounted over a path the entrypoint doesn't fix up is created root-owned, which would trade the ENOENT for an EACCES). Also updated `docker/README.md`'s volume-name list to match.

This is the Docker smoke test doing exactly what it's for — it caught a second real defect on the same code path that a narrower verification would have missed.

## Verification

- `bun run test:scripts` — 485 pass, 0 fail (scripts/ + hooks/ + skills tests).
- `bun run test` (full suite) — 1 pre-existing, unrelated failure: `MultiUserMode > Issue #918 ... does NOT inject any SSH_AUTH_SOCK` fails locally because the real host's 1Password SSH agent socket leaks into the test environment. Confirmed via baseline comparison (`git diff` isolate + `git checkout` to unmodified `main`-tip code, re-ran the same test file, same failure) — pre-existing and unrelated to this change, not introduced here. `main` is also independently known-red right now on two unrelated `@agent-console/integration` `System API > openPath` cross-file-pollution failures (Issue #1225, owned by another workstream) — not observed in my local run but noted per current sprint status.
- `bun run typecheck` — clean.
- `node .claude/skills/orchestrator/preflight-check.js` (run after commit, before push) — clean: no coverage gaps, no rule/skill duplication, no language violations, no blame-shift comment references.
- **Docker smoke** (both AC carve-outs honored: no `--soft`/`--postinstall` context flag anywhere; smoke asserts entrypoint gets past `bun install` and the server begins spawning, does NOT gate on full healthy since Issue #1211's `/ws` proxy hang is a separate open defect in the same stack):
  - Built a genuinely fresh `git clone --local` checkout (no pre-existing `node_modules`) of this branch.
  - `DEV_CLIENT_PORT=15173 DEV_SERVER_PORT=13457 docker compose -f docker/docker-compose.yml up --build -d` against that fresh checkout.
  - Result: container reached `Up ... (healthy)` — `bun install` exited 0, both dev servers (vite + `bun --watch` server) started, and the compose healthcheck (which itself only checks `/api/config` + the vite root, not `/ws`) passed. This exceeds the AC's minimum bar (get past `bun install` + server spawning) — full healthy was reached, and #1211's `/ws` hang did not block it since the healthcheck doesn't probe that path.
  - Before the docker-compose.yml fix, the identical fresh-checkout smoke reproduced the `ENOENT ... embedded-agent` failure described above (exit 1, container dies at `bun install`), confirming the fix was necessary.

## Unit tests

`scripts/__tests__/install-hooks.test.mjs` (12 tests total, TDD-verified: each new/changed assertion fails on unmodified code and passes after its corresponding fix):

- Soft-path polarity: `install-hooks.mjs` exits 0 with a stderr warning when no `.git` is reachable at all.
- `package.json#postinstall` (now `bun scripts/install-hooks.mjs`, no `||`) exits 0 in the same no-git scenario.
- Hard-path polarity (mandatory, prevents future over-softening): a conflicting existing hook target still exits 1 once git resolves.
- New: a `git rev-parse --git-path hooks` failure stays hard (exit 1) even when the repo itself was found (stubs `git` on `PATH` to isolate this from the "no repo at all" case).

Closes #1214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved development container support by persisting the embedded agent’s dependencies across restarts.

* **Bug Fixes**
  * Installation hooks now complete successfully when Git is unavailable, while still reporting a warning.
  * Hook installation continues to fail clearly for genuine configuration or repository errors.

* **Documentation**
  * Clarified instructions for removing Docker development volumes.

* **Tests**
  * Added coverage for Git-unavailable scenarios and confirmed that genuine hook installation failures remain visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->