### PR TITLE
ci: set persist-credentials: false on the six remaining checkout steps

### DIFF
--- a/.github/workflows/check-mirror-drift.yml
+++ b/.github/workflows/check-mirror-drift.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Bun is required to run the unit tests (`bun:test`). The drift check
       # script itself runs under `node`, but keeping a single runtime here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/comment-blame-shift-lint.yml
+++ b/.github/workflows/comment-blame-shift-lint.yml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/language-lint.yml
+++ b/.github/workflows/language-lint.yml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/preflight-check.yml
+++ b/.github/workflows/preflight-check.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # preflight-check.js spawns `bun` internally for the language-check helper.
       # Required even though the script itself is invoked via `node`.

--- a/.github/workflows/structural-metrics.yml
+++ b/.github/workflows/structural-metrics.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

Sets `persist-credentials: false` on the `actions/checkout` step of the six workflows that were still missing it. `docker-multiuser-e2e.yml` and `mock-module-lint.yml` already set the flag and served as the model for the change.

## Per-workflow confirmation (no post-checkout step consumes the Git credential)

| Workflow | Confirmation |
|---|---|
| `check-mirror-drift.yml` | Steps after checkout are `oven-sh/setup-bun`, a `node` drift-check script, and a `bun test` run — no git write / push / PR-create step. Safe. |
| `ci.yml` | Steps after checkout are Bun setup, `bun install`, `bun run build`, `bun run test` — build/test only, no git write. Safe. |
| `comment-blame-shift-lint.yml` | Steps after checkout are Bun setup, the blame-shift check script, and its unit tests — read-only lint, no git write. Safe. |
| `language-lint.yml` | Steps after checkout are Bun setup, `bun install`, the language check, and its unit tests — read-only lint, no git write. Safe. |
| `preflight-check.yml` | Steps after checkout are Bun setup, `node .claude/skills/orchestrator/preflight-check.js` (twice) and `marocchino/sticky-pull-request-comment@v2`. `preflight-check.js` has no `git push`/`git commit`/`git tag`/`gh pr create` call sites (grepped). The PR comment is posted by `marocchino/sticky-pull-request-comment` via the GitHub REST API using `github.token` (its own action input), not the git-persisted credential — unaffected by `persist-credentials`. Safe. |
| `structural-metrics.yml` | Steps after checkout are Bun setup, `bun install`, a prebuild, and three read-only lint checks (dependency-cruiser / madge / knip) — no git write. Safe. |

## Which of the six actually ran on this PR

This PR only modifies `.github/workflows/*.yml` files. All six target workflows are expected to execute on this PR:

- `check-mirror-drift.yml`, `comment-blame-shift-lint.yml`, `language-lint.yml` each list their own workflow file (`.github/workflows/<name>.yml`) in their `paths:` filter, so modifying them self-triggers a run.
- `ci.yml` and `structural-metrics.yml` use `paths-ignore` that excludes `**/*.md` / `docs/**` / `.claude/**` / `LICENSE` only — `.github/workflows/**` is not excluded, so both run on any push/PR.
- `preflight-check.yml` has no `paths:` filter at all (`on: pull_request: types: [opened, synchronize, reopened]`) — it always runs.

(Rollup will be verified via `gh pr view --json statusCheckRollup` before merge, per `workflow.md` Definition of Done item 7.)

## No other changes

Only the `persist-credentials: false` line (plus its `with:` block where needed) was added to the six workflows. No other change is bundled, per the Issue's Non-goals (broader Actions hardening, SHA pinning, etc. is explicitly out of scope).

## Verification

- `bun run test` (full suite, typecheck + tests): all packages green, 0 failures — output pasted below.
- `node .claude/skills/orchestrator/preflight-check.js`: all four checks (coverage / rule-skill duplication / language / blame-shift) clean. No production files matched coverage patterns (workflow YAML only).
- CodeRabbit CLI (`coderabbit review --agent --base main`) could not run in this headless worktree: `coderabbit auth status` reports `signed out`. This is an **auth failure**, not a rate-limit — the CLI has no stored credential in this environment. Recommend the CLI review be run by whoever has an authenticated CodeRabbit session, or rely on the GitHub-side bot review for this PR.

### Test output (last 100 lines, full suite)

```
[36m│[0m [0m[32m 2075 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  4361 expect() calls
[36m│[0m Ran 2075 tests across 142 files. [48.25s]
[36m└─[0m Running...
@agent-console/shared test $ bun test src/
[36m│[0m bun test v1.3.14 (0d9b296a)
[36m│[0m
[36m│[0m [0m[32m 596 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  891 expect() calls
[36m│[0m Ran 596 tests across 22 files. [2.61s]
[36m└─[0m Done in 2.62 s
@agent-console/integration test $ bun test --preload ./src/setup.ts src/
[36m│[0m bun test v1.3.14 (0d9b296a)
[36m│[0m
[36m│[0m src/schema-version-boundary.test.ts:
[36m│[0m [SchemaVersion] Schema-version mismatch persists after reload (client=ab98cef18cf6b3f3, server=drifted-server-version-0000). A cached stale bundle or an intermediary proxy may be serving old assets. Not reloading again to avoid a reload loop.
[36m│[0m
[36m│[0m [0m[32m 73 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  424 expect() calls
[36m│[0m Ran 73 tests across 27 files. [4.02s]
[36m└─[0m Done in 4.04 s
@agent-console/server test $ bun test src/
[36m│[0m [14 lines elided]
[36m│[0m src/routes/__tests__/workers-upload-dir-real-fs.test.ts:
[36m│[0m [skip] memfs is active in this process; fs.mkdir is mocked. Run this file alone (`bun test workers-upload-dir-real-fs.test.ts`) to probe the real Bun binding.
[36m│[0m [skip] memfs is active in this test process; ensureUploadDir() would land on memfs. Run this file alone to exercise.
[36m│[0m [skip] memfs is active in this test process; run this file alone to exercise.
[36m│[0m
[36m│[0m [0m[32m 3720 pass[0m
[36m│[0m [0m[33m 1 skip[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  10209 expect() calls
[36m│[0m Ran 3721 tests across 164 files. [73.33s]
[36m└─[0m Done in 73.36 s
@agent-console/embedded-agent test $ bun test src/
[36m│[0m bun test v1.3.14 (0d9b296a)
[36m│[0m
[36m│[0m [0m[32m 287 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  637 expect() calls
[36m│[0m Ran 287 tests across 26 files. [8.36s]
[36m└─[0m Done in 8.37 s
@agent-console/client test $ bun test --preload ./src/test/setup.ts src/
[36m│[0m [964 lines elided]
[36m│[0m
[36m│[0m [0m[32m 2075 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  4361 expect() calls
[36m│[0m Ran 2075 tests across 142 files. [48.25s]
[36m└─[0m Done in 48.28 s
@agent-console/shared test $ bun test src/
[36m│[0m [0m[32m 596 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  891 expect() calls
[36m│[0m Ran 596 tests across 22 files. [2.61s]
[36m└─[0m Done in 2.62 s
@agent-console/integration test $ bun test --preload ./src/setup.ts src/
[36m│[0m [0m[32m 73 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  424 expect() calls
[36m│[0m Ran 73 tests across 27 files. [4.02s]
[36m└─[0m Done in 4.04 s
@agent-console/server test $ bun test src/
[36m│[0m [0m[32m 3720 pass[0m
[36m│[0m [0m[33m 1 skip[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  10209 expect() calls
[36m│[0m Ran 3721 tests across 164 files. [73.33s]
[36m└─[0m Done in 73.36 s
$ bun test scripts/ ./.claude/hooks/__tests__/ ./.claude/skills/*/__tests__/
bun test v1.3.14 (0d9b296a)

[0m[32m 521 pass[0m
[0m[2m 0 fail[0m
 1168 expect() calls
Ran 521 tests across 17 files. [4.89s]
```

`TEST_EXIT: 0`

Closes #1240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved CI workflow security by preventing checkout credentials from being persisted after repository access.
* **Maintenance**
  * Applied consistent credential-handling settings across automated checks and validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->