### PR TITLE
fix: close PTY pre-attach byte-loss windows, add sentinel watchdog

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "check:mock-module": "bun scripts/check-mock-module-poisoners.mjs",
     "check:preview-sandbox-browser": "bun scripts/run-preview-sandbox-browser-check.mjs",
     "check:pty-fd-leak": "bun scripts/smoke/check-pty-fd-leak.ts",
+    "check:pty-early-output": "bun scripts/smoke/check-pty-early-output.ts",
     "hooks:install": "bun scripts/install-hooks.mjs",
     "preinstall": "bun scripts/check-bun-version.mjs",
     "postinstall": "bun scripts/install-hooks.mjs",

--- a/packages/server/src/__tests__/utils/mock-pty.ts
+++ b/packages/server/src/__tests__/utils/mock-pty.ts
@@ -1,5 +1,5 @@
 import { mock } from 'bun:test';
-import type { PtyProvider } from '../../lib/pty-provider.js';
+import type { PtyProvider, PtyDataDiagnostics } from '../../lib/pty-provider.js';
 
 /**
  * Disposable interface matching bun-pty's IDisposable.
@@ -33,7 +33,7 @@ export class MockPty {
    * "diagnostics absent" branch worker-manager.ts must handle gracefully
    * for `bunPtyProvider`.
    */
-  dataDiagnostics?: { fireCount: number; bufferedBytes: number; droppedBytes: number };
+  dataDiagnostics?: PtyDataDiagnostics;
   private sentinelEmitted = false;
   private autoEmitSentinel: boolean;
 
@@ -94,7 +94,7 @@ export class MockPty {
   }
 
   /** Mirrors PtyInstance's optional getDataDiagnostics() -- see `dataDiagnostics` field doc. */
-  getDataDiagnostics(): { fireCount: number; bufferedBytes: number; droppedBytes: number } | undefined {
+  getDataDiagnostics(): PtyDataDiagnostics | undefined {
     return this.dataDiagnostics;
   }
 

--- a/packages/server/src/__tests__/utils/mock-pty.ts
+++ b/packages/server/src/__tests__/utils/mock-pty.ts
@@ -26,6 +26,14 @@ export class MockPty {
   currentCols = 120;
   currentRows = 30;
   loginShellSentinel?: string;
+  /**
+   * Optional diagnostics stub for the sentinel watchdog (Issue #1242).
+   * Mirrors `BunTerminalPtyAdapter.getDataDiagnostics()`. Tests set this
+   * directly; left unset it returns `undefined`, exercising the same
+   * "diagnostics absent" branch worker-manager.ts must handle gracefully
+   * for `bunPtyProvider`.
+   */
+  dataDiagnostics?: { fireCount: number; bufferedBytes: number; droppedBytes: number };
   private sentinelEmitted = false;
   private autoEmitSentinel: boolean;
 
@@ -83,6 +91,11 @@ export class MockPty {
   /** Mirrors PtyInstance's optional dispose() so detachPty wiring is assertable. */
   dispose() {
     this.disposed = true;
+  }
+
+  /** Mirrors PtyInstance's optional getDataDiagnostics() -- see `dataDiagnostics` field doc. */
+  getDataDiagnostics(): { fireCount: number; bufferedBytes: number; droppedBytes: number } | undefined {
+    return this.dataDiagnostics;
   }
 
   // Test helpers - simulate PTY events

--- a/packages/server/src/lib/__tests__/pty-provider.test.ts
+++ b/packages/server/src/lib/__tests__/pty-provider.test.ts
@@ -342,5 +342,143 @@ describe('pty-provider', () => {
         expect(mockTerminal.close).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe('pre-attach data buffer (Issue #1242)', () => {
+      it('buffers chunks that arrive before onData is attached and delivers them on first attach, in order', () => {
+        const pty = bunTerminalProvider.spawn('sh', [], {});
+        const dataCb = lastSpawn!.options.terminal!.data!;
+
+        // Fires with no adapter listener attached yet -- window 2.
+        dataCb(null, new TextEncoder().encode('hello '));
+        dataCb(null, new TextEncoder().encode('world'));
+
+        const received: string[] = [];
+        pty.onData((data) => received.push(data));
+
+        expect(received).toEqual(['hello world']);
+      });
+
+      it('preserves a UTF-8 multi-byte sequence split across the pre-attach boundary', () => {
+        const pty = bunTerminalProvider.spawn('sh', [], {});
+        const dataCb = lastSpawn!.options.terminal!.data!;
+
+        // U+1F600 "GRINNING FACE" is F0 9F 98 80, split across two
+        // pre-attach chunks.
+        const bytes = new Uint8Array([0xf0, 0x9f, 0x98, 0x80]);
+        dataCb(null, bytes.slice(0, 2));
+        dataCb(null, bytes.slice(2));
+
+        const received: string[] = [];
+        pty.onData((data) => received.push(data));
+
+        expect(received.join('')).toBe('\u{1F600}');
+      });
+
+      it('does NOT deliver anything on attach when no pre-attach bytes arrived (empty buffer is not flushed as an empty string)', () => {
+        const pty = bunTerminalProvider.spawn('sh', [], {});
+        const received: string[] = [];
+        pty.onData((data) => received.push(data));
+
+        expect(received).toEqual([]);
+      });
+
+      it('caps buffered bytes at 64 KiB, keeps the FIRST bytes, and counts the rest as dropped', () => {
+        const pty = bunTerminalProvider.spawn('sh', [], {});
+        const dataCb = lastSpawn!.options.terminal!.data!;
+
+        const CAP = 64 * 1024;
+        const overflowBy = 100;
+        const chunk = new Uint8Array(CAP + overflowBy).fill(0x61); // 'a' repeated
+        dataCb(null, chunk);
+
+        const received: string[] = [];
+        pty.onData((data) => received.push(data));
+
+        expect(received.join('').length).toBe(CAP);
+        expect(received.join('')).toBe('a'.repeat(CAP));
+        expect(pty.getDataDiagnostics!().droppedBytes).toBe(overflowBy);
+        expect(pty.getDataDiagnostics!().bufferedBytes).toBe(0); // freed after flush
+      });
+
+      it('keeps exactly the cap with zero drops when a chunk lands exactly at the boundary', () => {
+        const pty = bunTerminalProvider.spawn('sh', [], {});
+        const dataCb = lastSpawn!.options.terminal!.data!;
+
+        const CAP = 64 * 1024;
+        dataCb(null, new Uint8Array(CAP).fill(0x62)); // 'b' repeated, exactly the cap
+
+        const received: string[] = [];
+        pty.onData((data) => received.push(data));
+
+        expect(received.join('').length).toBe(CAP);
+        expect(pty.getDataDiagnostics!().droppedBytes).toBe(0);
+      });
+
+      it('does NOT replay on a second onData attach (listener replacement)', () => {
+        const pty = bunTerminalProvider.spawn('sh', [], {});
+        const dataCb = lastSpawn!.options.terminal!.data!;
+
+        dataCb(null, new TextEncoder().encode('pre-attach'));
+
+        const received1: string[] = [];
+        const disp1 = pty.onData((data) => received1.push(data));
+        expect(received1).toEqual(['pre-attach']);
+
+        disp1.dispose();
+
+        // No listener attached right now -- this chunk is counted as
+        // dropped (buffer is already flushed/retired), NOT re-buffered.
+        dataCb(null, new TextEncoder().encode('post-flush-gap'));
+
+        const received2: string[] = [];
+        pty.onData((data) => received2.push(data));
+
+        expect(received2).toEqual([]);
+        expect(pty.getDataDiagnostics!().droppedBytes).toBe('post-flush-gap'.length);
+      });
+
+      it('dispose() before any onData attach discards buffered bytes (no retention, no replay)', () => {
+        const pty = bunTerminalProvider.spawn('sh', [], {});
+        const dataCb = lastSpawn!.options.terminal!.data!;
+
+        dataCb(null, new TextEncoder().encode('will be discarded'));
+
+        pty.dispose?.();
+
+        const received: string[] = [];
+        pty.onData((data) => received.push(data));
+
+        expect(received).toEqual([]);
+      });
+
+      it('getDataDiagnostics().fireCount counts every native data callback fire, pre- and post-attach', () => {
+        const pty = bunTerminalProvider.spawn('sh', [], {});
+        const dataCb = lastSpawn!.options.terminal!.data!;
+
+        dataCb(null, new TextEncoder().encode('a'));
+        dataCb(null, new TextEncoder().encode('b'));
+        dataCb(null, new TextEncoder().encode('c'));
+
+        pty.onData(() => {});
+
+        dataCb(null, new TextEncoder().encode('d'));
+        dataCb(null, new TextEncoder().encode('e'));
+
+        expect(pty.getDataDiagnostics!().fireCount).toBe(5);
+      });
+
+      it('live chunks after the first attach still flow straight through onData (no buffering once attached)', () => {
+        const pty = bunTerminalProvider.spawn('sh', [], {});
+        const dataCb = lastSpawn!.options.terminal!.data!;
+
+        const received: string[] = [];
+        pty.onData((data) => received.push(data));
+
+        dataCb(null, new TextEncoder().encode('live-chunk'));
+
+        expect(received).toEqual(['live-chunk']);
+        expect(pty.getDataDiagnostics!().bufferedBytes).toBe(0);
+      });
+    });
   });
 });

--- a/packages/server/src/lib/__tests__/pty-provider.test.ts
+++ b/packages/server/src/lib/__tests__/pty-provider.test.ts
@@ -358,6 +358,25 @@ describe('pty-provider', () => {
         expect(received).toEqual(['hello world']);
       });
 
+      it('copies pushed chunk bytes rather than retaining a view (Bun may reuse the callback buffer)', () => {
+        const pty = bunTerminalProvider.spawn('sh', [], {});
+        const dataCb = lastSpawn!.options.terminal!.data!;
+
+        const mutable = new TextEncoder().encode('original');
+        dataCb(null, mutable);
+
+        // Simulate Bun reusing/mutating the same underlying buffer for a
+        // later, unrelated event AFTER the callback that delivered
+        // `mutable` has already returned -- this must NOT corrupt what was
+        // buffered.
+        mutable.fill(0x58); // overwrite in place with 'X' bytes
+
+        const received: string[] = [];
+        pty.onData((data) => received.push(data));
+
+        expect(received.join('')).toBe('original');
+      });
+
       it('preserves a UTF-8 multi-byte sequence split across the pre-attach boundary', () => {
         const pty = bunTerminalProvider.spawn('sh', [], {});
         const dataCb = lastSpawn!.options.terminal!.data!;

--- a/packages/server/src/lib/pty-provider.ts
+++ b/packages/server/src/lib/pty-provider.ts
@@ -21,7 +21,19 @@ export interface PtySpawnOptions {
  * `bunPtyProvider`'s native Terminal (which has no such method) still
  * structurally satisfies this type.
  */
-export type PtyInstance = IPty & { dispose?(): void };
+export type PtyInstance = IPty & {
+  dispose?(): void;
+  /**
+   * @internal Diagnostics for the pre-attach data buffer, used by
+   * worker-manager's sentinel watchdog to distinguish "native
+   * never delivered any bytes" from "bytes arrived but the sentinel never
+   * matched" from "the 64 KiB pre-attach cap was hit". Present only on
+   * `BunTerminalPtyAdapter`; absent on `bunPtyProvider`'s native `IPty` (no
+   * such instrumentation) -- callers must treat this as optional and omit
+   * the diagnostics fields gracefully when absent.
+   */
+  getDataDiagnostics?(): { fireCount: number; bufferedBytes: number; droppedBytes: number };
+};
 
 /**
  * PTY provider interface for dependency injection.
@@ -76,6 +88,116 @@ function createStreamingDecoder(): (chunk: Uint8Array) => string {
 }
 
 /**
+ * Bytes kept from a pre-attach window before the rest are dropped. The
+ * sentinel `worker-manager.ts` waits for appears within the
+ * first few hundred bytes of a fresh login shell, so keeping the FIRST
+ * bytes (not a sliding tail) is the useful policy -- see
+ * `PreAttachDataBuffer`'s doc comment.
+ */
+const PRE_ATTACH_BUFFER_CAP_BYTES = 64 * 1024;
+
+/**
+ * Bounded buffer for raw PTY `data` bytes that arrive before a consumer is
+ * ready to receive them.
+ *
+ * Two silent byte-loss windows exist in {@link bunTerminalProvider}:
+ * 1. Between `Bun.spawn()` being called and the {@link BunTerminalPtyAdapter}
+ *    being constructed. The native `data` callback is passed as a
+ *    `Bun.spawn` argument, so the native side holds a reference to it
+ *    BEFORE spawn returns, while the `adapter` variable in the provider
+ *    closure is only assigned AFTER spawn returns -- a chunk delivered in
+ *    between had no adapter to reach.
+ * 2. Between adapter construction and the first `onData()` attach --
+ *    `_emitData` had no listener to forward to.
+ *
+ * A single instance is created in the provider closure BEFORE `Bun.spawn`
+ * is called and shared into the adapter's constructor, so both windows
+ * push into the same buffer and a single flush-on-first-attach replays
+ * whichever window(s) actually lost bytes, in arrival order. This gives
+ * `data` the same late-attach-safe contract `onExit` already has (see
+ * `BunTerminalPtyAdapter.onExit`'s replay-on-attach handling).
+ *
+ * Keeps only the FIRST `PRE_ATTACH_BUFFER_CAP_BYTES` bytes -- the sentinel
+ * this buffer exists to protect (`worker-manager.ts`'s `loginShellSentinel`
+ * detection) appears early in the stream, so early bytes are the valuable
+ * ones. Bytes beyond the cap are dropped and counted (surfaced via
+ * {@link BunTerminalPtyAdapter.getDataDiagnostics} for the sentinel
+ * watchdog).
+ */
+class PreAttachDataBuffer {
+  private chunks: Uint8Array[] = [];
+  private bufferedByteCount = 0;
+  private flushed = false;
+  private droppedByteCount = 0;
+  private fireCountValue = 0;
+
+  /** Record a native `data` callback fire, whether or not it gets buffered. */
+  recordFire(): void {
+    this.fireCountValue++;
+  }
+
+  /**
+   * Push a raw chunk into the buffer. No-op past the cap or after the
+   * buffer has been flushed -- both cases count the chunk as dropped
+   * instead.
+   */
+  push(chunk: Uint8Array): void {
+    if (this.flushed) {
+      this.droppedByteCount += chunk.byteLength;
+      return;
+    }
+    const remaining = PRE_ATTACH_BUFFER_CAP_BYTES - this.bufferedByteCount;
+    if (remaining <= 0) {
+      this.droppedByteCount += chunk.byteLength;
+      return;
+    }
+    if (chunk.byteLength > remaining) {
+      this.chunks.push(chunk.subarray(0, remaining));
+      this.bufferedByteCount += remaining;
+      this.droppedByteCount += chunk.byteLength - remaining;
+      return;
+    }
+    this.chunks.push(chunk);
+    this.bufferedByteCount += chunk.byteLength;
+  }
+
+  /**
+   * Decode and return every buffered chunk, in arrival order, through the
+   * caller-supplied streaming decoder (the SAME decoder instance used for
+   * live chunks, so a partial multi-byte sequence split across the
+   * pre-attach boundary still decodes correctly). Only meaningful on the
+   * first call -- the adapter guards against calling this more than once
+   * (subsequent `onData` attaches do not replay).
+   */
+  flush(decode: (chunk: Uint8Array) => string): string {
+    const decoded = this.chunks.map((chunk) => decode(chunk)).join('');
+    this.chunks = [];
+    this.bufferedByteCount = 0;
+    this.flushed = true;
+    return decoded;
+  }
+
+  /** Free retained bytes without decoding (dispose path -- #1196 hygiene). */
+  discard(): void {
+    this.chunks = [];
+    this.bufferedByteCount = 0;
+    this.flushed = true;
+  }
+
+  get bufferedBytes(): number {
+    return this.bufferedByteCount;
+  }
+
+  get droppedBytes(): number {
+    return this.droppedByteCount;
+  }
+
+  get fireCount(): number {
+    return this.fireCountValue;
+  }
+}
+
+/**
  * Adapter that wraps a `Bun.spawn(..., { terminal: ... })` subprocess to
  * conform to bun-pty's `IPty` shape.
  *
@@ -98,6 +220,8 @@ class BunTerminalPtyAdapter implements IPty {
   private readonly commandName: string;
   private readonly subprocess: Bun.Subprocess;
   private readonly terminal: Bun.Terminal;
+  private readonly preAttachBuffer: PreAttachDataBuffer;
+  private readonly decode: (chunk: Uint8Array) => string;
   private dataListener: ((data: string) => void) | null = null;
   private exitListener: ((event: IExitEvent) => void) | null = null;
   /**
@@ -112,6 +236,13 @@ class BunTerminalPtyAdapter implements IPty {
    * `dispose()` is called from multiple lifetime endpoints (see its JSDoc).
    */
   private disposed = false;
+  /**
+   * True once `onData()` has been called at least once. Guards the
+   * pre-attach buffer flush so only the FIRST attach replays
+   * buffered bytes -- a later listener replacement must not re-deliver
+   * them.
+   */
+  private hasAttachedOnData = false;
 
   constructor(args: {
     subprocess: Bun.Subprocess;
@@ -119,6 +250,8 @@ class BunTerminalPtyAdapter implements IPty {
     cols: number;
     rows: number;
     commandName: string;
+    preAttachBuffer: PreAttachDataBuffer;
+    decode: (chunk: Uint8Array) => string;
   }) {
     this.subprocess = args.subprocess;
     this.terminal = args.terminal;
@@ -126,6 +259,8 @@ class BunTerminalPtyAdapter implements IPty {
     this.rows = args.rows;
     this.commandName = args.commandName;
     this.pid = args.subprocess.pid;
+    this.preAttachBuffer = args.preAttachBuffer;
+    this.decode = args.decode;
 
     // Bridge subprocess.exited -> IPty.onExit. Bun.Terminal's `exit` callback
     // signals PTY stream close, not process exit. The real exit code lives on
@@ -161,6 +296,10 @@ class BunTerminalPtyAdapter implements IPty {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    // Free any bytes still sitting in the pre-attach buffer --
+    // same hygiene family as the Bun.Terminal fd release below: no
+    // retention past the point nothing will ever read it.
+    this.preAttachBuffer.discard();
     try {
       this.terminal.close();
     } catch (err) {
@@ -174,6 +313,18 @@ class BunTerminalPtyAdapter implements IPty {
 
   onData(listener: (data: string) => void): IDisposable {
     this.dataListener = listener;
+    // Flush the pre-attach buffer on the FIRST attach only --
+    // this is the "late attach must not lose the event" contract, mirrored
+    // from onExit's replay-on-attach handling below. Guarded by
+    // hasAttachedOnData so a later listener replacement does not replay
+    // bytes a previous listener already received.
+    if (!this.hasAttachedOnData) {
+      this.hasAttachedOnData = true;
+      const buffered = this.preAttachBuffer.flush(this.decode);
+      if (buffered.length > 0) {
+        listener(buffered);
+      }
+    }
     return {
       dispose: () => {
         if (this.dataListener === listener) {
@@ -209,13 +360,29 @@ class BunTerminalPtyAdapter implements IPty {
 
   /**
    * @internal Exposed so the spawn() factory can route Terminal `data`
-   * callbacks into the adapter's listener. Not part of IPty.
+   * callbacks into the adapter's listener. Not part of IPty. Falls back to
+   * the pre-attach buffer when no listener is attached yet,
+   * instead of silently discarding the chunk.
    */
-  _emitData(chunk: Uint8Array, decode: (c: Uint8Array) => string): void {
+  _emitData(chunk: Uint8Array): void {
     const listener = this.dataListener;
     if (listener) {
-      listener(decode(chunk));
+      listener(this.decode(chunk));
+    } else {
+      this.preAttachBuffer.push(chunk);
     }
+  }
+
+  /**
+   * @internal Diagnostics for the sentinel watchdog. See
+   * `PtyInstance.getDataDiagnostics`'s doc comment.
+   */
+  getDataDiagnostics(): { fireCount: number; bufferedBytes: number; droppedBytes: number } {
+    return {
+      fireCount: this.preAttachBuffer.fireCount,
+      bufferedBytes: this.preAttachBuffer.bufferedBytes,
+      droppedBytes: this.preAttachBuffer.droppedBytes,
+    };
   }
 
   write(data: string): void {
@@ -253,6 +420,12 @@ export const bunTerminalProvider: PtyProvider = {
     const rows = options.rows ?? 24;
     const decode = createStreamingDecoder();
 
+    // Created BEFORE Bun.spawn so both pre-attach windows (the native
+    // `data` callback firing before `adapter` is assigned below, and
+    // `_emitData` firing before the first `onData` attach) push into the
+    // same buffer -- see PreAttachDataBuffer's doc comment.
+    const preAttachBuffer = new PreAttachDataBuffer();
+
     // We need a reference to the adapter inside the `data` callback. Bun
     // returns the Subprocess from spawn(), and Subprocess.terminal is the
     // Terminal handle. The adapter is constructed after spawn returns.
@@ -266,8 +439,11 @@ export const bunTerminalProvider: PtyProvider = {
         rows,
         name: options.name ?? 'xterm-256color',
         data: (_terminal, chunk) => {
+          preAttachBuffer.recordFire();
           if (adapter) {
-            adapter._emitData(chunk, decode);
+            adapter._emitData(chunk);
+          } else {
+            preAttachBuffer.push(chunk);
           }
         },
       },
@@ -287,6 +463,8 @@ export const bunTerminalProvider: PtyProvider = {
       cols,
       rows,
       commandName: command,
+      preAttachBuffer,
+      decode,
     });
 
     return adapter;

--- a/packages/server/src/lib/pty-provider.ts
+++ b/packages/server/src/lib/pty-provider.ts
@@ -21,6 +21,11 @@ export interface PtySpawnOptions {
  * `bunPtyProvider`'s native Terminal (which has no such method) still
  * structurally satisfies this type.
  */
+/**
+ * Diagnostics for the pre-attach data buffer (see {@link PtyInstance.getDataDiagnostics}).
+ */
+export type PtyDataDiagnostics = { fireCount: number; bufferedBytes: number; droppedBytes: number };
+
 export type PtyInstance = IPty & {
   dispose?(): void;
   /**
@@ -32,7 +37,7 @@ export type PtyInstance = IPty & {
    * such instrumentation) -- callers must treat this as optional and omit
    * the diagnostics fields gracefully when absent.
    */
-  getDataDiagnostics?(): { fireCount: number; bufferedBytes: number; droppedBytes: number };
+  getDataDiagnostics?(): PtyDataDiagnostics;
 };
 
 /**
@@ -388,7 +393,7 @@ class BunTerminalPtyAdapter implements IPty {
    * @internal Diagnostics for the sentinel watchdog. See
    * `PtyInstance.getDataDiagnostics`'s doc comment.
    */
-  getDataDiagnostics(): { fireCount: number; bufferedBytes: number; droppedBytes: number } {
+  getDataDiagnostics(): PtyDataDiagnostics {
     return {
       fireCount: this.preAttachBuffer.fireCount,
       bufferedBytes: this.preAttachBuffer.bufferedBytes,

--- a/packages/server/src/lib/pty-provider.ts
+++ b/packages/server/src/lib/pty-provider.ts
@@ -152,12 +152,23 @@ class PreAttachDataBuffer {
       return;
     }
     if (chunk.byteLength > remaining) {
-      this.chunks.push(chunk.subarray(0, remaining));
+      // .slice() COPIES the bytes (unlike .subarray(), which is a view into
+      // the same underlying ArrayBuffer) -- the terminal `data` callback's
+      // buffer is only valid for the duration of that synchronous callback
+      // and may be reused/mutated by the runtime for a later event, so a
+      // view would risk silent corruption of buffered pre-attach bytes.
+      // Copying removes the need to know whether Bun's Terminal binding
+      // actually reuses that buffer across events -- the same
+      // don't-trust-native-behavior-assumptions principle this buffer
+      // itself exists for (see the class doc comment above).
+      this.chunks.push(chunk.slice(0, remaining));
       this.bufferedByteCount += remaining;
       this.droppedByteCount += chunk.byteLength - remaining;
       return;
     }
-    this.chunks.push(chunk);
+    // .slice() with no args also copies (same reasoning as above -- removes
+    // the native-buffer-reuse assumption entirely).
+    this.chunks.push(chunk.slice());
     this.bufferedByteCount += chunk.byteLength;
   }
 

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -6,7 +6,8 @@
  *
  * Uses mock PTY provider via dependency injection (no mock.module needed).
  */
-import { describe, it, expect, beforeEach, afterEach, mock, jest } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock, jest, spyOn } from 'bun:test';
+import { rootLogger } from '../../lib/logger.js';
 import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import { mockGit, resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
@@ -555,6 +556,133 @@ describe('WorkerManager', () => {
 
       expect(worker.loginShellSentinel).toBeUndefined();
       expect(worker.pendingCommand).toBeUndefined();
+    });
+  });
+
+  describe('sentinel watchdog (Issue #1242)', () => {
+    const WATCHDOG_MESSAGE =
+      'Login-shell sentinel not detected within timeout; agent worker PTY output may be stuck or lost';
+
+    afterEach(() => {
+      ptyFactory.setAutoEmitSentinel(true);
+    });
+
+    it('logs an ERROR with sessionId, workerId, and diagnostics when the sentinel is never detected within the timeout', async () => {
+      jest.useFakeTimers();
+      const errorSpy = spyOn(rootLogger, 'error');
+      try {
+        ptyFactory.setAutoEmitSentinel(false);
+        const worker = createTestAgentWorker();
+        await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+        const mockPty = ptyFactory.instances[0]!;
+        mockPty.dataDiagnostics = { fireCount: 3, bufferedBytes: 10, droppedBytes: 0 };
+        // Feed a few pre-sentinel bytes so preSentinelSample is non-empty.
+        mockPty.emitRaw('banner line before sentinel\r\n');
+
+        jest.advanceTimersByTime(15000);
+
+        const watchdogCalls = errorSpy.mock.calls.filter((call) => call[1] === WATCHDOG_MESSAGE);
+        expect(watchdogCalls.length).toBe(1);
+        const fields = watchdogCalls[0]![0] as Record<string, unknown>;
+        expect(fields.sessionId).toBe('session-1');
+        expect(fields.workerId).toBe(worker.id);
+        expect(fields.fireCount).toBe(3);
+        expect(fields.bufferedBytes).toBe(10);
+        expect(fields.droppedBytes).toBe(0);
+        expect(fields.preSentinelSample).toContain('banner line before sentinel');
+      } finally {
+        errorSpy.mockRestore();
+        jest.useRealTimers();
+      }
+    });
+
+    it('omits diagnostics fields gracefully when the PTY provider does not implement getDataDiagnostics', async () => {
+      jest.useFakeTimers();
+      const errorSpy = spyOn(rootLogger, 'error');
+      try {
+        ptyFactory.setAutoEmitSentinel(false);
+        const worker = createTestAgentWorker();
+        await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+        // Deliberately leave mockPty.dataDiagnostics unset (bunPtyProvider-shaped absence).
+
+        jest.advanceTimersByTime(15000);
+
+        const watchdogCalls = errorSpy.mock.calls.filter((call) => call[1] === WATCHDOG_MESSAGE);
+        expect(watchdogCalls.length).toBe(1);
+        const fields = watchdogCalls[0]![0] as Record<string, unknown>;
+        expect(fields.fireCount).toBeUndefined();
+        expect(fields.bufferedBytes).toBeUndefined();
+        expect(fields.droppedBytes).toBeUndefined();
+      } finally {
+        errorSpy.mockRestore();
+        jest.useRealTimers();
+      }
+    });
+
+    it('does NOT log after the sentinel is detected within the timeout (negative)', async () => {
+      jest.useFakeTimers();
+      const errorSpy = spyOn(rootLogger, 'error');
+      try {
+        // Default autoEmitSentinel=true -- MockPty fires the sentinel
+        // synchronously on the first onData() attach inside activation.
+        const worker = createTestAgentWorker();
+        await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+        jest.advanceTimersByTime(15000);
+
+        const watchdogCalls = errorSpy.mock.calls.filter((call) => call[1] === WATCHDOG_MESSAGE);
+        expect(watchdogCalls.length).toBe(0);
+      } finally {
+        errorSpy.mockRestore();
+        jest.useRealTimers();
+      }
+    });
+
+    it('does NOT log after the worker exits before the sentinel ever arrived (negative)', async () => {
+      jest.useFakeTimers();
+      const errorSpy = spyOn(rootLogger, 'error');
+      try {
+        ptyFactory.setAutoEmitSentinel(false);
+        const worker = createTestAgentWorker();
+        await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+        const mockPty = ptyFactory.instances[0]!;
+        mockPty.simulateExit(1);
+
+        jest.advanceTimersByTime(15000);
+
+        const watchdogCalls = errorSpy.mock.calls.filter((call) => call[1] === WATCHDOG_MESSAGE);
+        expect(watchdogCalls.length).toBe(0);
+      } finally {
+        errorSpy.mockRestore();
+        jest.useRealTimers();
+      }
+    });
+
+    it('clears the watchdog on managed kill (killWorker) so it does not fire afterward', async () => {
+      jest.useFakeTimers();
+      const errorSpy = spyOn(rootLogger, 'error');
+      try {
+        ptyFactory.setAutoEmitSentinel(false);
+        const worker = createTestAgentWorker();
+        await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+        const mockPty = ptyFactory.instances[0]!;
+        // killWorker awaits an exit race; make kill() resolve promptly like
+        // the default MockPty.kill() already does (fires exit via microtask).
+        const killPromise = workerManager.killWorker(worker, 'session-1');
+        await killPromise;
+
+        jest.advanceTimersByTime(15000);
+
+        const watchdogCalls = errorSpy.mock.calls.filter((call) => call[1] === WATCHDOG_MESSAGE);
+        expect(watchdogCalls.length).toBe(0);
+        void mockPty; // referenced for clarity; no further assertions needed
+      } finally {
+        errorSpy.mockRestore();
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -63,6 +63,10 @@ const MCP_TOKEN_FILE_ENV_VAR = 'AGENT_CONSOLE_MCP_TOKEN_FILE';
 
 /** Maximum time to wait for a PTY process to exit after kill signal. */
 const PTY_EXIT_TIMEOUT_MS = 5000;
+// If an agent worker's login-shell sentinel is never detected,
+// the pre-sentinel swallow gate keeps the worker's output log at 0 bytes
+// forever with no other signal. This bounds that silence.
+const SENTINEL_WATCHDOG_TIMEOUT_MS = 15000;
 
 /**
  * Context passed from SessionManager for worker operations.
@@ -786,11 +790,53 @@ export class WorkerManager {
     // sentinel.length - 1 characters (the largest partial match possible).
     let preSentinelCarry = '';
 
+    // Sentinel watchdog: the pre-sentinel swallow gate above
+    // keeps the worker's output log at 0 bytes forever if the sentinel is
+    // never observed, with no other signal to distinguish "stuck" from
+    // "just slow". Arm a bounded timer at handler setup (below); on expiry,
+    // log an ERROR carrying enough diagnostics (the PTY adapter's native
+    // data-callback fire count, buffered/dropped byte counts from the
+    // pre-attach buffer, and a sample of the pre-sentinel bytes actually
+    // received) to distinguish "native never delivered a byte" from "bytes
+    // arrived but never matched" from "the pre-attach cap was hit". Cleared
+    // on sentinel detection, on worker exit, and (via `disposables`) on
+    // managed kill -- it must never fire after any of those.
+    let sentinelWatchdogTimer: ReturnType<typeof setTimeout> | undefined;
+    let preSentinelSample = '';
+    const PRE_SENTINEL_SAMPLE_MAX_LEN = 256;
+    const clearSentinelWatchdog = (): void => {
+      if (sentinelWatchdogTimer !== undefined) {
+        clearTimeout(sentinelWatchdogTimer);
+        sentinelWatchdogTimer = undefined;
+      }
+    };
+    if (!sentinelDetected) {
+      sentinelWatchdogTimer = setTimeout(() => {
+        sentinelWatchdogTimer = undefined;
+        const diagnostics = worker.pty?.getDataDiagnostics?.();
+        logger.error(
+          {
+            sessionId,
+            workerId: worker.id,
+            fireCount: diagnostics?.fireCount,
+            bufferedBytes: diagnostics?.bufferedBytes,
+            droppedBytes: diagnostics?.droppedBytes,
+            preSentinelSample: JSON.stringify(preSentinelSample),
+          },
+          'Login-shell sentinel not detected within timeout; agent worker PTY output may be stuck or lost',
+        );
+      }, SENTINEL_WATCHDOG_TIMEOUT_MS);
+    }
+    disposables.push({ dispose: clearSentinelWatchdog });
+
     const onDataDisposable = worker.pty.onData((rawData) => {
       let data = rawData;
 
       if (!sentinelDetected && worker.type === 'agent' && worker.loginShellSentinel) {
         const sentinel = worker.loginShellSentinel;
+        if (preSentinelSample.length < PRE_SENTINEL_SAMPLE_MAX_LEN) {
+          preSentinelSample = (preSentinelSample + data).slice(0, PRE_SENTINEL_SAMPLE_MAX_LEN);
+        }
         const haystack = preSentinelCarry + data;
         const idx = haystack.indexOf(sentinel);
         if (idx === -1) {
@@ -798,6 +844,7 @@ export class WorkerManager {
           return;
         }
         sentinelDetected = true;
+        clearSentinelWatchdog();
         preSentinelCarry = '';
         if (worker.pendingCommand && worker.pty) {
           worker.pty.write(worker.pendingCommand + '\r');
@@ -846,6 +893,13 @@ export class WorkerManager {
     const onExitDisposable = pty.onExit(({ exitCode, signal }) => {
       const signalStr = signal !== undefined ? String(signal) : null;
       logger.info({ workerId: worker.id, pid: pty.pid, exitCode, signal: signalStr }, 'Worker exited');
+
+      // Sentinel watchdog: the worker exited (naturally, e.g.
+      // the agent binary failed to start) before the sentinel was ever
+      // detected -- no point logging a stuck-sentinel ERROR for a worker
+      // that is already gone. No-op if the watchdog was never armed or
+      // already cleared.
+      clearSentinelWatchdog();
 
       // Mark worker as deactivated (PTY no longer running)
       this.detachPty(worker);

--- a/scripts/smoke/check-pty-early-output.ts
+++ b/scripts/smoke/check-pty-early-output.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env bun
+/**
+ * Post-deploy smoke test for the PTY pre-attach data buffer (Issue #1242).
+ *
+ * `bunTerminalProvider` (the default `PTY_PROVIDER`) wraps
+ * `Bun.spawn({ terminal: ... })`. Two silent byte-loss windows existed in
+ * that wrapper before the pre-attach buffer fix:
+ *   1. Between `Bun.spawn()` returning and the `BunTerminalPtyAdapter`
+ *      being constructed (native `data` callback fires with no adapter).
+ *   2. Between adapter construction and the first `onData()` attach
+ *      (`_emitData` fires with no listener).
+ *
+ * `packages/server/src/lib/__tests__/pty-provider.test.ts` proves the
+ * buffer/flush LOGIC via synthetic `data` callback invocations against a
+ * mocked `Bun.spawn`. That is necessary but NOT sufficient: it proves the
+ * buffer works when fed bytes, not that bytes from a REAL `Bun.Terminal`
+ * actually reach the buffer through Bun's native path in the first place
+ * (see `.claude/rules/os-environment-coupling.md` Discipline 1 -- a unit
+ * test asserts the shape of a call site, not what the OS/native layer does
+ * with it). This script closes that gap: it imports the production
+ * `bunTerminalProvider` directly (no hand copy) and spawns a REAL PTY whose
+ * child emits output immediately, deliberately delaying the `onData`
+ * attach past at least one event-loop turn -- the exact race the buffer
+ * exists to close -- then asserts the early output is not lost.
+ *
+ * This does NOT exercise `worker-manager.ts`'s sentinel watchdog or
+ * chunk-boundary sentinel gate (covered by worker-manager's own unit
+ * tests); it isolates the PTY provider layer only, same scoping as
+ * `check-pty-fd-leak.ts`.
+ *
+ * Usage:
+ *   bun scripts/smoke/check-pty-early-output.ts
+ *
+ * Exit codes:
+ *   0  all cycles observed the complete early marker
+ *   1  one or more cycles lost bytes (the buffer did not close the race)
+ *   2  bad usage / cannot run at all (e.g. this environment cannot spawn a
+ *      basic PTY via bunTerminalProvider) -- distinct from 1 so operators
+ *      can tell apart "the smoke ran and found a real problem" vs "the
+ *      smoke could not run"
+ *
+ * Sync contract: NONE -- `bunTerminalProvider` is imported directly from
+ * production source. A regression in the pre-attach buffer (or its
+ * removal) changes this smoke's outcome automatically.
+ */
+
+import { bunTerminalProvider, type PtyInstance } from '../../packages/server/src/lib/pty-provider.js';
+
+const CYCLE_COUNT = 20;
+// Deliberately past at least one event-loop turn (a plain microtask/`await
+// Promise.resolve()` would not reliably span a real macrotask boundary on
+// every platform) -- long enough that the child's `echo` has certainly
+// already run and handed its bytes to the native layer before any JS
+// listener exists.
+const LATE_ATTACH_DELAY_MS = 50;
+const MARKER_WAIT_TIMEOUT_MS = 3000;
+const EXIT_WAIT_TIMEOUT_MS = 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Prove this environment can spawn a basic PTY via bunTerminalProvider
+ * before trusting the race-detection cycles below. If spawning itself is
+ * broken (no `sh`, Bun.Terminal unavailable, etc.), the cycles would fail
+ * for an unrelated reason and misreport a buffer regression (Issue #1200
+ * class of problem: verify the probe works before trusting what it reports).
+ */
+async function selfCheck(): Promise<void> {
+  try {
+    const pty = bunTerminalProvider.spawn('sh', ['-c', 'echo ok'], {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+    });
+    const exited = new Promise<void>((resolve) => {
+      pty.onExit(() => resolve());
+    });
+    pty.onData(() => {});
+    await Promise.race([exited, sleep(EXIT_WAIT_TIMEOUT_MS)]);
+  } catch (err) {
+    console.error(
+      'Self-check failed: could not spawn a basic PTY via bunTerminalProvider -- cannot run this smoke.',
+    );
+    console.error(err);
+    process.exit(2);
+  }
+}
+
+async function runCycle(index: number): Promise<{ ok: boolean; detail: string }> {
+  const marker = `SMOKE_EARLY_OUTPUT_${index}_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
+
+  // The child emits the marker IMMEDIATELY, then execs into an idle shell
+  // so the process stays alive until we kill it below -- mirrors the shape
+  // the production login-shell sentinel protocol depends on (output before
+  // any listener is attached, then a live interactive shell).
+  const pty: PtyInstance = bunTerminalProvider.spawn('sh', ['-c', `echo ${marker}; exec sh`], {
+    name: 'xterm-256color',
+    cols: 80,
+    rows: 24,
+  });
+
+  // Deliberately delay the onData attach past at least one event-loop turn
+  // -- this is the exact pre-attach race the buffer exists to close.
+  await sleep(LATE_ATTACH_DELAY_MS);
+
+  let output = '';
+  const exited = new Promise<void>((resolve) => {
+    pty.onExit(() => resolve());
+  });
+  pty.onData((chunk) => {
+    output += chunk;
+  });
+
+  const start = Date.now();
+  while (!output.includes(marker) && Date.now() - start < MARKER_WAIT_TIMEOUT_MS) {
+    await sleep(20);
+  }
+
+  const ok = output.includes(marker);
+  const diagnostics = pty.getDataDiagnostics?.();
+  const detail = ok
+    ? ''
+    : `marker not observed after a ${LATE_ATTACH_DELAY_MS}ms late onData attach; ` +
+      `diagnostics=${JSON.stringify(diagnostics)}; captured output: ${JSON.stringify(output.slice(0, 300))}`;
+
+  try {
+    pty.kill();
+  } catch {
+    // best-effort; the child may already be gone
+  }
+  await Promise.race([exited, sleep(EXIT_WAIT_TIMEOUT_MS)]);
+
+  return { ok, detail };
+}
+
+await selfCheck();
+
+console.log(
+  `==> running ${CYCLE_COUNT} early-output cycles via bunTerminalProvider (Issue #1242), ` +
+    `each with a deliberately-late (${LATE_ATTACH_DELAY_MS}ms) onData attach`,
+);
+
+const failures: string[] = [];
+let passes = 0;
+for (let i = 0; i < CYCLE_COUNT; i++) {
+  const result = await runCycle(i);
+  if (result.ok) {
+    console.log(`  OK    cycle ${i}: early marker observed complete after late attach`);
+    passes++;
+  } else {
+    console.error(`  FAIL  cycle ${i}: ${result.detail}`);
+    failures.push(`cycle ${i}`);
+  }
+}
+
+console.log();
+if (failures.length > 0) {
+  console.error(`FAILED: ${failures.length}/${CYCLE_COUNT} cycle(s) lost the early marker -- ${failures.join(', ')}`);
+  process.exit(1);
+}
+console.log(`PASSED: ${passes}/${CYCLE_COUNT} cycles observed the complete early marker after a deliberately-late onData attach`);
+process.exit(0);


### PR DESCRIPTION
## Summary

- Close two proven silent byte-loss windows in `bunTerminalProvider` / `BunTerminalPtyAdapter` (`packages/server/src/lib/pty-provider.ts`) with a single bounded (64 KiB, keep-first-bytes) pre-attach buffer, shared between the provider closure and the adapter, created **before** `Bun.spawn()`:
  1. Native `data` callback firing before the `adapter` variable is assigned (the callback is handed to `Bun.spawn` before it returns).
  2. `_emitData` firing before the first `onData()` attach.
  This extends the same late-attach-safe replay contract `onExit` already had to `data`.
- Add a 15s sentinel watchdog in `worker-manager.ts`'s `setupWorkerEventHandlers`: if an agent worker's login-shell sentinel is never detected, log an `ERROR` with the PTY adapter's native data-callback fire count, buffered/dropped byte counts, and a 256-byte sample of pre-sentinel bytes actually received — instead of leaving the worker silently stuck with a 0-byte output log forever. Cleared on sentinel detection, on natural worker exit, and (via `disposables`) on managed kill; two negative tests assert no spurious `ERROR` in either case.
- Add `scripts/smoke/check-pty-early-output.ts`: a real-PTY smoke that spawns a real child emitting output immediately, deliberately delays the `onData` attach past an event-loop turn, and asserts the early bytes are not lost. Wired as `bun run check:pty-early-output`.

Fix plan followed exactly per Issue #1242's architect-redlined plan; no design decisions were re-opened.

## Epistemic status

> This PR fixes two proven silent byte-loss windows in the bun-terminal PTY provider and adds sentinel-timeout instrumentation. It does NOT claim these windows are the cause of the macOS create-path failure (#1242). One instrumented delegation on the owner environment (see the issue's checkpoint section) decides that; this issue stays open until then.

Refs #1242. This PR does not close the issue.

## Verification

### Full suite (`bun run typecheck && bun run test`)

Typecheck: exit 0, all four packages report `Done`.

Full test suite tail:

```
[server] 3720 pass / 1 skip / 0 fail -- 10209 expect() calls -- Ran 3721 tests across 164 files
[embedded-agent] 287 pass / 0 fail -- 637 expect() calls -- Ran 287 tests across 26 files
[client] 2075 pass / 0 fail -- 4361 expect() calls -- Ran 2075 tests across 142 files
[shared] 596 pass / 0 fail -- 891 expect() calls -- Ran 596 tests across 22 files
[integration] 73 pass / 0 fail -- 424 expect() calls -- Ran 73 tests across 27 files
test:scripts (scripts/ + .claude hooks/skills) 521 pass / 0 fail -- 1168 expect() calls -- Ran 521 tests across 17 files
TEST_EXIT: 0
```

(Counts above are from the final commit, after the post-review copy-on-push fix below; +1 test vs. the original commit.)

### `bun run check:pty-fd-leak` (required by `test-trigger.md`, `pty-provider.ts` touched)

```
==> ran 100 spawn/kill cycles via bunTerminalProvider
==> ptmx fd count (this process, via /proc/<pid>/fd)
  OK    ptmx fd count non-increasing (before=0, after=0)
==> kernel pty counter (/proc/sys/kernel/pty/nr)
  OK    kernel pty counter non-increasing (before=44, after=44)
PASSED: 2 assertion(s) passed
```

### Polarity — `pty-provider.test.ts`'s new `describe('pre-attach data buffer (Issue #1242)', ...)` (9 tests)

Verified by reverting only `pty-provider.ts` (via a diff/patch apply-and-revert, not `git stash`, to avoid the shared-worktree stash collision risk) and running the file against the unbuffered implementation, then restoring and re-running:

- **7/9 tests polarity-flip** (fail against the unbuffered adapter, pass against the fix): "buffers chunks that arrive before onData is attached...", "preserves a UTF-8 multi-byte sequence split across the pre-attach boundary", "caps buffered bytes at 64 KiB...", "keeps exactly the cap with zero drops...", "does NOT replay on a second onData attach...", "getDataDiagnostics().fireCount counts every native data callback fire...", "live chunks after the first attach still flow straight through onData...". Pre-fix run: 7 fail / 25 pass (2 of the 32 pre-existing + new tests already existed and pass unaffected). Post-fix (restored) run: 149/149 pass across both touched test files.
- **2/9 are new-mechanism contract tests, not bug-polarity tests** (per architect ruling — no pre-fix counterpart mechanism exists to flip against):
  - `"does NOT deliver anything on attach when no pre-attach bytes arrived (empty buffer is not flushed as an empty string)"` locks the property *an empty pre-attach buffer must never synthesize a spurious empty-string `onData` event*. Pre-fix, there is no buffer/flush concept at all, so this property has no pre-fix analog to flip against — it guards a NEW code path (`PreAttachDataBuffer.flush()` / the `if (buffered.length > 0)` guard in `onData()`) that could regress independently of the byte-loss bug (e.g. a future refactor that always calls `listener('')` on attach).
  - `"dispose() before any onData attach discards buffered bytes (no retention, no replay)"` locks the property *`dispose()` must free the pre-attach buffer so it can never leak into a later listener*. Pre-fix, `dispose()` has nothing to discard (no buffer exists), so again there is no pre-fix mechanism to flip against — it guards `PreAttachDataBuffer.discard()`, a NEW method.

  Both properties are genuinely unwritable against the unfixed code (there is no buffer to assert boundary behavior on), not cases where a flip was possible and skipped.

### `scripts/smoke/check-pty-early-output.ts` — real-PTY polarity (Fix plan 3)

Pre-fix run (unbuffered `pty-provider.ts`, same revert/restore as above):

```
==> running 20 early-output cycles via bunTerminalProvider (Issue #1242), each with a deliberately-late (50ms) onData attach
  FAIL  cycle 0: marker not observed after a 50ms late onData attach; diagnostics=undefined; captured output: ""
  ... (all 20 cycles FAIL identically)
FAILED: 20/20 cycle(s) lost the early marker
```
Exit code: 1

Post-fix run:

```
==> running 20 early-output cycles via bunTerminalProvider (Issue #1242), each with a deliberately-late (50ms) onData attach
  OK    cycle 0: early marker observed complete after late attach
  ... (all 20 cycles OK)
PASSED: 20/20 cycles observed the complete early marker after a deliberately-late onData attach
```
Exit code: 0

### Dev-server regression evidence (per the issue's ✅ list — regression evidence only, NOT cited as fix proof)

**Why not the shared production orchestrator.** This worktree's own session runs on the shared "agent-console" orchestrator (port 6340, ~10 unrelated active sessions across other repositories). Two independent reasons rule it out for this check: (1) that server is running the deployed (pre-fix) binary — my worktree's source changes do not apply until the server is rebuilt and restarted, so any `delegate_to_worktree` call against it tests old code and carries zero evidence either way (the exact "old binary looks the same as new binary" proxy trap this Issue's own methodology warns about); (2) restarting that shared server to pick up this build is not a delegate-level decision under any circumstances — it would disrupt ~10 other active sessions and is owner/orchestrator territory, not something to do unilaterally for a single PR's regression check.

**What was done instead.** A fully isolated single-user dev instance was started from this worktree's own fixed build (`bun run dev`, custom ports, isolated `AGENT_CONSOLE_HOME`, and a from-scratch local git clone registered as its own repository — no shared state, no shared `.git` worktree registry, no interaction with the production orchestrator or any other session). All of the following were exercised against the FIXED build via that instance's REST API (the same API `delegate_to_worktree` / the UI itself calls) and confirmed by (a) a real OS pid on the worker, (b) `ps --forest` showing the login shell's child is the actual `claude` process (not a bare idle shell — the exact symptom this Issue reports on macOS), and (c) zero `Login-shell sentinel not detected within timeout` ERROR lines anywhere in the server log across the whole session:

- **Direct create path (N=2)**: two `POST /repositories/:id/worktrees` calls (custom branch, `autoStartSession: true`) — both produced a login shell with a live `claude ...` child process within seconds.
- **Worker restart**: `POST /sessions/:id/workers/:id/restart` on the first worker — produced a fresh login shell with a fresh `claude` child.
- **Terminal worker**: `POST /sessions/:id/workers` with `type: terminal` — produced a real PTY pid.
- **UI-created session equivalent**: `POST /sessions` with `type: quick` (the same endpoint the dashboard's "new session" UI calls, exercised directly rather than through a browser) — produced a real PTY pid for the agent worker.

The instance and all its processes, worktrees, and the throwaway git clone were torn down after verification (ports freed, process tree killed).

**Elevated (multi-user, privileged-spawn) create path: skipped, by argument, not by inability.** This PR's diff touches `pty-provider.ts` (`bunTerminalProvider` / `BunTerminalPtyAdapter`) and `worker-manager.ts`'s `setupWorkerEventHandlers` watchdog — both are shared identically by the direct and elevated spawn paths. The elevated path differs from direct only in spawn-argv/chain construction (`buildElevationArgs`, the elevation helper's elevated-login-shell invocation), which this diff does not touch. Direct-path E2E above + the untouched-elevation-argv argument + the full unit suite (including the pre-existing elevated-path-adjacent tests, all green and unchanged) together constitute adequate elevated-path regression evidence without needing a disruptive multi-user instance for this PR.

**This section is regression evidence only, per the issue's explicit prohibited-evidence clause: it is NOT cited as proof that the byte-loss windows are the cause of the macOS failure.** Ubuntu direct-path `delegate_to_worktree` success carries no polarity for that question regardless of which server it runs against (see Epistemic status above).

### `bun run check:pty-early-output` real-native-path note

The pre-fix/post-fix polarity above is the mandatory Fix-plan-3 evidence. The dev-server regression pass above additionally exercised the exact production entry point (`activateAgentWorkerPty` → `spawnPty` → `bunTerminalProvider.spawn` → `setupWorkerEventHandlers`) end-to-end on Linux with the fix applied, for free.

### CodeRabbit

`coderabbit review --agent --base main` failed with an **authentication failure** in this headless worktree (`automatic_login_failed` / `authentication_failed` — browser-based OAuth cannot complete without a display), not a rate-limit. This is the known headless-CLI-auth constraint (no local CLI review available in this environment).

The GitHub-side bot DID review the first commit (1777f3d2) and posted one actionable finding (the aliasing hazard, fixed in 0799b374 — see "Post-review fix" above) plus one nitpick (fixed in 4cbd9fc2 — the `PtyDataDiagnostics` extraction). After both fix commits, `@coderabbitai review` was retriggered; the bot's commit-status for the current head (`4cbd9fc2`) reads `success | Review rate limited | ...` (checked via the 4th-surface `commits/{sha}/status` endpoint, not just `statusCheckRollup`) — it has not actually re-reviewed the fix commits despite the retrigger and a ~15+ minute wait.

**Merge disposition note (2026-07-29).** CR state: round-1 walkthrough on 1777f3d2 was genuine (1 actionable + 1 nitpick, both now fixed). Round-2 verification of the fix commits (0799b374, 4cbd9fc2) is unobtainable from either channel — local CLI headless-auth-fail (structural, not time-bound) AND GitHub bot rate-limited on retrigger (checked past the abandon-the-wait window). Per `coderabbit-ops/troubleshooting.md`'s "local CLI headless auth-fail AND GitHub bot rate-limited... both channels unavailable for the SAME commit" disposition: substituting the Architect's independent code-appropriateness audit + Orchestrator acceptance as the dual-clean gate for the two fix commits. Both the copy-on-push fix and the type extraction were independently read and confirmed line-by-line by the Orchestrator during this PR's review thread; the Architect's full audit (7-point focus list) is the next step per the Orchestrator.

### Preflight

`node .claude/skills/orchestrator/preflight-check.js` — exit 0. Test coverage check, rule/skill duplication check, language check, and source-comment blame-shift check all pass clean.

## Post-review fix: CodeRabbit caught a real aliasing hazard

CodeRabbit's GitHub-side review flagged that `PreAttachDataBuffer.push()` stored the terminal `data` callback's `Uint8Array` (or a `subarray()` VIEW of it) directly into `this.chunks`, instead of copying it. The callback's buffer is only guaranteed valid for the synchronous duration of that callback; if Bun's `Terminal` binding reuses or mutates the backing memory for a later event (a common native-binding pattern to avoid per-event allocation), a retained view would silently corrupt the buffered pre-attach bytes before `flush()` ever reads them — reintroducing, inside the new buffer itself, the exact class of silent data loss this PR exists to close. Fixed by switching both storage sites to `.slice()` (which copies) instead of `.subarray()` / a bare reference, with a comment explaining why: copying removes the need to know or verify whether Bun's Terminal binding actually reuses its callback buffer across events at all — the same don't-trust-native-behavior-assumptions principle the pre-attach buffer itself exists for (`.claude/rules/os-environment-coupling.md`), applied recursively to its own internals.

**Regression test**: pushes a mutable `Uint8Array`, mutates it in place (`fill()`) immediately after the push call but before `flush()` — simulating a later event reusing/overwriting the same backing buffer — and asserts the pre-mutation content is what `flush()` returns.

**Polarity verified by actual execution** (diff/apply `-R` on just the two `.slice()` call sites, not `git stash`, then restored — same technique as the rest of this PR's polarity checks): running this test alone against the reverted (`subarray()`/bare-reference) code gives
```
Expected: "original"
Received: "XXXXXXXX"
```
i.e. it fails exactly as the hazard predicts (the mutation reached the stored reference). Restoring the fix and re-running: 1 pass, 0 fail.

**Follow-up nitpick fixed**: the same CodeRabbit review also flagged the `{ fireCount, bufferedBytes, droppedBytes }` diagnostics shape being inlined independently in 4 places across `pty-provider.ts` and `mock-pty.ts`. Extracted into one exported `PtyDataDiagnostics` type, reused everywhere (pure refactor, no behavior change).

**Why the existing unit tests and the real-PTY smoke did not already catch this**: the unit-test harness passes a fresh `TextEncoder().encode(...)` literal on every mock `data` call — no two calls ever share a backing buffer, so aliasing/reuse is structurally unobservable in that harness, independent of what the production code does or how many such tests are added; more tests of that shape cannot ever exercise this hazard. Whether Bun's actual native `Terminal` binding reuses or mutates its callback buffer across events, and on what cadence, is not something this PR has evidence for either way — the real-PTY smoke's single-marker-per-process, immediate-flush shape may simply never land inside such a reuse window if one exists, but that is not established; the fix is written to not need an answer to that question.

## Addendum (2026-07-29, post-merge-readiness): filling a dev-verification gap for #1237 / #1241 discovered during owner follow-up

Owner asked whether #1234 had been dev-verified; it had not (PR #1237 shipped without a `delegate_to_worktree` E2E — its own smoke is a mechanism probe, not the shipping path). This worktree (`fix/1242-pty-pre-attach-buffer`, based on `origin/main`, 0 commits behind) contains #1237 + #1239 + #1241 + this PR's fix, so it is the correct base to close that gap. Recorded here rather than on #1237/#1241 directly because this is the worktree it was run from; treat this as "two already-merged items whose dev verification was missing, filled in on this occasion."

**Verification start conditions (explicit, not inferred).** Per the discipline this PR itself is built on (copy-on-push removes a native-behavior assumption instead of arguing about it), the dev server was stopped and restarted immediately before verification, not assumed fresh from HMR/watch state:
```
git status --short  ->  (clean)
git log -1           ->  4cbd9fc2 2026-07-29T15:19:58+09:00
process restart time  ->  2026-07-29T18:10:36+09:00   (> commit time, confirmed after an explicit stop+restart, not inferred from uptime)
```
Run via `bun run dev` with custom ports (`PORT=17242 CLIENT_PORT=17243`, isolated `AGENT_CONSOLE_HOME`) from this worktree directly — NOT the shared systemd orchestrator (port 6340), which was not touched. Note: an unrelated pre-existing dev instance was found listening on the default ports 3457/5173 from a **different checkout** (`source-repos/agent-console`, launched independently, unrelated to this branch) — flagging since it could otherwise be mistaken for "the" dev server for this PR; it was not used or touched.

### Verification 1 (primary): #1234 AC item 1 — 5000-character `initialPrompt` E2E via `delegate_to_worktree`'s underlying API

Built a 5000-byte prompt containing single quotes, double quotes, backticks, `$`, and newlines, submitted via the same worktree-creation endpoint `delegate_to_worktree` uses (`autoStartSession: true`).

- **Agent process actually started**: `ps --forest` showed the login shell's child was a live `claude ...` process (not idle).
- **Prompt delivered verbatim**: read `/proc/<pid>/cmdline` (NUL-separated, unambiguous — `ps`'s space-joined display cannot distinguish "one argv with spaces" from "many argvs," so it was not relied on). Result: `argc=2`, `argv[1]` length 5000, and a byte-for-byte `diff` against the source prompt file showed **zero differences**.
- **Prompt file permissions**: `-rw-------` (0600), confirmed via `ls -la`.
- **Injected line stays bounded**: the actual line typed into the PTY (captured in the worker's own output log) was `claude "$(cat '/path/to/N.prompt')"` — **114 bytes**, independent of the 5000-byte prompt size, matching `check-login-shell-sentinel.ts`'s own `<512` bytes assertion for this mechanism.

All four AC sub-items confirmed on this build.

### Verification 2: #1241 — restart redelivery

Attempted to catch a worker in the "not yet delivered" state before restarting it, to exercise the redelivery path directly. **Both attempts lost the race** (the sentinel handshake + prompt injection completed before the restart could land):

- Attempt 1: detect the new worker's PID via a DB poll loop, then fire the restart HTTP call. The gap between polling-loop-detects-PID and the actual restart-triggered kill landing server-side was measured at **~21 seconds** in the server log (an LLM-tool-call round trip is not free), while the sentinel handshake itself completed in under 5 seconds (`activity-detector` idle→active→idle transition observed at +4.4s / +6.8s from worker creation). `initial_prompt_delivered` was already `1` by the time of restart; the post-restart process correctly launched with a bare `claude` (no prompt argv) — i.e. it correctly did NOT re-deliver an already-delivered prompt.
- Attempt 2: tightened the race into a single shell invocation (poll loop + immediate `kill` on first sight of the PID, no tool-call round trip in between) to shrink the reaction window. Still lost — by iteration 228 of a sub-millisecond-interval poll, `initial_prompt_delivered` was already `1`. (The tight loop itself caused `SQLITE_BUSY` read-lock contention against the live server, which added its own noise/overhead — noted as a limitation of this specific probing technique, not a product finding.)

**Disposition**: not proven live via a genuine "redeliver after failed first delivery" race in this session — the healthy-path delivery window (single-digit seconds) is faster than an external prober's reaction time by tool-call round trip. This was not treated as a reason to fabricate success; both failed attempts are reported as found. Two mitigating facts: (a) the DB-level contract was inspected directly — `session.initial_prompt` is persisted independently of the in-memory/on-disk prompt file that `killWorker` unconditionally deletes on every kill (including restart), and gating is driven by the persisted `initial_prompt_delivered` flag, not file existence, which is the shape #1241's fix requires; (b) PR #1241's own unit test suite (unchanged, still green in this PR's full-suite run) covers the redelivery branch directly at the unit level. Per the request's own allowance ("if difficult, report as not performed with a reason" — this was attempted twice and reported, not skipped outright).

### Verification 3: #1243 — watchdog does not spuriously fire

Across all of the above (6 total worktree/session creations including the two race attempts, 1 restart): `grep -c "Login-shell sentinel not detected"` across the full server log = **0**. No spurious watchdog ERRORs in this build.

## Scope

- `bunPtyProvider` (legacy, `PTY_PROVIDER=bun-pty`) is untouched, per the issue's explicit out-of-scope list.
- No change to sentinel comparison/gating semantics, spawn sequencing, or any speculative fix (sleeps/retries/event-loop yields).
- The Issue's optional/non-gating A/B parallel experiment (unfixed-build baseline on a direct-path Ubuntu instance, N=5) was not run — timeboxed against verifying this PR's own content, and explicitly authorized to drop without penalty by both the architect and the Orchestrator. This does not change this PR's content or verification.

## AC checklist (Issue #1242 PR-1)

- [x] Pre-attach buffer implemented per Fix-plan 1
- [x] Deterministic polarity tests (7/9 flip; 2 classified as new-mechanism contract tests — see Verification)
- [x] Watchdog implemented per Fix-plan 2 with both positive and both negative tests
- [x] Real-PTY early-output smoke implemented per Fix-plan 3, run on the dev server, pre-fix and post-fix runs both in this PR body
- [x] `bun run check:pty-fd-leak` run locally and pasted above
- [x] Dev-server regression checks recorded as regression evidence only (not cited as fix proof)
- [x] Epistemic status section present verbatim
- [x] Restart path, UI-created sessions, terminal workers, and `bunPtyProvider` behavior unchanged

Refs #1242
