### PR TITLE
docs: sprint retrospective improvements (2026-07-27)

### DIFF
--- a/.claude/rules/pre-pr-completeness.md
+++ b/.claude/rules/pre-pr-completeness.md
@@ -120,6 +120,20 @@ Before opening a PR that introduces a **new skill, script, rule, file type, or c
 
     (Lesson: this rule itself — Issue [#1160](https://github.com/ms2sato/agent-console/issues/1160) PR-D built the exposure-table mechanism specifically because Q11's original four questions catch tool-level gaps like the embedded-agent-v1 case above, but had no equivalent for operation-level gaps like `list_agents` silently excluding embedded agents while `delegate_to_worktree` accepted them — see `docs/design/agent-surface.md` §0 "Verified current state" for that concrete parity bug.)
 
+12. **Is the AC's own verification requirement still satisfiable? — before starting implementation:**
+
+    Read the acceptance criteria and ask what would have to be true for you to *demonstrate* they are met, then confirm each of those things holds. An AC that mandates a real-environment check ("run the Docker smoke on a fresh checkout", "verify on the multi-user host", "reproduce the original symptom") is asserting that the check is currently runnable — an assumption nobody validated when the AC was written.
+
+    Concretely, before the first commit:
+
+    1. **Name the verification the AC requires**, and the environment it needs.
+    2. **Run it once against unmodified `main`** — not to see it pass, but to see it *execute*. It should fail for the reason the Issue describes. Any other failure means the verification path itself is broken, and you have found that before it has cost you an implementation.
+    3. **If it cannot run, stop and report before implementing.** The blocker may be a second, unrelated defect (fix it, or get a scope decision), or the AC may need a different verification. Both are cheap now and expensive after the work is done.
+
+    **A blocker discovered here is a finding, not an obstacle.** The verification was mandated because the code path is environment-coupled; if the environment cannot even reach the starting line, that is information about the system.
+
+    (Lesson: Sprint 2026-07-18b PR [#1228](https://github.com/ms2sato/agent-console/pull/1228) — the AC for Issue #1214 required a Docker smoke proving `bun install` completes on a fresh checkout. Implementation finished, then the smoke could not run: a *second*, unrelated defect (a missing workspace volume in `docker-compose.yml`) broke `bun install` on any fresh clone. The AC had become unsatisfiable without also fixing that. Discovered mid-implementation, it stalled the delegate and crossed with an in-flight architect consultation; the Orchestrator ultimately bundled both fixes with a scope note. Asking this question first would have surfaced it in the first five minutes — and the second defect was real and worth finding either way.)
+
 ## When to apply
 
 - **Required** for PRs that introduce:
@@ -132,8 +146,9 @@ Before opening a PR that introduces a **new skill, script, rule, file type, or c
   - A shared / persistent artifact write (Question 7) — required regardless of whether other criteria match
   - A derived field added to a shared type that crosses the server/client wire (Question 10) — required regardless of whether other criteria match
   - A new worker / agent / execution surface analogous to an existing one, or a new entry in `AGENT_OPERATIONS` / a new agent-operations exposure table (Question 11) — required regardless of whether other criteria match
+- **Question 12 applies to any PR whose AC mandates a real-environment verification** (a smoke script, a dogfood pass, a container / multi-user / real-device check) — required regardless of whether other criteria match, and it runs **before implementation**, not before the PR. It is the one question here that is worthless if asked late.
 - **Optional but encouraged** for any production code PR touching infrastructure or cross-cutting patterns
-- **Not required** for single-file bug fixes, typo corrections, or test-only additions
+- **Not required** for single-file bug fixes, typo corrections, or test-only additions — **except** that Question 12 still applies if such a fix's AC mandates a real-environment check
 
 ## Why
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -64,7 +64,7 @@ When you form a conclusion from a *secondary signal* — a derived, lagging, or 
 | Domain | Secondary signal (do NOT conclude from this alone) | Primary information (verify here) |
 |---|---|---|
 | CI failure | "infra problem" / "rate-limit" / "external service" intuition; the red X without the log | `gh run view <run_id> --log-failed` |
-| CodeRabbit review | absence of new comments; pre-merge checks passing; a stale `CHANGES_REQUESTED`; a rate-limit message | the PR's 3-layer state (Pre-merge checks / `reviewDecision` / inline comments) re-read at decision time |
+| CodeRabbit review | absence of new comments; pre-merge checks passing; a stale `CHANGES_REQUESTED`; a rate-limit message; **`CodeRabbit=SUCCESS` in `statusCheckRollup`** | the PR's 3-layer state (Pre-merge checks / `reviewDecision` / inline comments) re-read at decision time, **plus the commit status's `description` string** — `state` is `success` even when the bot never reviewed (see [`coderabbit-ops`](../skills/coderabbit-ops/SKILL.md) "The fourth surface") |
 | Cross-repo issue | "this symptom looks like the other repo's known bug / shared pattern" | reproduce in *this* repo's own code path before filing, blaming, or claiming applicability |
 | Runtime observation | a dev-server log line / websocket frame / UI render / channel assumption taken as proof a path ran or a notification arrived | the authoritative store / server-side state / a deterministic probe / per-channel confirmation |
 
@@ -148,6 +148,33 @@ When the local CLI or GitHub-side bot is rate-limited or unresponsive, follow th
 3. **State the observation's confidence** — if a conclusion rests on a secondary runtime signal that could not be primary-verified, say so rather than reporting it as established fact.
 
 (Lesson: Sprint 2026-05-02 retro PR #758 / brew PR #759 — the lightweight-worktree notification limitation was first recorded as "webhook AND `conditional_wakeup` both fail", inferred from a single missed-event observation. The owner clarified `conditional_wakeup` works fine; only webhooks fail. One observation was generalized across channels without per-channel verification.)
+
+### Sub-pattern 5: absence of a signal
+
+**Inference trap.** Waiting on a signal that has no path to arrive, and reading the silence as "still in progress". This is the inverse of the other four: there, a weak signal was over-trusted; here, a *missing* signal is not questioned at all.
+
+Two shapes seen in Sprint 2026-07-18b:
+
+- **CI that cannot fire.** `ci.yml` triggers on `pull_request` and push-to-`main` only. A push to a feature branch with no PR open runs **nothing**. A delegate investigating a CI-only failure had added a temporary debug workflow with its own push trigger; once that scaffolding was removed, they pushed the real fix and waited ~40 minutes for a run that had no way to start.
+- **An agent that stopped answering.** The Architect session showed `activityState: idle` — indistinguishable from "finished and replied". Four requests went unanswered; it was only found by listing message files and observing that no architect-originated message existed after a certain timestamp.
+
+**Verify procedure.**
+
+1. **If a push produces zero CI runs, check the workflow's trigger before waiting.** `gh run list --branch <branch>` returning empty is a fact about triggers, not about queue latency. Suspect this immediately after removing temporary workflow scaffolding — the asymmetry between a debug workflow's triggers and the real one's is invisible until the debug one is gone.
+2. **For a silent counterpart, check for evidence of *output*, not of *state*.** An `idle` worker may have replied or may be stuck. What distinguishes them is whether anything was produced after your request. Timebox the wait and escalate rather than re-sending indefinitely; for the Architect specifically, `SKILL.md`'s First Action already prescribes provisioning a fresh session when the designated one is inactive.
+
+### Sub-pattern 6: hypothesis exhaustion
+
+**Inference trap.** Generating one more plausible mechanism after several have been disproven. Each individual hypothesis is reasonable given the evidence; the failure is in the *strategy*, which samples a space instead of partitioning it — and which is structurally bad at causes that require two conditions at once.
+
+**Verify procedure.**
+
+1. **Always pair a negative with a positive control in the same run.** A hypothesis probe that comes back clean means nothing unless the same run also reproduces the failure by a known-good path. This is what makes a string of negatives trustworthy enough to act on.
+2. **After roughly three consecutive disproven hypotheses, stop generating and start reducing.** Delta-debugging on the real artifact — deleting content until the failure disappears — is guaranteed to converge, where hypothesis generation is not.
+3. **Prefer the control experiment that holds everything fixed but one variable.** Re-running a known-good state unchanged, or running the same code outside the suspected environment, beats any number of plausible mechanisms. It is also the only thing that can exonerate a whole category (the repository, the runtime, the config) in one step.
+4. **When each iteration costs a CI round-trip, go wide, not deep.** Binary search is optimal when probes are cheap and sequential; when a round-trip is the binding cost, put every enumerable variant into a single run.
+
+(Lesson: Sprint 2026-07-18b Issue #1225 — `main` was red for four days. Four single-mechanism hypotheses were disproven in sequence, each with a positive control that made the negatives credible. What resolved it was re-running the last green CI run byte-identically — which exonerated the repository and isolated the runner image as the only changed variable — followed by delta-debugging the real test file. Issue #1211 was settled the same day by the same shape: running the identical config and binary outside Docker. Neither was reached by the hypotheses.)
 
 ## Commands
 

--- a/.claude/skills/coderabbit-ops/SKILL.md
+++ b/.claude/skills/coderabbit-ops/SKILL.md
@@ -46,6 +46,34 @@ An empty `reviewDecision` means the bot has not yet reviewed and the PR is **not
 
 "CodeRabbit clean" requires all three. Pre-merge checks alone are insufficient. (Sprint 2026-04-25 PR #694 — agent declared "clean" based on pre-merge 5/5 while review state was `CHANGES_REQUESTED` with 3 actionable issues.)
 
+### The fourth surface: `statusCheckRollup`'s `CodeRabbit` entry is NOT a verdict
+
+None of the three layers above is the **commit-status context** named `CodeRabbit`. That context nonetheless appears in `gh pr view <N> --json statusCheckRollup` — the command everyone runs to confirm CI — rendered alongside `test`, `preflight`, and the rest as:
+
+```
+CodeRabbit=SUCCESS
+```
+
+**Its `state` is `success` regardless of whether a review happened.** The truth is in the `description`, which `statusCheckRollup` does not surface by default. Read it explicitly:
+
+```bash
+SHA=$(gh pr view <N> --json headRefOid -q .headRefOid)
+gh api repos/<owner>/<repo>/commits/$SHA/status \
+  -q '[.statuses[] | select(.context=="CodeRabbit") | "\(.state) | \(.description) | \(.updated_at)"] | .[0]'
+```
+
+Three descriptions observed, all with `state=success`:
+
+| `description` | Meaning | Action |
+|---|---|---|
+| `Review completed` | A real review ran | Proceed to layers 2 and 3 |
+| `Review rate limited` | **The bot never reviewed this commit** | Wait, or apply the `troubleshooting.md` disposition |
+| `Review skipped: ignored keyword in the PR title` | Deliberately skipped by `.coderabbit.yaml` config (the `docs:` carve-out above) | Layer 2 is N/A — verify the diff really is docs-only |
+
+Note the `updated_at` too: the status is re-issued per head SHA, so **updating a PR branch resets it**. A `Review completed` from before a rebase says nothing about the current head.
+
+(Sprint 2026-07-18b — three PRs (#1227, #1231, #1229) carried `CodeRabbit=SUCCESS` in the rollup while the description read `Review rate limited`. Reading only the rollup state would have merged all three as "CodeRabbit clean" with no review. #1227 in particular later produced a Major finding that a standards document would otherwise have shipped with.)
+
 ## Case-by-case dispositions
 
 For the following situations, see [`troubleshooting.md`](troubleshooting.md):

--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -133,6 +133,23 @@ The Architect observes no ambient state — no CI, no PR status, no dogfood, no 
 
 Full rationale and the ambient-observation guarantee: [`docs/design/architect-role.md`](../../../docs/design/architect-role.md) §6.
 
+### When the Architect stops answering
+
+`get_session_status` reports `activityState: idle` both for "replied and waiting" and for "stuck" — the field describes the worker, not the exchange. Re-sending into silence is the default failure mode; it produced four unanswered pushes in one sprint before anyone checked.
+
+**Track outstanding pushes, and judge on output rather than state.** After pushing to the Architect, note the time. On each self-check, ask whether anything has come back — and if not, whether the Architect has produced output *for anyone*:
+
+```bash
+find /var/lib/agent-console/repositories/agent-console/messages \
+  -name '*<architect-session-id>*' -newermt '<time of your push>'
+```
+
+Empty means the Architect has not written to any inbox since your push — not merely that it has not answered you. That distinction matters: answering a delegate while ignoring you is a routing or priority problem; answering nobody is a stuck session.
+
+**Escalate rather than re-send.** One re-send is reasonable (messages can cross). By the second, change something: send a deliberately short message asking only for acknowledgement, and state that no answer will be read as "cannot proceed". If that also goes unanswered, the designated Architect is inactive and First Action step 1 applies — provision a fresh session, bootstrap it from the handoff memory, and leave the old one in place rather than destroying it.
+
+A generation change is cheap because the handoff memory carries the binding rulings. Waiting is not cheap: the Architect gates every delivered PR's verdict.
+
 ### Verdict shape
 
 The Architect returns one of three verdicts:
@@ -145,6 +162,19 @@ The Architect returns one of three verdicts:
 Delegate workers **may consult the Architect directly** (bypassing you) during implementation when they hit uncertainty (ambiguous AC, code-shape decisions, sibling-site consistency questions, constraint collisions). This is default-allowed; you do not gate or approve these exchanges. The worker summarizes any AC/design change from the exchange in their next report to you.
 
 If direct-channel volume becomes excessive (Architect saturation), treat it as a workload / AC-quality signal in the next retro — not as a channel to block.
+
+**Write the permission and the reporting duty as two separate sentences in the delegation prompt.** A single clause granting the channel will be read as also waiving the report:
+
+```
+Consulting the architect needs no approval from me.
+Any exchange that touches AC, scope, or a design decision MUST appear as a
+one-line summary in your next report — including when you judge it already
+resolved. Your judgment that it is resolved is what I need to see, not infer.
+```
+
+The failure is not disobedience. A worker who resolves a scope question correctly has, from their side, *handled* it — and "handled" collapses into "no longer outstanding" unless the report is named as a separate obligation. What you lose is exactly the judgment call you would have wanted to see.
+
+(Lesson: Sprint 2026-07-18b — a delegate prompt said "you may consult the architect directly — no need to route through me", meaning no pre-approval. The Architect ruled on whether a PR needed a production-side extraction — which decides whether it is Orchestrator-mergeable or owner-gated — and explicitly asked for the outcome to reach the Orchestrator. It never did; the Orchestrator found the exchange by reading message files during the retro. The ruling happened to land on the test-only branch, so nothing broke. Asked directly, the delegate confirmed they knew who the Orchestrator was and had reported everything else correctly — the gap was the prompt's wording, not role confusion.)
 
 ## Core Responsibilities
 

--- a/.claude/skills/orchestrator/sprint-lifecycle.md
+++ b/.claude/skills/orchestrator/sprint-lifecycle.md
@@ -56,6 +56,18 @@ Each sprint is labeled by the calendar date its retrospective runs (e.g., `2026-
 - Task progression, acceptance checks, merges
 - When new gotchas are discovered, append them to `memory/project_sprint_status.md` (Claude memory) immediately
 - Example: "WorkerType does not have 'custom' variant yet. If referenced, it's wrong"
+- **Check `main`'s CI health whenever the pipeline goes quiet.** `main` is only exercised when something merges. During a wait — an owner gate, a dogfood pass, an overnight pause — nothing merges, so nothing runs, so a red `main` produces no signal at all. It is not that the failure is missed; it is that no observation is being made.
+
+  Include it in the self-check timer, and always before proposing the next batch of work:
+
+  ```bash
+  gh run list --branch main --workflow CI --limit 1 --json conclusion,headSha,createdAt
+  ```
+
+  A `failure` here means every open PR is unmergeable and every new branch starts broken — the highest-priority item on the board, regardless of what was planned. Note that the cause need not be in the repository: a runner-image update, an action version bump, or an external service can turn `main` red with no commit behind it (see `workflow.md` "Inference vs Verification" Sub-pattern 6).
+
+  (Lesson: Sprint 2026-07-18b — `main` was red for four days while the sprint waited on an owner smoke gate. It surfaced only because the Orchestrator dispatched unrelated backfill work and its CI failed. Four completed PRs had been silently unmergeable the whole time.)
+
 - **Idle time utilization**: When waiting for agent completion or owner approval and **active worktrees are ≤1**, consider running `review-loop` on the full codebase or specific packages. This catches systemic issues and makes productive use of wait time. Do NOT run review-loop when many worktrees are active — it competes for compute resources.
 - **Dogfood verification as a late-sprint fixture.** When the sprint ships user-observable behavior (new UI affordance, new operator command, multi-user identity flow, webhook integration, etc.), schedule a **dogfood verification pass after all PRs land but before sprint retro**. The pass: redeploy to the relevant environment, walk the acceptance criteria matrix as a user would, and capture observations as the next retro's inputs. Sprint 2026-06-29 demonstrated the leverage — dogfooding [#871](https://github.com/ms2sato/agent-console/issues/871) Unregister flow surfaced [#905](https://github.com/ms2sato/agent-console/issues/905) (source-repos cleanup option), [#912](https://github.com/ms2sato/agent-console/issues/912) (server fetch elevation gap), [#914](https://github.com/ms2sato/agent-console/issues/914) (sidebar owner label), and [#916](https://github.com/ms2sato/agent-console/issues/916) (multi-user webhook setup docs) in a single afternoon. Without the scheduled dogfood pass these would have surfaced ad-hoc post-release. Codify the matrix in the sprint memo before the pass so observations land in a structured form.
 

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -439,6 +439,60 @@ curl -X POST http://localhost:8080/api/auth/login \
 > isolation), run the Docker verification: `scripts/verify-multiuser-docker.sh`
 > (see [`docker/README.md`](../docker/README.md)).
 
+## Re-running the bootstrap script against an existing deployment
+
+**Read the live systemd unit before re-running `setup-multiuser-for-ubuntu.sh`
+on a host that is already serving.** The script renders a unit from its own
+defaults and refuses to overwrite a differing one:
+
+```
+error: /etc/systemd/system/agent-console.service exists and differs from the
+rendered template; re-run with --force to overwrite
+```
+
+That refusal is the safety mechanism working. `--force` overwrites the unit
+**with the script's defaults for every parameter you did not pass explicitly** —
+so a value that was set once at install time and never recorded anywhere else
+is silently replaced.
+
+The port is the sharp edge: the script's default is `8080`, and a deployment
+running on any other port will be moved to `8080` by a bare `--force`, breaking
+the URL its users have. Before re-running:
+
+```bash
+# 1. Read what is actually deployed.
+cat /etc/systemd/system/agent-console.service
+
+# 2. Preview what the script would write, without touching anything.
+sudo bash scripts/setup-multiuser-for-ubuntu.sh --port <live-port> --force --dry-run
+
+# 3. Diff the rendered unit (printed between the "Rendered unit" markers)
+#    against the live one, and carry over every parameter that differs —
+#    not just the port.
+```
+
+Environment lines such as `AUTH_COOKIE_SECURE` and `HOST` are part of the unit
+and are subject to the same replacement.
+
+**Prefer the narrowest operation that achieves the goal.** Re-running the whole
+bootstrap to pick up one new provisioning step is rarely the right tool — it
+also re-syncs the application tree and re-renders sudoers. If the change you
+need is a single file, apply that file. For example, the `/usr/local/bin/bun`
+copy the script performs for `EMBEDDED_AGENT_BUN_PATH` (Issue
+[#1221](https://github.com/ms2sato/agent-console/issues/1221)) is, on its own:
+
+```bash
+sudo install -m 0755 ~agentconsole/.bun/bin/bun /usr/local/bin/bun
+```
+
+(Lesson: Sprint 2026-07-18b — a smoke-test procedure said to re-run the
+bootstrap script to provision `/usr/local/bin/bun`. Two things were wrong.
+The provisioning step existed only on the un-merged PR branch, so running the
+script from `main` could never produce the file; and the live unit used a
+non-default port, so the `--force` needed to get past the unit conflict would
+have moved the running service. The one-line `install` above was the whole
+requirement.)
+
 ## Iterative Updates (after the initial setup)
 
 After the bootstrap script has completed once, ongoing source-code updates and


### PR DESCRIPTION
Sprint 2026-07-18b retrospective improvements. 19 PRs merged; the sprint's defining event was `main` sitting red for four days without anyone observing it.

Each change below is traceable to something that actually went wrong, or to something that was caught by luck and should not have to be next time.

## 1. CodeRabbit's fourth surface

`.claude/skills/coderabbit-ops/SKILL.md`, `.claude/rules/workflow.md`

The skill documents a 3-layer verdict (Pre-merge checks / `reviewDecision` / inline comments). **None of the three is the `CodeRabbit` commit-status context** — which nonetheless appears in `gh pr view --json statusCheckRollup`, the command everyone runs to confirm CI, rendered next to `test` and `preflight` as `CodeRabbit=SUCCESS`.

Its `state` is `success` in all three of these cases:

| `description` | Reality |
|---|---|
| `Review completed` | reviewed |
| `Review rate limited` | **never reviewed** |
| `Review skipped: ignored keyword in the PR title` | skipped on purpose by `.coderabbit.yaml` |

Three PRs this sprint (#1227, #1231, #1229) showed a green rollup with no review behind it. #1227 later produced a Major finding — a factually wrong claim about `spyOn` isolation that would have shipped in a standards document.

Adds the read command, the table, and a note that the status is per-head-SHA so updating a branch invalidates an earlier `Review completed`.

## 2. Re-running the bootstrap script against a live deployment

`docs/multi-user-setup-guide.md`

`setup-multiuser-for-ubuntu.sh` refuses to overwrite a differing systemd unit and tells you to re-run with `--force`. `--force` then replaces **every parameter not passed explicitly** with the script's defaults. The live service ran on a non-default port; a bare `--force` would have moved it and broken the URL in use.

Adds: read the live unit first, preview with `--dry-run`, carry over everything that differs. Plus the more general point — prefer the narrowest operation. The provisioning step actually needed was one `install` command; re-running the whole bootstrap was the wrong tool.

## 3. Consult permission is not a waiver of the report

`.claude/skills/orchestrator/SKILL.md`

A delegation prompt said "you may consult the architect directly — no need to route through me", meaning no pre-approval. The Architect then ruled on whether a PR required a production-side extraction — the thing that decides whether it is Orchestrator-mergeable or owner-gated — and asked for the outcome to reach the Orchestrator. It never did.

Asked directly, the delegate confirmed they knew who the Orchestrator was and had reported everything else correctly. The gap was the prompt. Adds a two-sentence template and names why the collapse happens: a worker who resolves a question has, from their side, *handled* it.

## 4-5. Two new Inference vs Verification sub-patterns

`.claude/rules/workflow.md`

**Sub-pattern 5 — absence of a signal.** The existing four sub-patterns all cover over-trusting a weak signal. These are the inverse: waiting on something with no path to arrive. `ci.yml` fires on `pull_request` only, so a push to a branch with no PR runs nothing — a delegate waited ~40 minutes after removing a temporary debug workflow that *had* a push trigger. And `activityState: idle` cannot distinguish an agent that replied from one that is stuck.

**Sub-pattern 6 — hypothesis exhaustion.** Four single-mechanism hypotheses for #1225 were disproven in sequence, each individually reasonable. What resolved it was re-running the last green CI run byte-identically (exonerating the repository in one step, isolating the runner image as the only changed variable) and then delta-debugging the real file. #1211 was settled the same day by the same shape: the identical config and binary run outside Docker. Codifies: pair every negative with a positive control, stop generating after ~3 disproven, prefer the control experiment, go wide when iterations cost a round trip.

## 6. Check `main` when the pipeline goes quiet

`.claude/skills/orchestrator/sprint-lifecycle.md`

`main` is only exercised when something merges. During a wait — an owner gate, a dogfood pass — nothing merges, so nothing runs, so a red `main` produces no signal. It is not that the failure is missed; no observation is being made.

It surfaced only because unrelated backfill work was dispatched and its CI failed. Four completed PRs had been silently unmergeable for days. Also notes the cause need not be in the repository.

## 7. Is the AC's own verification still satisfiable?

`.claude/rules/pre-pr-completeness.md` Q12

An AC mandating a real-environment check ("run the Docker smoke on a fresh checkout") asserts that check is currently runnable — an assumption nobody validates when writing it. On PR #1228, implementation finished and *then* the smoke could not run: a second, unrelated defect broke `bun install` on any fresh clone.

Q12 runs **before implementation**, unlike every other question here — run the verification once against unmodified `main` to see it *execute*, not to see it pass. Registered in "When to apply" including the not-required carve-out, since a single-file fix can still carry a real-environment AC.

## Also

Architect-unresponsive escalation (`orchestrator/SKILL.md`): judge on whether the Architect produced output for *anyone*, not on session state; escalate to a fresh generation rather than re-sending.

## Deferred to Issues

- **TTM measurement** — `sprint-retro.js`'s time-to-mergeable is wall-clock and is dominated by owner gates, `main` outages, and bot rate limits. All five flagged outliers this sprint were waiting, and none matched the interpretation the script suggests. Needs a script change, not a doc change.
- **Architect unresponsiveness detection** — the procedure above is manual. Surfacing per-session last-output time is product work.

## Test plan

- [x] `bun run check:lang` — clean, 114 files
- [x] `node .claude/skills/orchestrator/rule-skill-duplication-check.js` — no rule paragraphs duplicated into skills
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
