### PR TITLE
fix: spawn Bun.Terminal PTYs outside any AsyncLocalStorage context (closes #1242)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "check:preview-sandbox-browser": "bun scripts/run-preview-sandbox-browser-check.mjs",
     "check:pty-fd-leak": "bun scripts/smoke/check-pty-fd-leak.ts",
     "check:pty-early-output": "bun scripts/smoke/check-pty-early-output.ts",
+    "check:pty-als-data": "bun scripts/smoke/check-pty-als-data.ts",
     "hooks:install": "bun scripts/install-hooks.mjs",
     "preinstall": "bun scripts/check-bun-version.mjs",
     "postinstall": "bun scripts/install-hooks.mjs",

--- a/packages/server/src/lib/__tests__/pty-provider.test.ts
+++ b/packages/server/src/lib/__tests__/pty-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   bunPtyProvider,
   bunTerminalProvider,
@@ -497,6 +498,55 @@ describe('pty-provider', () => {
 
         expect(received).toEqual(['live-chunk']);
         expect(pty.getDataDiagnostics!().bufferedBytes).toBe(0);
+      });
+    });
+
+    describe('async-context escape (Issue #1242)', () => {
+      // Bun (verified on 1.3.5, macOS and Linux) never delivers
+      // `terminal.data` callbacks for a Bun.spawn({ terminal }) call made
+      // while an AsyncLocalStorage context is active. bunTerminalProvider
+      // must spawn under the pristine (empty) async context captured at
+      // module load, regardless of any ALS scope active at call time -- see
+      // `runInPristineAsyncContext` in pty-provider.ts.
+
+      it('invokes Bun.spawn with the pristine async context even when spawn() is called inside AsyncLocalStorage.run()', () => {
+        const als = new AsyncLocalStorage<string>();
+        let recordedStore: string | undefined;
+
+        // Override the mock spawn installed in beforeEach so it also records
+        // the ALS store visible at the moment Bun.spawn actually runs.
+        const spawnable = Bun as unknown as SpawnableBun;
+        spawnable.spawn = (cmd, options) => {
+          recordedStore = als.getStore();
+          lastSpawn = { cmd, options };
+          return mockSubprocess;
+        };
+
+        als.run('mcp-request-scope', () => {
+          bunTerminalProvider.spawn('sh', [], {});
+        });
+
+        // Bun.spawn must have run outside the ALS scope (pristine context),
+        // not inside it -- an unfixed provider would record
+        // 'mcp-request-scope' here.
+        expect(recordedStore).toBeUndefined();
+      });
+
+      it('adapter still routes terminal data to onData listeners when spawned inside AsyncLocalStorage.run()', () => {
+        const als = new AsyncLocalStorage<string>();
+
+        let pty: ReturnType<typeof bunTerminalProvider.spawn> | undefined;
+        als.run('mcp-request-scope', () => {
+          pty = bunTerminalProvider.spawn('sh', [], {});
+        });
+
+        const received: string[] = [];
+        pty!.onData((data) => received.push(data));
+
+        const dataCb = lastSpawn!.options.terminal!.data!;
+        dataCb(null, new TextEncoder().encode('hello from inside ALS'));
+
+        expect(received).toEqual(['hello from inside ALS']);
       });
     });
   });

--- a/packages/server/src/lib/pty-provider.ts
+++ b/packages/server/src/lib/pty-provider.ts
@@ -1,7 +1,32 @@
 import type { IPty, IDisposable, IExitEvent } from 'bun-pty';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { createLogger } from './logger.js';
 
 const logger = createLogger('pty-provider');
+
+/**
+ * Runs a callback in the pristine (empty) async context captured at module
+ * load, before any `AsyncLocalStorage.run()` scope exists.
+ *
+ * Why this exists: Bun (verified on 1.3.5, macOS and Linux) never delivers
+ * `terminal.data` callbacks for a subprocess whose `Bun.spawn({ terminal })`
+ * call happens while an AsyncLocalStorage context is active (a non-empty
+ * AsyncContextFrame is current) -- the callback simply never fires and zero
+ * bytes ever reach JS. Non-terminal (pipe) spawns are unaffected, and
+ * `als.exit()` does NOT avoid the bug; only spawning under the pristine
+ * top-level frame does. The server's MCP tool handlers run inside
+ * `mcpCallerStorage.run(...)` (see mcp-server.ts), so PTYs spawned by MCP
+ * `delegate_to_worktree`'s create path hit exactly this: the sentinel
+ * watchdog recorded `fireCount: 0` -- the native side never invoked the
+ * `data` callback at all, while the same worker restarted via
+ * the plain REST route (no AsyncLocalStorage) worked every time.
+ *
+ * This module is imported during server startup (never lazily inside a
+ * request scope), so the snapshot is guaranteed to capture the empty
+ * top-level context. Real-PTY regression check:
+ * `scripts/smoke/check-pty-als-data.ts`.
+ */
+const runInPristineAsyncContext = AsyncLocalStorage.snapshot();
 
 /**
  * PTY spawn options (subset of bun-pty options)
@@ -447,23 +472,28 @@ export const bunTerminalProvider: PtyProvider = {
     // Terminal handle. The adapter is constructed after spawn returns.
     let adapter: BunTerminalPtyAdapter | null = null;
 
-    const subprocess = Bun.spawn([command, ...args], {
-      cwd: options.cwd,
-      env: options.env,
-      terminal: {
-        cols,
-        rows,
-        name: options.name ?? 'xterm-256color',
-        data: (_terminal, chunk) => {
-          preAttachBuffer.recordFire();
-          if (adapter) {
-            adapter._emitData(chunk);
-          } else {
-            preAttachBuffer.push(chunk);
-          }
+    // Spawn under the pristine (empty) async context captured at module
+    // load, not whatever AsyncLocalStorage scope happens to be active at
+    // call time -- see runInPristineAsyncContext's doc comment above.
+    const subprocess = runInPristineAsyncContext(() =>
+      Bun.spawn([command, ...args], {
+        cwd: options.cwd,
+        env: options.env,
+        terminal: {
+          cols,
+          rows,
+          name: options.name ?? 'xterm-256color',
+          data: (_terminal, chunk) => {
+            preAttachBuffer.recordFire();
+            if (adapter) {
+              adapter._emitData(chunk);
+            } else {
+              preAttachBuffer.push(chunk);
+            }
+          },
         },
-      },
-    });
+      }),
+    );
 
     const terminal = subprocess.terminal;
     if (!terminal) {

--- a/scripts/smoke/check-pty-als-data.ts
+++ b/scripts/smoke/check-pty-als-data.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env bun
+/**
+ * Post-deploy smoke test for the AsyncLocalStorage / Bun.spawn({ terminal })
+ * data-delivery bug (Issue #1242).
+ *
+ * Root cause: Bun (verified on 1.3.5, macOS and Linux) never invokes the
+ * `terminal.data` callback for a `Bun.spawn({ terminal: ... })` subprocess
+ * whose spawn call happens while an AsyncLocalStorage context is active (a
+ * non-empty AsyncContextFrame is current) -- zero bytes ever reach JS.
+ * Non-terminal (pipe) spawns are unaffected, and `als.exit()` does NOT avoid
+ * the bug; only spawning under the pristine (empty) top-level async context
+ * works. The server's MCP tool handlers run inside
+ * `mcpCallerStorage.run(caller, () => transport.handleRequest(c))` (see
+ * `packages/server/src/mcp/mcp-server.ts`), so agent-worker PTYs spawned
+ * during MCP `delegate_to_worktree`'s create path hit this directly: the
+ * login-shell sentinel watchdog recorded `fireCount: 0` -- the native side
+ * never called back into JS at all. The fix wraps the `Bun.spawn` call in
+ * `bunTerminalProvider` with a callback obtained from
+ * `AsyncLocalStorage.snapshot()`, captured at module load (before any
+ * `AsyncLocalStorage.run()` scope exists).
+ *
+ * `packages/server/src/lib/__tests__/pty-provider.test.ts`'s
+ * "async-context escape (Issue #1242)" describe block proves the CALL-SITE
+ * SHAPE: that `Bun.spawn` is invoked outside the caller's ALS scope. That is
+ * necessary but NOT sufficient: it cannot prove the native layer actually
+ * delivers bytes on a real PTY when spawned this way (see
+ * `.claude/rules/os-environment-coupling.md` Discipline 1 -- a unit test
+ * asserts the shape of a call site, not what the OS/native layer does with
+ * it). This script closes that gap: it imports the production
+ * `bunTerminalProvider` directly (no hand copy), spawns a REAL PTY from
+ * inside a real `AsyncLocalStorage.run()` scope (mirroring the MCP request
+ * scope in production), and asserts the child's output actually arrives.
+ *
+ * This script is ALSO the minimal reproduction to report upstream to Bun if
+ * this regresses: run it against an unfixed `bunTerminalProvider` (spawn
+ * called directly, no snapshot wrapper) and it fails deterministically.
+ *
+ * This does NOT exercise `worker-manager.ts`'s sentinel watchdog or
+ * chunk-boundary sentinel gate (covered by worker-manager's own unit
+ * tests); it isolates the PTY provider layer only, same scoping as
+ * `check-pty-early-output.ts` and `check-pty-fd-leak.ts`.
+ *
+ * Usage:
+ *   bun scripts/smoke/check-pty-als-data.ts
+ *
+ * Exit codes:
+ *   0  all cycles observed the complete marker while spawned inside an
+ *      AsyncLocalStorage.run() scope
+ *   1  one or more cycles never observed the marker (the async-context
+ *      escape did not close the gap -- a regression of Issue #1242)
+ *   2  bad usage / cannot run at all (e.g. this environment cannot spawn a
+ *      basic PTY via bunTerminalProvider) -- distinct from 1 so operators
+ *      can tell apart "the smoke ran and found a real problem" vs "the
+ *      smoke could not run"
+ *
+ * Sync contract: NONE -- `bunTerminalProvider` is imported directly from
+ * production source. A regression in the async-context escape (or its
+ * removal) changes this smoke's outcome automatically.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { bunTerminalProvider, type PtyInstance } from '../../packages/server/src/lib/pty-provider.js';
+
+const CYCLE_COUNT = 10;
+const MARKER_WAIT_TIMEOUT_MS = 3000;
+const EXIT_WAIT_TIMEOUT_MS = 1000;
+
+// Mirrors the ALS instance shape used by the server's MCP request scope
+// (`mcpCallerStorage` in packages/server/src/mcp/mcp-server.ts) -- an
+// AsyncLocalStorage carrying some request-scoped value across the
+// spawn call.
+const requestScope = new AsyncLocalStorage<string>();
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Prove this environment can spawn a basic PTY via bunTerminalProvider
+ * before trusting the async-context cycles below. If spawning itself is
+ * broken (no `sh`, Bun.Terminal unavailable, etc.), the cycles would fail
+ * for an unrelated reason and misreport an async-context regression (Issue
+ * #1200 class of problem: verify the probe works before trusting what it
+ * reports). Spawned OUTSIDE any AsyncLocalStorage scope on purpose -- this
+ * check is only about basic PTY viability, not the bug under test.
+ */
+async function selfCheck(): Promise<void> {
+  try {
+    const pty = bunTerminalProvider.spawn('sh', ['-c', 'echo ok'], {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+    });
+    const exited = new Promise<void>((resolve) => {
+      pty.onExit(() => resolve());
+    });
+    pty.onData(() => {});
+    await Promise.race([exited, sleep(EXIT_WAIT_TIMEOUT_MS)]);
+  } catch (err) {
+    console.error(
+      'Self-check failed: could not spawn a basic PTY via bunTerminalProvider -- cannot run this smoke.',
+    );
+    console.error(err);
+    process.exit(2);
+  }
+}
+
+async function runCycle(index: number): Promise<{ ok: boolean; detail: string }> {
+  const marker = `SMOKE_ALS_DATA_${index}_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
+
+  // Spawn from INSIDE a real AsyncLocalStorage.run() scope -- this is the
+  // exact shape production hits: MCP tool handlers run inside
+  // `mcpCallerStorage.run(caller, () => ...)`, and delegate_to_worktree's
+  // create path spawns the agent-worker PTY from within that scope.
+  let pty: PtyInstance | undefined;
+  requestScope.run('mcp-request-scope', () => {
+    pty = bunTerminalProvider.spawn('sh', ['-c', `echo ${marker}; exec sh`], {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+    });
+  });
+  if (!pty) {
+    return { ok: false, detail: 'spawn() did not return a PtyInstance' };
+  }
+  const ptyInstance = pty;
+
+  let output = '';
+  const exited = new Promise<void>((resolve) => {
+    ptyInstance.onExit(() => resolve());
+  });
+  ptyInstance.onData((chunk) => {
+    output += chunk;
+  });
+
+  const start = Date.now();
+  while (!output.includes(marker) && Date.now() - start < MARKER_WAIT_TIMEOUT_MS) {
+    await sleep(20);
+  }
+
+  const ok = output.includes(marker);
+  const diagnostics = ptyInstance.getDataDiagnostics?.();
+  const detail = ok
+    ? ''
+    : `marker not observed after spawning inside AsyncLocalStorage.run(); ` +
+      `diagnostics=${JSON.stringify(diagnostics)}; captured output: ${JSON.stringify(output.slice(0, 300))}`;
+
+  try {
+    ptyInstance.kill();
+  } catch {
+    // best-effort; the child may already be gone
+  }
+  await Promise.race([exited, sleep(EXIT_WAIT_TIMEOUT_MS)]);
+
+  return { ok, detail };
+}
+
+await selfCheck();
+
+console.log(
+  `==> running ${CYCLE_COUNT} AsyncLocalStorage-scoped spawn cycles via bunTerminalProvider (Issue #1242)`,
+);
+
+const failures: string[] = [];
+let passes = 0;
+for (let i = 0; i < CYCLE_COUNT; i++) {
+  const result = await runCycle(i);
+  if (result.ok) {
+    console.log(`  OK    cycle ${i}: marker observed after spawning inside AsyncLocalStorage.run()`);
+    passes++;
+  } else {
+    console.error(`  FAIL  cycle ${i}: ${result.detail}`);
+    failures.push(`cycle ${i}`);
+  }
+}
+
+console.log();
+if (failures.length > 0) {
+  console.error(`FAILED: ${failures.length}/${CYCLE_COUNT} cycle(s) never observed the marker -- ${failures.join(', ')}`);
+  process.exit(1);
+}
+console.log(`PASSED: ${passes}/${CYCLE_COUNT} cycles observed the complete marker when spawned inside AsyncLocalStorage.run()`);
+process.exit(0);


### PR DESCRIPTION
## Summary

Fixes the Issue #1242 create-path failure at its root: **a Bun 1.3.5 runtime bug** where `Bun.spawn({ terminal })` **never delivers `terminal.data` callbacks when the spawn call happens while an `AsyncLocalStorage` context is active** (any non-empty AsyncContextFrame; `als.exit()` does not help; non-terminal pipe spawns are unaffected). Zero bytes ever reach JS — exactly the `fireCount: 0` signature #1243's sentinel watchdog recorded in production.

### Why create failed and restart always worked (the asymmetry)

- The MCP tool handlers are the **only** code in the server that runs inside an `AsyncLocalStorage` scope: `mcpCallerStorage.run(caller, () => transport.handleRequest(c))` (`packages/server/src/mcp/mcp-server.ts`). Agent-worker PTYs spawned during `delegate_to_worktree` therefore spawn inside an active ALS context → the native side never delivers a single chunk → the login-shell sentinel is never observed → the agent command is never injected.
- `POST /api/sessions/:sid/workers/:wid/restart` is a plain Hono route with no ALS wrapper → same server process, same provider, works every time. Same for UI-created sessions (REST worktree route), which is why only the MCP create path was affected.

### The fix

`bunTerminalProvider.spawn` now routes the `Bun.spawn({ terminal })` call through a snapshot function captured at module load (`AsyncLocalStorage.snapshot()` at top level = pristine empty context), making PTY spawns immune to whatever request-scoped ALS context is active at the call site. The `data`/adapter wiring, env routing, and `bunPtyProvider` are unchanged.

### Upstream status and recommended follow-up

- Reproduced deterministically on **bun 1.3.5 on both macOS (darwin 25.5.0) and Linux (Docker oven/bun:1.3.5)** — this is not platform-specific. (The earlier Ubuntu dev-server 3/3 success in the issue's "Environment asymmetry" section is therefore most plausibly a bun-version or provider-config difference on that host, not an OS difference — worth checking `bun --version` / `PTY_PROVIDER` there.)
- **Fixed upstream by bun 1.3.14**: the standalone repro passes all cases on 1.3.14 (macOS and Linux), and the **unfixed** provider passes the new smoke 10/10 under 1.3.14. No matching upstream issue was found in oven-sh/bun, so the bug appears to have been fixed incidentally between 1.3.6 and 1.3.14.
- This workaround is kept because the repo's minimum supported bun is 1.3.5 (`scripts/check-bun-version.mjs`) and the production host runs 1.3.5. It is harmless on newer bun. **Recommended follow-up (separate track): upgrade hosts to bun >= 1.3.14 and consider raising `MIN_BUN_VERSION`**, after which this wrapper can be retired.

## Reproduction

Minimal repro matrix (standalone, no repo code) is posted on Issue #1242. In-repo, the new smoke is the repro: `git stash` the `pty-provider.ts` hunk and run `bun run check:pty-als-data` → 10/10 FAIL with `fireCount: 0`.

## Test plan / verification

**Polarity (all checks fail against the unfixed provider, pass with the fix):**

| Check | Unfixed | Fixed |
|---|---|---|
| Unit: `Bun.spawn` runs in pristine context when called inside `als.run()` (`pty-provider.test.ts`) | FAIL | PASS |
| Smoke `bun run check:pty-als-data` (real PTY, spawn inside `als.run()`), macOS | 10/10 FAIL, `fireCount: 0` | 10/10 PASS |
| Same smoke, Linux (Docker oven/bun:1.3.5) | (bug reproduced via standalone matrix) | 10/10 PASS |
| **Shipping-path E2E** (temp server on port 3999, isolated `AGENT_CONSOLE_HOME`, real MCP `delegate_to_worktree` via `@modelcontextprotocol/sdk` client → worktree + session + agent worker → sentinel → command injection) | FAIL: worker output log 0 bytes, watchdog ERROR `fireCount: 0` (byte-identical to the production signature) | PASS: output log contains the injected command's output, ×2 runs |

The second unit test added (`adapter still routes terminal data to onData listeners when spawned inside AsyncLocalStorage.run()`) intentionally passes in both directions — it guards the wrapper's adapter wiring (a regression the fix itself could introduce), not the bug; the polarity-bearing regression guards are the first unit test and the smoke.

**Regression checks:**

- `bun test packages/server/src/lib/__tests__/pty-provider.test.ts` → 35 pass / 0 fail.
- `bun run check:pty-early-output` → 20/20 PASS (macOS).
- `bun run typecheck` → clean (all four packages).
- `bun run check:pty-fd-leak` → exit 2 by design on macOS ("This smoke depends on /proc (Linux-only). Skipping on darwin"); in a bare Linux container the probe also cannot run (`countPtmxFds() self-check failed` — container devpts), identically on unmodified main. The fix does not touch dispose/fd lifecycle.

**Full suite:** clean Linux container (oven/bun:1.3.5, fresh `bun install --frozen-lockfile`, `bun run test`): typecheck passes; **3716 pass / 6 fail — and the identical 6 fail on unmodified main in the same container** (ptmx-fd probe, `readProcessTable`, process-tree pgid, sweeper environ-read, 2× git-diff real-repo), i.e. all pre-existing container-environment limitations, none related to this diff. On the local macOS host the full suite is additionally disturbed by pre-existing real-process test failures/hangs in `orphan-process-sweeper.test.ts` that reproduce identically on unmodified main (baseline-verified via stash) — this host runs inside an agent-console worker environment, which those real-process tests do not tolerate. CI rollup is the authoritative full-suite gate for this PR.

Tail of the container full-suite run (fix branch):

```
@agent-console/server test:  3716 pass
@agent-console/server test:  1 skip
@agent-console/server test:  6 fail
@agent-console/server test: Ran 3723 tests across 164 files. [64.86s]
```

(Same 6 on clean main: `86 pass / 4 fail` on the filtered 4-file set, identical failure list.)

## Notes

- The smoke follows `check-pty-early-output.ts` conventions (imports the production provider, exit 0/1/2 contract) and doubles as the in-repo reproduction for the upstream report.
- Browser QA skipped: server-only change, no UI surface; client behavior covered by the shipping-path E2E above.

Closes #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PTY terminal data delivery when processes are started within asynchronous context scopes.
  * Preserved reliable routing of subprocess output to data listeners.

* **Validation**
  * Added automated smoke checks that repeatedly verify PTY output delivery after deployment.
  * Added coverage for PTY behavior and data callbacks in asynchronous contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->