### PR TITLE
feat: redeliver session initialPrompt on terminal-agent worker restart (closes #1236)

### DIFF
--- a/packages/server/src/__tests__/utils/build-test-data.ts
+++ b/packages/server/src/__tests__/utils/build-test-data.ts
@@ -42,6 +42,7 @@ export function buildPersistedAgentWorker(
     name: 'Test Agent',
     agentId: 'claude-code-builtin',
     pid: null,
+    deliverInitialPromptOnActivation: false,
     createdAt: '2026-01-01T00:00:00.000Z',
     ...overrides,
   };
@@ -155,6 +156,7 @@ export function buildInternalAgentWorker(
     activityDetector: null,
     mcpToken: null,
     promptFile: null,
+    deliverInitialPromptOnActivation: false,
     ...overrides,
   };
 }

--- a/packages/server/src/database/__tests__/mappers.test.ts
+++ b/packages/server/src/database/__tests__/mappers.test.ts
@@ -248,6 +248,28 @@ describe('mappers', () => {
 
       expect(row.deliver_initial_prompt_on_activation).toBe(0);
     });
+
+    it('writes deliver_initial_prompt_on_activation: 1 when the persisted agent worker is eligible (Issue #1236)', () => {
+      const worker = buildPersistedAgentWorker({
+        id: 'worker-1',
+        deliverInitialPromptOnActivation: true,
+      });
+
+      const row = toWorkerRow(worker, 'session-1');
+
+      expect(row.deliver_initial_prompt_on_activation).toBe(1);
+    });
+
+    it('writes deliver_initial_prompt_on_activation: 0 when the persisted agent worker is not eligible (Issue #1236)', () => {
+      const worker = buildPersistedAgentWorker({
+        id: 'worker-1',
+        deliverInitialPromptOnActivation: false,
+      });
+
+      const row = toWorkerRow(worker, 'session-1');
+
+      expect(row.deliver_initial_prompt_on_activation).toBe(0);
+    });
   });
 
   describe('toSessionRow - scope+slug invariants', () => {
@@ -488,6 +510,46 @@ describe('mappers', () => {
 
       expect(worker.type).toBe('agent');
       expect((worker as PersistedAgentWorker).agentId).toBe('claude-code-builtin');
+    });
+
+    it('maps deliver_initial_prompt_on_activation: 1 to deliverInitialPromptOnActivation: true for agent workers (Issue #1236)', () => {
+      const dbWorker: Worker = {
+        id: 'worker-1',
+        session_id: 'session-1',
+        type: 'agent',
+        name: 'Agent',
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-01T00:00:00.000Z',
+        pid: 1234,
+        agent_id: 'claude-code-builtin',
+        base_commit: null,
+        embedded_agent_id: null,
+        deliver_initial_prompt_on_activation: 1,
+      };
+
+      const worker = toPersistedWorker(dbWorker);
+
+      expect((worker as PersistedAgentWorker).deliverInitialPromptOnActivation).toBe(true);
+    });
+
+    it('maps deliver_initial_prompt_on_activation: null to deliverInitialPromptOnActivation: false for agent workers (Issue #1236)', () => {
+      const dbWorker: Worker = {
+        id: 'worker-1',
+        session_id: 'session-1',
+        type: 'agent',
+        name: 'Agent',
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-01T00:00:00.000Z',
+        pid: 1234,
+        agent_id: 'claude-code-builtin',
+        base_commit: null,
+        embedded_agent_id: null,
+        deliver_initial_prompt_on_activation: null,
+      };
+
+      const worker = toPersistedWorker(dbWorker);
+
+      expect((worker as PersistedAgentWorker).deliverInitialPromptOnActivation).toBe(false);
     });
 
     it('should convert valid terminal worker', () => {

--- a/packages/server/src/database/mappers.ts
+++ b/packages/server/src/database/mappers.ts
@@ -146,7 +146,7 @@ export function toWorkerRow(worker: PersistedWorker, sessionId: string): NewWork
       agent_id: worker.agentId,
       base_commit: null,
       embedded_agent_id: null,
-      deliver_initial_prompt_on_activation: null,
+      deliver_initial_prompt_on_activation: worker.deliverInitialPromptOnActivation ? 1 : 0,
     };
   } else if (worker.type === 'terminal') {
     return {
@@ -211,6 +211,7 @@ export function toPersistedWorker(worker: Worker): PersistedWorker {
       createdAt: worker.created_at,
       pid: worker.pid ?? null,
       agentId: worker.agent_id,
+      deliverInitialPromptOnActivation: worker.deliver_initial_prompt_on_activation === 1,
     } as PersistedAgentWorker;
   } else if (worker.type === 'terminal') {
     return {

--- a/packages/server/src/services/__tests__/persistence-service.test.ts
+++ b/packages/server/src/services/__tests__/persistence-service.test.ts
@@ -143,6 +143,7 @@ describe('PersistenceService', () => {
               agentId: 'claude-code',
               pid: 12345,
               createdAt: '2024-01-01T00:00:00.000Z',
+              deliverInitialPromptOnActivation: false,
             },
           ],
           serverPid: 99999,

--- a/packages/server/src/services/__tests__/session-converter-service.test.ts
+++ b/packages/server/src/services/__tests__/session-converter-service.test.ts
@@ -76,7 +76,15 @@ describe('SessionConverterService', () => {
         const existing = toPersistedWorkerResults.get(w.id);
         if (existing) return existing;
         if (w.type === 'agent') {
-          return { id: w.id, type: 'agent', name: w.name, agentId: w.agentId, createdAt: w.createdAt, pid: w.pty?.pid ?? null };
+          return {
+            id: w.id,
+            type: 'agent',
+            name: w.name,
+            agentId: w.agentId,
+            createdAt: w.createdAt,
+            pid: w.pty?.pid ?? null,
+            deliverInitialPromptOnActivation: w.deliverInitialPromptOnActivation,
+          };
         } else if (w.type === 'terminal') {
           return { id: w.id, type: 'terminal', name: w.name, createdAt: w.createdAt, pid: w.pty?.pid ?? null };
         } else if (w.type === 'git-diff') {

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import * as fs from 'fs';
 import { JOB_TYPES } from '@agent-console/shared';
 import type { CreateSessionRequest, CreateWorkerParams, Session, Worker } from '@agent-console/shared';
@@ -15,6 +15,7 @@ import type { PersistedWorker } from '../persistence-service.js';
 import { JobQueue } from '../../jobs/index.js';
 import type { PtyProvider, PtySpawnOptions } from '../../lib/pty-provider.js';
 import { SingleUserMode } from '../user-mode.js';
+import { WorkerManager } from '../worker-manager.js';
 import type { UserMode, PtySpawnRequest } from '../user-mode.js';
 import { PtyMessageInjectionService } from '../pty-message-injection-service.js';
 import { UsernameLookupService } from '../username-lookup.js';
@@ -1177,6 +1178,110 @@ describe('SessionManager', () => {
         } else {
           process.env.AUTH_MODE = originalAuthMode;
         }
+      }
+    });
+  });
+
+  describe('initial-prompt injected callback wiring (Issue #1236)', () => {
+    // SessionManager wires WorkerManager.setOnInitialPromptInjected in its
+    // constructor to mark session.initialPromptDelivered = true and persist
+    // it. These tests exercise the real end-to-end shipping path: create a
+    // session with a non-empty initialPrompt for a terminal-agent worker
+    // (the mock PTY factory auto-emits the login-shell sentinel synchronously
+    // on activation, so the injection write -- and this callback -- fires
+    // before createSession's promise resolves).
+    function createNoopRunAsUser(): typeof runAsUser {
+      return (async () => ({ stdout: '', stderr: '', exitCode: 0, timedOut: false })) as typeof runAsUser;
+    }
+
+    it('sets session.initialPromptDelivered = true after the terminal-agent worker injects the prompt', async () => {
+      const module = await import(`../session-manager.js?v=${++importCounter}`);
+      const manager = await module.SessionManager.create({
+        userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
+        pathExists: mockPathExists,
+        jobQueue: testJobQueue,
+        agentManager,
+        mcpTokenRegistry: new McpTokenRegistry(),
+        repositoryLookup: defaultRepositoryLookup,
+        repositoryEnvLookup: defaultRepositoryEnvLookup,
+        runAsUserImpl: createNoopRunAsUser(),
+      });
+
+      const session = await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: CLAUDE_CODE_AGENT_ID,
+        initialPrompt: 'Hello from the injected-callback wiring test',
+      });
+
+      expect(session.initialPromptDelivered).toBe(true);
+
+      // Also confirm the flag round-trips through getSession (reads the same
+      // in-memory session the callback mutated).
+      const fetched = manager.getSession(session.id);
+      expect(fetched?.initialPromptDelivered).toBe(true);
+    });
+
+    it('does not re-persist or throw when the callback fires again for an already-delivered session', async () => {
+      const module = await import(`../session-manager.js?v=${++importCounter}`);
+      const manager = await module.SessionManager.create({
+        userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
+        pathExists: mockPathExists,
+        jobQueue: testJobQueue,
+        agentManager,
+        mcpTokenRegistry: new McpTokenRegistry(),
+        repositoryLookup: defaultRepositoryLookup,
+        repositoryEnvLookup: defaultRepositoryEnvLookup,
+        runAsUserImpl: createNoopRunAsUser(),
+      });
+
+      const session = await manager.createSession({
+        type: 'quick',
+        locationPath: '/test/path',
+        agentId: CLAUDE_CODE_AGENT_ID,
+        initialPrompt: 'Hello from the re-fire guard test',
+      });
+      expect(session.initialPromptDelivered).toBe(true);
+
+      // Re-trigger the sentinel path on the same worker: simulate another
+      // exit + no-op re-emit is unnecessary here since the callback itself
+      // is idempotent by construction (guarded on session.initialPromptDelivered);
+      // directly re-invoke the underlying WorkerManager callback via a second
+      // PTY sentinel emission is not straightforward from this layer, so
+      // this test instead confirms the guard holds when the flag is already
+      // true and a second worker is created for the same session (an
+      // add-worker-route worker is never eligible, so it must not flip
+      // anything, and the session must not throw or corrupt state).
+      const worker = await manager.createWorker(session.id, { type: 'terminal' });
+      expect(worker).not.toBeNull();
+
+      const fetched = manager.getSession(session.id);
+      expect(fetched?.initialPromptDelivered).toBe(true);
+    });
+
+    it('does not throw when invoked for an unknown sessionId', async () => {
+      // Capture the callback SessionManager registers with WorkerManager
+      // (spyOn defaults to call-through, so registration itself is
+      // unaffected) and invoke it directly with a sessionId that was never
+      // created -- the callback's `getSession` lookup must miss cleanly.
+      const registerSpy = spyOn(WorkerManager.prototype, 'setOnInitialPromptInjected');
+      try {
+        const module = await import(`../session-manager.js?v=${++importCounter}`);
+        await module.SessionManager.create({
+          userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
+          pathExists: mockPathExists,
+          jobQueue: testJobQueue,
+          agentManager,
+          mcpTokenRegistry: new McpTokenRegistry(),
+          repositoryLookup: defaultRepositoryLookup,
+          repositoryEnvLookup: defaultRepositoryEnvLookup,
+        });
+
+        expect(registerSpy).toHaveBeenCalledTimes(1);
+        const registeredCallback = registerSpy.mock.calls[0][0];
+        expect(() => registeredCallback('non-existent-session', 'non-existent-worker')).not.toThrow();
+      } finally {
+        registerSpy.mockRestore();
       }
     });
   });

--- a/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-lifecycle-manager.test.ts
@@ -201,6 +201,64 @@ describe('WorkerLifecycleManager', () => {
       expect(ptyFactory.instances.length).toBe(1);
     });
 
+    it('should mark an agent worker eligible for initial-prompt redelivery when created with a non-empty initialPrompt (Issue #1236)', async () => {
+      const session = createTestSession();
+      sessions.set(session.id, session);
+
+      // Mock out activation: this test only asserts the eligibility flag on
+      // the initialized worker object, not the real prompt-file write --
+      // a non-empty initialPrompt would otherwise trigger a real elevated
+      // `cat >` subprocess spawn via the unmocked `runAsUser`.
+      const spy = spyOn(workerManager, 'activateAgentWorkerPty').mockImplementation(async () => {});
+      try {
+        const request: CreateWorkerParams = {
+          type: 'agent',
+          agentId: CLAUDE_CODE_AGENT_ID,
+        };
+
+        // Mirrors SessionManager.createSession's initial-worker call shape:
+        // createWorker(id, request, continueConversation, initialPrompt, templateVars).
+        const worker = await lifecycleManager.createWorker(session.id, request, false, 'Do the thing');
+
+        const internal = session.workers.get(worker!.id) as InternalAgentWorker;
+        expect(internal.deliverInitialPromptOnActivation).toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('should NOT mark an agent worker eligible when created without an initialPrompt (generic add-worker route shape) (Issue #1236)', async () => {
+      const session = createTestSession();
+      sessions.set(session.id, session);
+
+      const request: CreateWorkerParams = {
+        type: 'agent',
+        agentId: CLAUDE_CODE_AGENT_ID,
+      };
+
+      // Mirrors routes/workers.ts's generic add-worker call shape: no
+      // initialPrompt argument is passed at all.
+      const worker = await lifecycleManager.createWorker(session.id, request, false);
+
+      const internal = session.workers.get(worker!.id) as InternalAgentWorker;
+      expect(internal.deliverInitialPromptOnActivation).toBe(false);
+    });
+
+    it('should NOT mark an agent worker eligible when initialPrompt is whitespace-only (Issue #1236)', async () => {
+      const session = createTestSession();
+      sessions.set(session.id, session);
+
+      const request: CreateWorkerParams = {
+        type: 'agent',
+        agentId: CLAUDE_CODE_AGENT_ID,
+      };
+
+      const worker = await lifecycleManager.createWorker(session.id, request, false, '   ');
+
+      const internal = session.workers.get(worker!.id) as InternalAgentWorker;
+      expect(internal.deliverInitialPromptOnActivation).toBe(false);
+    });
+
     it('should create a terminal worker successfully', async () => {
       const session = createTestSession();
       sessions.set(session.id, session);
@@ -1052,6 +1110,141 @@ describe('WorkerLifecycleManager', () => {
     });
   });
 
+  // ========== Restart Initial-Prompt Re-delivery (Issue #1236) ==========
+
+  describe('restartAgentWorker initial-prompt re-delivery (Issue #1236)', () => {
+    /**
+     * Creates an agent worker via the real (unmocked) activation path (no
+     * initialPrompt passed to createWorker, so no real prompt-file write is
+     * ever triggered), then marks the resulting internal worker object
+     * eligible directly -- mirrors this file's existing pattern of
+     * hand-constructing InternalAgentWorker state for restart-path tests
+     * (see e.g. the "restoreWorker" / "templateVars propagation" describe
+     * blocks) rather than routing a real initialPrompt through creation's
+     * own real activateAgentWorkerPty call, which would attempt a real
+     * elevated `cat >` subprocess spawn via the unmocked `runAsUser`.
+     */
+    async function setupEligibleWorker(
+      sessionOverrides: Parameters<typeof createTestSession>[0] = {},
+    ): Promise<{ session: InternalSession; workerId: string }> {
+      const session = createTestSession(sessionOverrides);
+      sessions.set(session.id, session);
+
+      const worker = await lifecycleManager.createWorker(session.id, {
+        type: 'agent',
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+      const internal = session.workers.get(worker!.id) as InternalAgentWorker;
+      internal.deliverInitialPromptOnActivation = true;
+
+      return { session, workerId: worker!.id };
+    }
+
+    it('redelivers session.initialPrompt on restart when eligible, undelivered, and continueConversation is false [POLARITY]', async () => {
+      const { session, workerId } = await setupEligibleWorker({ initialPrompt: 'Do the important thing' });
+      expect(session.initialPromptDelivered).toBeUndefined();
+
+      const spy = spyOn(workerManager, 'activateAgentWorkerPty').mockImplementation(async () => {});
+      try {
+        await lifecycleManager.restartAgentWorker(session.id, workerId, false);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        const params = spy.mock.calls[0][1];
+        expect(params.initialPrompt).toBe('Do the important thing');
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('does not redeliver when session.initialPromptDelivered is already true', async () => {
+      const { session, workerId } = await setupEligibleWorker({ initialPrompt: 'Do the important thing' });
+      session.initialPromptDelivered = true;
+
+      const spy = spyOn(workerManager, 'activateAgentWorkerPty').mockImplementation(async () => {});
+      try {
+        await lifecycleManager.restartAgentWorker(session.id, workerId, false);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy.mock.calls[0][1].initialPrompt).toBeUndefined();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('does not redeliver when continueConversation is true, and does not consume eligibility for a later restart', async () => {
+      const { session, workerId } = await setupEligibleWorker({ initialPrompt: 'Do the important thing' });
+
+      const spy = spyOn(workerManager, 'activateAgentWorkerPty').mockImplementation(async () => {});
+      try {
+        await lifecycleManager.restartAgentWorker(session.id, workerId, true);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy.mock.calls[0][1].initialPrompt).toBeUndefined();
+        // continueConversation:true never flips the delivered flag itself --
+        // only the injection-time callback (WorkerManager, separately
+        // tested) does that.
+        expect(session.initialPromptDelivered).not.toBe(true);
+
+        // Same worker restarted again, this time with continueConversation:
+        // false and still undelivered -- the earlier continue-restart must
+        // not have "used up" the eligibility.
+        await lifecycleManager.restartAgentWorker(session.id, workerId, false);
+
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy.mock.calls[1][1].initialPrompt).toBe('Do the important thing');
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it.each([
+      ['undefined', undefined],
+      ['empty string', ''],
+      ['whitespace-only', '   '],
+    ])('does not redeliver when session.initialPrompt is %s, even though eligible and undelivered', async (_label, initialPromptValue) => {
+      const { session, workerId } = await setupEligibleWorker({ initialPrompt: initialPromptValue });
+
+      const spy = spyOn(workerManager, 'activateAgentWorkerPty').mockImplementation(async () => {});
+      try {
+        await lifecycleManager.restartAgentWorker(session.id, workerId, false);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy.mock.calls[0][1].initialPrompt).toBeUndefined();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("carries the original worker's deliverInitialPromptOnActivation across restart unchanged (eligible case)", async () => {
+      const { session, workerId } = await setupEligibleWorker({ initialPrompt: 'Do the important thing' });
+      // Already delivered, so this restart's redelivery gate is false --
+      // but eligibility itself must still carry over unrecomputed.
+      session.initialPromptDelivered = true;
+
+      await lifecycleManager.restartAgentWorker(session.id, workerId, false);
+
+      const newInternal = session.workers.get(workerId) as InternalAgentWorker;
+      expect(newInternal.deliverInitialPromptOnActivation).toBe(true);
+    });
+
+    it('carries deliverInitialPromptOnActivation: false across restart when the original worker was never eligible', async () => {
+      const session = createTestSession();
+      sessions.set(session.id, session);
+
+      const worker = await lifecycleManager.createWorker(session.id, {
+        type: 'agent',
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+      const before = session.workers.get(worker!.id) as InternalAgentWorker;
+      expect(before.deliverInitialPromptOnActivation).toBe(false);
+
+      await lifecycleManager.restartAgentWorker(session.id, worker!.id, false);
+
+      const after = session.workers.get(worker!.id) as InternalAgentWorker;
+      expect(after.deliverInitialPromptOnActivation).toBe(false);
+    });
+  });
+
   // ========== Update Git-Diff Workers After Branch Rename ==========
 
   describe('updateGitDiffWorkersAfterBranchRename', () => {
@@ -1142,6 +1335,7 @@ describe('WorkerLifecycleManager', () => {
         connectionCallbacks: new Map(),
         mcpToken: null,
         promptFile: null,
+        deliverInitialPromptOnActivation: false,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -1251,6 +1445,7 @@ describe('WorkerLifecycleManager', () => {
         connectionCallbacks: new Map(),
         mcpToken: null,
         promptFile: null,
+        deliverInitialPromptOnActivation: false,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -1290,6 +1485,7 @@ describe('WorkerLifecycleManager', () => {
         connectionCallbacks: new Map(),
         mcpToken: null,
         promptFile: null,
+        deliverInitialPromptOnActivation: false,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -1320,6 +1516,7 @@ describe('WorkerLifecycleManager', () => {
         connectionCallbacks: new Map(),
         mcpToken: null,
         promptFile: null,
+        deliverInitialPromptOnActivation: false,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -1348,6 +1545,7 @@ describe('WorkerLifecycleManager', () => {
         connectionCallbacks: new Map(),
         mcpToken: null,
         promptFile: null,
+        deliverInitialPromptOnActivation: false,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -1378,6 +1576,7 @@ describe('WorkerLifecycleManager', () => {
         connectionCallbacks: new Map(),
         mcpToken: null,
         promptFile: null,
+        deliverInitialPromptOnActivation: false,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -2144,6 +2343,7 @@ describe('WorkerLifecycleManager', () => {
         connectionCallbacks: new Map(),
         mcpToken: null,
         promptFile: null,
+        deliverInitialPromptOnActivation: false,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -2179,6 +2379,7 @@ describe('WorkerLifecycleManager', () => {
         connectionCallbacks: new Map(),
         mcpToken: null,
         promptFile: null,
+        deliverInitialPromptOnActivation: false,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -2261,6 +2462,7 @@ describe('WorkerLifecycleManager', () => {
         connectionCallbacks: new Map(),
         mcpToken: null,
         promptFile: null,
+        deliverInitialPromptOnActivation: false,
       };
       session.workers.set(agentWorker.id, agentWorker);
 
@@ -2393,6 +2595,7 @@ describe('WorkerLifecycleManager', () => {
         connectionCallbacks: new Map(),
         mcpToken: null,
         promptFile: null,
+        deliverInitialPromptOnActivation: false,
       };
       session.workers.set(agentWorker.id, agentWorker);
 

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -132,6 +132,29 @@ describe('WorkerManager', () => {
 
       expect(worker.agentId).toBe(CLAUDE_CODE_AGENT_ID);
     });
+
+    it('defaults deliverInitialPromptOnActivation to false when omitted (Issue #1236)', () => {
+      const worker = workerManager.initializeAgentWorker({
+        id: 'w-no-flag',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+
+      expect(worker.deliverInitialPromptOnActivation).toBe(false);
+    });
+
+    it('threads deliverInitialPromptOnActivation: true through to the worker (Issue #1236)', () => {
+      const worker = workerManager.initializeAgentWorker({
+        id: 'w-with-flag',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+        deliverInitialPromptOnActivation: true,
+      });
+
+      expect(worker.deliverInitialPromptOnActivation).toBe(true);
+    });
   });
 
   describe('initializeTerminalWorker', () => {
@@ -1058,6 +1081,34 @@ describe('WorkerManager', () => {
       }
     });
 
+    it('should carry deliverInitialPromptOnActivation: true through to PersistedAgentWorker (Issue #1236)', () => {
+      const worker = workerManager.initializeAgentWorker({
+        id: 'agent-eligible',
+        name: 'Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+        deliverInitialPromptOnActivation: true,
+      });
+
+      const persisted = workerManager.toPersistedWorker(worker);
+
+      expect(persisted.type).toBe('agent');
+      if (persisted.type === 'agent') {
+        expect(persisted.deliverInitialPromptOnActivation).toBe(true);
+      }
+    });
+
+    it('should carry deliverInitialPromptOnActivation: false through to PersistedAgentWorker (Issue #1236)', () => {
+      const worker = createTestAgentWorker();
+
+      const persisted = workerManager.toPersistedWorker(worker);
+
+      expect(persisted.type).toBe('agent');
+      if (persisted.type === 'agent') {
+        expect(persisted.deliverInitialPromptOnActivation).toBe(false);
+      }
+    });
+
     it('should persist terminal worker', () => {
       const worker = createTestTerminalWorker();
 
@@ -1187,6 +1238,42 @@ describe('WorkerManager', () => {
         expect(worker.activityState).toBe('unknown');
         expect(worker.activityDetector).toBeNull();
         expect(worker.connectionCallbacks.size).toBe(0);
+      }
+    });
+
+    it('should restore agent workers with deliverInitialPromptOnActivation: true when persisted as eligible (Issue #1236)', () => {
+      const persistedWorkers: PersistedAgentWorker[] = [
+        buildPersistedAgentWorker({
+          id: 'restored-agent-eligible',
+          agentId: 'claude-code',
+          deliverInitialPromptOnActivation: true,
+        }),
+      ];
+
+      const workers = workerManager.restoreWorkersFromPersistence(persistedWorkers);
+
+      const worker = workers.get('restored-agent-eligible')!;
+      expect(worker.type).toBe('agent');
+      if (worker.type === 'agent') {
+        expect(worker.deliverInitialPromptOnActivation).toBe(true);
+      }
+    });
+
+    it('should restore agent workers with deliverInitialPromptOnActivation: false when persisted as not eligible (Issue #1236)', () => {
+      const persistedWorkers: PersistedAgentWorker[] = [
+        buildPersistedAgentWorker({
+          id: 'restored-agent-ineligible',
+          agentId: 'claude-code',
+          deliverInitialPromptOnActivation: false,
+        }),
+      ];
+
+      const workers = workerManager.restoreWorkersFromPersistence(persistedWorkers);
+
+      const worker = workers.get('restored-agent-ineligible')!;
+      expect(worker.type).toBe('agent');
+      if (worker.type === 'agent') {
+        expect(worker.deliverInitialPromptOnActivation).toBe(false);
       }
     });
 
@@ -2302,6 +2389,61 @@ describe('WorkerManager', () => {
         await wm.killWorker(worker, 'session-1');
 
         expect(rmCalls.length).toBe(0);
+      });
+    });
+
+    describe('initial-prompt injection callback (Issue #1236)', () => {
+      it('fires once with (sessionId, worker.id) when the injection write occurs with a prompt file attached', async () => {
+        delete process.env.AUTH_MODE;
+        const { fake: runAsUserImpl } = createCommandDiscriminatingRunAsUser();
+        const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+        const calls: Array<[string, string]> = [];
+        wm.setOnInitialPromptInjected((sessionId, workerId) => {
+          calls.push([sessionId, workerId]);
+        });
+
+        const worker = wm.initializeAgentWorker({
+          id: 'prompt-callback-1',
+          name: 'Agent',
+          createdAt: new Date().toISOString(),
+          agentId: CLAUDE_CODE_AGENT_ID,
+        });
+
+        await wm.activateAgentWorkerPty(worker, {
+          ...defaultAgentActivationParams,
+          username: 'testuser',
+          initialPrompt: 'hello world',
+        });
+
+        expect(worker.promptFile).not.toBeNull();
+        expect(calls).toEqual([['session-1', worker.id]]);
+      });
+
+      it('does not fire when the worker activates without a prompt file (no initialPrompt)', async () => {
+        delete process.env.AUTH_MODE;
+        const { fake: runAsUserImpl } = createCommandDiscriminatingRunAsUser();
+        const wm = buildManagerWithSeams({ lookupOsUserFn: defaultLookupOsUserFn, runAsUserImpl });
+
+        const calls: Array<[string, string]> = [];
+        wm.setOnInitialPromptInjected((sessionId, workerId) => {
+          calls.push([sessionId, workerId]);
+        });
+
+        const worker = wm.initializeAgentWorker({
+          id: 'prompt-callback-2',
+          name: 'Agent',
+          createdAt: new Date().toISOString(),
+          agentId: CLAUDE_CODE_AGENT_ID,
+        });
+
+        await wm.activateAgentWorkerPty(worker, {
+          ...defaultAgentActivationParams,
+          username: 'testuser',
+        });
+
+        expect(worker.promptFile).toBeNull();
+        expect(calls).toEqual([]);
       });
     });
   });

--- a/packages/server/src/services/internal-types.ts
+++ b/packages/server/src/services/internal-types.ts
@@ -47,7 +47,10 @@ export interface InternalSessionBase {
   initialPrompt?: string;
   /**
    * Whether `initialPrompt` has already been delivered as the session's
-   * initial embedded-agent worker's first user message. See
+   * initial agent-kind worker's (embedded OR terminal-agent) first message.
+   * An embedded-agent worker delivers it as a first user message once its
+   * loop reports `ready`; a terminal-agent worker delivers it via a
+   * sentinel-injected command referencing a prompt file. See
    * `packages/shared/src/types/session.ts` `Session.initialPromptDelivered`
    * for the full contract (never re-fires once true, including across
    * restart).

--- a/packages/server/src/services/persistence-service.ts
+++ b/packages/server/src/services/persistence-service.ts
@@ -57,6 +57,8 @@ export interface PersistedAgentWorker extends PersistedWorkerBase {
   type: 'agent';
   agentId: string;
   pid: number | null;  // PTY process ID (null when not yet activated after server restart)
+  /** See `InternalAgentWorker.deliverInitialPromptOnActivation`. */
+  deliverInitialPromptOnActivation: boolean;
 }
 
 export interface PersistedTerminalWorker extends PersistedWorkerBase {
@@ -164,6 +166,10 @@ function migrateSession(old: OldPersistedSession): PersistedSession {
     agentId: 'claude-code-builtin',
     pid: old.pid,
     createdAt: old.createdAt,
+    // Legacy pre-migration rows predate this eligibility gate entirely;
+    // never redeliver a prompt this old format never tracked in the first
+    // place.
+    deliverInitialPromptOnActivation: false,
   }];
 
   if (isQuick) {

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -308,6 +308,21 @@ export class SessionManager {
       options.lookupOsUserFn,
       options.runAsUserImpl,
     );
+    this.workerManager.setOnInitialPromptInjected((sessionId, workerId) => {
+      // Fire-and-forget: this callback is invoked synchronously from a PTY
+      // onData event listener (see WorkerManager.setupWorkerEventHandlers) and
+      // cannot be awaited by its caller. "Delivered" here means the prompt was
+      // injected into the PTY, not that the agent process actually received or
+      // acted on it -- if the agent binary fails immediately after this
+      // write, the flag is still set and a future restart will not
+      // re-deliver. Failures are logged, not thrown.
+      const session = this.sessions.get(sessionId);
+      if (!session || session.initialPromptDelivered) return;
+      session.initialPromptDelivered = true;
+      this.persistSession(session).catch((err: unknown) => {
+        logger.error({ sessionId, workerId, err }, 'Failed to persist initialPromptDelivered after prompt injection');
+      });
+    });
     this.pathExists = options?.pathExists ?? defaultPathExists;
     this.sessionRepository = options?.sessionRepository ??
       new JsonSessionRepository(path.join(getConfigDir(), 'sessions.json'));

--- a/packages/server/src/services/worker-lifecycle-manager.ts
+++ b/packages/server/src/services/worker-lifecycle-manager.ts
@@ -175,6 +175,9 @@ export class WorkerLifecycleManager {
         name: workerName,
         createdAt,
         agentId: request.agentId,
+        // Only the session's initial agent worker (created with a
+        // non-empty initialPrompt) is eligible for restart re-delivery.
+        deliverInitialPromptOnActivation: !!initialPrompt?.trim(),
       });
       await this.deps.workerManager.activateAgentWorkerPty(agentWorker, {
         sessionId,
@@ -418,6 +421,20 @@ export class WorkerLifecycleManager {
     const existingWorker = session.workers.get(workerId);
     if (!existingWorker || existingWorker.type !== 'agent') return null;
 
+    // Redelivery gate: only re-inject session.initialPrompt on
+    // this restart when this is the session's eligible initial agent worker,
+    // a prompt actually exists, it was never actually delivered (delivered
+    // here means the sentinel-injected write occurred -- see
+    // WorkerManager.setupWorkerEventHandlers), and the caller isn't asking to
+    // continue the existing conversation (a fresh prompt makes no sense
+    // there). Computed BEFORE the worker is killed/recreated below, from the
+    // still-live existingWorker/session state.
+    const shouldRedeliverInitialPrompt =
+      continueConversation === false &&
+      existingWorker.deliverInitialPromptOnActivation &&
+      !!session.initialPrompt?.trim() &&
+      session.initialPromptDelivered !== true;
+
     // Resolve agent ID: use provided agentId or fall back to existing
     const workerAgentId = agentId ?? existingWorker.agentId;
 
@@ -487,6 +504,11 @@ export class WorkerLifecycleManager {
       name: workerName,
       createdAt: workerCreatedAt,
       agentId: workerAgentId,
+      // Eligibility carries over unchanged across restart -- it is a
+      // property of "is this the session's initial agent worker", which
+      // restart does not change. NOT recomputed from whether THIS restart
+      // redelivers (see shouldRedeliverInitialPrompt above).
+      deliverInitialPromptOnActivation: existingWorker.deliverInitialPromptOnActivation,
     });
     // Adopt the epoch minted by resetWorkerOutput so the manifest and the
     // in-memory worker agree from the first live chunk (activation is
@@ -500,6 +522,10 @@ export class WorkerLifecycleManager {
       resolver,
       agentId: workerAgentId,
       continueConversation,
+      // Only carries a value when this restart's redelivery gate passed
+      // (see shouldRedeliverInitialPrompt above); otherwise the activation
+      // machinery behaves exactly as before this issue.
+      initialPrompt: shouldRedeliverInitialPrompt ? session.initialPrompt : undefined,
       repositoryId,
       context: {
         parentSessionId: session.parentSessionId,

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -86,6 +86,14 @@ export interface AgentWorkerInitParams {
   name: string;
   createdAt: string;
   agentId: string;
+  /**
+   * Whether this worker is the session's initial agent worker, created with
+   * a non-empty `initialPrompt`. Gates whether `restartAgentWorker` re-injects
+   * the session's `initialPrompt` on a restart that never actually delivered
+   * it. `false`/omitted for workers added later via the generic add-worker
+   * route.
+   */
+  deliverInitialPromptOnActivation?: boolean;
 }
 
 /**
@@ -209,6 +217,16 @@ export type GlobalWorkerExitCallback = (
 ) => void;
 
 /**
+ * Callback fired when a terminal-agent worker's initial-prompt command is
+ * injected into its PTY (the post-sentinel `pty.write` in
+ * setupWorkerEventHandlers), gated on `worker.promptFile !== null`. Wired
+ * by SessionManager to mark `session.initialPromptDelivered = true` and
+ * persist it. "Delivered" here means injected, not received; the server
+ * cannot observe actual agent receipt.
+ */
+export type OnInitialPromptInjectedCallback = (sessionId: string, workerId: string) => void;
+
+/**
  * Session info for notification events.
  * Minimal interface to avoid circular dependency with InternalSession.
  */
@@ -225,6 +243,7 @@ export class WorkerManager {
   private globalActivityCallback?: GlobalActivityCallback;
   private globalPtyExitCallback?: PtyExitCallback;
   private globalWorkerExitCallback?: GlobalWorkerExitCallback;
+  private onInitialPromptInjectedCallback?: OnInitialPromptInjectedCallback;
 
   constructor(
     userMode: UserMode,
@@ -272,6 +291,14 @@ export class WorkerManager {
     this.globalWorkerExitCallback = callback;
   }
 
+  /**
+   * Set the callback fired when a terminal-agent worker's initial-prompt
+   * command is injected into its PTY. See `OnInitialPromptInjectedCallback`.
+   */
+  setOnInitialPromptInjected(callback: OnInitialPromptInjectedCallback): void {
+    this.onInitialPromptInjectedCallback = callback;
+  }
+
   // ========== Worker Initialization ==========
 
   /**
@@ -280,6 +307,7 @@ export class WorkerManager {
    */
   initializeAgentWorker(params: AgentWorkerInitParams): InternalAgentWorker {
     const { id, name, createdAt, agentId } = params;
+    const deliverInitialPromptOnActivation = params.deliverInitialPromptOnActivation ?? false;
 
     const resolvedAgentId = agentId ?? CLAUDE_CODE_AGENT_ID;
     const agentManager = this.agentManager;
@@ -300,6 +328,7 @@ export class WorkerManager {
       connectionCallbacks: new Map(),
       mcpToken: null,
       promptFile: null,
+      deliverInitialPromptOnActivation,
     };
 
     return worker;
@@ -773,6 +802,16 @@ export class WorkerManager {
         if (worker.pendingCommand && worker.pty) {
           worker.pty.write(worker.pendingCommand + '\r');
           worker.pendingCommand = undefined;
+          // "Delivered" for a terminal-agent worker means this injection write
+          // occurred while a prompt file was attached to the command. This is
+          // delivered=injected, not delivered=received: if the agent binary
+          // fails after this write (e.g. command not found), this callback
+          // still fires and a future restart will NOT re-deliver. The server
+          // cannot observe actual agent receipt; do not approximate it with
+          // activity-pattern heuristics.
+          if (worker.promptFile !== null) {
+            this.onInitialPromptInjectedCallback?.(sessionId, worker.id);
+          }
         }
         const afterSentinel = haystack.slice(idx + sentinel.length).replace(/^[\r\n]+/, '');
         worker.loginShellSentinel = undefined;
@@ -945,6 +984,10 @@ export class WorkerManager {
             activityDetector: null,
             mcpToken: null,
             promptFile: null,
+            // Round-trips from PersistedAgentWorker.deliverInitialPromptOnActivation,
+            // written at create time by toPersistedWorker, so eligibility
+            // survives a server restart.
+            deliverInitialPromptOnActivation: pw.deliverInitialPromptOnActivation,
           };
           break;
         case 'terminal':
@@ -1026,7 +1069,13 @@ export class WorkerManager {
 
     switch (worker.type) {
       case 'agent': {
-        const persistedAgent: PersistedAgentWorker = { ...base, type: 'agent', agentId: worker.agentId, pid: worker.pty?.pid ?? null };
+        const persistedAgent: PersistedAgentWorker = {
+          ...base,
+          type: 'agent',
+          agentId: worker.agentId,
+          pid: worker.pty?.pid ?? null,
+          deliverInitialPromptOnActivation: worker.deliverInitialPromptOnActivation,
+        };
         return persistedAgent;
       }
       case 'terminal': {

--- a/packages/server/src/services/worker-types.ts
+++ b/packages/server/src/services/worker-types.ts
@@ -90,6 +90,17 @@ export interface InternalAgentWorker extends InternalPtyWorkerBase {
    * pendingCommand cleanup.
    */
   promptFile: { filePath: string; username: string } | null;
+  /**
+   * Whether this worker is eligible to receive the session's `initialPrompt`
+   * on activation or restart. The terminal-agent counterpart of
+   * `InternalEmbeddedAgentWorker.deliverInitialPromptOnActivation` below.
+   * Set true only for the session's initial agent worker (created with a
+   * non-empty `initialPrompt`); workers added later via the generic
+   * add-worker route, or created without a prompt, are never eligible.
+   * Persisted via `PersistedAgentWorker.deliverInitialPromptOnActivation`
+   * and survives server restart.
+   */
+  deliverInitialPromptOnActivation: boolean;
 }
 
 /**
@@ -130,15 +141,19 @@ export interface InternalEmbeddedAgentWorker extends InternalWorkerBase {
   epoch: number;
   connectionCallbacks: Map<string, WorkerCallbacks>;
   /**
-   * Whether this worker is eligible to receive the session's `initialPrompt`
-   * as its first user message once the loop reports `ready`.
+   * Whether this worker is eligible to receive the session's `initialPrompt`.
+   * One of two mechanisms for the same family: the session's initial
+   * agent-kind worker (embedded OR terminal-agent) is eligible; workers
+   * added later via the generic add-worker route, or created without a
+   * prompt, are never eligible. For this (embedded-agent) worker kind,
+   * delivery happens as this worker's first user message once its loop
+   * reports `ready`. See `InternalAgentWorker.deliverInitialPromptOnActivation`
+   * for the terminal-agent twin, which instead delivers via a
+   * sentinel-injected command referencing a prompt file.
    * Persisted via `PersistedEmbeddedAgentWorker.deliverInitialPromptOnActivation`
    * and survives server restart -- unlike `subprocess`/`stdin`, which are
-   * always null-on-restore. Set true only for the session's initial
-   * embedded-agent worker (created with a non-empty `initialPrompt`);
-   * workers added later via the generic add-worker route are never
-   * eligible. See `docs/design/embedded-agent-worker.md` "Initial prompt
-   * delivery".
+   * always null-on-restore. See `docs/design/embedded-agent-worker.md`
+   * "Initial prompt delivery".
    */
   deliverInitialPromptOnActivation: boolean;
 }

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -44,11 +44,12 @@ export interface SessionBase {
   initialPrompt?: string;    // The prompt used to start the session
   /**
    * Whether `initialPrompt` has already been delivered as the session's
-   * initial embedded-agent worker's first user message. Once
-   * true, delivery never re-fires, including across worker/server restart --
-   * this is intentional (a one-time creation-time prompt, distinct from the
-   * ephemeral chat history that DOES reset on restart). Undefined for
-   * sessions with no `initialPrompt` or no embedded-agent worker.
+   * initial agent-kind worker's (embedded OR terminal-agent) first message.
+   * Once true, delivery never re-fires, including across worker/server
+   * restart -- this is intentional (a one-time creation-time prompt,
+   * distinct from the ephemeral chat history that DOES reset on restart).
+   * Undefined for sessions with no `initialPrompt` or no eligible
+   * agent-kind worker.
    */
   initialPromptDelivered?: boolean;
   title?: string;            // Human-readable title for the session


### PR DESCRIPTION
## Summary

Generalizes the embedded-agent worker's two-level initial-prompt-delivery mechanism to terminal-agent workers, so that `restartAgentWorker` can re-inject `session.initialPrompt` when a restarted agent worker never actually received it. This fixes the production bug where activation succeeds but the agent process never actually starts, leaving the worker idle with no instructions -- previously, restart never passed `initialPrompt` at all, so the prompt was permanently lost.

### Three-field generalization

1. **Eligibility field (worker-level)**: `InternalAgentWorker.deliverInitialPromptOnActivation: boolean` -- the terminal-agent counterpart of `InternalEmbeddedAgentWorker.deliverInitialPromptOnActivation`. `true` only for the session's initial agent worker created with a non-empty `initialPrompt`; carries through `initializeAgentWorker`, `restoreWorkersFromPersistence`, `toPersistedWorker`, and is persisted via the existing (nullable, migration v26) `workers.deliver_initial_prompt_on_activation` column -- **no new migration**.
2. **Completion field (session-level)**: `InternalSessionBase.initialPromptDelivered` / `SessionBase.initialPromptDelivered` JSDoc generalized from "initial embedded-agent worker's first user message" to "the session's initial agent-kind worker (embedded OR terminal-agent)". No shape change -- both mechanisms already shared this session-level flag; only the doc contract is broadened, which is what makes the field reuse a legitimate generalization rather than a repurpose.
3. **Restart gate**: `WorkerLifecycleManager.restartAgentWorker` computes `shouldRedeliverInitialPrompt` BEFORE killing/recreating the worker, from four conditions: `continueConversation === false`, `existingWorker.deliverInitialPromptOnActivation`, non-empty `session.initialPrompt`, and `session.initialPromptDelivered !== true`. When true, `initialPrompt: session.initialPrompt` is passed to `activateAgentWorkerPty`; existing #1234 prompt-file-delivery machinery handles the rest unchanged. Eligibility itself carries over unrecomputed across restart (`deliverInitialPromptOnActivation: existingWorker.deliverInitialPromptOnActivation`).

A new `WorkerManager.OnInitialPromptInjectedCallback` fires from the sentinel-detection injection site in `setupWorkerEventHandlers` (`worker.pty.write(worker.pendingCommand + '\r')`), gated on `worker.promptFile !== null`. `SessionManager` wires this callback in its constructor to set `session.initialPromptDelivered = true` and persist it -- this is the ONLY place the flag is ever set for a terminal-agent worker; it is explicitly NOT set at activation time (activation can succeed while the agent process never starts, which is exactly the bug this issue fixes -- marking at activation would permanently suppress the fix).

### Accepted limitation

**"Delivered" means injected, not received.** The completion flag is set when the sentinel-injected shell command write occurs while a prompt file is attached -- this is the only point the server can observe. If the agent binary fails immediately after this write (e.g. command not found), the flag is already `true` and a future restart will NOT re-deliver the prompt. This is an accepted, documented limitation per the design ruling -- approximating "actually received" via activity-pattern heuristics was explicitly out of scope.

### Design-doc check

`docs/design/embedded-agent-worker.md`'s "Initial prompt delivery" section is entirely embedded-agent-specific documentation and does not claim the mechanism is embedded-agent-exclusive (it already says "mirroring how terminal-agent workers already receive `initialPrompt` via `activateAgentWorkerPty`") -- left unchanged, no false claim to correct.

## Polarity-flip verification

Per `.claude/rules/workflow.md`'s TDD discipline, the primary AC test (`restartAgentWorker initial-prompt re-delivery (Issue #1236) > redelivers session.initialPrompt on restart when eligible, undelivered, and continueConversation is false [POLARITY]`) was verified in both directions:

- **Pre-fix (gate computation + initialPrompt pass-through temporarily removed, test present)**: test FAILED for the right reason -- `activateAgentWorkerPty` was called with `initialPrompt: undefined` instead of the session's prompt.
- **Post-fix (restored)**: test PASSES.

All other new tests in the `restartAgentWorker initial-prompt re-delivery` describe block are classified as **regression-guarding invariants unrelated to this specific polarity flip, not adjacent-code probes**:
- "already delivered" / "continueConversation: true" / boundary-row (`undefined`/`''`/`'   '`) cases assert the gate stays OFF -- these are byte-identical to pre-#1236 behavior by construction and cannot polarity-flip against a fix that only turns the gate ON in one specific case; they guard against future regressions accidentally turning the gate on too eagerly.
- The "does not consume eligibility" chained-restart test and the two eligibility-carry-over tests guard the `deliverInitialPromptOnActivation` propagation invariant, a separate (also load-bearing) contract from the redelivery gate itself.

## Test plan

- [x] `bun run typecheck && bun run test` -- full suite, 0 failures (paste below)
- [x] Primary AC polarity-flip confirmed (fail pre-fix / pass post-fix, see above)
- [x] `node .claude/skills/orchestrator/preflight-check.js` -- coverage clean, blame-shift clean, language clean
- [x] `coderabbit review --agent --base main` -- **local CLI auth failure** (headless worktree, no interactive browser session available; NOT a rate-limit -- confirmed via explicit `authentication_failed` / `automatic_login_failed` status from the CLI itself)

### Full suite output tail (exit code 0)

```
[1m@agent-console/server[0m test $ [2mbun test src/[0m
[36m│[0m [32m 3705 pass[0m
[36m│[0m  [33m1 skip[0m
[36m│[0m [2m 0 fail[0m
[36m│[0m  10178 expect() calls
[36m│[0m Ran 3706 tests across 164 files. [1m75.40s[0m
[36m└─[0m [36mDone in 75.43 s[0m
[1m@agent-console/embedded-agent[0m test $ [2mbun test src/[0m
[36m│[0m [32m 287 pass[0m
[36m│[0m [2m 0 fail[0m
[36m│[0m  637 expect() calls
[36m│[0m Ran 287 tests across 26 files. [1m8.31s[0m
[36m└─[0m [36mDone in 8.32 s[0m
[1m@agent-console/client[0m test $ [2mbun test --preload ./src/test/setup.ts src/[0m
[36m│[0m [32m 2075 pass[0m
[36m│[0m [2m 0 fail[0m
[36m│[0m  4363 expect() calls
[36m│[0m Ran 2075 tests across 142 files. [1m51.27s[0m
[36m└─[0m [36mDone in 51.31 s[0m
[1m@agent-console/shared[0m test $ [2mbun test src/[0m
[36m│[0m [32m 596 pass[0m
[36m│[0m [2m 0 fail[0m
[36m│[0m  891 expect() calls
[36m│[0m Ran 596 tests across 22 files. [1m2.42s[0m
[36m└─[0m [36mDone in 2.42 s[0m
[1m@agent-console/integration[0m test $ [2mbun test --preload ./src/setup.ts src/[0m
[36m│[0m [32m 73 pass[0m
[36m│[0m [2m 0 fail[0m
[36m│[0m  424 expect() calls
[36m│[0m Ran 73 tests across 27 files. [1m3.93s[0m
[36m└─[0m [36mDone in 3.93 s[0m
[2m[35m$[0m [1mbun test scripts/ ./.claude/hooks/__tests__/ ./.claude/skills/*/__tests__/[0m
[32m 486 pass[0m
[2m 0 fail[0m
 1078 expect() calls
Ran 486 tests across 16 files. [1m3.83s[0m
TEST_EXIT: 0
```

## Merge disposition note (2026-07-28)

**CR state**: no genuine walkthrough was ever obtained for this PR's only commit (`92226bbd`). Local CLI: `authentication_failed`/`automatic_login_failed` (headless worktree, no interactive browser session -- a structural auth failure, not a rate-limit). GitHub-side bot commit status: `state=success`, `description="Review rate limited"`. `reviewDecision`: empty. Inline comments: 0. Bot PR comment: a rate-limit notice only, no walkthrough content.

Unlike [#1239](https://github.com/ms2sato/agent-console/pull/1239) -- which obtained a genuine round-1 walkthrough (3 MAJOR findings) before its fix-commit re-verification hit the same both-channels-unavailable shape, letting it fall back on "prior round's verification still counts" (`coderabbit-ops` disposition step 2) -- **this PR never received a genuine CodeRabbit review at any point**. There is no prior-round walkthrough to fall back on; the dual-clean substitute below covers the entire diff, not a delta.

**Fallback disposition applied** (`coderabbit-ops` skill, "Local CLI headless auth-fail AND GitHub bot rate-limited -- both channels unavailable for the same commit"): Architect independent code-appropriateness audit (verdict: **CLEAN** against the #1236 Design ruling and all 8 Acceptance Criteria) + Orchestrator acceptance check = dual-clean gate, substituting for CodeRabbit review. This note satisfies the CodeRabbit-clean precondition only -- merge itself still requires owner approval per PR Merge Authority (production logic change).

Closes #1236

