### PR TITLE
chore: raise the Bun floor to 1.3.14 across the repo (closes #1245)

### DIFF
--- a/.github/workflows/check-mirror-drift.yml
+++ b/.github/workflows/check-mirror-drift.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Run mirror drift check
         run: node .claude/skills/orchestrator/check-mirror-drift.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/comment-blame-shift-lint.yml
+++ b/.github/workflows/comment-blame-shift-lint.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Run comment blame-shift check
         run: bun scripts/check-source-comment-blame-shift.mjs

--- a/.github/workflows/docker-multiuser-e2e.yml
+++ b/.github/workflows/docker-multiuser-e2e.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Build image and run multi-user E2E (home 0700)
         run: scripts/verify-multiuser-docker.sh

--- a/.github/workflows/language-lint.yml
+++ b/.github/workflows/language-lint.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/mock-module-lint.yml
+++ b/.github/workflows/mock-module-lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/preflight-check.yml
+++ b/.github/workflows/preflight-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Run preflight check
         id: check

--- a/.github/workflows/structural-metrics.yml
+++ b/.github/workflows/structural-metrics.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,14 +11,15 @@
 #
 # The default BUN_BASE is a directly-pullable fixed tag so a clean environment
 # (CI, another machine) can `docker build` this without any local cache. The
-# in-image step below normalizes bun to BUN_VERSION (>= 1.3.5, required by
-# Bun.Terminal and the repo's preinstall gate), so you may override BUN_BASE
+# in-image step below normalizes bun to BUN_VERSION (>= 1.3.14, required by
+# the repo's preinstall gate -- see scripts/check-bun-version.mjs for the
+# reasons behind the floor), so you may override BUN_BASE
 # with an older locally-cached base when registry pulls are unavailable, e.g.:
 #   DOCKER_BUILDKIT=0 docker build --build-arg BUN_BASE=oven/bun:1.3.4 ...
 # See docker/README.md ("Building behind a blocked Docker Hub").
 
-ARG BUN_BASE=oven/bun:1.3.8
-ARG BUN_VERSION=1.3.8
+ARG BUN_BASE=oven/bun:1.3.14
+ARG BUN_VERSION=1.3.14
 
 # ===== Stage 1: build the standalone dist bundle =====
 FROM ${BUN_BASE} AS builder

--- a/docker/README.md
+++ b/docker/README.md
@@ -213,7 +213,7 @@ beyond loopback**; they exist solely for local development and verification.
 
 ## Building behind a blocked Docker Hub
 
-The default `BUN_BASE` (`oven/bun:1.3.8`) is a directly-pullable fixed tag, so a
+The default `BUN_BASE` (`oven/bun:1.3.14`) is a directly-pullable fixed tag, so a
 clean environment with normal Docker Hub access builds with no extra flags:
 
 ```bash
@@ -231,7 +231,7 @@ DOCKER_BUILDKIT=0 docker build \
   -f docker/Dockerfile -t agent-console-multiuser-verify .
 ```
 
-The in-image step normalizes bun to `BUN_VERSION` (default `1.3.8`) regardless of
+The in-image step normalizes bun to `BUN_VERSION` (default `1.3.14`) regardless of
 the base tag, so an older cached base still produces a `>= 1.3.5` runtime. bun
 itself is fetched from `bun.sh` and npm packages from the npm registry — neither
 goes through Docker Hub.

--- a/docker/README.md
+++ b/docker/README.md
@@ -232,7 +232,7 @@ DOCKER_BUILDKIT=0 docker build \
 ```
 
 The in-image step normalizes bun to `BUN_VERSION` (default `1.3.14`) regardless of
-the base tag, so an older cached base still produces a `>= 1.3.5` runtime. bun
+the base tag, so an older cached base still produces a `>= 1.3.14` runtime. bun
 itself is fetched from `bun.sh` and npm packages from the npm registry — neither
 goes through Docker Hub.
 

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -24,7 +24,7 @@ Browser (User: alice) ──> Agent Console Server (agentconsole)
 ## Prerequisites
 
 - Agent Console installed and working in single-user mode first (verify with `AUTH_MODE=none`)
-- [Bun](https://bun.com) **≥ 1.3.5** (required by `Bun.Terminal`; enforced by the repo's preinstall check)
+- [Bun](https://bun.com) **≥ 1.3.14** (required by `Bun.Terminal` and by the fix for a PTY output-delivery bug in earlier 1.3.x releases; enforced by the repo's preinstall check)
 - Root or sudo access on the server machine (for initial setup only)
 - Linux (Ubuntu/Debian, RHEL/Fedora, etc.) or macOS
 - **Linux only:** the `pamtester` package must be installed (see [Step 0](#step-0-install-pamtester-linux-only)). Without it, **every login returns 401.**

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "bun": ">=1.3.5"
+    "bun": ">=1.3.14"
   },
   "workspaces": ["packages/*"],
   "scripts": {
@@ -22,6 +22,7 @@
     "check:preview-sandbox-browser": "bun scripts/run-preview-sandbox-browser-check.mjs",
     "check:pty-fd-leak": "bun scripts/smoke/check-pty-fd-leak.ts",
     "check:pty-early-output": "bun scripts/smoke/check-pty-early-output.ts",
+    "check:pty-als-data": "bun scripts/smoke/check-pty-als-data.ts",
     "hooks:install": "bun scripts/install-hooks.mjs",
     "preinstall": "bun scripts/check-bun-version.mjs",
     "postinstall": "bun scripts/install-hooks.mjs",

--- a/packages/embedded-agent/package.json
+++ b/packages/embedded-agent/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "type": "module",
-  "engines": { "bun": ">=1.3.5" },
+  "engines": { "bun": ">=1.3.14" },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test src/",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,7 +9,7 @@
     }
   },
   "engines": {
-    "bun": ">=1.3.5"
+    "bun": ">=1.3.14"
   },
   "scripts": {
     "dev": "bun --watch src/index.ts",

--- a/scripts/check-bun-version.mjs
+++ b/scripts/check-bun-version.mjs
@@ -1,13 +1,19 @@
 #!/usr/bin/env bun
 // Hard-fail when Bun is too old to satisfy the repo's minimum version.
-// Two reasons for the floor:
+// Three reasons for the floor:
 //   - `minimumReleaseAge` (the supply-chain age gate in bunfig.toml) was added
 //     in Bun 1.3.0. An older Bun silently ignores the setting.
 //   - `Bun.Terminal` (used by packages/server) requires Bun 1.3.5+.
-// The higher floor wins: 1.3.5. Bun's `engines` enforcement is advisory
+//   - On Bun 1.3.5-1.3.13, `Bun.spawn({ terminal })` never delivers
+//     `terminal.data` callbacks when the spawn call happens inside an active
+//     AsyncLocalStorage context (e.g. the MCP request scope), so agent worker
+//     PTYs created via MCP `delegate_to_worktree` produce no output at all.
+//     Fixed upstream in Bun 1.3.14. Regression gate:
+//     `bun run check:pty-als-data`.
+// The higher floor wins: 1.3.14. Bun's `engines` enforcement is advisory
 // (warning only) as of Bun 1.3.x, so we need this explicit check.
 
-const MIN_BUN_VERSION = "1.3.5";
+const MIN_BUN_VERSION = "1.3.14";
 
 if (typeof Bun === "undefined") {
   console.error("This project must be installed with Bun (https://bun.com).");
@@ -20,9 +26,14 @@ if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
     `agent-console requires Bun >= ${MIN_BUN_VERSION} (detected ${Bun.version}).`,
   );
   console.error(
-    "Bun's `minimumReleaseAge` supply-chain age gate (configured in bunfig.toml)",
+    "Older Bun versions break this project: PTY terminal.data delivery is",
   );
-  console.error(`only works on Bun >= ${MIN_BUN_VERSION}.`);
+  console.error(
+    "broken inside AsyncLocalStorage contexts on Bun 1.3.5-1.3.13, and the",
+  );
+  console.error(
+    "`minimumReleaseAge` supply-chain age gate needs Bun >= 1.3.0.",
+  );
   console.error("Upgrade Bun: https://bun.com/docs/installation");
   process.exit(1);
 }

--- a/scripts/smoke/check-pty-als-data.ts
+++ b/scripts/smoke/check-pty-als-data.ts
@@ -76,8 +76,12 @@ function sleep(ms: number): Promise<void> {
  * check is only about basic PTY viability, not the bug under test.
  */
 async function selfCheck(): Promise<void> {
+  // The probe runs OUTSIDE any AsyncLocalStorage scope on purpose: data
+  // delivery here works even on runtimes where the ALS-scoped bug exists,
+  // so requiring the marker below does not weaken the cycles' polarity.
+  const probeMarker = 'SMOKE_ALS_SELFCHECK_OK';
   try {
-    const pty = bunTerminalProvider.spawn('sh', ['-c', 'echo ok'], {
+    const pty = bunTerminalProvider.spawn('sh', ['-c', `echo ${probeMarker}`], {
       name: 'xterm-256color',
       cols: 80,
       rows: 24,
@@ -85,11 +89,23 @@ async function selfCheck(): Promise<void> {
     const exited = new Promise<void>((resolve) => {
       pty.onExit(() => resolve());
     });
-    pty.onData(() => {});
+    let output = '';
+    pty.onData((chunk) => {
+      output += chunk;
+    });
+    const start = Date.now();
+    while (!output.includes(probeMarker) && Date.now() - start < MARKER_WAIT_TIMEOUT_MS) {
+      await sleep(20);
+    }
+    if (!output.includes(probeMarker)) {
+      throw new Error(
+        `basic PTY output never arrived outside AsyncLocalStorage (captured: ${JSON.stringify(output.slice(0, 200))})`,
+      );
+    }
     await Promise.race([exited, sleep(EXIT_WAIT_TIMEOUT_MS)]);
   } catch (err) {
     console.error(
-      'Self-check failed: could not spawn a basic PTY via bunTerminalProvider -- cannot run this smoke.',
+      'Self-check failed: could not spawn a basic working PTY via bunTerminalProvider -- cannot run this smoke.',
     );
     console.error(err);
     process.exit(2);

--- a/scripts/smoke/check-pty-als-data.ts
+++ b/scripts/smoke/check-pty-als-data.ts
@@ -36,6 +36,11 @@
  * Usage:
  *   bun scripts/smoke/check-pty-als-data.ts
  *
+ * When to run: before (and after, on the upgraded host) ANY Bun runtime
+ * upgrade or floor change. The failure mode this guards is silent in
+ * production -- a delegated agent worker simply never starts -- so this
+ * 15-second check is the designated canary for it.
+ *
  * Exit codes:
  *   0  all cycles observed the complete marker while spawned inside an
  *      AsyncLocalStorage.run() scope

--- a/scripts/smoke/check-pty-als-data.ts
+++ b/scripts/smoke/check-pty-als-data.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env bun
+/**
+ * Regression smoke for AsyncLocalStorage / Bun.spawn({ terminal }) data
+ * delivery.
+ *
+ * On Bun 1.3.5-1.3.13, the `terminal.data` callback of a
+ * `Bun.spawn({ terminal: ... })` subprocess NEVER fires when the spawn call
+ * happens while an AsyncLocalStorage context is active (a non-empty
+ * AsyncContextFrame is current) -- zero bytes ever reach JS. Non-terminal
+ * (pipe) spawns are unaffected, and `als.exit()` does NOT avoid the bug.
+ * The server's MCP tool handlers run inside
+ * `mcpCallerStorage.run(caller, () => transport.handleRequest(c))` (see
+ * `packages/server/src/mcp/mcp-server.ts`), so agent-worker PTYs spawned
+ * during MCP `delegate_to_worktree`'s create path hit this directly: the
+ * login-shell sentinel watchdog recorded `fireCount: 0` -- the native side
+ * never called back into JS at all -- while the same worker restarted via
+ * the plain REST route (no AsyncLocalStorage scope) worked every time.
+ *
+ * The bug is fixed upstream in Bun 1.3.14, and the repo pins its floor
+ * there (`MIN_BUN_VERSION` in scripts/check-bun-version.mjs). This smoke is
+ * the gate that keeps the floor honest: it imports the production
+ * `bunTerminalProvider` directly (no hand copy), spawns a REAL PTY from
+ * inside a real `AsyncLocalStorage.run()` scope (mirroring the MCP request
+ * scope in production), and asserts the child's output actually arrives.
+ * It fails deterministically on any Bun where the bug exists (10/10 cycles,
+ * fireCount 0 in the diagnostics), so it catches both a future Bun
+ * regression of terminal+ALS delivery and any accidental downgrade of the
+ * runtime below the floor. It is also the self-contained reproduction to
+ * report upstream to Bun if the behavior ever regresses.
+ *
+ * This does NOT exercise `worker-manager.ts`'s sentinel watchdog or
+ * chunk-boundary sentinel gate (covered by worker-manager's own unit
+ * tests); it isolates the PTY provider layer only, same scoping as
+ * `check-pty-early-output.ts` and `check-pty-fd-leak.ts`.
+ *
+ * Usage:
+ *   bun scripts/smoke/check-pty-als-data.ts
+ *
+ * Exit codes:
+ *   0  all cycles observed the complete marker while spawned inside an
+ *      AsyncLocalStorage.run() scope
+ *   1  one or more cycles never observed the marker (the terminal+ALS
+ *      data-delivery bug is present in this runtime)
+ *   2  bad usage / cannot run at all (e.g. this environment cannot spawn a
+ *      basic PTY via bunTerminalProvider) -- distinct from 1 so operators
+ *      can tell apart "the smoke ran and found a real problem" vs "the
+ *      smoke could not run"
+ *
+ * Sync contract: NONE -- `bunTerminalProvider` is imported directly from
+ * production source.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { bunTerminalProvider, type PtyInstance } from '../../packages/server/src/lib/pty-provider.js';
+
+const CYCLE_COUNT = 10;
+const MARKER_WAIT_TIMEOUT_MS = 3000;
+const EXIT_WAIT_TIMEOUT_MS = 1000;
+
+// Mirrors the ALS instance shape used by the server's MCP request scope
+// (`mcpCallerStorage` in packages/server/src/mcp/mcp-server.ts) -- an
+// AsyncLocalStorage carrying some request-scoped value across the
+// spawn call.
+const requestScope = new AsyncLocalStorage<string>();
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Prove this environment can spawn a basic PTY via bunTerminalProvider
+ * before trusting the async-context cycles below. If spawning itself is
+ * broken (no `sh`, Bun.Terminal unavailable, etc.), the cycles would fail
+ * for an unrelated reason and misreport an async-context regression (verify the probe works before trusting what it
+ * reports). Spawned OUTSIDE any AsyncLocalStorage scope on purpose -- this
+ * check is only about basic PTY viability, not the bug under test.
+ */
+async function selfCheck(): Promise<void> {
+  try {
+    const pty = bunTerminalProvider.spawn('sh', ['-c', 'echo ok'], {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+    });
+    const exited = new Promise<void>((resolve) => {
+      pty.onExit(() => resolve());
+    });
+    pty.onData(() => {});
+    await Promise.race([exited, sleep(EXIT_WAIT_TIMEOUT_MS)]);
+  } catch (err) {
+    console.error(
+      'Self-check failed: could not spawn a basic PTY via bunTerminalProvider -- cannot run this smoke.',
+    );
+    console.error(err);
+    process.exit(2);
+  }
+}
+
+async function runCycle(index: number): Promise<{ ok: boolean; detail: string }> {
+  const marker = `SMOKE_ALS_DATA_${index}_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
+
+  // Spawn from INSIDE a real AsyncLocalStorage.run() scope -- this is the
+  // exact shape production hits: MCP tool handlers run inside
+  // `mcpCallerStorage.run(caller, () => ...)`, and delegate_to_worktree's
+  // create path spawns the agent-worker PTY from within that scope.
+  let pty: PtyInstance | undefined;
+  requestScope.run('mcp-request-scope', () => {
+    pty = bunTerminalProvider.spawn('sh', ['-c', `echo ${marker}; exec sh`], {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+    });
+  });
+  if (!pty) {
+    return { ok: false, detail: 'spawn() did not return a PtyInstance' };
+  }
+  const ptyInstance = pty;
+
+  let output = '';
+  const exited = new Promise<void>((resolve) => {
+    ptyInstance.onExit(() => resolve());
+  });
+  ptyInstance.onData((chunk) => {
+    output += chunk;
+  });
+
+  const start = Date.now();
+  while (!output.includes(marker) && Date.now() - start < MARKER_WAIT_TIMEOUT_MS) {
+    await sleep(20);
+  }
+
+  const ok = output.includes(marker);
+  const diagnostics = ptyInstance.getDataDiagnostics?.();
+  const detail = ok
+    ? ''
+    : `marker not observed after spawning inside AsyncLocalStorage.run(); ` +
+      `diagnostics=${JSON.stringify(diagnostics)}; captured output: ${JSON.stringify(output.slice(0, 300))}`;
+
+  try {
+    ptyInstance.kill();
+  } catch {
+    // best-effort; the child may already be gone
+  }
+  await Promise.race([exited, sleep(EXIT_WAIT_TIMEOUT_MS)]);
+
+  return { ok, detail };
+}
+
+await selfCheck();
+
+console.log(
+  `==> running ${CYCLE_COUNT} AsyncLocalStorage-scoped spawn cycles via bunTerminalProvider`,
+);
+
+const failures: string[] = [];
+let passes = 0;
+for (let i = 0; i < CYCLE_COUNT; i++) {
+  const result = await runCycle(i);
+  if (result.ok) {
+    console.log(`  OK    cycle ${i}: marker observed after spawning inside AsyncLocalStorage.run()`);
+    passes++;
+  } else {
+    console.error(`  FAIL  cycle ${i}: ${result.detail}`);
+    failures.push(`cycle ${i}`);
+  }
+}
+
+console.log();
+if (failures.length > 0) {
+  console.error(`FAILED: ${failures.length}/${CYCLE_COUNT} cycle(s) never observed the marker -- ${failures.join(', ')}`);
+  process.exit(1);
+}
+console.log(`PASSED: ${passes}/${CYCLE_COUNT} cycles observed the complete marker when spawned inside AsyncLocalStorage.run()`);
+process.exit(0);


### PR DESCRIPTION
## Summary

Raises the repository's Bun floor from **1.3.5 to 1.3.14** everywhere a version is pinned, and adds the real-PTY regression smoke that keeps the floor honest.

**Why:** Bun 1.3.5-1.3.13 never delivers `Bun.spawn({ terminal })` `data` callbacks when the spawn call happens inside an active `AsyncLocalStorage` context — the MCP request scope in this server — which silently broke every agent-worker PTY created via MCP `delegate_to_worktree` (the create path produced zero output while REST restart worked). Full mechanism and minimal repro: https://github.com/ms2sato/agent-console/issues/1242#issuecomment-5118172274. The bug is fixed upstream in Bun 1.3.14. The owner's production host was upgraded in place and the production checkpoint passed (one real delegation started its agent with no restart kick: https://github.com/ms2sato/agent-console/issues/1242#issuecomment-5118627427), and the code-workaround PR #1244 was closed in favor of this version-floor track.

## Changes

| Location | Before | After |
|---|---|---|
| `scripts/check-bun-version.mjs` `MIN_BUN_VERSION` (preinstall hard gate) | 1.3.5 | 1.3.14, with the terminal+ALS bug documented as a floor reason and an accurate failure message |
| 8 GitHub workflows (`ci`, `preflight-check`, `check-mirror-drift`, `comment-blame-shift-lint`, `docker-multiuser-e2e`, `language-lint`, `mock-module-lint`, `structural-metrics`) | `bun-version: "1.3.5"` | `"1.3.14"` |
| `engines.bun` (root, `packages/server`, `packages/embedded-agent`) | `>=1.3.5` | `>=1.3.14` |
| `docker/Dockerfile` `BUN_BASE` / `BUN_VERSION` (+ `docker/README.md`) | `oven/bun:1.3.8` / `1.3.8` | `1.3.14` |
| `docs/multi-user-setup-guide.md` prerequisite | ≥ 1.3.5 | ≥ 1.3.14 |
| `scripts/smoke/check-pty-als-data.ts` + `bun run check:pty-als-data` | (new) | real-PTY regression gate: spawns via the production `bunTerminalProvider` from inside `AsyncLocalStorage.run()` and asserts output arrives; follows the `check-pty-early-output.ts` conventions (exit 0/1/2, self-check, production import) |

No `packages/*` production code changes. The provider itself is untouched — on Bun >= 1.3.14 it works as-is.

## Verification

**Floor-gate polarity (Docker `oven/bun:1.3.5` vs local/container 1.3.14):**

- Bun 1.3.5: `scripts/check-bun-version.mjs` exits 1 with the new message (pasted below). Bun 1.3.14: exits 0.

```
agent-console requires Bun >= 1.3.14 (detected 1.3.5).
Older Bun versions break this project: PTY terminal.data delivery is
broken inside AsyncLocalStorage contexts on Bun 1.3.5-1.3.13, and the
`minimumReleaseAge` supply-chain age gate needs Bun >= 1.3.0.
Upgrade Bun: https://bun.com/docs/installation
```

**Smoke polarity (the bug the floor guards against):**

- Bun 1.3.5 (Docker, this branch's untouched provider): `check:pty-als-data` **10/10 FAIL** with `diagnostics={"fireCount":0,...}` — the exact production watchdog signature.
- Bun 1.3.14 (macOS local AND Docker Linux): **10/10 PASS**.

**Full suite under Bun 1.3.14** (clean Linux container, fresh `bun install --frozen-lockfile`, `bun run test`): typecheck clean; client 2075/0, shared 596/0, integration 73/0, embedded-agent 286 pass + 1 container-artifact fail, server 3714 pass + 6 pre-existing container-environment fails.

- The 6 server fails (ptmx-fd probe, `readProcessTable`, process-tree pgid, sweeper environ-read, 2x git-diff real-repo) are **byte-identical to the unmodified-main baseline in the same container under Bun 1.3.5** (verified during the #1242 investigation) — bare-container probe limitations, not version regressions.
- The 1 embedded-agent fail (`editTool` write-back failure message) is a **root-only artifact**: the test injects failure via `chmod 0o555` on the directory, which root ignores on Bun 1.3.14's write path. The same test passes 16/16 as a non-root user in the same 1.3.14 container and 16/16 locally on macOS. GitHub CI runs as the non-root `runner` user and is unaffected (this PR's own CI is the proof).
- Local full-suite on the owner's Mac remains blocked by known pre-existing env-coupled real-process tests (baseline-verified during #1242); the CI rollup is the authoritative gate.

**Other local checks:** `bun run typecheck` clean (Bun 1.3.14); `bun test scripts/` 170/170 pass; `bun run check:lang` clean; preflight clean; `bun scripts/check-bun-version.mjs` passes on the local 1.3.14.

## Operational state / remaining steps

- **Owner macOS production host: already on 1.3.14** (upgraded + restarted + checkpoint passed 2026-07-29). This PR makes the requirement explicit rather than changing that host.
- **Ubuntu dev server: still needs its bun upgraded to >= 1.3.14** before pulling a build of this branch (the preinstall gate will otherwise refuse `bun install`, loudly — which is the intended behavior). Recording `bun --version` there before upgrading would also close the loop on #1242's "Environment asymmetry" observation (its 3/3 pre-fix success was most plausibly a newer bun already).
- CI images and the Docker verification image are updated by this PR itself; `docker-multiuser-e2e` CI validates the 1.3.14 image build.

Closes #1245
Refs #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Raised the minimum supported Bun version to **1.3.14** across development, server, embedded-agent, and Docker environments.
  * Updated CI/workflow, container defaults, and setup guidance to match the newer Bun release.

* **Bug Fixes**
  * Improved reliability of PTY output delivery when processes run within asynchronous context scopes.

* **Tests**
  * Added a PTY smoke regression check to validate repeated output delivery and robust timeout handling.

* **Documentation**
  * Refreshed Docker and multi-user setup instructions for the new Bun requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->