### PR TITLE
test: convert mock-module-lint baseline call sites (closes #1238)

### DIFF
--- a/packages/integration/src/paste-focus-isolation.test.tsx
+++ b/packages/integration/src/paste-focus-isolation.test.tsx
@@ -6,37 +6,27 @@
  */
 import { describe, it, expect, mock, afterEach, beforeEach } from 'bun:test';
 import { fireEvent, cleanup, act, within } from '@testing-library/react';
-
-// Mock dependencies required by MessagePanel
-const mockSendWorkerMessage = mock(() =>
-  Promise.resolve({
-    message: {
-      id: 'msg-1',
-      sessionId: 'session-1',
-      fromWorkerId: 'user',
-      fromWorkerName: 'User',
-      toWorkerId: 'worker-1',
-      toWorkerName: 'Worker 1',
-      content: '',
-      timestamp: new Date().toISOString(),
-    },
-  })
-);
-mock.module('@agent-console/client/src/lib/api', () => ({
-  sendWorkerMessage: mockSendWorkerMessage,
-}));
-mock.module('@agent-console/client/src/lib/worker-websocket', () => ({
-  sendInput: mock(() => true),
-}));
-
 import { MessagePanel } from '@agent-console/client/src/components/sessions/MessagePanel';
 import { renderWithRouter } from '@agent-console/client/src/test/renderWithRouter';
 import { _getDraftsMap } from '@agent-console/client/src/hooks/useDraftMessage';
+
+// MessagePanel resolves its send action via an injected `onSend` prop, not
+// via a module-level import of `lib/api` / `lib/worker-websocket` -- the
+// prior `mock.module()` of those two modules was a leftover from before
+// that DI seam existed and mocked exports MessagePanel no longer reads.
+// Neither test below triggers a send, but `onSend` is a required prop.
+// Using the real DI seam (Pattern 1) instead of `mock.module()` avoids
+// process-globally poisoning sibling integration tests that import
+// `lib/api` / `lib/worker-websocket` for real in the same bun:test
+// process (e.g. system-api-boundary.test.ts) -- the live #1225-class
+// poisoner this file used to be (`.claude/rules/testing.md` Anti-Pattern #2).
+const mockOnSend = mock(() => Promise.resolve());
 
 const defaultProps = {
   sessionId: 'session-1',
   targetWorkerId: 'worker-1',
   newMessage: null,
+  onSend: mockOnSend,
 };
 
 describe('Paste Focus Isolation (#523)', () => {

--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -11,7 +11,7 @@ import type {
 } from '@agent-console/shared';
 import { setupMemfs, cleanupMemfs, createMockGitRepoFiles } from './utils/mock-fs-helper.js';
 import { mockProcess, resetProcessMock } from './utils/mock-process-helper.js';
-import { MockPty, createMockPtyFactory } from './utils/mock-pty.js';
+import { createMockPtyFactory } from './utils/mock-pty.js';
 import { mockGit, GitError } from './utils/mock-git-helper.js';
 
 // Set up test config directory BEFORE any service imports to ensure
@@ -23,28 +23,7 @@ process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
 // Infrastructure Mocks (must be before any service imports)
 // =============================================================================
 
-// Track PTY instances
-const mockPtyInstances: MockPty[] = [];
-let nextPtyPid = 10000;
-
-// Mock pty-provider module to avoid spawning real PTY processes in tests
-mock.module('../lib/pty-provider.js', () => ({
-  bunPtyProvider: {
-    spawn: () => {
-      const pty = new MockPty(nextPtyPid++);
-      mockPtyInstances.push(pty);
-      return pty;
-    },
-  },
-}));
-
 // Note: process-utils is mocked via mock-process-helper.js (imported above)
-
-// Mock open package to prevent actual file opening
-const mockOpen = mock(async () => {});
-mock.module('open', () => ({
-  default: mockOpen,
-}));
 
 // Mock session-metadata-suggester to avoid running actual agent commands
 const mockSuggestSessionMetadata = mock(async () => ({
@@ -114,7 +93,7 @@ import { WorkerOutputFileManager } from '../lib/worker-output-file.js';
 import { SystemCapabilitiesService } from '../services/system-capabilities-service.js';
 import { WorktreeService } from '../services/worktree-service.js';
 import type { AppBindings } from '../app-context.js';
-import { asAppContext, TEST_AUTH_USER, ensureTestAuthUser } from './test-utils.js';
+import { asAppContext, TEST_AUTH_USER, ensureTestAuthUser, mockOpen } from './test-utils.js';
 import { SingleUserMode } from '../services/user-mode.js';
 import { McpTokenRegistry } from '../mcp/mcp-auth.js';
 
@@ -201,8 +180,6 @@ describe('API Routes Integration', () => {
     process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
 
     // Reset PTY tracking
-    mockPtyInstances.length = 0;
-    nextPtyPid = 10000;
     ptyFactory.reset();
 
     // Reset process tracking

--- a/packages/server/src/routes/__tests__/system.test.ts
+++ b/packages/server/src/routes/__tests__/system.test.ts
@@ -1,14 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { Hono } from 'hono';
 import type { AppBindings } from '../../app-context.js';
 import { asAppContext } from '../../__tests__/test-utils.js';
-
-// Mock open package BEFORE importing mock-fs-helper
-// The open package internally uses fs and needs to be mocked first
-const mockOpen = mock(async () => {});
-mock.module('open', () => ({
-  default: mockOpen,
-}));
 
 // Import mock-fs-helper to set up memfs mocks
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';

--- a/packages/server/src/services/__tests__/worktree-creation-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-creation-service.test.ts
@@ -50,17 +50,11 @@ const mockWorktreeService = {
   executeHookCommand: mockExecuteHookCommand,
 };
 
-// --- Mock logger ---
-mock.module('../../lib/logger.js', () => ({
-  createLogger: () => ({
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    debug: () => {},
-  }),
-}));
-
-// Import after mocks
+// No logger mock needed: `lib/logger.js`'s pino instance is already disabled
+// (`enabled: !isTest`) whenever `NODE_ENV === 'test'`, which Bun sets by
+// default for `bun test` runs. The real (silent) logger is used directly,
+// avoiding a process-global `mock.module()` of a module other test files
+// import for real (`.claude/rules/testing.md` Anti-Pattern #2).
 const { createWorktreeWithSession } = await import('../worktree-creation-service.js');
 
 // --- Helpers ---

--- a/packages/server/src/services/__tests__/worktree-deletion-service.test.ts
+++ b/packages/server/src/services/__tests__/worktree-deletion-service.test.ts
@@ -48,15 +48,11 @@ const mockWorktreeService = {
   removeOrphanedWorktree: mockRemoveOrphanedWorktree,
 };
 
-// --- Mock logger ---
-mock.module('../../lib/logger.js', () => ({
-  createLogger: () => ({
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    debug: () => {},
-  }),
-}));
+// No logger mock needed: `lib/logger.js`'s pino instance is already disabled
+// (`enabled: !isTest`) whenever `NODE_ENV === 'test'`, which Bun sets by
+// default for `bun test` runs. The real (silent) logger is used directly,
+// avoiding a process-global `mock.module()` of a module other test files
+// import for real (`.claude/rules/testing.md` Anti-Pattern #2).
 
 // Note: The Bun shell ($) tagged template literal cannot be reliably mocked
 // via mock.module('bun', ...). The gitStatus capture path runs a real `git -C`

--- a/packages/server/src/services/inbound/__tests__/diff-worker-handler.test.ts
+++ b/packages/server/src/services/inbound/__tests__/diff-worker-handler.test.ts
@@ -1,13 +1,25 @@
-import { describe, it, expect, mock } from 'bun:test';
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test';
 import type { InboundSystemEvent, Session, Worker } from '@agent-console/shared';
 import { createInboundHandlers, type InboundEventHandler, type InboundHandlerDependencies, type EventTarget } from '../handlers.js';
 import { buildWorktreeSession } from '../../../__tests__/utils/build-test-data.js';
+import * as gitDiffServiceModule from '../../git-diff-service.js';
 
-// Mock triggerRefresh at the module level since it's a standalone function import
+// `triggerRefresh` is a standalone function import in handlers.ts (no DI
+// seam via InboundHandlerDependencies exists for it yet -- see the PR
+// description for this conversion). spyOn() on the real module keeps this
+// test file-scoped and restorable, instead of process-globally poisoning
+// every other importer of git-diff-service.js the way mock.module() would
+// (`.claude/rules/testing.md` Anti-Pattern #2).
 const mockTriggerRefresh = mock(() => {});
-mock.module('../../git-diff-service.js', () => ({
-  triggerRefresh: mockTriggerRefresh,
-}));
+let triggerRefreshSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  triggerRefreshSpy = spyOn(gitDiffServiceModule, 'triggerRefresh').mockImplementation(mockTriggerRefresh);
+});
+
+afterEach(() => {
+  triggerRefreshSpy.mockRestore();
+});
 
 function createEvent(type: 'ci:completed' | 'pr:merged' = 'ci:completed'): InboundSystemEvent {
   return {

--- a/scripts/__tests__/check-mock-module-poisoners.test.mjs
+++ b/scripts/__tests__/check-mock-module-poisoners.test.mjs
@@ -319,8 +319,11 @@ describe('findDefaultFiles — scan glob', () => {
 });
 
 describe('KNOWN_VIOLATIONS / SANCTIONED_LOCATIONS — baseline integrity', () => {
-  it('every KNOWN_VIOLATIONS entry has a file, specifier, and one-line reason', () => {
-    expect(KNOWN_VIOLATIONS.length).toBeGreaterThan(0);
+  it('every KNOWN_VIOLATIONS entry (if any) has a file, specifier, and one-line reason', () => {
+    // The original 8-entry baseline was fully converted in Issue #1238;
+    // the array is expected to be empty until a new justified exception is
+    // added (see the file-exclusive exception in testing.md Anti-Pattern #2).
+    expect(KNOWN_VIOLATIONS.length).toBeGreaterThanOrEqual(0);
     for (const entry of KNOWN_VIOLATIONS) {
       expect(typeof entry.file).toBe('string');
       expect(typeof entry.specifier).toBe('string');

--- a/scripts/check-mock-module-poisoners.mjs
+++ b/scripts/check-mock-module-poisoners.mjs
@@ -340,56 +340,15 @@ export async function runCheck({ cwd = process.cwd(), files, allowlist = KNOWN_V
 
 // ---------------------------------------------------------------------------
 // KNOWN_VIOLATIONS — see the file header for the allowlist strategy. Keys
-// are `file + specifier` pairs. Enumerated by running this detector
-// against `main` at the time this script landed (Issue #1226); the
-// follow-up cleanup Issue (see .claude/rules/testing.md Anti-Pattern #2)
-// converts these to DI seam / spyOn / central registry migration per the
-// #977 playbook. Remove an entry here in the same PR that converts it —
-// a stale entry left behind fails CI by design.
+// are `file + specifier` pairs. The original 8-entry baseline (enumerated
+// against `main` at the time this script landed, Issue #1226) was fully
+// converted to DI seam / spyOn / central-registry migration per the #977
+// playbook in Issue #1238. Empty now; a new justified entry is added the
+// same way -- via the permitted file-exclusive exception in
+// `.claude/rules/testing.md` Anti-Pattern #2 -- and removed in the same PR
+// that converts it. A stale entry left behind fails CI by design.
 // ---------------------------------------------------------------------------
-export const KNOWN_VIOLATIONS = [
-  {
-    file: 'packages/integration/src/paste-focus-isolation.test.tsx',
-    specifier: '@agent-console/client/src/lib/api',
-    reason:
-      'Live #1225-class poisoner: mocked here but imported for real by sibling integration tests in the same bun:test process; priority conversion target.',
-  },
-  {
-    file: 'packages/integration/src/paste-focus-isolation.test.tsx',
-    specifier: '@agent-console/client/src/lib/worker-websocket',
-    reason: 'Same file/priority as the api.ts entry above.',
-  },
-  {
-    file: 'packages/server/src/__tests__/api.test.ts',
-    specifier: '../lib/pty-provider.js',
-    reason: 'Ad-hoc baseline; large integration-style test file, not yet converted to DI.',
-  },
-  {
-    file: 'packages/server/src/__tests__/api.test.ts',
-    specifier: 'open',
-    reason: 'Ad-hoc baseline, duplicate of the system.test.ts open mock below.',
-  },
-  {
-    file: 'packages/server/src/routes/__tests__/system.test.ts',
-    specifier: 'open',
-    reason: 'Ad-hoc baseline, duplicate of the api.test.ts open mock above.',
-  },
-  {
-    file: 'packages/server/src/services/__tests__/worktree-creation-service.test.ts',
-    specifier: '../../lib/logger.js',
-    reason: 'Ad-hoc baseline; logger mock, candidate for DI conversion.',
-  },
-  {
-    file: 'packages/server/src/services/__tests__/worktree-deletion-service.test.ts',
-    specifier: '../../lib/logger.js',
-    reason: 'Ad-hoc baseline; logger mock, candidate for DI conversion.',
-  },
-  {
-    file: 'packages/server/src/services/inbound/__tests__/diff-worker-handler.test.ts',
-    specifier: '../../git-diff-service.js',
-    reason: 'Ad-hoc baseline; standalone function mock, candidate for DI via InboundHandlerDependencies.',
-  },
-];
+export const KNOWN_VIOLATIONS = [];
 
 // ---------------------------------------------------------------------------
 // CLI wrapper


### PR DESCRIPTION
Closes #1238

## Summary

Converts all 8 `KNOWN_VIOLATIONS` baseline entries from Issue #1226 (introduced by PR #1239) to cross-file-safe patterns, per the #977 playbook priority order (DI seam > `spyOn()` > fetch-level stub > central-registry migration).

| File | Specifier | Conversion |
|---|---|---|
| `packages/integration/src/paste-focus-isolation.test.tsx` | `@agent-console/client/src/lib/api` | Pattern 1 (DI seam, existing) |
| `packages/integration/src/paste-focus-isolation.test.tsx` | `@agent-console/client/src/lib/worker-websocket` | Deleted (mocked an export the real module doesn't have) |
| `packages/server/src/__tests__/api.test.ts` | `../lib/pty-provider.js` | Deleted (redundant duplicate of the sanctioned central-registry mock) |
| `packages/server/src/__tests__/api.test.ts` | `open` | Deleted (redundant duplicate; now imports the shared `mockOpen`) |
| `packages/server/src/routes/__tests__/system.test.ts` | `open` | Deleted (redundant duplicate; central-registry mock already active) |
| `packages/server/src/services/__tests__/worktree-creation-service.test.ts` | `../../lib/logger.js` | Deleted (vestigial -- real logger already silent in `NODE_ENV=test`) |
| `packages/server/src/services/__tests__/worktree-deletion-service.test.ts` | `../../lib/logger.js` | Deleted (same as above) |
| `packages/server/src/services/inbound/__tests__/diff-worker-handler.test.ts` | `../../git-diff-service.js` | Pattern 2 (`spyOn()` + `.mockRestore()`) |

### Priority item: `paste-focus-isolation.test.tsx`

This was the live `#1225`-class poisoner named in the Issue: it `mock.module()`'d `@agent-console/client/src/lib/api` (overriding `sendWorkerMessage`), which sibling integration tests (`system-api-boundary.test.ts`, `config-api-boundary.test.ts`, etc.) import for real in the same `bun:test` process.

Investigation found both mocks were leftover from before `MessagePanel` gained its current `onSend` prop -- `MessagePanel` no longer imports `sendWorkerMessage` or anything from `worker-websocket.ts` at all (it takes `onSend`/`onEscape` as injected callbacks), and `worker-websocket.ts` doesn't even export a `sendInput` function today. Fix: removed both `mock.module()` calls and passed `onSend: mock(() => Promise.resolve())` via the existing DI seam (also closes a latent gap where `defaultProps` omitted a required prop, invisible because `packages/integration` isn't part of `bun run typecheck`).

**Load-order-independence verification** (PR #1227 methodology -- forced deterministic order via a temp `src/__poison_check/` pair, not committed): with the *pre-fix* content forced to load before a probe that imports the real `sendWorkerMessage`, the probe observed a mock-stringified function (`"function () { [native code] }"`) instead of the real implementation's source -- confirming the poisoning. With the *post-fix* content, the probe passed in both load orders (poisoner-first and reversed). The real integration suite (`bun test --preload ./src/setup.ts src/`, 73 tests / 27 files) is also green.

### `pty-provider.js` / `open` duplicates (`api.test.ts`, `system.test.ts`)

Both files already import `./test-utils.js`, which is the sanctioned central mock registry and already registers equivalent `mock.module()` calls for `../lib/pty-provider.js` (its own `bunPtyProvider.spawn` mock) and `open` (via `mock-open-helper.ts`, re-exported as `mockOpen`). The two files' own local re-declarations were 100% redundant duplicates -- verified by deleting them and confirming all assertions still pass (`api.test.ts`: 137 tests; `system.test.ts`'s local `mockOpen` was never even asserted on). `api.test.ts` now imports the shared `mockOpen` from `test-utils.js` for its existing assertions.

### `logger.js` (`worktree-creation-service.test.ts`, `worktree-deletion-service.test.ts`)

`lib/logger.js`'s pino instance sets `enabled: !isTest`, and Bun sets `NODE_ENV=test` by default for `bun test` runs -- so the real logger is already silent. Verified empirically (removed the mock, ran both files, all 57 tests still pass) before deleting the mocks outright; no replacement mock needed.

### `git-diff-service.js` (`diff-worker-handler.test.ts`)

`handlers.ts` imports `triggerRefresh` directly at module scope (no DI seam via `InboundHandlerDependencies` today, contrary to the Issue's "candidate for DI" framing -- see the DI-gap note below). Per playbook priority, converted to `spyOn(gitDiffServiceModule, 'triggerRefresh')` + `.mockRestore()` in `afterEach` (Pattern 2) instead of adding a production DI seam in this test-only PR.

## Production DI gap found (reported, not fixed)

`packages/server/src/services/inbound/handlers.ts` imports `triggerRefresh` from `git-diff-service.js` as a bare module-level function call, with no seam through `InboundHandlerDependencies` (unlike `sessionManager`/`broadcastToApp`, which are already injected). The Issue's own baseline table flagged this as "candidate for DI via `InboundHandlerDependencies`". Since this PR's reversibility is scoped to test-only changes, I used `spyOn()` (next playbook priority) instead of adding the production seam. If threading `triggerRefresh` through `InboundHandlerDependencies` is wanted, that's a separate, reviewable production change -- happy to file a follow-up Issue if desired.

## Verification

- `bun run test` (full workspace) -- green, `TEST_EXIT: 0` (client 2075, shared 596, integration 73, server 3720+1 skip, embedded-agent 287, scripts/hooks 521 -- all 0 fail)
- `bun run check:mock-module` -- exit 0, `KNOWN_VIOLATIONS` is now `[]`
- `node .claude/skills/orchestrator/preflight-check.js` -- clean (no coverage gaps, no rule/skill duplication, no language violations, no blame-shift comments), exit 0
- `bun run typecheck` -- clean (ran as part of `bun run test`)

## CodeRabbit status

Two independent layers checked, per `coderabbit-ops`'s "fourth surface" guidance (commit-status `state` alone is not the verdict -- the `description` string is):

- **Local CLI** (`coderabbit review --agent --base main`): hung with no output until timeout. `coderabbit auth status` confirms **authentication, not rate-limiting**: `Status: signed out`, `Next step: coderabbit auth login`. This is the documented headless-worktree `automatic_login_failed` case (interactive login is required and unavailable here).
- **GitHub-side bot**: commit status is `state: success` / `description: "Review rate limited"` -- rate-limited, not a genuine clean review. `reviewDecision` is empty (no review submitted yet).

Both layers are currently unavailable for a genuine review (one by auth, one by rate-limit) -- distinct root causes on each surface. Flagging explicitly per the reversibility/verification requirements; owner or a session with interactive CodeRabbit auth, or a retry once the GitHub-side rate-limit clears, should confirm the review before merge.

## Reversibility

Test-only changes, no production behavior change (per the Issue's own reversibility note). The one production DI gap found during conversion is reported above, not applied.
