### PR TITLE
ci: pin structural-metrics install with --frozen-lockfile

### DIFF
--- a/.github/workflows/structural-metrics.yml
+++ b/.github/workflows/structural-metrics.yml
@@ -32,7 +32,7 @@ jobs:
           bun-version: "1.3.5"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       # Generate TanStack Router files so dep-cruiser can resolve imports.
       - name: Prebuild (generate routeTree.gen.ts)


### PR DESCRIPTION
## Why

PR #1229 added `--frozen-lockfile` to `ci.yml`'s install step, after an unpinned install made a four-day CI bisection materially more expensive than it needed to be (Issue #1225 — `main` was red from 2026-07-23 and the unpinned inputs had to be ruled out by hand before the real cause could be isolated).

`structural-metrics.yml` was missed in that pass. It runs on every PR and still installs unpinned, so the same non-reproducible-input gap is still open.

## Audit

Every workflow that installs dependencies, on `main` at `35ab69dd`:

| Workflow | Install step | State |
|---|---|---|
| `ci.yml:32` | `bun install --frozen-lockfile` | pinned (PR #1229) |
| `language-lint.yml:43` | `bun install --frozen-lockfile` | already pinned |
| `structural-metrics.yml:35` | `bun install` | **unpinned — this PR** |

No other workflow installs dependencies. This closes the last one.

## Scope

One line. No behaviour change when the lockfile and `package.json` already agree — which is the normal state, and CI failing loudly when they do not is the point.

Found by the Architect during the post-merge review of PR #1229, as a follow-up the merged PR did not cover. Recording that because it is the second time today a completeness gap surfaced only after a change had already landed.

## Test plan

- [ ] `check-structure` job passes on this PR — that job is itself the thing being modified, so its own green run is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
