### PR TITLE
fix: deliver long initialPrompt via a file instead of inline shell-escaped text

### DIFF
--- a/packages/integration/src/initial-prompt-delivered-boundary.test.ts
+++ b/packages/integration/src/initial-prompt-delivered-boundary.test.ts
@@ -35,15 +35,35 @@ import {
 } from '@agent-console/server/src/__tests__/test-utils';
 import { createTestContext, shutdownAppContext } from '@agent-console/server/src/app-context';
 import type { AppContext } from '@agent-console/server/src/app-context';
+import type { runAsUser } from '@agent-console/server/src/services/privilege-elevation';
 
 import { AppServerMessageSchema } from '@agent-console/shared';
+
+/**
+ * Always-success fake for WorkerManager's `runAsUser`-shaped elevation
+ * calls, injected via the `runAsUserImpl` test seam threaded through
+ * `createTestContext` (Issue #1234). `createSession` below activates an
+ * agent worker with a non-empty `initialPrompt`, and that write is NOT
+ * AUTH_MODE-gated -- without this fake, `activateAgentWorkerPty`'s
+ * prompt-file write would hit the REAL elevation helper's
+ * `Bun.spawn(['sh', '-c', ...])` subprocess against the real filesystem
+ * (this test's `AGENT_CONSOLE_HOME` is a synthetic path set up by
+ * `setupTestEnvironment`, not a directory that real subprocess I/O can
+ * write to), and fail with a real `mkdir: Permission denied`.
+ */
+const fakeRunAsUserAlwaysSuccess: typeof runAsUser = async () => ({
+  stdout: '',
+  stderr: '',
+  exitCode: 0,
+  timedOut: false,
+});
 
 describe('Client-Server Boundary: Session.initialPromptDelivered', () => {
   let ctx: AppContext;
 
   beforeEach(async () => {
     await setupTestEnvironment();
-    ctx = await createTestContext();
+    ctx = await createTestContext({ runAsUserImpl: fakeRunAsUserAlwaysSuccess });
   });
 
   afterEach(async () => {

--- a/packages/server/src/__tests__/utils/build-test-data.ts
+++ b/packages/server/src/__tests__/utils/build-test-data.ts
@@ -154,6 +154,7 @@ export function buildInternalAgentWorker(
     activityState: 'unknown',
     activityDetector: null,
     mcpToken: null,
+    promptFile: null,
     ...overrides,
   };
 }

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -16,6 +16,7 @@ import type { JobQueue } from './jobs/job-queue.js';
 import type { SessionRepository } from './repositories/session-repository.js';
 import type { UserRepository } from './repositories/user-repository.js';
 import type { SessionManager } from './services/session-manager.js';
+import type { runAsUser } from './services/privilege-elevation.js';
 import type { RepositoryManager } from './services/repository-manager.js';
 import type { NotificationManager } from './services/notifications/notification-manager.js';
 import type { AgentManager } from './services/agent-manager.js';
@@ -603,6 +604,18 @@ export interface CreateTestContextOptions {
    * port known only after `Bun.serve` starts.
    */
   getMcpBaseUrl?: () => string;
+  /**
+   * Test seam for WorkerManager's `runAsUser`-shaped elevation calls (MCP
+   * token file write/delete, prompt file write/delete). Threaded straight
+   * through to `SessionManager.create()`'s own `runAsUserImpl` seam.
+   * Defaults to `undefined`, which leaves `WorkerManager` on its own default
+   * (the real `runAsUser`) -- production and every existing test context are
+   * unaffected. The prompt-file write runs unconditionally whenever an
+   * activated agent worker carries a non-empty `initialPrompt` (not gated on
+   * auth mode), so integration tests that create such a worker and don't
+   * want a real filesystem write should inject an always-success fake here.
+   */
+  runAsUserImpl?: typeof runAsUser;
 }
 
 /**
@@ -696,6 +709,7 @@ export async function createTestContext(
     // Thread only when provided so default behavior (local /mcp URL) is
     // unchanged for tests that do not override it.
     ...(overrides?.getMcpBaseUrl ? { getMcpBaseUrl: overrides.getMcpBaseUrl } : {}),
+    runAsUserImpl: overrides?.runAsUserImpl,
     notificationManager,
     annotationService,
     workerOutputFileManager,

--- a/packages/server/src/lib/__tests__/template.test.ts
+++ b/packages/server/src/lib/__tests__/template.test.ts
@@ -181,6 +181,32 @@ describe('expandTemplate', () => {
       expect(result.command).toBe("test-cli '$HOME and $(whoami)'");
       expect(result.env).toEqual({});
     });
+
+    it('should not interpret String.replace special replacement patterns ($$, $&, $`, $\') in the prompt', () => {
+      // String.prototype.replace() treats a STRING second argument
+      // specially: $$ -> literal $, $& -> the matched substring, $` -> text
+      // before the match, $' -> text after the match. A plain-string
+      // replacer would silently mangle a prompt containing these sequences
+      // before it ever reaches the shell. This locks in the function-form
+      // replacer fix for the inline-prompt branch.
+      const prompt = 'price is $$5, ref $&, before $` marker, after $\' marker';
+      const result = expandTemplate({
+        template: 'test-cli {{prompt}}',
+        prompt,
+        cwd: '/repo',
+      });
+
+      // shellEscape wraps in single quotes; the one literal `'` in the
+      // prompt (from `$'`) is itself escaped via the `'\''` technique
+      // (see the "should safely handle prompts with quotes" test above) --
+      // that escaping is orthogonal to this test's concern, which is that
+      // NONE of the $$/$&/$`/$' sequences get reinterpreted as
+      // String.replace patterns.
+      expect(result.command).toBe(
+        "test-cli 'price is $$5, ref $&, before $` marker, after $'\\'' marker'"
+      );
+      expect(result.env).toEqual({});
+    });
   });
 
   describe('path handling', () => {
@@ -205,6 +231,20 @@ describe('expandTemplate', () => {
 
       // Single quotes in paths are escaped using the '\'' technique
       expect(result.command).toBe("cd '/path/with'\\''quote/repo' && run 'test'");
+      expect(result.env).toEqual({});
+    });
+
+    it('should not interpret String.replace special replacement patterns ($&) in cwd', () => {
+      // Same String.prototype.replace() trap as {{prompt}}: a plain-string
+      // replacer would silently mangle a cwd containing these sequences.
+      // Locks in the function-form replacer fix for the {{cwd}} site.
+      const result = expandTemplate({
+        template: 'cd {{cwd}} && run {{prompt}}',
+        prompt: 'test',
+        cwd: '/repo/$&marker',
+      });
+
+      expect(result.command).toBe("cd '/repo/$&marker' && run 'test'");
       expect(result.env).toEqual({});
     });
   });
@@ -417,6 +457,32 @@ describe('promptFilePath option', () => {
     expect(result.env).toEqual({});
   });
 
+  it('should not interpret String.replace special replacement patterns ($$, $&, $`, $\') in the promptFilePath', () => {
+    // Same String.prototype.replace() trap as the inline-prompt branch: a
+    // plain-string replacer would silently mangle a path containing these
+    // sequences. Paths are derived from AGENT_CONSOLE_HOME / an OS user's
+    // homeDir, which could theoretically contain such characters depending
+    // on system configuration. Locks in the function-form replacer fix for
+    // the promptFilePath branch.
+    const promptFilePath = "/home/weird$$user/$&marker/$`before/$'after/w1.prompt";
+    const result = expandTemplate({
+      template: 'claude {{prompt}}',
+      promptFilePath,
+      cwd: '/repo',
+    });
+
+    // shellEscape wraps in single quotes; the one literal `'` in the path
+    // (from `$'`) is itself escaped via the `'\''` technique (see the
+    // "should shell-escape a promptFilePath containing a single quote" test
+    // above) -- that escaping is orthogonal to this test's concern, which
+    // is that NONE of the $$/$&/$`/$' sequences get reinterpreted as
+    // String.replace patterns.
+    expect(result.command).toBe(
+      "claude \"$(cat '/home/weird$$user/$&marker/$`before/$'\\''after/w1.prompt')\""
+    );
+    expect(result.env).toEqual({});
+  });
+
   it('should throw TemplateExpansionError when both prompt and promptFilePath are provided', () => {
     expect(() =>
       expandTemplate({
@@ -429,7 +495,12 @@ describe('promptFilePath option', () => {
   });
 
   // Regression lock: promptFilePath being absent must not change existing
-  // behavior at all (Issue #1234 fix must be byte-identical when unused).
+  // behavior for ordinary inputs (Issue #1234 fix must be byte-identical
+  // when unused). This covers the LEGACY CONTRACT, not the legacy $$/$&/
+  // $`/$' mangling bug -- inputs containing those sequences now produce
+  // verbatim (fixed) output regardless of whether promptFilePath is used;
+  // see "should not interpret String.replace special replacement
+  // patterns..." above for that corrected contract.
   it('should produce byte-identical output to before when promptFilePath is absent (basic prompt)', () => {
     const result = expandTemplate({
       template: 'test-cli {{prompt}}',

--- a/packages/server/src/lib/__tests__/template.test.ts
+++ b/packages/server/src/lib/__tests__/template.test.ts
@@ -392,6 +392,90 @@ describe('custom template variables', () => {
   });
 });
 
+describe('promptFilePath option', () => {
+  it('should expand {{prompt}} to a quoted command substitution reading the prompt file', () => {
+    const result = expandTemplate({
+      template: 'claude {{prompt}}',
+      promptFilePath: '/home/alice/.agent-console/prompts/w1.prompt',
+      cwd: '/repo',
+    });
+
+    expect(result.command).toBe(
+      `claude "$(cat '/home/alice/.agent-console/prompts/w1.prompt')"`
+    );
+    expect(result.env).toEqual({});
+  });
+
+  it('should shell-escape a promptFilePath containing a single quote', () => {
+    const result = expandTemplate({
+      template: 'claude {{prompt}}',
+      promptFilePath: "/home/al'ice/w1.prompt",
+      cwd: '/repo',
+    });
+
+    expect(result.command).toBe(`claude "$(cat '/home/al'\\''ice/w1.prompt')"`);
+    expect(result.env).toEqual({});
+  });
+
+  it('should throw TemplateExpansionError when both prompt and promptFilePath are provided', () => {
+    expect(() =>
+      expandTemplate({
+        template: 'claude {{prompt}}',
+        prompt: 'inline prompt',
+        promptFilePath: '/home/alice/.agent-console/prompts/w1.prompt',
+        cwd: '/repo',
+      })
+    ).toThrow(TemplateExpansionError);
+  });
+
+  // Regression lock: promptFilePath being absent must not change existing
+  // behavior at all (Issue #1234 fix must be byte-identical when unused).
+  it('should produce byte-identical output to before when promptFilePath is absent (basic prompt)', () => {
+    const result = expandTemplate({
+      template: 'test-cli {{prompt}}',
+      prompt: 'Hello World',
+      cwd: '/repo',
+    });
+
+    expect(result.command).toBe("test-cli 'Hello World'");
+    expect(result.env).toEqual({});
+  });
+
+  it('should produce byte-identical output to before when promptFilePath is absent (special characters)', () => {
+    const result = expandTemplate({
+      template: 'test-cli {{prompt}}',
+      prompt: '$HOME and $(whoami)',
+      cwd: '/repo',
+    });
+
+    expect(result.command).toBe("test-cli '$HOME and $(whoami)'");
+    expect(result.env).toEqual({});
+  });
+
+  it('should be a no-op when promptFilePath is set but the template has no {{prompt}}', () => {
+    const result = expandTemplate({
+      template: 'cli --continue',
+      promptFilePath: '/home/alice/.agent-console/prompts/w1.prompt',
+      cwd: '/repo',
+    });
+
+    expect(result.command).toBe('cli --continue');
+    expect(result.env).toEqual({});
+  });
+
+  it('should replace multiple {{prompt}} occurrences identically when promptFilePath is set', () => {
+    const result = expandTemplate({
+      template: 'cmd {{prompt}} --extra {{prompt}}',
+      promptFilePath: '/home/alice/.agent-console/prompts/w1.prompt',
+      cwd: '/repo',
+    });
+
+    const expected = `"$(cat '/home/alice/.agent-console/prompts/w1.prompt')"`;
+    expect(result.command).toBe(`cmd ${expected} --extra ${expected}`);
+    expect(result.env).toEqual({});
+  });
+});
+
 describe('TemplateExpansionError', () => {
   it('should be instance of Error', () => {
     const error = new TemplateExpansionError('test message');

--- a/packages/server/src/lib/template.ts
+++ b/packages/server/src/lib/template.ts
@@ -17,6 +17,17 @@ export type ExpandTemplateOptions = {
   prompt?: string;
   cwd: string;
   templateVars?: Record<string, string>;
+  /**
+   * Path to a file containing the prompt payload. When provided, {{prompt}}
+   * is expanded to `"$(cat '<escaped path>')"` instead of the shell-escaped
+   * prompt text. Command substitution inside double quotes is
+   * never re-parsed by the shell (no word splitting/globbing; quotes,
+   * backticks, `$`, and backslashes in the prompt file's contents are
+   * inert), so this avoids embedding a long prompt directly on the injected
+   * command line, which can exceed the tty's canonical-mode input buffer
+   * and silently truncate. Mutually exclusive with `prompt`.
+   */
+  promptFilePath?: string;
 };
 
 export type ExpandTemplateResult = {
@@ -46,10 +57,14 @@ export class TemplateExpansionError extends Error {
  * @throws {TemplateExpansionError} If template is empty or expansion fails
  */
 export function expandTemplate(options: ExpandTemplateOptions): ExpandTemplateResult {
-  const { template, prompt, cwd, templateVars } = options;
+  const { template, prompt, cwd, templateVars, promptFilePath } = options;
 
   if (!template || template.trim().length === 0) {
     throw new TemplateExpansionError('Template is empty');
+  }
+
+  if (prompt !== undefined && promptFilePath !== undefined) {
+    throw new TemplateExpansionError('prompt and promptFilePath are mutually exclusive');
   }
 
   let command = template;
@@ -74,7 +89,11 @@ export function expandTemplate(options: ExpandTemplateOptions): ExpandTemplateRe
   // the placeholder is replaced with an empty shell-escaped string, which
   // allows starting agents interactively without a pre-filled prompt.
   if (command.includes('{{prompt}}')) {
-    command = command.replace(/\{\{prompt\}\}/g, shellEscape(prompt ?? ''));
+    if (promptFilePath !== undefined) {
+      command = command.replace(/\{\{prompt\}\}/g, `"$(cat ${shellEscape(promptFilePath)})"`);
+    } else {
+      command = command.replace(/\{\{prompt\}\}/g, shellEscape(prompt ?? ''));
+    }
   }
 
   // Expand custom template variables (after reserved variables are already expanded)

--- a/packages/server/src/lib/template.ts
+++ b/packages/server/src/lib/template.ts
@@ -72,9 +72,11 @@ export function expandTemplate(options: ExpandTemplateOptions): ExpandTemplateRe
 
   // Expand {{cwd}} - shell-escaped to handle paths with special characters safely
   // Although cwd is validated by validateSessionPath before reaching here,
-  // we still escape it as defense-in-depth against shell metacharacter issues
+  // we still escape it as defense-in-depth against shell metacharacter issues.
+  // Function-form replacer: see the {{prompt}} block below for why a plain
+  // string replacer is unsafe here too ($$/$&/$`/$' reinterpretation).
   if (command.includes('{{cwd}}')) {
-    command = command.replace(/\{\{cwd\}\}/g, shellEscape(cwd));
+    command = command.replace(/\{\{cwd\}\}/g, () => shellEscape(cwd));
   }
 
   // Expand {{prompt}} - shell-escaped and embedded directly into the command,
@@ -89,10 +91,19 @@ export function expandTemplate(options: ExpandTemplateOptions): ExpandTemplateRe
   // the placeholder is replaced with an empty shell-escaped string, which
   // allows starting agents interactively without a pre-filled prompt.
   if (command.includes('{{prompt}}')) {
+    // Function-form replacer: a string replacer interprets special patterns
+    // ($$, $&, $`, $', $<name>) in the replacement text, which would
+    // silently mangle the substituted value if it happened to contain one
+    // of those sequences (e.g. a prompt containing "cost is $$5" would
+    // become "cost is $5"). The function form inserts the value literally,
+    // matching the custom-template-var replacer below. Applied to both
+    // branches: the promptFilePath branch interpolates a filesystem path
+    // (derived from AGENT_CONSOLE_HOME / an OS user's homeDir), which is
+    // lower-risk than arbitrary prompt text but not immune to the same trap.
     if (promptFilePath !== undefined) {
-      command = command.replace(/\{\{prompt\}\}/g, `"$(cat ${shellEscape(promptFilePath)})"`);
+      command = command.replace(/\{\{prompt\}\}/g, () => `"$(cat ${shellEscape(promptFilePath)})"`);
     } else {
-      command = command.replace(/\{\{prompt\}\}/g, shellEscape(prompt ?? ''));
+      command = command.replace(/\{\{prompt\}\}/g, () => shellEscape(prompt ?? ''));
     }
   }
 

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -37,6 +37,7 @@ import { deleteWorktree, _getDeletionsInProgress } from '../../services/worktree
 import type { SuggestSessionMetadataFn } from '../../services/session-metadata-suggester.js';
 import { AgentDirectory } from '../../services/agent-directory.js';
 import type { AgentDirectoryEntry, EmbeddedAgentDefinition } from '@agent-console/shared';
+import type { runAsUser } from '../../services/privilege-elevation.js';
 
 // Mock session-metadata-suggester to avoid spawning real agent processes.
 // Declaring the parameter type makes `mock.calls` typed correctly so the
@@ -57,6 +58,47 @@ const mockFindOpenPullRequest = mock<
 const mockFetchPullRequestUrl = mock<
   (branch: string, cwd: string, requestUsername: string | null) => Promise<string | null>
 >(async () => null);
+
+/**
+ * Captures the content written to each prompt file via the injected
+ * `runAsUserImpl` seam below (Issue #1234), keyed by destination file path.
+ * `writeUserOwnedSecretFile`'s command ends in `cat > '<path>'`; the actual
+ * payload travels via `opts.stdin`, never through argv/the command string
+ * (see privilege-elevation.ts). Reset in `beforeEach`. Consumed by
+ * `getAgentPromptForSession` below to recover the delivered prompt text now
+ * that it no longer travels inline in the spawn command.
+ */
+const capturedPromptFileWrites = new Map<string, string>();
+
+/**
+ * Always-success fake for WorkerManager's `runAsUser`-shaped elevation
+ * calls, injected via SessionManager's `runAsUserImpl` seam (Issue #1234).
+ * `delegate_to_worktree` always activates its agent worker with a non-empty
+ * `initialPrompt`, and that write is NOT AUTH_MODE-gated -- without this
+ * fake, `activateAgentWorkerPty`'s prompt-file write would hit the REAL
+ * elevation helper's `Bun.spawn(['sh', '-c', ...])` subprocess against the
+ * real filesystem (memfs mocking here only covers `fs`/`fs/promises`, not
+ * real subprocess spawns), and fail with a real `mkdir: Permission denied`
+ * under the synthetic `TEST_CONFIG_DIR` used by this suite.
+ *
+ * Discriminates the prompt-file write call by its `cat >` command shape
+ * (mirrors `createCommandDiscriminatingRunAsUser` in worker-manager.test.ts)
+ * and captures its content rather than loosening the tests that inspect the
+ * delivered prompt text.
+ */
+const fakeRunAsUserAlwaysSuccess: typeof runAsUser = async (opts) => {
+  const writeMatch = opts.command.match(/cat > '((?:[^']|'\\'')*)'$/);
+  if (writeMatch && typeof opts.stdin === 'string') {
+    const filePath = writeMatch[1].replace(/'\\''/g, "'");
+    capturedPromptFileWrites.set(filePath, opts.stdin);
+  }
+  return {
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+    timedOut: false,
+  };
+};
 
 // Test config directory
 const TEST_CONFIG_DIR = '/test/config';
@@ -281,6 +323,10 @@ describe('MCP Server Tools', () => {
     mcpRunAsUserCapture.capturedWorktreePath = '';
     mcpRunAsUserCapture.responseOverride = null;
 
+    // Reset the prompt-file write capture (Issue #1234, used by
+    // getAgentPromptForSession below).
+    capturedPromptFileWrites.clear();
+
     // Reset the embedded-agent registry stub, seeded with the default
     // fixture (see `testEmbeddedAgentManagerStub` comment above).
     embeddedAgentDefsById = new Map([[TEST_EMBEDDED_AGENT_DEF.id, TEST_EMBEDDED_AGENT_DEF]]);
@@ -326,6 +372,7 @@ describe('MCP Server Tools', () => {
       agentManager,
       annotationService,
       mcpTokenRegistry: new McpTokenRegistry(),
+      runAsUserImpl: fakeRunAsUserAlwaysSuccess,
       repositoryLookup: { getRepositorySlug: (id: string) => repositoryManager?.getRepositorySlug(id) },
       repositoryEnvLookup: {
         getRepositoryInfo: (id: string) => {
@@ -2249,10 +2296,16 @@ describe('MCP Server Tools', () => {
     // -----------------------------------------------------------------------
 
     /**
-     * Extract the embedded prompt from the PTY spawn call that matches the
-     * given session ID. After Issue #851, the prompt is embedded directly
+     * Extract the delivered prompt for the PTY spawn call that matches the
+     * given session ID. After Issue #851, the prompt was embedded directly
      * into the spawn command via shellEscape (single-quoted literal),
-     * instead of being indirected through env.__AGENT_PROMPT__.
+     * instead of being indirected through env.__AGENT_PROMPT__. After Issue
+     * #1234, the injected command no longer embeds the prompt at all --
+     * `activateAgentWorkerPty` writes it to a file and injects a bounded
+     * `claude "$(cat '<path>')"` command instead (avoids truncation when the
+     * injected line exceeds the tty's canonical-mode input buffer). This
+     * helper extracts the file path from the injected command and looks up
+     * the content captured by the `fakeRunAsUserAlwaysSuccess` seam above.
      */
     function getAgentPromptForSession(sessionId: string): string {
       const calls = ptyFactory.spawn.mock.calls as unknown as Array<[string, string[], PtySpawnOptions]>;
@@ -2265,6 +2318,15 @@ describe('MCP Server Tools', () => {
       const commandWithCR = pty.writtenData.find((d) => d.endsWith('\r'));
       expect(commandWithCR).toBeDefined();
       const command = commandWithCR!.slice(0, -1);
+      const fileMatch = command.match(/\$\(cat '((?:[^']|'\\'')*)'\)/);
+      if (fileMatch) {
+        const filePath = fileMatch[1].replace(/'\\''/g, "'");
+        const content = capturedPromptFileWrites.get(filePath);
+        expect(content).toBeDefined();
+        return content!;
+      }
+      // Fallback for templates that still embed the prompt inline (no
+      // {{prompt}}-bearing promptFilePath write occurred).
       return extractPromptFromSpawnCommand(command);
     }
 

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -20,7 +20,8 @@ import { PtyMessageInjectionService } from '../pty-message-injection-service.js'
 import { UsernameLookupService } from '../username-lookup.js';
 import type { UserRepository } from '../../repositories/user-repository.js';
 import type { AuthUser } from '@agent-console/shared';
-import type { SpawnAsUserFn } from '../privilege-elevation.js';
+import type { SpawnAsUserFn, runAsUser, RunAsUserOpts } from '../privilege-elevation.js';
+import type { LookupOsUserFn } from '../os-user-lookup.js';
 import type { sweepOrphanProcesses } from '../orphan-process-sweeper.js';
 import { McpTokenRegistry } from '../../mcp/mcp-auth.js';
 
@@ -942,11 +943,12 @@ describe('SessionManager', () => {
       // activation path, which mints directly on `options.mcpTokenRegistry`
       // (see worker-manager.ts's `this.mcpTokenRegistry.mint(...)` call in
       // AUTH_MODE=multi-user). We mint directly here rather than driving a
-      // real multi-user PTY activation because WorkerManager's multi-user
-      // mint path additionally depends on `lookupOsUserFn` /
-      // `runAsUserImpl` seams that SessionManagerOptions does not expose
-      // (those are covered by dedicated tests in worker-manager.test.ts);
-      // this test's concern is purely the shared-instance wiring.
+      // real multi-user PTY activation to keep this test's concern isolated
+      // to the shared-registry-instance wiring; WorkerManager's own
+      // `lookupOsUserFn` / `runAsUserImpl` passthrough (now exposed on
+      // `SessionManagerOptions` too) is covered by dedicated tests in
+      // worker-manager.test.ts and the "lookupOsUserFn / runAsUserImpl
+      // passthrough to WorkerManager" describe block below.
       const terminalWorkerToken = sharedRegistry.mint({
         sessionId: 'terminal-session',
         workerId: 'terminal-worker-fake',
@@ -1043,6 +1045,139 @@ describe('SessionManager', () => {
       const deactivatePromise = manager.deactivateEmbeddedAgentWorker(session.id, embeddedWorkerId);
       simulateExit(0);
       await deactivatePromise;
+    });
+  });
+
+  describe('lookupOsUserFn / runAsUserImpl passthrough to WorkerManager', () => {
+    // SessionManagerOptions.lookupOsUserFn / .runAsUserImpl are threaded
+    // straight through to the WorkerManager constructor's own optional DI
+    // params (see worker-manager.ts's constructor, params 5-6). Without this
+    // passthrough, WorkerManager falls back to its own defaults (the real
+    // `lookupOsUser` / `runAsUser`) -- for `runAsUserImpl` that means a REAL
+    // `Bun.spawn(['sh', '-c', ...])` subprocess, since
+    // activateAgentWorkerPty's prompt-file write is not gated on AUTH_MODE
+    // and fires for any activated agent worker carrying a non-empty
+    // `initialPrompt`. These tests prove the passthrough by injecting a
+    // distinguishable fake and observing it actually fires.
+
+    /**
+     * Command-discriminating fake `runAsUser`, mirroring the pattern already
+     * used in worker-manager.test.ts / mcp-server.test.ts:
+     * writeUserOwnedSecretFile's command contains `cat >`.
+     */
+    function createCapturingRunAsUser() {
+      const writeCalls: RunAsUserOpts[] = [];
+      const fake: typeof runAsUser = async (opts) => {
+        if (opts.command.includes('cat >')) {
+          writeCalls.push(opts);
+        }
+        return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+      };
+      return { fake, writeCalls };
+    }
+
+    it('threads runAsUserImpl through to WorkerManager: activating an agent worker with a non-empty initialPrompt calls the injected fake', async () => {
+      const { fake: runAsUserImpl, writeCalls } = createCapturingRunAsUser();
+      const module = await import(`../session-manager.js?v=${++importCounter}`);
+      const manager = await module.SessionManager.create({
+        userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
+        pathExists: mockPathExists,
+        jobQueue: testJobQueue,
+        agentManager,
+        mcpTokenRegistry: new McpTokenRegistry(),
+        repositoryLookup: defaultRepositoryLookup,
+        repositoryEnvLookup: defaultRepositoryEnvLookup,
+        runAsUserImpl,
+      });
+
+      await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: CLAUDE_CODE_AGENT_ID,
+        initialPrompt: 'Hello from the runAsUserImpl passthrough test',
+      });
+
+      // If SessionManager had NOT threaded `runAsUserImpl` through to its
+      // WorkerManager constructor call, WorkerManager would have fallen
+      // back to its own default (the real `runAsUser`) and this fake would
+      // never have observed a call -- the real subprocess would instead
+      // have tried (and, against this test's synthetic AGENT_CONSOLE_HOME,
+      // failed) to write to the real filesystem.
+      expect(writeCalls.length).toBe(1);
+      expect(writeCalls[0].command).toContain('cat >');
+      expect(writeCalls[0].stdin).toBe('Hello from the runAsUserImpl passthrough test');
+    });
+
+    it('threads lookupOsUserFn through to WorkerManager: multi-user prompt-file activation resolves the destination directory from the injected fake', async () => {
+      const originalAuthMode = process.env.AUTH_MODE;
+      process.env.AUTH_MODE = 'multi-user';
+      try {
+        const { fake: runAsUserImpl, writeCalls } = createCapturingRunAsUser();
+        const distinguishableHomeDir = '/home/lookup-passthrough-fake-homedir';
+        const lookupOsUserFn: LookupOsUserFn = async () => ({ uid: 4242, homeDir: distinguishableHomeDir });
+
+        // Resolve session.createdBy -> a username different from the real
+        // OS user running this test process, so WorkerManager's
+        // shouldElevateForUser(...) actually takes the elevated branch that
+        // consults lookupOsUserFn (mirrors the stub UserRepository pattern
+        // used by the "resolveSpawnUsername wiring" describe block above).
+        const stubUserRepo: UserRepository = {
+          async upsertByOsUid(): Promise<AuthUser> {
+            throw new Error('upsertByOsUid not used by this test');
+          },
+          async findById(id: string): Promise<AuthUser | null> {
+            if (id === 'user-alice-uuid') {
+              return { id, username: 'alice', homeDir: '/home/alice' };
+            }
+            return null;
+          },
+        };
+
+        const module = await import(`../session-manager.js?v=${++importCounter}`);
+        const manager = await module.SessionManager.create({
+          userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
+          pathExists: mockPathExists,
+          jobQueue: testJobQueue,
+          agentManager,
+          mcpTokenRegistry: new McpTokenRegistry(),
+          repositoryLookup: defaultRepositoryLookup,
+          repositoryEnvLookup: defaultRepositoryEnvLookup,
+          userRepository: stubUserRepo,
+          runAsUserImpl,
+          lookupOsUserFn,
+        });
+
+        await manager.createSession(
+          {
+            type: 'quick',
+            locationPath: '/test/path',
+            agentId: CLAUDE_CODE_AGENT_ID,
+            initialPrompt: 'Hello from the lookupOsUserFn passthrough test',
+          },
+          { createdBy: 'user-alice-uuid' },
+        );
+
+        // With AUTH_MODE=multi-user and a resolved createdBy, WorkerManager
+        // also mints an MCP token (a separate `cat >` write to a sibling
+        // `.agent-console/mcp-tokens/` file, using the SAME lookupOsUserFn
+        // seam) alongside the prompt-file write -- discriminate by the
+        // `.prompt` destination suffix rather than asserting on write count,
+        // so this test isolates the prompt-file write specifically.
+        const promptWrite = writeCalls.find((c) => c.command.includes('.prompt'));
+        expect(promptWrite).toBeDefined();
+        // If SessionManager had NOT threaded `lookupOsUserFn` through to its
+        // WorkerManager constructor call, WorkerManager would have fallen
+        // back to its own default (the real `lookupOsUser`, an OS-level
+        // dscl/getent lookup) and the write destination would not carry
+        // this fake's distinguishable homeDir.
+        expect(promptWrite!.command).toContain(distinguishableHomeDir);
+      } finally {
+        if (originalAuthMode === undefined) {
+          delete process.env.AUTH_MODE;
+        } else {
+          process.env.AUTH_MODE = originalAuthMode;
+        }
+      }
     });
   });
 

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -1141,6 +1141,7 @@ describe('WorkerLifecycleManager', () => {
         activityDetector: null,
         connectionCallbacks: new Map(),
         mcpToken: null,
+        promptFile: null,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -1249,6 +1250,7 @@ describe('WorkerLifecycleManager', () => {
         activityDetector: null,
         connectionCallbacks: new Map(),
         mcpToken: null,
+        promptFile: null,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -1287,6 +1289,7 @@ describe('WorkerLifecycleManager', () => {
         activityDetector: null,
         connectionCallbacks: new Map(),
         mcpToken: null,
+        promptFile: null,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -1316,6 +1319,7 @@ describe('WorkerLifecycleManager', () => {
         activityDetector: null,
         connectionCallbacks: new Map(),
         mcpToken: null,
+        promptFile: null,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -1343,6 +1347,7 @@ describe('WorkerLifecycleManager', () => {
         activityDetector: null,
         connectionCallbacks: new Map(),
         mcpToken: null,
+        promptFile: null,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -1372,6 +1377,7 @@ describe('WorkerLifecycleManager', () => {
         activityDetector: null,
         connectionCallbacks: new Map(),
         mcpToken: null,
+        promptFile: null,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -2137,6 +2143,7 @@ describe('WorkerLifecycleManager', () => {
         activityDetector: null,
         connectionCallbacks: new Map(),
         mcpToken: null,
+        promptFile: null,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -2171,6 +2178,7 @@ describe('WorkerLifecycleManager', () => {
         activityDetector: null,
         connectionCallbacks: new Map(),
         mcpToken: null,
+        promptFile: null,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -2252,6 +2260,7 @@ describe('WorkerLifecycleManager', () => {
         activityDetector: null,
         connectionCallbacks: new Map(),
         mcpToken: null,
+        promptFile: null,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -2383,6 +2392,7 @@ describe('WorkerLifecycleManager', () => {
         activityDetector: null,
         connectionCallbacks: new Map(),
         mcpToken: null,
+        promptFile: null,
       };
       session.workers.set(agentWorker.id, agentWorker);
 

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -34,6 +34,7 @@ import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import type { LookupOsUserFn } from '../os-user-lookup.js';
 import type { runAsUser, RunAsUserOpts } from '../privilege-elevation.js';
 import type { listDescendantPids, signalPids } from '../../lib/process-tree.js';
+import * as os from 'node:os';
 
 const TEST_CONFIG_DIR = '/test/config';
 
@@ -1786,6 +1787,417 @@ describe('WorkerManager', () => {
         await wm.killWorker(worker, 'session-1');
 
         expect(registry.revokeByWorker).not.toHaveBeenCalled();
+        expect(rmCalls.length).toBe(0);
+      });
+    });
+  });
+
+  describe('prompt file lifecycle (Issue #1234)', () => {
+    const originalAuthMode = process.env.AUTH_MODE;
+
+    afterEach(() => {
+      if (originalAuthMode === undefined) {
+        delete process.env.AUTH_MODE;
+      } else {
+        process.env.AUTH_MODE = originalAuthMode;
+      }
+    });
+
+    /**
+     * Command-discriminating fake `runAsUser`, mirroring the MCP token
+     * lifecycle describe block's helper of the same shape (see "wrapper-
+     * consumer test responder splitting" in memory): writeUserOwnedSecretFile's
+     * command contains `cat >`; rmRecursiveAsUser's command contains `rm -rf`.
+     */
+    function createCommandDiscriminatingRunAsUser(opts: {
+      writeExitCode?: number;
+      writeTimedOut?: boolean;
+    } = {}) {
+      const writeCalls: RunAsUserOpts[] = [];
+      const rmCalls: RunAsUserOpts[] = [];
+      const fake: typeof runAsUser = async (callOpts) => {
+        if (callOpts.command.includes('cat >')) {
+          writeCalls.push(callOpts);
+          return {
+            stdout: '',
+            stderr: '',
+            exitCode: opts.writeExitCode ?? 0,
+            timedOut: opts.writeTimedOut ?? false,
+          };
+        }
+        rmCalls.push(callOpts);
+        return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+      };
+      return { fake, writeCalls, rmCalls };
+    }
+
+    function buildManagerWithSeams(seams: {
+      lookupOsUserFn?: LookupOsUserFn;
+      runAsUserImpl?: typeof runAsUser;
+    }): WorkerManager {
+      const userMode = new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' });
+      return new WorkerManager(
+        userMode,
+        agentManager,
+        new WorkerOutputFileManager(),
+        undefined,
+        seams.lookupOsUserFn,
+        seams.runAsUserImpl,
+      );
+    }
+
+    const defaultLookupOsUserFn: LookupOsUserFn = async (username) => ({
+      uid: 1000,
+      homeDir: `/home/${username}`,
+    });
+
+    /** The actual bytes injected into the PTY as typeahead (see setupWorkerEventHandlers). */
+    function getLastInjectedCommand(): string | undefined {
+      const mockPty = ptyFactory.instances[ptyFactory.instances.length - 1];
+      return mockPty?.writtenData[0];
+    }
+
+    const LONG_PROMPT = 'A'.repeat(5200);
+
+    it('single-user mode, non-empty prompt, template with {{prompt}}: writes a prompt file and injects a bounded command (no AUTH_MODE gate)', async () => {
+      // Explicit single-user-mode regression guard: this is the exact bug the
+      // issue exists to fix, and the fix must NOT be gated on AUTH_MODE.
+      delete process.env.AUTH_MODE;
+      const { fake: runAsUserImpl, writeCalls } = createCommandDiscriminatingRunAsUser();
+      const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'prompt-agent-1',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      await wm.activateAgentWorkerPty(worker, {
+        ...defaultAgentActivationParams,
+        username: 'testuser',
+        initialPrompt: LONG_PROMPT,
+      });
+
+      const expectedFilePath = `${TEST_CONFIG_DIR}/prompts/prompt-agent-1.prompt`;
+      expect(worker.promptFile).toEqual({ filePath: expectedFilePath, username: 'testuser' });
+
+      expect(writeCalls.length).toBe(1);
+      expect(writeCalls[0].command).toContain(`cat > '${expectedFilePath}'`);
+      expect(writeCalls[0].stdin).toBe(LONG_PROMPT);
+
+      const injectedCommand = getLastInjectedCommand();
+      expect(injectedCommand).toBeDefined();
+      // Bounded well under the ~1KB/4096B tty canonical-mode input buffer,
+      // even though the prompt itself is 5200 bytes.
+      expect(Buffer.byteLength(injectedCommand!, 'utf-8')).toBeLessThan(512);
+      expect(injectedCommand).toContain(`"$(cat '`);
+      expect(injectedCommand).not.toContain('AAAA');
+    });
+
+    it('multi-user elevated: prompt file path uses the OS user home directory', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const { fake: runAsUserImpl } = createCommandDiscriminatingRunAsUser();
+      const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'prompt-agent-2',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      await wm.activateAgentWorkerPty(worker, {
+        ...defaultAgentActivationParams,
+        username: 'alice',
+        initialPrompt: 'hello world',
+      });
+
+      expect(worker.promptFile).toEqual({
+        filePath: '/home/alice/.agent-console/prompts/prompt-agent-2.prompt',
+        username: 'alice',
+      });
+    });
+
+    it('multi-user elevation-skip (username equals server process user): prompt file path uses getConfigDir()', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const { fake: runAsUserImpl } = createCommandDiscriminatingRunAsUser();
+      const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'prompt-agent-3',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      // shouldElevateForUser bypasses elevation when username === the server
+      // process's own OS user, even under AUTH_MODE=multi-user.
+      const serverUsername = os.userInfo().username;
+
+      await wm.activateAgentWorkerPty(worker, {
+        ...defaultAgentActivationParams,
+        username: serverUsername,
+        initialPrompt: 'hello world',
+      });
+
+      expect(worker.promptFile).toEqual({
+        filePath: `${TEST_CONFIG_DIR}/prompts/prompt-agent-3.prompt`,
+        username: serverUsername,
+      });
+    });
+
+    it('delivers special characters (quotes, backticks, $, backslashes, newlines) to the prompt file verbatim via stdin', async () => {
+      delete process.env.AUTH_MODE;
+      const { fake: runAsUserImpl, writeCalls } = createCommandDiscriminatingRunAsUser();
+      const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'prompt-agent-4',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      const trickyPrompt = 'Say "hello" and \'goodbye\'\nrun `whoami` and $HOME and $(rm -rf /) and a\\backslash';
+
+      await wm.activateAgentWorkerPty(worker, {
+        ...defaultAgentActivationParams,
+        username: 'testuser',
+        initialPrompt: trickyPrompt,
+      });
+
+      expect(writeCalls.length).toBe(1);
+      expect(writeCalls[0].stdin).toBe(trickyPrompt);
+    });
+
+    it('core regression guard: a 5000+ char initialPrompt produces an injected command well under 512 bytes', async () => {
+      delete process.env.AUTH_MODE;
+      const { fake: runAsUserImpl } = createCommandDiscriminatingRunAsUser();
+      const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'prompt-agent-5',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      const veryLongPrompt = 'the quick brown fox jumps over the lazy dog. '.repeat(120); // > 5000 chars
+      expect(veryLongPrompt.length).toBeGreaterThan(5000);
+
+      await wm.activateAgentWorkerPty(worker, {
+        ...defaultAgentActivationParams,
+        username: 'testuser',
+        initialPrompt: veryLongPrompt,
+      });
+
+      const injectedCommand = getLastInjectedCommand();
+      expect(injectedCommand).toBeDefined();
+      expect(Buffer.byteLength(injectedCommand!, 'utf-8')).toBeLessThan(512);
+      expect(injectedCommand).not.toContain('quick brown fox');
+    });
+
+    it('elevation-required home-dir resolution failure aborts activation (hard-fail, unlike the MCP-token block\'s soft skip)', async () => {
+      process.env.AUTH_MODE = 'multi-user';
+      const { fake: runAsUserImpl } = createCommandDiscriminatingRunAsUser();
+      const wm = buildManagerWithSeams({ lookupOsUserFn: async () => null, runAsUserImpl });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'prompt-agent-6',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      await expect(
+        wm.activateAgentWorkerPty(worker, {
+          ...defaultAgentActivationParams,
+          username: 'alice',
+          initialPrompt: 'hello world',
+        }),
+      ).rejects.toThrow();
+
+      expect(worker.promptFile).toBeNull();
+      expect(worker.pty).toBeNull();
+    });
+
+    it('prompt file write failure aborts activation with no fallback embedding of the raw prompt', async () => {
+      delete process.env.AUTH_MODE;
+      const { fake: runAsUserImpl, rmCalls } = createCommandDiscriminatingRunAsUser({ writeExitCode: 1 });
+      const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'prompt-agent-7',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      const spawnCallsBefore = ptyFactory.spawn.mock.calls.length;
+
+      await expect(
+        wm.activateAgentWorkerPty(worker, {
+          ...defaultAgentActivationParams,
+          username: 'testuser',
+          initialPrompt: 'hello world',
+        }),
+      ).rejects.toThrow();
+
+      // No orphaned reference left on the worker, and no cleanup was
+      // triggered (nothing was ever set to clean up).
+      expect(worker.promptFile).toBeNull();
+      expect(worker.pty).toBeNull();
+      expect(rmCalls.length).toBe(0);
+      // The failure happens before spawnPty is reached, so no PTY (and thus
+      // no fallback embedding of the raw prompt into any spawned command)
+      // was ever created.
+      expect(ptyFactory.spawn.mock.calls.length).toBe(spawnCallsBefore);
+    });
+
+    it('no-op: no initialPrompt (interactive start) does not write a prompt file', async () => {
+      delete process.env.AUTH_MODE;
+      const { fake: runAsUserImpl, writeCalls } = createCommandDiscriminatingRunAsUser();
+      const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'prompt-agent-8a',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      await wm.activateAgentWorkerPty(worker, {
+        ...defaultAgentActivationParams,
+        username: 'testuser',
+      });
+
+      expect(worker.promptFile).toBeNull();
+      expect(writeCalls.length).toBe(0);
+    });
+
+    it('no-op: continueConversation with continueTemplate (no {{prompt}}) does not write a prompt file', async () => {
+      delete process.env.AUTH_MODE;
+      const { fake: runAsUserImpl, writeCalls } = createCommandDiscriminatingRunAsUser();
+      const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'prompt-agent-8b',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      await wm.activateAgentWorkerPty(worker, {
+        ...defaultAgentActivationParams,
+        username: 'testuser',
+        continueConversation: true,
+        // continueTemplate ('claude -c') has no {{prompt}}; a stray
+        // initialPrompt must not cause a write against a templateless target.
+        initialPrompt: 'this should be ignored',
+      });
+
+      expect(worker.promptFile).toBeNull();
+      expect(writeCalls.length).toBe(0);
+    });
+
+    it('no-op: whitespace-only initialPrompt (trims to empty) does not write a prompt file', async () => {
+      delete process.env.AUTH_MODE;
+      const { fake: runAsUserImpl, writeCalls } = createCommandDiscriminatingRunAsUser();
+      const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'prompt-agent-8c',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      await wm.activateAgentWorkerPty(worker, {
+        ...defaultAgentActivationParams,
+        username: 'testuser',
+        initialPrompt: '   \n\t  ',
+      });
+
+      expect(worker.promptFile).toBeNull();
+      expect(writeCalls.length).toBe(0);
+    });
+
+    describe('cleanup on kill / exit', () => {
+      async function activateWithPromptFile(id: string): Promise<{
+        wm: WorkerManager;
+        worker: InternalAgentWorker;
+        rmCalls: RunAsUserOpts[];
+      }> {
+        delete process.env.AUTH_MODE;
+        const { fake: runAsUserImpl, rmCalls } = createCommandDiscriminatingRunAsUser();
+        const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+        const worker = wm.initializeAgentWorker({
+          id,
+          name: 'Agent',
+          createdAt: new Date().toISOString(),
+          agentId: CLAUDE_CODE_AGENT_ID,
+        });
+
+        await wm.activateAgentWorkerPty(worker, {
+          ...defaultAgentActivationParams,
+          username: 'testuser',
+          initialPrompt: 'hello world',
+        });
+
+        expect(worker.promptFile).not.toBeNull();
+        return { wm, worker, rmCalls };
+      }
+
+      it('killWorker deletes the prompt file', async () => {
+        const { wm, worker, rmCalls } = await activateWithPromptFile('prompt-kill-1');
+        const filePath = worker.promptFile!.filePath;
+
+        await wm.killWorker(worker, 'session-1');
+
+        expect(worker.promptFile).toBeNull();
+        expect(rmCalls.length).toBe(1);
+        expect(rmCalls[0].command).toContain(`rm -rf -- '${filePath}'`);
+        expect(rmCalls[0].username).toBe('testuser');
+      });
+
+      it('PTY exit (unexpected) deletes the prompt file', async () => {
+        const { worker, rmCalls } = await activateWithPromptFile('prompt-exit-1');
+        const filePath = worker.promptFile!.filePath;
+
+        const mockPty = ptyFactory.instances[ptyFactory.instances.length - 1];
+        mockPty.simulateExit(1);
+
+        // deletePromptFile is fire-and-forget from the sync PTY exit
+        // callback; flush microtasks so its awaited rmRecursiveAsUser call
+        // has a chance to run.
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(worker.promptFile).toBeNull();
+        expect(rmCalls.length).toBe(1);
+        expect(rmCalls[0].command).toContain(`rm -rf -- '${filePath}'`);
+      });
+
+      it('killWorker on a worker with promptFile: null is a no-op for prompt-file cleanup', async () => {
+        const { fake: runAsUserImpl, rmCalls } = createCommandDiscriminatingRunAsUser();
+        const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+        delete process.env.AUTH_MODE;
+        const worker = wm.initializeAgentWorker({
+          id: 'prompt-none-1',
+          name: 'Agent',
+          createdAt: new Date().toISOString(),
+          agentId: CLAUDE_CODE_AGENT_ID,
+        });
+        // No initialPrompt: no prompt file is ever written.
+        await wm.activateAgentWorkerPty(worker, {
+          ...defaultAgentActivationParams,
+          username: 'testuser',
+        });
+        expect(worker.promptFile).toBeNull();
+
+        await wm.killWorker(worker, 'session-1');
+
         expect(rmCalls.length).toBe(0);
       });
     });

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -1629,7 +1629,13 @@ describe('WorkerManager', () => {
       ).rejects.toThrow();
 
       expect(registry.mintedIdentities.length).toBe(1);
-      expect(registry.revokedWorkerIds).toEqual(['mcp-agent-4']);
+      // Revoked twice: once from the MCP-token block's own inline
+      // fast-path revoke (fires immediately on the write-failure branch,
+      // before the throw), and again from the outer catch block's
+      // revokeAndDeleteMcpToken -- worker.mcpToken is set BEFORE the write
+      // (not after success), so it is already non-null when the catch
+      // runs and its null-check no longer short-circuits.
+      expect(registry.revokedWorkerIds).toEqual(['mcp-agent-4', 'mcp-agent-4']);
       expect(worker.mcpToken).toBeNull();
     });
 
@@ -2091,18 +2097,27 @@ describe('WorkerManager', () => {
       expect(worker.promptFile).toBeNull();
       expect(worker.mcpToken).toBeNull();
       expect(worker.pty).toBeNull();
-      // Exactly one `rm -rf` fires -- for the prompt file. The MCP-token
-      // write itself failed (never produced a file), so there is nothing
-      // for revokeAndDeleteMcpToken to `rm`; its own internal null-check
-      // short-circuits before issuing a second rm call.
-      expect(rmCalls.length).toBe(1);
-      expect(rmCalls[0].command).toContain('.prompt');
-      // revokeByWorker fires exactly once, from the MCP-token block's own
-      // inline revoke-on-write-failure branch (worker.mcpToken was never
-      // assigned on this path, so the catch block's
-      // revokeAndDeleteMcpToken sees a null token and short-circuits
-      // without a second revoke call).
-      expect(revokedWorkerIds).toEqual(['prompt-agent-later-throw']);
+      // Both worker.promptFile and worker.mcpToken are now set BEFORE their
+      // respective writes (not after success), so the outer catch's
+      // cleanup reaches BOTH artifacts unconditionally on any later throw
+      // -- regardless of which specific artifact's own write is what
+      // failed. Two `rm -rf` calls fire: one for the prompt file (its write
+      // succeeded), one for the token file (its write is what failed here,
+      // but `worker.mcpToken` was already assigned before that write, so
+      // the catch's revokeAndDeleteMcpToken still issues the `rm` -- this
+      // matters because writeUserOwnedSecretFile's `cat >` truncates the
+      // destination before writing, so even a failed write can leave a
+      // truncated file containing a fragment of the secret token behind).
+      expect(rmCalls.length).toBe(2);
+      expect(rmCalls.some((c) => c.command.includes('.prompt'))).toBe(true);
+      expect(rmCalls.some((c) => c.command.includes('.token'))).toBe(true);
+      // revokeByWorker fires TWICE: once from the MCP-token block's own
+      // inline fast-path revoke (runs immediately on the write-failure
+      // branch, before the throw), and again from the catch block's
+      // revokeAndDeleteMcpToken (worker.mcpToken is now non-null at that
+      // point, since it was assigned before the write, so the catch's
+      // null-check no longer short-circuits).
+      expect(revokedWorkerIds).toEqual(['prompt-agent-later-throw', 'prompt-agent-later-throw']);
     });
 
     it('prompt file write failure aborts activation with no fallback embedding of the raw prompt, and cleans up via the catch block', async () => {

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -1834,16 +1834,43 @@ describe('WorkerManager', () => {
     function buildManagerWithSeams(seams: {
       lookupOsUserFn?: LookupOsUserFn;
       runAsUserImpl?: typeof runAsUser;
+      mcpTokenRegistry?: { mint: (identity: { sessionId: string; workerId: string; userId: string }) => string; revokeByWorker: (workerId: string) => void };
     }): WorkerManager {
       const userMode = new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' });
       return new WorkerManager(
         userMode,
         agentManager,
         new WorkerOutputFileManager(),
-        undefined,
+        seams.mcpTokenRegistry,
         seams.lookupOsUserFn,
         seams.runAsUserImpl,
       );
+    }
+
+    /**
+     * Path-discriminating fake `runAsUser` for tests that need ONE `cat >`
+     * write (prompt file or MCP token file) to succeed while the OTHER
+     * fails, within the same activation. `failSuffix` matches against the
+     * destination path embedded in the write command (`.prompt` vs
+     * `.token`).
+     */
+    function createPathDiscriminatingRunAsUser(opts: { failSuffix: string }) {
+      const writeCalls: RunAsUserOpts[] = [];
+      const rmCalls: RunAsUserOpts[] = [];
+      const fake: typeof runAsUser = async (callOpts) => {
+        if (callOpts.command.includes('cat >')) {
+          writeCalls.push(callOpts);
+          return {
+            stdout: '',
+            stderr: '',
+            exitCode: callOpts.command.includes(opts.failSuffix) ? 1 : 0,
+            timedOut: false,
+          };
+        }
+        rmCalls.push(callOpts);
+        return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+      };
+      return { fake, writeCalls, rmCalls };
     }
 
     const defaultLookupOsUserFn: LookupOsUserFn = async (username) => ({
@@ -2022,7 +2049,63 @@ describe('WorkerManager', () => {
       expect(worker.pty).toBeNull();
     });
 
-    it('prompt file write failure aborts activation with no fallback embedding of the raw prompt', async () => {
+    it('a later throw (MCP-token write failure) after a successful prompt-file write cleans up the prompt file via the shared catch block', async () => {
+      // The prompt-file write and the MCP-token mint/write both attach
+      // state to `worker` before `worker.pty` is assigned. This test proves
+      // the single shared try/catch in activateAgentWorkerPty closes the
+      // gap for BOTH artifacts even when the prompt-file write itself
+      // succeeded and the LATER MCP-token write is what actually fails.
+      process.env.AUTH_MODE = 'multi-user';
+      const { fake: runAsUserImpl, rmCalls } = createPathDiscriminatingRunAsUser({ failSuffix: '.token' });
+      const revokedWorkerIds: string[] = [];
+      const fakeMcpTokenRegistry = {
+        mint: () => 'fake-mcp-token-value',
+        revokeByWorker: (workerId: string) => { revokedWorkerIds.push(workerId); },
+      };
+      const wm = buildManagerWithSeams({
+        lookupOsUserFn: defaultLookupOsUserFn,
+        runAsUserImpl,
+        mcpTokenRegistry: fakeMcpTokenRegistry,
+      });
+
+      const worker = wm.initializeAgentWorker({
+        id: 'prompt-agent-later-throw',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      await expect(
+        wm.activateAgentWorkerPty(worker, {
+          ...defaultAgentActivationParams,
+          username: 'alice',
+          initialPrompt: 'hello world',
+          createdByUserId: 'user-uuid-1',
+        }),
+      ).rejects.toThrow();
+
+      // The prompt-file write succeeded; the MCP-token write (later in the
+      // same activation) is what failed and triggered the throw. Both
+      // artifacts must be cleaned up / cleared despite worker.pty never
+      // being set.
+      expect(worker.promptFile).toBeNull();
+      expect(worker.mcpToken).toBeNull();
+      expect(worker.pty).toBeNull();
+      // Exactly one `rm -rf` fires -- for the prompt file. The MCP-token
+      // write itself failed (never produced a file), so there is nothing
+      // for revokeAndDeleteMcpToken to `rm`; its own internal null-check
+      // short-circuits before issuing a second rm call.
+      expect(rmCalls.length).toBe(1);
+      expect(rmCalls[0].command).toContain('.prompt');
+      // revokeByWorker fires exactly once, from the MCP-token block's own
+      // inline revoke-on-write-failure branch (worker.mcpToken was never
+      // assigned on this path, so the catch block's
+      // revokeAndDeleteMcpToken sees a null token and short-circuits
+      // without a second revoke call).
+      expect(revokedWorkerIds).toEqual(['prompt-agent-later-throw']);
+    });
+
+    it('prompt file write failure aborts activation with no fallback embedding of the raw prompt, and cleans up via the catch block', async () => {
       delete process.env.AUTH_MODE;
       const { fake: runAsUserImpl, rmCalls } = createCommandDiscriminatingRunAsUser({ writeExitCode: 1 });
       const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
@@ -2044,11 +2127,16 @@ describe('WorkerManager', () => {
         }),
       ).rejects.toThrow();
 
-      // No orphaned reference left on the worker, and no cleanup was
-      // triggered (nothing was ever set to clean up).
+      // worker.promptFile is set BEFORE the write is attempted (so a
+      // partially-interrupted write is still covered by cleanup), so the
+      // catch block's deletePromptFile call clears it back to null and
+      // issues an `rm -rf` -- a no-op success against a path the write
+      // never actually produced (POSIX `rm -f` is idempotent on a missing
+      // path), but observable via the fake regardless.
       expect(worker.promptFile).toBeNull();
       expect(worker.pty).toBeNull();
-      expect(rmCalls.length).toBe(0);
+      expect(rmCalls.length).toBe(1);
+      expect(rmCalls[0].command).toContain('rm -rf --');
       // The failure happens before spawnPty is reached, so no PTY (and thus
       // no fallback embedding of the raw prompt into any spawned command)
       // was ever created.

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -26,7 +26,8 @@ import {
   type SendUserMessageResult,
   type TriggerHandoffResult,
 } from './embedded-agent-worker-service.js';
-import type { SpawnAsUserFn } from './privilege-elevation.js';
+import type { SpawnAsUserFn, runAsUser } from './privilege-elevation.js';
+import type { LookupOsUserFn } from './os-user-lookup.js';
 import type { sweepOrphanProcesses } from './orphan-process-sweeper.js';
 import { CLAUDE_CODE_AGENT_ID } from './agent-manager.js';
 import type { AgentManager } from './agent-manager.js';
@@ -145,6 +146,30 @@ interface SessionManagerOptions {
    * `EmbeddedAgentWorkerService` test seam.
    */
   spawnAsUserFn?: SpawnAsUserFn;
+  /**
+   * Test seam for WorkerManager's OS user lookup (used to resolve the
+   * destination directory for a multi-user-mode MCP token file or prompt
+   * file). Threaded straight through to the `WorkerManager`
+   * constructor (which already accepts this as an optional param). Defaults
+   * to `WorkerManager`'s own default (the real `lookupOsUser`) when omitted
+   * -- production and every existing caller are unaffected.
+   */
+  lookupOsUserFn?: LookupOsUserFn;
+  /**
+   * Test seam for WorkerManager's `runAsUser`-shaped elevation calls (MCP
+   * token file write/delete, prompt file write/delete).
+   * Threaded straight through to the `WorkerManager` constructor (which
+   * already accepts this as an optional param). Defaults to `WorkerManager`'s
+   * own default (the real `runAsUser`) when omitted -- production and every
+   * existing caller are unaffected. The prompt-file write runs
+   * unconditionally whenever an activated agent worker carries a non-empty
+   * `initialPrompt` (not gated on auth mode), so it is on the hot path for
+   * any such test -- tests using a synthetic `AGENT_CONSOLE_HOME`
+   * (e.g. memfs-backed fixtures) should inject an always-success fake here to
+   * avoid the elevation helper's real `Bun.spawn` subprocess touching the
+   * real filesystem.
+   */
+  runAsUserImpl?: typeof runAsUser;
   /**
    * Test seam for the SESSION_ID marker orphan-process sweep. Defaults to
    * the real `sweepOrphanProcesses`. Threaded through
@@ -275,7 +300,14 @@ export class SessionManager {
     // registry explicitly so it can never be silently disconnected from the
     // one `/mcp` verifies against.
     this.mcpTokenRegistry = options.mcpTokenRegistry;
-    this.workerManager = new WorkerManager(userMode, agentManager, workerOutputFileManager, this.mcpTokenRegistry);
+    this.workerManager = new WorkerManager(
+      userMode,
+      agentManager,
+      workerOutputFileManager,
+      this.mcpTokenRegistry,
+      options.lookupOsUserFn,
+      options.runAsUserImpl,
+    );
     this.pathExists = options?.pathExists ?? defaultPathExists;
     this.sessionRepository = options?.sessionRepository ??
       new JsonSessionRepository(path.join(getConfigDir(), 'sessions.json'));

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -581,6 +581,17 @@ export class WorkerManager {
               'mcp-tokens',
               `${worker.id}.token`,
             );
+            // Set BEFORE the write (not after a successful write):
+            // writeUserOwnedSecretFile's command truncates the destination
+            // (`cat >`) before streaming the new content, so a write that
+            // fails partway through (the elevated process gets killed
+            // mid-stream, or the shell fails after truncation but before the
+            // full payload lands) can leave a truncated/partial file behind
+            // -- and that file may contain a FRAGMENT OF THE SECRET TOKEN.
+            // The outer catch block's cleanup must reach this path even when
+            // the failure happens mid-write, not only on a clean exitCode
+            // !== 0 result.
+            worker.mcpToken = { filePath: tokenFilePath, username: params.username };
             const writeResult = await writeUserOwnedSecretFile({
               username: params.username,
               filePath: tokenFilePath,
@@ -594,8 +605,11 @@ export class WorkerManager {
               // orphaned token from a failed activation" invariant. The
               // in-memory revoke here is a fast-path for THIS failure only;
               // the outer catch below also unconditionally calls
-              // revokeAndDeleteMcpToken (idempotent no-op if already revoked
-              // and no worker.mcpToken was ever assigned in this branch).
+              // revokeAndDeleteMcpToken, which now (worker.mcpToken having
+              // just been assigned above) also issues the file-level `rm`
+              // for the possibly-truncated token file -- this fast-path call
+              // only revokes the registry entry a moment sooner than the
+              // catch would.
               this.mcpTokenRegistry.revokeByWorker(worker.id);
               logger.error(
                 {
@@ -608,7 +622,6 @@ export class WorkerManager {
               );
               throw new Error(`Failed to write MCP token file for worker ${worker.id}`);
             }
-            worker.mcpToken = { filePath: tokenFilePath, username: params.username };
             additionalEnvVars[MCP_TOKEN_FILE_ENV_VAR] = tokenFilePath;
           }
         }

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -438,204 +438,234 @@ export class WorkerManager {
       ? agent.continueTemplate
       : agent.commandTemplate;
 
-    // Persist initialPrompt to a file and inject a short `"$(cat '<path>')"`
-    // substitution instead of embedding the raw prompt on the sentinel-
-    // injected command line: the injected line is typed as PTY
-    // typeahead while the tty is still in canonical mode, and canonical-mode
-    // input buffers are bounded (~1KB macOS / 4096B Linux) -- a long prompt
-    // silently truncates and the agent never starts. Deliberately NOT gated
-    // on AUTH_MODE: the underlying truncation reproduces in single-user mode.
-    let promptFilePath: string | undefined;
-    if (initialPrompt?.trim() && template.includes('{{prompt}}')) {
-      const elevate = shouldElevateForUser(params.username);
-      let promptsDir: string;
-      if (elevate) {
-        const osUser = await this.lookupOsUserFn(params.username);
-        if (!osUser) {
-          logger.error(
-            { workerId: worker.id, username: params.username },
-            'Could not resolve OS user home directory for prompt file; aborting agent worker PTY activation',
-          );
-          throw new Error(`Failed to resolve OS user home directory for prompt file (worker ${worker.id})`);
-        }
-        promptsDir = path.join(osUser.homeDir, '.agent-console', 'prompts');
-      } else {
-        promptsDir = path.join(getConfigDir(), 'prompts');
-      }
-      const filePath = path.join(promptsDir, `${worker.id}.prompt`);
-      const writeResult = await writeUserOwnedSecretFile({
-        username: params.username,
-        filePath,
-        content: initialPrompt,
-        runAsUserImpl: this.runAsUserImpl,
-      });
-      if (writeResult.exitCode !== 0 || writeResult.timedOut) {
-        logger.error(
-          {
-            workerId: worker.id,
-            exitCode: writeResult.exitCode,
-            timedOut: writeResult.timedOut,
-            stderr: writeResult.stderr,
-          },
-          'Failed to write prompt file; aborting agent worker PTY activation',
-        );
-        throw new Error(`Failed to write prompt file for worker ${worker.id}`);
-      }
-      worker.promptFile = { filePath, username: params.username };
-      promptFilePath = filePath;
-    }
-
-    const { command, env: templateEnv } = expandTemplate({
-      template,
-      cwd: locationPath,
-      templateVars: context?.templateVars,
-      ...(promptFilePath !== undefined ? { promptFilePath } : { prompt: initialPrompt }),
-    });
-
-    // Build AgentConsole context so the agent knows its own identity.
-    // These enable self-delegation (e.g., MCP tools) and agent self-awareness.
-    const agentConsoleContext: AgentConsoleContext = {
-      baseUrl: `http://localhost:${serverConfig.PORT}`,
-      sessionId,
-      workerId: worker.id,
-      repositoryId,
-      parentSessionId: context?.parentSessionId,
-      parentWorkerId: context?.parentWorkerId,
-    };
-
-    // additionalEnvVars: repository + template env vars
-    // Base env (getCleanChildProcessEnv) and AGENT_CONSOLE_* conversion
-    // are handled internally by UserMode.spawnPty()
-    const additionalEnvVars: Record<string, string> = {
-      ...repositoryEnvVars,
-      ...templateEnv,
-    };
-
-    // Multi-user mode: mint an MCP bearer token for this worker, write it to
-    // a user-owned 0600 file, and inject only the FILE PATH via env. The raw
-    // token must NEVER travel through argv or an env var embedded into the
-    // elevation's inner shell command string (visible via
-    // /proc/<pid>/cmdline of the inner `sh -c` process, see
-    // privilege-elevation.ts:buildInnerCommand) -- a file path is not a
-    // secret and is safe to pass this way.
-    // (docs/design/embedded-agent-worker.md § "MCP caller identity")
-    if (process.env.AUTH_MODE === 'multi-user') {
-      if (!params.createdByUserId) {
-        // Non-fatal skip (unlike EmbeddedAgentWorkerService's hard-fail):
-        // terminal-agent PTY activation is a long-established
-        // availability-critical path (create / revive / restart / restore).
-        // The default AGENT_CONSOLE_MCP_AUTH mode is `warn`, so this
-        // worker's tokenless MCP calls are merely logged, not rejected;
-        // only an operator-opted-in `enforce` would reject them
-        // (fail-closed). The worker itself still starts either way.
-        logger.warn(
-          { workerId: worker.id, sessionId },
-          'Agent worker activated without session.createdBy; skipping MCP token mint (MCP calls from this worker will be rejected if AGENT_CONSOLE_MCP_AUTH=enforce is set; see Issue #1107)',
-        );
-      } else if (this.mcpTokenRegistry) {
-        // lookupOsUserFn is an injectable seam (LookupOsUserFn); the built-in
-        // implementation never rejects, but an injected implementation (test
-        // stub, future variant) is not contractually guaranteed not to throw
-        // -- see os-user-lookup.ts's LookupOsUserFn JSDoc. Fold a throw into
-        // the same "skip mint, don't fail activation" path as a null result,
-        // distinguished by `logger.error` (implementation misbehaved) vs the
-        // `logger.warn` below (genuinely unresolved).
-        const osUser = await this.lookupOsUserFn(params.username).catch((err: unknown) => {
-          logger.error(
-            { workerId: worker.id, username: params.username, err },
-            'lookupOsUserFn threw unexpectedly during MCP token mint; skipping mint',
-          );
-          return null;
-        });
-        if (!osUser) {
-          logger.warn(
-            { workerId: worker.id, username: params.username },
-            'Could not resolve OS user home directory for MCP token file; skipping MCP token mint',
-          );
-        } else {
-          const token = this.mcpTokenRegistry.mint({
-            sessionId,
-            workerId: worker.id,
-            userId: params.createdByUserId,
-          });
-          const tokenFilePath = path.join(
-            osUser.homeDir,
-            '.agent-console',
-            'mcp-tokens',
-            `${worker.id}.token`,
-          );
-          const writeResult = await writeUserOwnedSecretFile({
-            username: params.username,
-            filePath: tokenFilePath,
-            content: token,
-            runAsUserImpl: this.runAsUserImpl,
-          });
-          if (writeResult.exitCode !== 0 || writeResult.timedOut) {
-            // Unlike the missing-createdBy case above (a deliberate skip),
-            // a write FAILURE after a successful mint is an unexpected error
-            // state -- fail loud, mirroring EmbeddedAgentWorkerService's "no
-            // orphaned token from a failed activation" invariant.
-            this.mcpTokenRegistry.revokeByWorker(worker.id);
+    // Everything below can leave a partially-activated worker behind: the
+    // prompt-file write and the MCP-token mint/write both attach state to
+    // `worker` (promptFile / mcpToken) before `worker.pty` is assigned, and
+    // `spawnPty` itself can throw synchronously (PTY allocation failure).
+    // Neither `pty.onExit` nor `killWorker` ever runs for a worker whose
+    // `pty` was never assigned -- and callers (createWorker/restartWorker)
+    // discard the worker object entirely on a rejected activation, so
+    // nothing else can reach it either. This try/catch is the ONLY closure
+    // point for both artifacts; on any failure in this span, clean up
+    // whatever was already written before rethrowing the original error
+    // unchanged (activation must still fail loudly).
+    try {
+      // Persist initialPrompt to a file and inject a short `"$(cat '<path>')"`
+      // substitution instead of embedding the raw prompt on the sentinel-
+      // injected command line: the injected line is typed as PTY
+      // typeahead while the tty is still in canonical mode, and canonical-mode
+      // input buffers are bounded (~1KB macOS / 4096B Linux) -- a long prompt
+      // silently truncates and the agent never starts. Deliberately NOT gated
+      // on AUTH_MODE: the underlying truncation reproduces in single-user mode.
+      let promptFilePath: string | undefined;
+      if (initialPrompt?.trim() && template.includes('{{prompt}}')) {
+        const elevate = shouldElevateForUser(params.username);
+        let promptsDir: string;
+        if (elevate) {
+          const osUser = await this.lookupOsUserFn(params.username);
+          if (!osUser) {
             logger.error(
-              {
-                workerId: worker.id,
-                exitCode: writeResult.exitCode,
-                timedOut: writeResult.timedOut,
-                stderr: writeResult.stderr,
-              },
-              'Failed to write MCP token file; aborting agent worker PTY activation',
+              { workerId: worker.id, username: params.username },
+              'Could not resolve OS user home directory for prompt file; aborting agent worker PTY activation',
             );
-            throw new Error(`Failed to write MCP token file for worker ${worker.id}`);
+            throw new Error(`Failed to resolve OS user home directory for prompt file (worker ${worker.id})`);
           }
-          worker.mcpToken = { filePath: tokenFilePath, username: params.username };
-          additionalEnvVars[MCP_TOKEN_FILE_ENV_VAR] = tokenFilePath;
+          promptsDir = path.join(osUser.homeDir, '.agent-console', 'prompts');
+        } else {
+          promptsDir = path.join(getConfigDir(), 'prompts');
+        }
+        const filePath = path.join(promptsDir, `${worker.id}.prompt`);
+        // Set BEFORE the write (not after a successful write): if the write
+        // is interrupted partway through (e.g. `cat >` receives a partial
+        // stream), the catch block's cleanup below still reaches this path
+        // -- `rmRecursiveAsUser`'s `rm -f` is idempotent on a missing or
+        // partial file either way.
+        worker.promptFile = { filePath, username: params.username };
+        const writeResult = await writeUserOwnedSecretFile({
+          username: params.username,
+          filePath,
+          content: initialPrompt,
+          runAsUserImpl: this.runAsUserImpl,
+        });
+        if (writeResult.exitCode !== 0 || writeResult.timedOut) {
+          logger.error(
+            {
+              workerId: worker.id,
+              exitCode: writeResult.exitCode,
+              timedOut: writeResult.timedOut,
+              stderr: writeResult.stderr,
+            },
+            'Failed to write prompt file; aborting agent worker PTY activation',
+          );
+          throw new Error(`Failed to write prompt file for worker ${worker.id}`);
+        }
+        promptFilePath = filePath;
+      }
+
+      const { command, env: templateEnv } = expandTemplate({
+        template,
+        cwd: locationPath,
+        templateVars: context?.templateVars,
+        ...(promptFilePath !== undefined ? { promptFilePath } : { prompt: initialPrompt }),
+      });
+
+      // Build AgentConsole context so the agent knows its own identity.
+      // These enable self-delegation (e.g., MCP tools) and agent self-awareness.
+      const agentConsoleContext: AgentConsoleContext = {
+        baseUrl: `http://localhost:${serverConfig.PORT}`,
+        sessionId,
+        workerId: worker.id,
+        repositoryId,
+        parentSessionId: context?.parentSessionId,
+        parentWorkerId: context?.parentWorkerId,
+      };
+
+      // additionalEnvVars: repository + template env vars
+      // Base env (getCleanChildProcessEnv) and AGENT_CONSOLE_* conversion
+      // are handled internally by UserMode.spawnPty()
+      const additionalEnvVars: Record<string, string> = {
+        ...repositoryEnvVars,
+        ...templateEnv,
+      };
+
+      // Multi-user mode: mint an MCP bearer token for this worker, write it to
+      // a user-owned 0600 file, and inject only the FILE PATH via env. The raw
+      // token must NEVER travel through argv or an env var embedded into the
+      // elevation's inner shell command string (visible via
+      // /proc/<pid>/cmdline of the inner `sh -c` process, see
+      // privilege-elevation.ts:buildInnerCommand) -- a file path is not a
+      // secret and is safe to pass this way.
+      // (docs/design/embedded-agent-worker.md § "MCP caller identity")
+      if (process.env.AUTH_MODE === 'multi-user') {
+        if (!params.createdByUserId) {
+          // Non-fatal skip (unlike EmbeddedAgentWorkerService's hard-fail):
+          // terminal-agent PTY activation is a long-established
+          // availability-critical path (create / revive / restart / restore).
+          // The default AGENT_CONSOLE_MCP_AUTH mode is `warn`, so this
+          // worker's tokenless MCP calls are merely logged, not rejected;
+          // only an operator-opted-in `enforce` would reject them
+          // (fail-closed). The worker itself still starts either way.
+          logger.warn(
+            { workerId: worker.id, sessionId },
+            'Agent worker activated without session.createdBy; skipping MCP token mint (MCP calls from this worker will be rejected if AGENT_CONSOLE_MCP_AUTH=enforce is set; see Issue #1107)',
+          );
+        } else if (this.mcpTokenRegistry) {
+          // lookupOsUserFn is an injectable seam (LookupOsUserFn); the built-in
+          // implementation never rejects, but an injected implementation (test
+          // stub, future variant) is not contractually guaranteed not to throw
+          // -- see os-user-lookup.ts's LookupOsUserFn JSDoc. Fold a throw into
+          // the same "skip mint, don't fail activation" path as a null result,
+          // distinguished by `logger.error` (implementation misbehaved) vs the
+          // `logger.warn` below (genuinely unresolved).
+          const osUser = await this.lookupOsUserFn(params.username).catch((err: unknown) => {
+            logger.error(
+              { workerId: worker.id, username: params.username, err },
+              'lookupOsUserFn threw unexpectedly during MCP token mint; skipping mint',
+            );
+            return null;
+          });
+          if (!osUser) {
+            logger.warn(
+              { workerId: worker.id, username: params.username },
+              'Could not resolve OS user home directory for MCP token file; skipping MCP token mint',
+            );
+          } else {
+            const token = this.mcpTokenRegistry.mint({
+              sessionId,
+              workerId: worker.id,
+              userId: params.createdByUserId,
+            });
+            const tokenFilePath = path.join(
+              osUser.homeDir,
+              '.agent-console',
+              'mcp-tokens',
+              `${worker.id}.token`,
+            );
+            const writeResult = await writeUserOwnedSecretFile({
+              username: params.username,
+              filePath: tokenFilePath,
+              content: token,
+              runAsUserImpl: this.runAsUserImpl,
+            });
+            if (writeResult.exitCode !== 0 || writeResult.timedOut) {
+              // Unlike the missing-createdBy case above (a deliberate skip),
+              // a write FAILURE after a successful mint is an unexpected error
+              // state -- fail loud, mirroring EmbeddedAgentWorkerService's "no
+              // orphaned token from a failed activation" invariant. The
+              // in-memory revoke here is a fast-path for THIS failure only;
+              // the outer catch below also unconditionally calls
+              // revokeAndDeleteMcpToken (idempotent no-op if already revoked
+              // and no worker.mcpToken was ever assigned in this branch).
+              this.mcpTokenRegistry.revokeByWorker(worker.id);
+              logger.error(
+                {
+                  workerId: worker.id,
+                  exitCode: writeResult.exitCode,
+                  timedOut: writeResult.timedOut,
+                  stderr: writeResult.stderr,
+                },
+                'Failed to write MCP token file; aborting agent worker PTY activation',
+              );
+              throw new Error(`Failed to write MCP token file for worker ${worker.id}`);
+            }
+            worker.mcpToken = { filePath: tokenFilePath, username: params.username };
+            additionalEnvVars[MCP_TOKEN_FILE_ENV_VAR] = tokenFilePath;
+          }
         }
       }
+
+      const sentinel = `__AGENT_CONSOLE_READY_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
+
+      const ptyProcess = this.userMode.spawnPty({
+        type: 'agent',
+        username: params.username,
+        cwd: locationPath,
+        additionalEnvVars,
+        cols: 120,
+        rows: 30,
+        command,
+        agentConsoleContext,
+        sentinel,
+        // Forward the optional SSH_AUTH_SOCK fallback from the session
+        // creation context. Populated only by the MCP delegate path;
+        // undefined for every other path so existing behavior is preserved.
+        sshAuthSockFallback: context?.sshAuthSockFallback,
+      });
+
+      const activityDetector = new ActivityDetector({
+        onStateChange: (state) => {
+          worker.activityState = state;
+          const callbacksSnapshot = Array.from(worker.connectionCallbacks.values());
+          for (const callbacks of callbacksSnapshot) {
+            callbacks.onActivityChange?.(state);
+          }
+          this.globalActivityCallback?.(sessionId, worker.id, state);
+        },
+        activityPatterns: agent.activityPatterns,
+      });
+
+      worker.pty = ptyProcess;
+      worker.activityDetector = activityDetector;
+      worker.agentId = agent.id;
+      worker.loginShellSentinel = sentinel;
+      worker.pendingCommand = command;
+
+      // Set initial activity state to match ActivityDetector's initial state ('idle').
+      // The onStateChange callback only fires on state *changes*, not on initialization,
+      // so we must explicitly set the initial state here.
+      worker.activityState = 'idle';
+      this.globalActivityCallback?.(sessionId, worker.id, 'idle');
+
+      this.setupWorkerEventHandlers(worker, sessionId, params.resolver);
+    } catch (err) {
+      // Both cleanup calls are null-safe (no-op when nothing was ever set)
+      // and never throw (internal failures are logged as warnings) -- see
+      // deletePromptFile / revokeAndDeleteMcpToken. Always rethrow the
+      // ORIGINAL error unmodified; activation must still fail loudly.
+      await this.deletePromptFile(worker);
+      await this.revokeAndDeleteMcpToken(worker);
+      throw err;
     }
-
-    const sentinel = `__AGENT_CONSOLE_READY_${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`;
-
-    const ptyProcess = this.userMode.spawnPty({
-      type: 'agent',
-      username: params.username,
-      cwd: locationPath,
-      additionalEnvVars,
-      cols: 120,
-      rows: 30,
-      command,
-      agentConsoleContext,
-      sentinel,
-      // Forward the optional SSH_AUTH_SOCK fallback from the session
-      // creation context. Populated only by the MCP delegate path;
-      // undefined for every other path so existing behavior is preserved.
-      sshAuthSockFallback: context?.sshAuthSockFallback,
-    });
-
-    const activityDetector = new ActivityDetector({
-      onStateChange: (state) => {
-        worker.activityState = state;
-        const callbacksSnapshot = Array.from(worker.connectionCallbacks.values());
-        for (const callbacks of callbacksSnapshot) {
-          callbacks.onActivityChange?.(state);
-        }
-        this.globalActivityCallback?.(sessionId, worker.id, state);
-      },
-      activityPatterns: agent.activityPatterns,
-    });
-
-    worker.pty = ptyProcess;
-    worker.activityDetector = activityDetector;
-    worker.agentId = agent.id;
-    worker.loginShellSentinel = sentinel;
-    worker.pendingCommand = command;
-
-    // Set initial activity state to match ActivityDetector's initial state ('idle').
-    // The onStateChange callback only fires on state *changes*, not on initialization,
-    // so we must explicitly set the initial state here.
-    worker.activityState = 'idle';
-    this.globalActivityCallback?.(sessionId, worker.id, 'idle');
-
-    this.setupWorkerEventHandlers(worker, sessionId, params.resolver);
   }
 
   /**

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -49,10 +49,11 @@ import { computeDefaultBaseSpec } from './git-diff-service.js';
 import { serverConfig } from '../lib/server-config.js';
 import type { WorkerOutputFileManager } from '../lib/worker-output-file.js';
 import type { McpTokenRegistry } from '../mcp/mcp-auth.js';
-import { writeUserOwnedSecretFile, rmRecursiveAsUser, type runAsUser } from './privilege-elevation.js';
+import { writeUserOwnedSecretFile, rmRecursiveAsUser, shouldElevateForUser, type runAsUser } from './privilege-elevation.js';
 import { lookupOsUser, type LookupOsUserFn } from './os-user-lookup.js';
 import { listDescendantPids, signalPids } from '../lib/process-tree.js';
 import { createLogger } from '../lib/logger.js';
+import { getConfigDir } from '../lib/config.js';
 import * as path from 'node:path';
 
 const logger = createLogger('worker-manager');
@@ -298,6 +299,7 @@ export class WorkerManager {
       activityDetector: null,
       connectionCallbacks: new Map(),
       mcpToken: null,
+      promptFile: null,
     };
 
     return worker;
@@ -436,11 +438,58 @@ export class WorkerManager {
       ? agent.continueTemplate
       : agent.commandTemplate;
 
+    // Persist initialPrompt to a file and inject a short `"$(cat '<path>')"`
+    // substitution instead of embedding the raw prompt on the sentinel-
+    // injected command line: the injected line is typed as PTY
+    // typeahead while the tty is still in canonical mode, and canonical-mode
+    // input buffers are bounded (~1KB macOS / 4096B Linux) -- a long prompt
+    // silently truncates and the agent never starts. Deliberately NOT gated
+    // on AUTH_MODE: the underlying truncation reproduces in single-user mode.
+    let promptFilePath: string | undefined;
+    if (initialPrompt?.trim() && template.includes('{{prompt}}')) {
+      const elevate = shouldElevateForUser(params.username);
+      let promptsDir: string;
+      if (elevate) {
+        const osUser = await this.lookupOsUserFn(params.username);
+        if (!osUser) {
+          logger.error(
+            { workerId: worker.id, username: params.username },
+            'Could not resolve OS user home directory for prompt file; aborting agent worker PTY activation',
+          );
+          throw new Error(`Failed to resolve OS user home directory for prompt file (worker ${worker.id})`);
+        }
+        promptsDir = path.join(osUser.homeDir, '.agent-console', 'prompts');
+      } else {
+        promptsDir = path.join(getConfigDir(), 'prompts');
+      }
+      const filePath = path.join(promptsDir, `${worker.id}.prompt`);
+      const writeResult = await writeUserOwnedSecretFile({
+        username: params.username,
+        filePath,
+        content: initialPrompt,
+        runAsUserImpl: this.runAsUserImpl,
+      });
+      if (writeResult.exitCode !== 0 || writeResult.timedOut) {
+        logger.error(
+          {
+            workerId: worker.id,
+            exitCode: writeResult.exitCode,
+            timedOut: writeResult.timedOut,
+            stderr: writeResult.stderr,
+          },
+          'Failed to write prompt file; aborting agent worker PTY activation',
+        );
+        throw new Error(`Failed to write prompt file for worker ${worker.id}`);
+      }
+      worker.promptFile = { filePath, username: params.username };
+      promptFilePath = filePath;
+    }
+
     const { command, env: templateEnv } = expandTemplate({
       template,
-      prompt: initialPrompt,
       cwd: locationPath,
       templateVars: context?.templateVars,
+      ...(promptFilePath !== undefined ? { promptFilePath } : { prompt: initialPrompt }),
     });
 
     // Build AgentConsole context so the agent knows its own identity.
@@ -731,6 +780,7 @@ export class WorkerManager {
         // and cannot be awaited by its caller. Failures are logged inside
         // revokeAndDeleteMcpToken itself.
         void this.revokeAndDeleteMcpToken(worker);
+        void this.deletePromptFile(worker);
       }
 
       const callbacksSnapshot = Array.from(worker.connectionCallbacks.values());
@@ -851,6 +901,7 @@ export class WorkerManager {
             activityState: 'unknown',
             activityDetector: null,
             mcpToken: null,
+            promptFile: null,
           };
           break;
         case 'terminal':
@@ -1018,6 +1069,31 @@ export class WorkerManager {
   }
 
   /**
+   * Delete the prompt file written for an agent worker. Called
+   * on every path a terminal-agent PTY can stop existing through:
+   * unexpected exit (pty.onExit) and managed kill (killWorker). No-op when
+   * the worker never had a prompt file. Never throws -- deletion failures
+   * are logged as warnings so cleanup never blocks the exit/kill flow.
+   */
+  private async deletePromptFile(worker: InternalAgentWorker): Promise<void> {
+    const promptFile = worker.promptFile;
+    if (promptFile === null) {
+      return;
+    }
+    worker.promptFile = null;
+    try {
+      await rmRecursiveAsUser(promptFile.filePath, promptFile.username, {
+        runAsUserImpl: this.runAsUserImpl,
+      });
+    } catch (err) {
+      logger.warn(
+        { workerId: worker.id, filePath: promptFile.filePath, err },
+        'Failed to delete prompt file',
+      );
+    }
+  }
+
+  /**
    * Kill a worker's PTY process and clean up resources.
    * Awaits PTY process exit to ensure directory handles are released
    * before callers proceed (e.g., git worktree remove).
@@ -1152,6 +1228,7 @@ export class WorkerManager {
       // expects the timer to already be registered.
       if (worker.type === 'agent') {
         await this.revokeAndDeleteMcpToken(worker);
+        await this.deletePromptFile(worker);
       }
     }
     // git-diff workers have no PTY to kill

--- a/packages/server/src/services/worker-types.ts
+++ b/packages/server/src/services/worker-types.ts
@@ -80,6 +80,16 @@ export interface InternalAgentWorker extends InternalPtyWorkerBase {
    * delete the file on exit/kill/delete alongside the in-memory token revoke.
    */
   mcpToken: { filePath: string; username: string } | null;
+  /**
+   * Prompt file delivered to this worker's shell via the sentinel-injected
+   * `claude "$(cat '<path>')"` command -- avoids embedding a
+   * long initialPrompt directly on the injected line, which truncates once
+   * it exceeds the tty's canonical-mode input buffer. null when no prompt
+   * file was written (no initialPrompt, template lacks {{prompt}}, or
+   * restart/continue). Used to delete the file on exit/kill alongside the
+   * pendingCommand cleanup.
+   */
+  promptFile: { filePath: string; username: string } | null;
 }
 
 /**

--- a/scripts/smoke/check-login-shell-sentinel.ts
+++ b/scripts/smoke/check-login-shell-sentinel.ts
@@ -25,6 +25,13 @@
  *     directly.
  *   - bun-pty's internal PTY allocation. That is a library concern.
  *   - The agent-console server. The builders are pure; no server runs here.
+ *   - (long-prompt case, Issue #1234) The --elevated variant of the
+ *     long-prompt case is intentionally omitted. Writing the payload file as
+ *     the target user would require `writeUserOwnedSecretFile` plumbing this
+ *     smoke does not otherwise need; the direct-mode case already exercises
+ *     the exact mechanism the issue is about (the injected line typed as PTY
+ *     typeahead while the tty is in canonical mode), which is identical in
+ *     shape between direct and elevated activation.
  *
  * Usage:
  *   bun scripts/smoke/check-login-shell-sentinel.ts               # direct mode
@@ -52,7 +59,7 @@
 
 import * as os from 'os';
 import * as crypto from 'crypto';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
 import type { PtyInstance } from '../../packages/server/src/lib/pty-provider.js';
 import { bunPtyProvider } from '../../packages/server/src/lib/pty-provider.js';
 import { getUnsetEnvPrefix } from '../../packages/server/src/services/env-filter.js';
@@ -61,6 +68,7 @@ import {
   buildElevatedSentinelCommand,
 } from '../../packages/server/src/services/sentinel-spawn-command.js';
 import { buildElevationArgs } from '../../packages/server/src/services/elevation-args.js';
+import { expandTemplate } from '../../packages/server/src/lib/template.js';
 
 // Neutralize any unreadable inherited cwd (see check-multiuser-pty-env.ts):
 // when invoked via an elevation wrapper the caller's cwd may be untraversable
@@ -225,6 +233,58 @@ await waitFor(() =>
     }),
 );
 
+// Phase 3 (direct mode only): long-initialPrompt case (Issue #1234). Builds
+// the injected command via the SAME production `expandTemplate` helper
+// (promptFilePath variant) that `activateAgentWorkerPty` uses, and asserts
+// the injected command stays well under the tty's canonical-mode input
+// buffer even though the underlying prompt is far larger than that buffer.
+// >4096 bytes: the issue is explicit that <=4096 bytes is NOT sufficient to
+// reproduce the pre-fix truncation on Linux.
+const longPromptPayload = 'the quick brown fox jumps over the lazy dog. '.repeat(120);
+let longPromptCommand = '';
+let longPromptMarkerSeen = false;
+let longPromptFile: string | undefined;
+if (mode === 'direct') {
+  if (longPromptPayload.length <= 5000) {
+    console.error(`FAILED: smoke misconfiguration -- payload length ${longPromptPayload.length} <= 5000`);
+    finish(2);
+  }
+
+  longPromptFile = `/tmp/agent-console-smoke-prompt-${crypto.randomUUID()}.prompt`;
+  await Bun.write(longPromptFile, longPromptPayload);
+
+  const { command } = expandTemplate({
+    template: "printf '%s' {{prompt}} | wc -c; echo SMOKE_LONG_PROMPT_DONE",
+    cwd: '/',
+    promptFilePath: longPromptFile,
+  });
+  longPromptCommand = command;
+  if (Buffer.byteLength(command, 'utf-8') >= 512) {
+    console.error(
+      `FAILED: smoke misconfiguration -- injected command is ${Buffer.byteLength(command, 'utf-8')} bytes (expected < 512)`,
+    );
+    finish(2);
+  }
+
+  pty.write(command + '\r');
+  longPromptMarkerSeen = await waitFor(() => output.includes('SMOKE_LONG_PROMPT_DONE'));
+
+  // Best-effort cleanup: by the time the marker (or the timeout) is
+  // observed, `cat` has already read the file (or never will), so it's safe
+  // to remove now. Never let cleanup failure change the exit code.
+  try {
+    unlinkSync(longPromptFile);
+  } catch {
+    // best-effort; ignore
+  }
+  if (!longPromptMarkerSeen) {
+    console.error('FAILED: long-prompt probe never produced its marker (command was not executed).');
+    console.error('  captured output (first 800 chars, tail):');
+    console.error(output.slice(-800));
+    finish(1);
+  }
+}
+
 // ---------- assertions ----------
 const failures: string[] = [];
 let passes = 0;
@@ -268,6 +328,29 @@ if (expectedHome) {
   }
 } else {
   console.warn('  WARN  could not resolve expected home; skipping login-init PATH check');
+}
+
+if (mode === 'direct') {
+  console.log('==> long initialPrompt (Issue #1234) -- injected command stays bounded');
+  expect(
+    Buffer.byteLength(longPromptCommand, 'utf-8') < 512,
+    'injected command for a 5000+ char prompt is under 512 bytes',
+    `got ${Buffer.byteLength(longPromptCommand, 'utf-8')} bytes`,
+  );
+  expect(longPromptMarkerSeen, 'long-prompt probe completed (SMOKE_LONG_PROMPT_DONE observed)');
+
+  const doneIdx = lines.findIndex((l) => l === 'SMOKE_LONG_PROMPT_DONE');
+  const wcLine = doneIdx > 0 ? lines[doneIdx - 1] : '';
+  // The tty may prefix the line with terminal control sequences (e.g. a
+  // bracketed-paste-mode toggle); extract the trailing digit run rather than
+  // parsing from the start of the line.
+  const wcMatch = wcLine.match(/(\d+)\s*$/);
+  const wcCount = wcMatch ? parseInt(wcMatch[1], 10) : NaN;
+  expect(
+    !isNaN(wcCount) && wcCount === longPromptPayload.length,
+    `wc -c reports the exact payload byte length (${longPromptPayload.length})`,
+    `got line: "${wcLine}"`,
+  );
 }
 
 console.log('==> sentinel-gate negatives');


### PR DESCRIPTION
## Summary

`delegate_to_worktree` with a long `initialPrompt` (up to 5000 chars) never starts the agent: the login-shell sentinel mechanism injects the fully expanded shell command — including the prompt, shell-escaped into one line — as PTY typeahead while the tty is still in canonical mode. Canonical-mode input buffers are bounded (~1KB macOS, 4096B Linux), so a long injected line silently truncates and never executes. Reproduces in single-user mode.

This implements the architect-reviewed Plan A design from the issue: never put the prompt payload on the injected line. `initialPrompt` is persisted to a user-owned 0600 file at activation time, and a short, fixed-size command is injected instead:

```
claude "$(cat '/path/to/<workerId>.prompt')"
```

Command substitution inside double quotes is never re-parsed by the shell (no word splitting/globbing; quotes/backticks/`$`/backslashes in the prompt are inert). Only the file path needs shell-escaping.

## Changes

- `expandTemplate` (`template.ts`) gains a `promptFilePath` option: when set, `{{prompt}}` expands to `"$(cat '<escaped path>')"` instead of the shell-escaped prompt text. Mutually exclusive with `prompt`; byte-identical to prior behavior when absent (locked by regression tests). The two other `expandTemplate` consumers (`repository-description-generator.ts`, `session-metadata-suggester.ts`) are untouched — zero diff.
- `activateAgentWorkerPty` (`worker-manager.ts`) writes `initialPrompt` to a prompt file before template expansion, whenever the prompt is non-empty AND the selected template contains `{{prompt}}`. **Not gated on `AUTH_MODE`** — the bug reproduces in single-user mode, so gating on multi-user (like the adjacent MCP-token block) would not fix the reported bug. File location branches on `shouldElevateForUser`: the target OS user's home directory when elevation is required, `getConfigDir()`-relative otherwise (honors `AGENT_CONSOLE_HOME` for dev/prod coexistence). Written via `writeUserOwnedSecretFile` (content travels over stdin, never argv).
- Failure semantics deliberately diverge from the MCP-token precedent: home-dir resolution failure under required elevation, or a failed write, **abort activation** (throw) rather than falling back to inline embedding — a fallback would silently reintroduce the exact truncation bug this PR exists to kill.
- `InternalAgentWorker` gains a `promptFile` field (mirrors `mcpToken`); the file is deleted on worker exit (fire-and-forget) and `killWorker` (awaited), which also covers session delete (routes through `killWorker`) for free.
- `scripts/smoke/check-login-shell-sentinel.ts` gains a direct-mode long-prompt case (>5000 chars, built through the production `expandTemplate({ promptFilePath })` path) asserting the injected command stays under 512 bytes and the full payload is observed by the shell. The `--elevated` variant is intentionally omitted (documented in the script) — it would need `writeUserOwnedSecretFile` plumbing this smoke doesn't otherwise use, and the direct-mode case already exercises the exact truncation mechanism (typeahead into a canonical-mode tty), which is identical in shape between direct and elevated activation.

Restart re-delivery of a never-delivered prompt is split to #1236 (depends on this PR) — this PR just deletes the prompt file plainly on exit/kill, no survive-across-restart lifecycle.

## CodeRabbit findings addressed (architect-ruled scope, both binding)

Two MAJOR findings from the GitHub-side CodeRabbit review, both confirmed and ruled in-scope by the architect:

1. **`template.ts` — JS `String.replace` special-pattern interpretation.** All three `{{...}}` expansion sites that used a plain-string second argument to `.replace()` (`{{cwd}}`, and both branches of `{{prompt}}`) are now function-form replacers, matching the custom-template-var expansion's existing pattern. A plain-string replacer silently reinterprets `$$`, `$&`, `` $` ``, `$'` sequences in the substituted value (e.g. a prompt containing `cost is $$5` became `cost is $5`), corrupting the delivered content before it ever reaches the shell. Because this fix lives inside the shared `expandTemplate` function, it also fixes the same pre-existing bug for the function's other two callers, `repository-description-generator.ts` and `session-metadata-suggester.ts` — with zero diff to either file. The architect ruled this a safe behavior change: no legitimate caller could have depended on the mangling.
2. **`worker-manager.ts` — orphaned prompt file / MCP token on later activation failure.** `worker.promptFile` (and the pre-existing `worker.mcpToken`) could be set on a worker that later fails activation before `worker.pty` is assigned; neither `pty.onExit` nor `killWorker` ever runs for such a worker, and both `createWorker`/`restartWorker` discard it without ever adding it to `session.workers`, so no caller-side rollback can reach it either. `activateAgentWorkerPty` now wraps the entire post-prompt-file-write span in a single `try/catch` that cleans up both artifacts before rethrowing the original error unchanged. `worker.promptFile` is now set *before* the write attempt (not after success), so an interrupted write is also covered.

## Scope note (architect-approved, outside the issue's originally-listed file set)

`session-manager.ts` and `app-context.ts` gain an optional `runAsUserImpl`/`lookupOsUserFn` test-seam passthrough to `WorkerManager`'s existing constructor params (which already accepted them — this just threads `SessionManager.create()`'s options through). This is a reciprocal test-correctness consequence of the prompt-file write no longer being `AUTH_MODE`-gated: two existing test suites (`mcp-server.test.ts`, `initial-prompt-delivered-boundary.test.ts`) activate agent workers with a non-empty `initialPrompt` against a synthetic `AGENT_CONSOLE_HOME`, and without the seam the write's underlying `Bun.spawn` subprocess would hit the real filesystem and fail the full suite. Trailing-optional only; zero behavior change for every other caller. `session-manager.test.ts` gained direct coverage of the passthrough itself.

The `mcpToken` failed-activation leak (finding 2 above) was a **pre-existing gap**, predating this PR; closing it required no additional surface beyond the same `try/catch` block already needed for `promptFile`, so per the architect's ruling it is closed here **en passant** rather than filed as a separate follow-up Issue.

## Note on CodeRabbit

Local CodeRabbit CLI returned `authentication_failed` / `automatic_login_failed` — this is the headless-worktree structural auth-failure shape (no browser available to complete interactive login), not a rate-limit; it will not resolve by waiting. Per `coderabbit-ops` skill disposition, relying on the GitHub-side bot review for this PR.

## Test plan

- [x] `bun run typecheck` — clean across all 5 workspace packages
- [x] `bun run test` (full monorepo suite) — green, 0 failures (verified independently, not just by the implementing agent)
- [x] TDD polarity: reverting only the 3 core production files (`template.ts`, `worker-manager.ts`, `worker-types.ts`) to their pre-fix state fails 17 of the 20 new unit tests, each for the correct reason (independently re-verified, not just by the implementing agent). The remaining 3 do not flip **by design**, not partial-polarity gaps — each is an invariant-lock regression test that must hold in both branches:
  - `template.test.ts` — `promptFilePath option > should produce byte-identical output to before when promptFilePath is absent (basic prompt)` — asserts legacy behavior when `promptFilePath` is not used at all; that path is untouched by the fix.
  - `template.test.ts` — `promptFilePath option > should produce byte-identical output to before when promptFilePath is absent (special characters)` — same.
  - `template.test.ts` — `promptFilePath option > should be a no-op when promptFilePath is set but the template has no {{prompt}}` — no `{{prompt}}` occurrence exists to substitute in either branch (this is one of design point 1's explicitly required boundary rows, not a fix-verification case).

  The smoke script's new case demonstrates a genuine pre/post-fix behavioral difference (payload byte-count assertion fails pre-fix).
- [x] CodeRabbit-fix follow-up polarity (both independently re-verified): the `String.replace` special-pattern tests (prompt / cwd / promptFilePath each containing `$$`/`$&`/`` $` ``/`$'`) fail against a plain-string `.replace()` and pass with the function-form replacer; the shared-catch-block tests (a: prompt-file write succeeds, later MCP-token write fails — asserts both `promptFile` and `mcpToken` are cleared and cleaned up; b: prompt-file write itself fails — asserts a cleanup `rm` now fires, corrected from the prior "0 rm calls" assertion) both fail against a no-try/catch implementation.
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (test coverage, glossary/duplication, language, blame-shift)
- [x] `bun scripts/smoke/check-login-shell-sentinel.ts` — 10/10 assertions pass, direct mode

## Merge disposition note (2026-07-28)

**CR state**: initial walkthrough at 02:11 produced 2 Major findings (both real, both fixed). Manual `@coderabbitai review` retry at 02:36 produced no review submission within the abandon-the-wait window; the commit status for head `fba011c0` remains `state=success / description="Review rate limited"`. inline: 2, both auto-resolved by `coderabbitai[bot]` with `<review_comment_addressed>` markers and per-finding verification replies against the current code. reviewDecision: empty. Local CodeRabbit CLI is unavailable in this headless worktree (`authentication_failed` — a structural auth limitation, NOT a rate limit).

**Fallback disposition applied** (`coderabbit-ops` skill, headless-auth-unavailable + bot rate-limited on the same commit): architect independent audit + Orchestrator acceptance dual-clean. The architect performed a full code-appropriateness audit of the complete diff (all 12 AC items walked; one required micro-fix R1 raised and closed in `fba011c0`) plus a differential re-audit of R1 — both CLEAN. Merging under existing [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority); this PR is a logic change and therefore requires owner approval, which the dual-clean gate does not waive.

Closes #1234


