### PR TITLE
fix: scope Stop/Pause session pending state to the affected session

### DIFF
--- a/packages/client/src/__tests__/routes/WorktreeRow.test.tsx
+++ b/packages/client/src/__tests__/routes/WorktreeRow.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
 import { screen, cleanup } from '@testing-library/react';
 import { renderWithRouter } from '../../test/renderWithRouter';
-import { WorktreeDeletionTasksContext } from '../../contexts/root-contexts';
+import { WorktreeDeletionTasksContext, SessionStopTasksContext } from '../../contexts/root-contexts';
 import { setCapabilities } from '../../lib/capabilities';
 import { WorktreeRow, type WorktreeRowProps, type SessionWithActivity } from '../../routes/index';
 import type { UseWorktreeDeletionTasksReturn } from '../../hooks/useWorktreeDeletionTasks';
+import type { UseSessionStopTasksReturn } from '../../hooks/useSessionStopTasks';
 import type { Worktree, WorktreeSession, WorktreeDeletionTask, Session } from '@agent-console/shared';
 
 // lib/capabilities reads from a module-level cache populated at app boot via the
@@ -85,11 +86,28 @@ function createMockDeletionContext(
   };
 }
 
+// WorktreeRow always calls useSessionStopTasksContext() (Issue #1247), so every
+// render needs a Provider ancestor even when the test doesn't exercise a
+// stop/pause task.
+function createMockSessionStopTasks(
+  overrides?: Partial<UseSessionStopTasksReturn>
+): UseSessionStopTasksReturn {
+  return {
+    tasks: [],
+    addTask: mock(() => true),
+    removeTask: mock(() => {}),
+    getTask: mock(() => undefined),
+    markAsFailed: mock(() => {}),
+    ...overrides,
+  };
+}
+
 // -- Render helper --
 
 async function renderWorktreeRow(
   props: Partial<WorktreeRowProps> = {},
-  deletionContext?: UseWorktreeDeletionTasksReturn
+  deletionContext?: UseWorktreeDeletionTasksReturn,
+  sessionStopTasks?: UseSessionStopTasksReturn
 ) {
   const defaultProps: WorktreeRowProps = {
     worktree: createTestWorktree(),
@@ -100,10 +118,13 @@ async function renderWorktreeRow(
   };
 
   const ctx = deletionContext ?? createMockDeletionContext();
+  const stopTasksCtx = sessionStopTasks ?? createMockSessionStopTasks();
 
   return renderWithRouter(
     <WorktreeDeletionTasksContext.Provider value={ctx}>
-      <WorktreeRow {...defaultProps} />
+      <SessionStopTasksContext.Provider value={stopTasksCtx}>
+        <WorktreeRow {...defaultProps} />
+      </SessionStopTasksContext.Provider>
     </WorktreeDeletionTasksContext.Provider>
   );
 }

--- a/packages/client/src/components/QuickSessionSettings.tsx
+++ b/packages/client/src/components/QuickSessionSettings.tsx
@@ -14,6 +14,8 @@ interface QuickSessionSettingsProps {
   session?: Session;
   /** Activity states for workers in this session: { workerId: state } */
   workerActivityStates?: Record<string, AgentActivityState>;
+  /** Disables the "Stop Session" menu entry, e.g. while a stop task is already in flight */
+  stopDisabled?: boolean;
 }
 
 type DialogType = QuickMenuAction | null;
@@ -24,6 +26,7 @@ export function QuickSessionSettings({
   initialPrompt,
   session,
   workerActivityStates,
+  stopDisabled,
 }: QuickSessionSettingsProps) {
   const [activeDialog, setActiveDialog] = useState<DialogType>(null);
 
@@ -39,6 +42,7 @@ export function QuickSessionSettings({
     <>
       <QuickSessionSettingsMenu
         initialPrompt={initialPrompt}
+        stopDisabled={stopDisabled}
         onMenuAction={handleMenuAction}
       />
 

--- a/packages/client/src/components/SessionSettings.tsx
+++ b/packages/client/src/components/SessionSettings.tsx
@@ -21,6 +21,8 @@ interface SessionSettingsProps {
   session?: Session;
   /** Activity states for workers in this session: { workerId: state } */
   workerActivityStates?: Record<string, AgentActivityState>;
+  /** Disables the "Pause" menu entry, e.g. while a stop/pause task is already in flight */
+  pauseDisabled?: boolean;
   onBranchChange?: (newBranch: string) => void;
   onTitleChange?: (newTitle: string) => void;
   onSessionRestart?: () => void;
@@ -38,6 +40,7 @@ export function SessionSettings({
   isMainWorktree,
   session,
   workerActivityStates,
+  pauseDisabled,
   onBranchChange,
   onTitleChange,
   onSessionRestart,
@@ -59,6 +62,7 @@ export function SessionSettings({
         worktreePath={worktreePath}
         initialPrompt={initialPrompt}
         isMainWorktree={isMainWorktree}
+        pauseDisabled={pauseDisabled}
         onMenuAction={handleMenuAction}
       />
 

--- a/packages/client/src/components/__tests__/QuickSessionSettings.test.tsx
+++ b/packages/client/src/components/__tests__/QuickSessionSettings.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { QuickSessionSettings } from '../QuickSessionSettings';
+import { SessionStopTasksContext } from '../../contexts/root-contexts';
+import type { UseSessionStopTasksReturn } from '../../hooks/useSessionStopTasks';
+
+afterEach(() => {
+  cleanup();
+});
+
+function createMockSessionStopTasks(): UseSessionStopTasksReturn {
+  return {
+    tasks: [],
+    addTask: mock(() => true),
+    removeTask: mock(() => {}),
+    getTask: mock(() => undefined),
+    markAsFailed: mock(() => {}),
+  };
+}
+
+function renderQuickSessionSettings(props: Partial<React.ComponentProps<typeof QuickSessionSettings>> = {}) {
+  // QuickSessionSettings always mounts EndSessionDialog (visibility is
+  // controlled by its `open` prop, not conditional rendering), so it always
+  // calls useSessionStopTasksContext() and requires a Provider ancestor.
+  return render(
+    <SessionStopTasksContext.Provider value={createMockSessionStopTasks()}>
+      <QuickSessionSettings sessionId="session-1" {...props} />
+    </SessionStopTasksContext.Provider>
+  );
+}
+
+describe('QuickSessionSettings / stopDisabled threading (Issue #1247)', () => {
+  it('disables the Stop Session menu entry when stopDisabled is true', async () => {
+    renderQuickSessionSettings({ stopDisabled: true });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Session settings' }));
+    });
+
+    const stopButton = screen.getByRole('button', { name: /Stop Session/ });
+    expect((stopButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('leaves the Stop Session menu entry enabled when stopDisabled is false/omitted', async () => {
+    renderQuickSessionSettings();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Session settings' }));
+    });
+
+    const stopButton = screen.getByRole('button', { name: /Stop Session/ });
+    expect((stopButton as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/packages/client/src/components/__tests__/SessionSettings.test.tsx
+++ b/packages/client/src/components/__tests__/SessionSettings.test.tsx
@@ -3,8 +3,9 @@ import { screen, fireEvent, waitFor, act, cleanup, render } from '@testing-libra
 import { createRootRoute, createRouter, createMemoryHistory, RouterProvider } from '@tanstack/react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SessionSettings } from '../SessionSettings';
-import { WorktreeDeletionTasksContext } from '../../contexts/root-contexts';
+import { WorktreeDeletionTasksContext, SessionStopTasksContext } from '../../contexts/root-contexts';
 import type { UseWorktreeDeletionTasksReturn } from '../../hooks/useWorktreeDeletionTasks';
+import type { UseSessionStopTasksReturn } from '../../hooks/useSessionStopTasks';
 
 // Helper to create mock Response
 function createMockResponse(body: unknown, options: { status?: number; ok?: boolean } = {}) {
@@ -37,11 +38,26 @@ function createMockDeletionTasks(): UseWorktreeDeletionTasksReturn {
   };
 }
 
+// Create mock session stop tasks context. SessionSettings always mounts
+// PauseSessionDialog (visibility is controlled by its `open` prop, not by
+// conditional rendering), so it always calls useSessionStopTasksContext()
+// and requires a Provider ancestor.
+function createMockSessionStopTasks(): UseSessionStopTasksReturn {
+  return {
+    tasks: [],
+    addTask: mock(() => true),
+    removeTask: mock(() => {}),
+    getTask: mock(() => undefined),
+    markAsFailed: mock(() => {}),
+  };
+}
+
 // Helper to render with router and context
 async function renderWithRouterAndContext(
   ui: React.ReactNode,
   deletionTasks: UseWorktreeDeletionTasksReturn,
-  initialPath = '/'
+  initialPath = '/',
+  sessionStopTasks: UseSessionStopTasksReturn = createMockSessionStopTasks()
 ) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -64,7 +80,9 @@ async function renderWithRouterAndContext(
   const rootRoute = createRootRoute({
     component: () => (
       <WorktreeDeletionTasksContext.Provider value={deletionTasks}>
-        {ui}
+        <SessionStopTasksContext.Provider value={sessionStopTasks}>
+          {ui}
+        </SessionStopTasksContext.Provider>
       </WorktreeDeletionTasksContext.Provider>
     ),
   });
@@ -221,6 +239,36 @@ describe('SessionSettings', () => {
         );
         expect(deleteCall).toBeTruthy();
       });
+    });
+  });
+
+  describe('pauseDisabled threading (Issue #1247)', () => {
+    it('disables the Pause menu entry when pauseDisabled is true', async () => {
+      await renderWithRouterAndContext(
+        <SessionSettings {...defaultProps} pauseDisabled />,
+        mockDeletionTasks
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTitle('Session settings'));
+      });
+
+      const pauseButton = screen.getByRole('button', { name: /Pause/ });
+      expect((pauseButton as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('leaves the Pause menu entry enabled when pauseDisabled is false/omitted', async () => {
+      await renderWithRouterAndContext(
+        <SessionSettings {...defaultProps} />,
+        mockDeletionTasks
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTitle('Session settings'));
+      });
+
+      const pauseButton = screen.getByRole('button', { name: /Pause/ });
+      expect((pauseButton as HTMLButtonElement).disabled).toBe(false);
     });
   });
 });

--- a/packages/client/src/components/sessions/EndSessionDialog.tsx
+++ b/packages/client/src/components/sessions/EndSessionDialog.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
-import { useMutation } from '@tanstack/react-query';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -10,8 +8,8 @@ import {
   AlertDialogFooter,
   AlertDialogCancel,
 } from '../ui/alert-dialog';
-import { ButtonSpinner } from '../ui/Spinner';
 import { deleteSession } from '../../lib/api';
+import { useSessionStopTasksContext } from '../../routes/__root';
 import type { Session, AgentActivityState } from '@agent-console/shared';
 
 export interface EndSessionDialogProps {
@@ -25,8 +23,12 @@ export interface EndSessionDialogProps {
 }
 
 /**
- * Dialog for ending (deleting) a quick session.
- * Quick sessions are deleted synchronously without task management.
+ * Dialog for ending (stopping/deleting) a quick session.
+ *
+ * The pending/error state lives in `SessionStopTasksContext` (scoped to the
+ * affected session -- dashboard row + session page banner) instead of this
+ * modal, so stopping a session no longer freezes the whole app for the
+ * server round-trip. See DeleteWorktreeDialog for the sibling pattern.
  */
 export function EndSessionDialog({
   open,
@@ -37,7 +39,7 @@ export function EndSessionDialog({
   workerActivityStates,
 }: EndSessionDialogProps) {
   const navigate = useNavigate();
-  const [error, setError] = useState<string | null>(null);
+  const { addTask, markAsFailed } = useSessionStopTasksContext();
 
   // Check if any agent or embedded-agent workers are in 'active' or 'asking' state
   // (embedded-agent workers only ever report 'active'/'idle', never 'asking')
@@ -46,34 +48,28 @@ export function EndSessionDialog({
       (workerActivityStates[w.id] === 'active' || workerActivityStates[w.id] === 'asking')
   );
 
-  const deleteMutation = useMutation({
-    mutationFn: () => deleteSession(sessionId),
-    onSuccess: () => {
-      // Close dialog and navigate immediately
-      onOpenChange(false);
-      navigate({ to: '/' });
-      // Session will be removed from UI when WebSocket broadcast arrives from server
-      // (no optimistic update to avoid race condition/flicker)
-    },
-    onError: (err) => {
-      setError(err instanceof Error ? err.message : 'Failed to stop session');
-    },
-  });
+  const handleStop = async () => {
+    const added = addTask({ sessionId, action: 'stop', sessionTitle });
+    if (!added) return;
 
-  const handleConfirm = () => {
-    setError(null);
-    deleteMutation.mutate();
-  };
+    // Close dialog and navigate immediately
+    onOpenChange(false);
+    navigate({ to: '/' });
 
-  const handleClose = () => {
-    if (!deleteMutation.isPending) {
-      setError(null);
-      onOpenChange(false);
+    // Session will be removed from UI when WebSocket broadcast arrives from server
+    // (no optimistic update to avoid race condition/flicker)
+
+    try {
+      await deleteSession(sessionId);
+      // Success will be handled via WebSocket (session-deleted / sessions-sync).
+    } catch (err) {
+      // If API call fails immediately (network error), mark task as failed
+      markAsFailed(sessionId, err instanceof Error ? err.message : 'Failed to stop session');
     }
   };
 
   return (
-    <AlertDialog open={open} onOpenChange={handleClose}>
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle className="text-red-400">Stop Session</AlertDialogTitle>
@@ -94,26 +90,18 @@ export function EndSessionDialog({
               <p className="text-xs text-gray-500">
                 This will terminate all running workers and close their terminals.
               </p>
-              {error && (
-                <p className="text-xs text-red-400 bg-red-950/50 p-2 rounded">
-                  {error}
-                </p>
-              )}
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={deleteMutation.isPending}>
+          <AlertDialogCancel>
             Cancel
           </AlertDialogCancel>
           <button
-            onClick={handleConfirm}
+            onClick={handleStop}
             className="btn btn-danger"
-            disabled={deleteMutation.isPending}
           >
-            <ButtonSpinner isPending={deleteMutation.isPending} pendingText="Stopping...">
-              Stop Session
-            </ButtonSpinner>
+            Stop Session
           </button>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/packages/client/src/components/sessions/PauseSessionDialog.tsx
+++ b/packages/client/src/components/sessions/PauseSessionDialog.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
-import { useMutation } from '@tanstack/react-query';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -10,8 +8,8 @@ import {
   AlertDialogFooter,
   AlertDialogCancel,
 } from '../ui/alert-dialog';
-import { ButtonSpinner } from '../ui/Spinner';
 import { pauseSession } from '../../lib/api';
+import { useSessionStopTasksContext } from '../../routes/__root';
 import type { Session, AgentActivityState } from '@agent-console/shared';
 
 export interface PauseSessionDialogProps {
@@ -27,6 +25,11 @@ export interface PauseSessionDialogProps {
 /**
  * Dialog for pausing a worktree session.
  * Pausing kills PTY processes but preserves session data for later resume.
+ *
+ * The pending/error state lives in `SessionStopTasksContext` (scoped to the
+ * affected session -- dashboard row + session page banner) instead of this
+ * modal, so pausing a session no longer freezes the whole app for the
+ * server round-trip. See DeleteWorktreeDialog for the sibling pattern.
  */
 export function PauseSessionDialog({
   open,
@@ -37,7 +40,7 @@ export function PauseSessionDialog({
   workerActivityStates,
 }: PauseSessionDialogProps) {
   const navigate = useNavigate();
-  const [error, setError] = useState<string | null>(null);
+  const { addTask, markAsFailed } = useSessionStopTasksContext();
 
   // Check if any agent or embedded-agent workers are in 'active' or 'asking' state
   // (embedded-agent workers only ever report 'active'/'idle', never 'asking')
@@ -46,33 +49,27 @@ export function PauseSessionDialog({
       (workerActivityStates[w.id] === 'active' || workerActivityStates[w.id] === 'asking')
   );
 
-  const pauseMutation = useMutation({
-    mutationFn: () => pauseSession(sessionId),
-    onSuccess: () => {
-      // Close dialog and navigate immediately
-      onOpenChange(false);
-      navigate({ to: '/' });
-      // Session will be updated when WebSocket broadcast arrives from server
-    },
-    onError: (err) => {
-      setError(err instanceof Error ? err.message : 'Failed to pause session');
-    },
-  });
+  const handlePause = async () => {
+    const added = addTask({ sessionId, action: 'pause', sessionTitle });
+    if (!added) return;
 
-  const handleConfirm = () => {
-    setError(null);
-    pauseMutation.mutate();
-  };
+    // Close dialog and navigate immediately
+    onOpenChange(false);
+    navigate({ to: '/' });
 
-  const handleClose = () => {
-    if (!pauseMutation.isPending) {
-      setError(null);
-      onOpenChange(false);
+    // Session will be updated when WebSocket broadcast arrives from server
+
+    try {
+      await pauseSession(sessionId);
+      // Success will be handled via WebSocket (session-paused / sessions-sync).
+    } catch (err) {
+      // If API call fails immediately (network error), mark task as failed
+      markAsFailed(sessionId, err instanceof Error ? err.message : 'Failed to pause session');
     }
   };
 
   return (
-    <AlertDialog open={open} onOpenChange={handleClose}>
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle className="text-yellow-400">Pause Session</AlertDialogTitle>
@@ -93,26 +90,18 @@ export function PauseSessionDialog({
               <p className="text-xs text-gray-500">
                 Session data will be preserved. You can resume this session later from the dashboard.
               </p>
-              {error && (
-                <p className="text-xs text-red-400 bg-red-950/50 p-2 rounded">
-                  {error}
-                </p>
-              )}
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={pauseMutation.isPending}>
+          <AlertDialogCancel>
             Cancel
           </AlertDialogCancel>
           <button
-            onClick={handleConfirm}
+            onClick={handlePause}
             className="btn bg-yellow-600 hover:bg-yellow-500 text-white"
-            disabled={pauseMutation.isPending}
           >
-            <ButtonSpinner isPending={pauseMutation.isPending} pendingText="Pausing...">
-              Pause
-            </ButtonSpinner>
+            Pause
           </button>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/packages/client/src/components/sessions/QuickSessionSettingsMenu.tsx
+++ b/packages/client/src/components/sessions/QuickSessionSettingsMenu.tsx
@@ -9,11 +9,14 @@ export type QuickMenuAction = 'view-initial-prompt' | 'stop-session';
 
 export interface QuickSessionSettingsMenuProps {
   initialPrompt?: string;
+  /** Disables the "Stop Session" menu entry, e.g. while a stop task is already in flight */
+  stopDisabled?: boolean;
   onMenuAction: (action: QuickMenuAction) => void;
 }
 
 export function QuickSessionSettingsMenu({
   initialPrompt,
+  stopDisabled = false,
   onMenuAction,
 }: QuickSessionSettingsMenuProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -82,7 +85,8 @@ export function QuickSessionSettingsMenu({
             )}
             <button
               onClick={() => handleMenuAction('stop-session')}
-              className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2"
+              disabled={stopDisabled}
+              className="w-full px-4 py-2 text-left text-sm text-red-400 hover:bg-slate-700 hover:text-red-300 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-red-400"
             >
               <StopIcon />
               Stop Session

--- a/packages/client/src/components/sessions/SessionPage.tsx
+++ b/packages/client/src/components/sessions/SessionPage.tsx
@@ -25,6 +25,9 @@ import type { AgentDefinition, Session, Worker } from '@agent-console/shared';
 import { MessagePanel, type MessagePanelHandle } from './MessagePanel';
 import { MemoPanel } from './MemoPanel';
 import { useAgents } from '../../hooks/useAgents';
+import { useSessionStopTasksContext } from '../../routes/__root';
+import type { SessionStopTask } from '../../hooks/useSessionStopTasks';
+import { Spinner } from '../ui/Spinner';
 import { logger } from '../../lib/logger';
 
 export { sessionToPageState } from './hooks/useSessionPageState';
@@ -96,6 +99,18 @@ export interface SessionPageProps {
  *
  * @internal Exported for testing
  */
+/**
+ * Resolves the non-modal banner text for an in-flight stop/pause task,
+ * shown on SessionPage while a `SessionStopTasksContext` task targets the
+ * displayed session. Extracted for testability without a full component
+ * render, mirroring `resolveShouldStripScrollback` above.
+ *
+ * @internal Exported for testing
+ */
+export function getSessionStopTaskBannerText(task: SessionStopTask): string {
+  return task.action === 'pause' ? 'Pausing this session...' : 'Stopping this session...';
+}
+
 export function resolveShouldStripScrollback(
   workers: Worker[],
   activeTabId: string | null,
@@ -112,6 +127,8 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
   const [exitInfo, setExitInfo] = useState<{ code: number; signal: string | null } | undefined>();
   const { errorDialogProps, showError } = useErrorDialog();
   const { agents } = useAgents();
+  const { getTask: getStopTask, removeTask: removeStopTask } = useSessionStopTasksContext();
+  const stopTask = getStopTask(sessionId);
   const messagePanelRef = useRef<MessagePanelHandle>(null);
   const navigate = useNavigate();
   // State for resuming paused session
@@ -558,6 +575,25 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
 
   return (
     <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+      {/* Non-modal Stop/Pause task banner (scoped to this session) */}
+      {stopTask && (
+        stopTask.error ? (
+          <div className="bg-red-950/50 border-b border-red-900 px-3 py-1.5 flex items-center justify-between gap-2 shrink-0 text-xs text-red-400">
+            <span>{stopTask.error}</span>
+            <button
+              onClick={() => removeStopTask(stopTask.sessionId)}
+              className="btn text-xs bg-slate-700 hover:bg-slate-600 shrink-0"
+            >
+              Dismiss
+            </button>
+          </div>
+        ) : (
+          <div className="bg-yellow-950/50 border-b border-yellow-900 px-3 py-1.5 flex items-center gap-2 shrink-0 text-xs text-yellow-400">
+            <Spinner size="sm" />
+            {getSessionStopTaskBannerText(stopTask)}
+          </div>
+        )
+      )}
       {/* Tab bar with worker tabs */}
       <div className="bg-slate-800 border-b border-slate-600 flex items-center shrink-0">
         {/* Worker tabs */}
@@ -582,6 +618,7 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
               isMainWorktree={session.isMainWorktree}
               session={session}
               workerActivityStates={workerActivityStates}
+              pauseDisabled={Boolean(stopTask)}
             />
           ) : (
             <QuickSessionSettings
@@ -590,6 +627,7 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
               initialPrompt={session.initialPrompt}
               session={session}
               workerActivityStates={workerActivityStates}
+              stopDisabled={Boolean(stopTask)}
             />
           )}
         </div>

--- a/packages/client/src/components/sessions/SessionPage.tsx
+++ b/packages/client/src/components/sessions/SessionPage.tsx
@@ -578,7 +578,7 @@ export function SessionPage({ sessionId, workerId: urlWorkerId }: SessionPagePro
       {/* Non-modal Stop/Pause task banner (scoped to this session) */}
       {stopTask && (
         stopTask.error ? (
-          <div className="bg-red-950/50 border-b border-red-900 px-3 py-1.5 flex items-center justify-between gap-2 shrink-0 text-xs text-red-400">
+          <div role="alert" className="bg-red-950/50 border-b border-red-900 px-3 py-1.5 flex items-center justify-between gap-2 shrink-0 text-xs text-red-400">
             <span>{stopTask.error}</span>
             <button
               onClick={() => removeStopTask(stopTask.sessionId)}

--- a/packages/client/src/components/sessions/SessionSettingsMenu.tsx
+++ b/packages/client/src/components/sessions/SessionSettingsMenu.tsx
@@ -25,6 +25,8 @@ export interface SessionSettingsMenuProps {
   worktreePath: string;
   initialPrompt?: string;
   isMainWorktree: boolean;
+  /** Disables the "Pause" menu entry, e.g. while a stop/pause task is already in flight */
+  pauseDisabled?: boolean;
   onMenuAction: (action: MenuAction) => void;
 }
 
@@ -33,6 +35,7 @@ export function SessionSettingsMenu({
   worktreePath,
   initialPrompt,
   isMainWorktree,
+  pauseDisabled = false,
   onMenuAction,
 }: SessionSettingsMenuProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -190,7 +193,8 @@ export function SessionSettingsMenu({
             <div className="border-t border-slate-700 my-1" />
             <button
               onClick={() => handleMenuAction('pause')}
-              className="w-full px-4 py-2 text-left text-sm text-yellow-400 hover:bg-slate-700 hover:text-yellow-300 flex items-center gap-2"
+              disabled={pauseDisabled}
+              className="w-full px-4 py-2 text-left text-sm text-yellow-400 hover:bg-slate-700 hover:text-yellow-300 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-yellow-400"
             >
               <PauseIcon />
               Pause

--- a/packages/client/src/components/sessions/__tests__/EndSessionDialog.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/EndSessionDialog.test.tsx
@@ -1,11 +1,22 @@
 import { describe, it, expect, mock, afterEach, afterAll } from 'bun:test';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { EndSessionDialog, type EndSessionDialogProps } from '../EndSessionDialog';
+import { SessionStopTasksContext } from '../../../contexts/root-contexts';
+import { useSessionStopTasks, type UseSessionStopTasksReturn } from '../../../hooks/useSessionStopTasks';
+import { renderWithRouter } from '../../../test/renderWithRouter';
 import type { Session, Worker, AgentActivityState } from '@agent-console/shared';
 
 const originalFetch = globalThis.fetch;
-const mockFetch = mock(() => Promise.resolve(new Response()));
+let resolveDeleteSession: (() => void) | null = null;
+let rejectDeleteSession: ((err: Error) => void) | null = null;
+const mockFetch = mock(
+  () =>
+    new Promise<Response>((resolve, reject) => {
+      resolveDeleteSession = () => resolve(new Response(null, { status: 204 }));
+      rejectDeleteSession = (err) => reject(err);
+    })
+);
 globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} });
 
 afterAll(() => {
@@ -14,6 +25,9 @@ afterAll(() => {
 
 afterEach(() => {
   cleanup();
+  mockFetch.mockClear();
+  resolveDeleteSession = null;
+  rejectDeleteSession = null;
 });
 
 function createMockSession(workers: Worker[]): Session {
@@ -38,12 +52,29 @@ function embeddedAgentWorker(id: string): Worker {
   return { id, type: 'embedded-agent', name: 'Embedded Agent', createdAt: '2026-01-01T00:00:00Z', embeddedAgentId: 'embedded-1', activated: true };
 }
 
-function TestWrapper({ children }: { children: React.ReactNode }) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+function createMockSessionStopTasks(overrides: Partial<UseSessionStopTasksReturn> = {}): UseSessionStopTasksReturn {
+  return {
+    tasks: [],
+    addTask: mock(() => true),
+    removeTask: mock(() => {}),
+    getTask: mock(() => undefined),
+    markAsFailed: mock(() => {}),
+    ...overrides,
+  };
 }
 
-function renderDialog(props: Partial<EndSessionDialogProps> = {}) {
+function TestWrapper({ children, sessionStopTasks }: { children: React.ReactNode; sessionStopTasks: UseSessionStopTasksReturn }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <SessionStopTasksContext.Provider value={sessionStopTasks}>
+        {children}
+      </SessionStopTasksContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+function renderDialog(props: Partial<EndSessionDialogProps> = {}, sessionStopTasks: UseSessionStopTasksReturn = createMockSessionStopTasks()) {
   const defaultProps: EndSessionDialogProps = {
     open: true,
     onOpenChange: mock(() => {}),
@@ -51,7 +82,7 @@ function renderDialog(props: Partial<EndSessionDialogProps> = {}) {
   };
 
   return render(
-    <TestWrapper>
+    <TestWrapper sessionStopTasks={sessionStopTasks}>
       <EndSessionDialog {...defaultProps} {...props} />
     </TestWrapper>
   );
@@ -100,5 +131,106 @@ describe('EndSessionDialog', () => {
     renderDialog();
 
     expect(screen.queryByText(WARNING_TEXT)).toBeNull();
+  });
+});
+
+/**
+ * Tests for Issue #1247 -- Stop Session no longer holds a modal open while the
+ * server round-trip is in flight. These tests exercise the confirm handler's
+ * synchronous close + fire-and-forget API call, mirroring DeleteWorktreeDialog's
+ * pattern. A real router (via renderWithRouter) and a real
+ * SessionStopTasksContext.Provider are used instead of mock.module(), which is
+ * process-global in bun:test and would poison other test files that import
+ * routes/__root or contexts/root-contexts for real (testing.md Anti-Pattern #2).
+ */
+describe('EndSessionDialog / Issue #1247 scoped pending state', () => {
+  async function renderWithRouterAndContext(
+    props: Partial<EndSessionDialogProps> = {},
+    sessionStopTasks: UseSessionStopTasksReturn = createMockSessionStopTasks()
+  ) {
+    const defaultProps: EndSessionDialogProps = {
+      open: true,
+      onOpenChange: mock(() => {}),
+      sessionId: 'session-1',
+    };
+
+    return renderWithRouter(
+      <SessionStopTasksContext.Provider value={sessionStopTasks}>
+        <EndSessionDialog {...defaultProps} {...props} />
+      </SessionStopTasksContext.Provider>
+    );
+  }
+
+  it('closes the dialog synchronously on confirm, without awaiting the deleteSession fetch call', async () => {
+    // POLARITY CHECK (workflow.md TDD requirement): this exact assertion was
+    // run against the pre-conversion EndSessionDialog.tsx (the useMutation +
+    // isPending-gated AlertDialog implementation) and FAILED there, because
+    // the old handleClose guarded onOpenChange(false) behind
+    // `!deleteMutation.isPending` -- the dialog stayed open until the fetch
+    // promise settled. It passes here against the converted implementation,
+    // which calls onOpenChange(false) synchronously in handleStop before ever
+    // awaiting deleteSession().
+    const onOpenChange = mock(() => {});
+    await renderWithRouterAndContext({ onOpenChange });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop Session' }));
+
+    // Assert synchronously (before resolving/flushing the mocked fetch promise).
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    // The underlying fetch call has been made, but is still unresolved.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(resolveDeleteSession).not.toBeNull();
+
+    // Clean up: resolve the pending fetch so the test doesn't leak a dangling promise.
+    resolveDeleteSession?.();
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+  });
+
+  it('double-clicking confirm before the dialog unmounts results in exactly one deleteSession call', async () => {
+    // Uses the REAL useSessionStopTasks hook (not a mock) so addTask's
+    // at-most-one-per-session dedupe is actually exercised -- a mock that
+    // unconditionally returns `true` would not catch a regression where the
+    // guard `if (!added) return;` is removed from handleStop.
+    function RealSessionStopTasksProvider({ children }: { children: React.ReactNode }) {
+      const sessionStopTasks = useSessionStopTasks();
+      return (
+        <SessionStopTasksContext.Provider value={sessionStopTasks}>
+          {children}
+        </SessionStopTasksContext.Provider>
+      );
+    }
+
+    const defaultProps: EndSessionDialogProps = {
+      open: true,
+      onOpenChange: mock(() => {}),
+      sessionId: 'session-1',
+    };
+    await renderWithRouter(
+      <RealSessionStopTasksProvider>
+        <EndSessionDialog {...defaultProps} />
+      </RealSessionStopTasksProvider>
+    );
+
+    const button = screen.getByRole('button', { name: 'Stop Session' });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    resolveDeleteSession?.();
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+  });
+
+  it('calls markAsFailed with a message when deleteSession rejects', async () => {
+    const sessionStopTasks = createMockSessionStopTasks();
+    await renderWithRouterAndContext({}, sessionStopTasks);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop Session' }));
+
+    rejectDeleteSession?.(new Error('Network error'));
+
+    await waitFor(() => {
+      expect(sessionStopTasks.markAsFailed).toHaveBeenCalledWith('session-1', 'Network error');
+    });
   });
 });

--- a/packages/client/src/components/sessions/__tests__/PauseSessionDialog.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/PauseSessionDialog.test.tsx
@@ -1,11 +1,22 @@
 import { describe, it, expect, mock, afterEach, afterAll } from 'bun:test';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PauseSessionDialog, type PauseSessionDialogProps } from '../PauseSessionDialog';
+import { SessionStopTasksContext } from '../../../contexts/root-contexts';
+import { useSessionStopTasks, type UseSessionStopTasksReturn } from '../../../hooks/useSessionStopTasks';
+import { renderWithRouter } from '../../../test/renderWithRouter';
 import type { Session, Worker, AgentActivityState } from '@agent-console/shared';
 
 const originalFetch = globalThis.fetch;
-const mockFetch = mock(() => Promise.resolve(new Response()));
+let resolvePauseSession: (() => void) | null = null;
+let rejectPauseSession: ((err: Error) => void) | null = null;
+const mockFetch = mock(
+  () =>
+    new Promise<Response>((resolve, reject) => {
+      resolvePauseSession = () => resolve(new Response(null, { status: 204 }));
+      rejectPauseSession = (err) => reject(err);
+    })
+);
 globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} });
 
 afterAll(() => {
@@ -14,6 +25,9 @@ afterAll(() => {
 
 afterEach(() => {
   cleanup();
+  mockFetch.mockClear();
+  resolvePauseSession = null;
+  rejectPauseSession = null;
 });
 
 function createMockSession(workers: Worker[]): Session {
@@ -42,12 +56,29 @@ function embeddedAgentWorker(id: string): Worker {
   return { id, type: 'embedded-agent', name: 'Embedded Agent', createdAt: '2026-01-01T00:00:00Z', embeddedAgentId: 'embedded-1', activated: true };
 }
 
-function TestWrapper({ children }: { children: React.ReactNode }) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+function createMockSessionStopTasks(overrides: Partial<UseSessionStopTasksReturn> = {}): UseSessionStopTasksReturn {
+  return {
+    tasks: [],
+    addTask: mock(() => true),
+    removeTask: mock(() => {}),
+    getTask: mock(() => undefined),
+    markAsFailed: mock(() => {}),
+    ...overrides,
+  };
 }
 
-function renderDialog(props: Partial<PauseSessionDialogProps> = {}) {
+function TestWrapper({ children, sessionStopTasks }: { children: React.ReactNode; sessionStopTasks: UseSessionStopTasksReturn }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <SessionStopTasksContext.Provider value={sessionStopTasks}>
+        {children}
+      </SessionStopTasksContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+function renderDialog(props: Partial<PauseSessionDialogProps> = {}, sessionStopTasks: UseSessionStopTasksReturn = createMockSessionStopTasks()) {
   const defaultProps: PauseSessionDialogProps = {
     open: true,
     onOpenChange: mock(() => {}),
@@ -55,7 +86,7 @@ function renderDialog(props: Partial<PauseSessionDialogProps> = {}) {
   };
 
   return render(
-    <TestWrapper>
+    <TestWrapper sessionStopTasks={sessionStopTasks}>
       <PauseSessionDialog {...defaultProps} {...props} />
     </TestWrapper>
   );
@@ -104,5 +135,104 @@ describe('PauseSessionDialog', () => {
     renderDialog();
 
     expect(screen.queryByText(WARNING_TEXT)).toBeNull();
+  });
+});
+
+/**
+ * Tests for Issue #1247 -- Pause Session no longer holds a modal open while the
+ * server round-trip is in flight. These tests exercise the confirm handler's
+ * synchronous close + fire-and-forget API call, mirroring DeleteWorktreeDialog's
+ * pattern. A real router (via renderWithRouter) and a real
+ * SessionStopTasksContext.Provider are used instead of mock.module(), which is
+ * process-global in bun:test and would poison other test files that import
+ * routes/__root or contexts/root-contexts for real (testing.md Anti-Pattern #2).
+ */
+describe('PauseSessionDialog / Issue #1247 scoped pending state', () => {
+  async function renderWithRouterAndContext(
+    props: Partial<PauseSessionDialogProps> = {},
+    sessionStopTasks: UseSessionStopTasksReturn = createMockSessionStopTasks()
+  ) {
+    const defaultProps: PauseSessionDialogProps = {
+      open: true,
+      onOpenChange: mock(() => {}),
+      sessionId: 'session-1',
+    };
+
+    return renderWithRouter(
+      <SessionStopTasksContext.Provider value={sessionStopTasks}>
+        <PauseSessionDialog {...defaultProps} {...props} />
+      </SessionStopTasksContext.Provider>
+    );
+  }
+
+  it('closes the dialog synchronously on confirm, without awaiting the pauseSession fetch call', async () => {
+    // POLARITY CHECK (workflow.md TDD requirement): this exact assertion was
+    // run against the pre-conversion PauseSessionDialog.tsx (the useMutation +
+    // isPending-gated AlertDialog implementation) and FAILED there, because
+    // the old handleClose guarded onOpenChange(false) behind
+    // `!pauseMutation.isPending` -- the dialog stayed open until the fetch
+    // promise settled. It passes here against the converted implementation,
+    // which calls onOpenChange(false) synchronously in handlePause before
+    // ever awaiting pauseSession().
+    const onOpenChange = mock(() => {});
+    await renderWithRouterAndContext({ onOpenChange });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pause' }));
+
+    // Assert synchronously (before resolving/flushing the mocked fetch promise).
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(resolvePauseSession).not.toBeNull();
+
+    resolvePauseSession?.();
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+  });
+
+  it('double-clicking confirm before the dialog unmounts results in exactly one pauseSession call', async () => {
+    // Uses the REAL useSessionStopTasks hook (not a mock) so addTask's
+    // at-most-one-per-session dedupe is actually exercised -- a mock that
+    // unconditionally returns `true` would not catch a regression where the
+    // guard `if (!added) return;` is removed from handlePause.
+    function RealSessionStopTasksProvider({ children }: { children: React.ReactNode }) {
+      const sessionStopTasks = useSessionStopTasks();
+      return (
+        <SessionStopTasksContext.Provider value={sessionStopTasks}>
+          {children}
+        </SessionStopTasksContext.Provider>
+      );
+    }
+
+    const defaultProps: PauseSessionDialogProps = {
+      open: true,
+      onOpenChange: mock(() => {}),
+      sessionId: 'session-1',
+    };
+    await renderWithRouter(
+      <RealSessionStopTasksProvider>
+        <PauseSessionDialog {...defaultProps} />
+      </RealSessionStopTasksProvider>
+    );
+
+    const button = screen.getByRole('button', { name: 'Pause' });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    resolvePauseSession?.();
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+  });
+
+  it('calls markAsFailed with a message when pauseSession rejects', async () => {
+    const sessionStopTasks = createMockSessionStopTasks();
+    await renderWithRouterAndContext({}, sessionStopTasks);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pause' }));
+
+    rejectPauseSession?.(new Error('Network error'));
+
+    await waitFor(() => {
+      expect(sessionStopTasks.markAsFailed).toHaveBeenCalledWith('session-1', 'Network error');
+    });
   });
 });

--- a/packages/client/src/components/sessions/__tests__/QuickSessionSettingsMenu.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/QuickSessionSettingsMenu.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach } from 'bun:test';
-import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
 import { QuickSessionSettingsMenu } from '../QuickSessionSettingsMenu';
 
 afterEach(() => {
@@ -14,5 +14,37 @@ describe('QuickSessionSettingsMenu', () => {
 
     const button = screen.getByRole('button', { name: 'Session settings' });
     expect(button).toBeTruthy();
+  });
+
+  describe('stopDisabled (Issue #1247)', () => {
+    it('disables the Stop Session menu entry and does not fire onMenuAction when clicked', async () => {
+      const onMenuAction = mock(() => {});
+      render(<QuickSessionSettingsMenu stopDisabled onMenuAction={onMenuAction} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Session settings' }));
+      });
+
+      const stopButton = screen.getByRole('button', { name: /Stop Session/ });
+      expect((stopButton as HTMLButtonElement).disabled).toBe(true);
+
+      fireEvent.click(stopButton);
+      expect(onMenuAction).not.toHaveBeenCalled();
+    });
+
+    it('leaves the Stop Session menu entry enabled by default', async () => {
+      const onMenuAction = mock(() => {});
+      render(<QuickSessionSettingsMenu onMenuAction={onMenuAction} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Session settings' }));
+      });
+
+      const stopButton = screen.getByRole('button', { name: /Stop Session/ });
+      expect((stopButton as HTMLButtonElement).disabled).toBe(false);
+
+      fireEvent.click(stopButton);
+      expect(onMenuAction).toHaveBeenCalledWith('stop-session');
+    });
   });
 });

--- a/packages/client/src/components/sessions/__tests__/SessionPage.test.ts
+++ b/packages/client/src/components/sessions/__tests__/SessionPage.test.ts
@@ -13,7 +13,8 @@ import {
   executeWorkerRestart,
   type WorkerRestartResult,
 } from '../workerRestart';
-import { sessionToPageState, resolveShouldStripScrollback, resolveActiveEmbeddedAgentId } from '../SessionPage';
+import { sessionToPageState, resolveShouldStripScrollback, resolveActiveEmbeddedAgentId, getSessionStopTaskBannerText } from '../SessionPage';
+import type { SessionStopTask } from '../../../hooks/useSessionStopTasks';
 import { getTabDotColor, isCloseableTabType, getWorkerTypeLabel, showsActivityBadge } from '../tabAppearance';
 import type { UseTabManagementResult, AddAgentWorkerParams, Tab } from '../hooks/useTabManagement';
 import { AddAgentWorkerMenu } from '../AddAgentWorkerMenu';
@@ -572,6 +573,18 @@ describe('primary agent tab close-button wiring (Issue #1134)', () => {
 
     expect(isCloseableTabType('agent', tabs[0].id === primaryAgentTabId)).toBe(false);
     expect(isCloseableTabType('agent', tabs[2].id === primaryAgentTabId)).toBe(true);
+  });
+});
+
+describe('getSessionStopTaskBannerText (Issue #1247)', () => {
+  it('returns the pausing copy for a pause task', () => {
+    const task: SessionStopTask = { sessionId: 'session-1', action: 'pause', error: null };
+    expect(getSessionStopTaskBannerText(task)).toBe('Pausing this session...');
+  });
+
+  it('returns the stopping copy for a stop task', () => {
+    const task: SessionStopTask = { sessionId: 'session-1', action: 'stop', error: null };
+    expect(getSessionStopTaskBannerText(task)).toBe('Stopping this session...');
   });
 });
 

--- a/packages/client/src/components/sessions/__tests__/SessionSettingsMenu.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/SessionSettingsMenu.test.tsx
@@ -1,10 +1,30 @@
-import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { describe, it, expect, mock, afterEach, afterAll } from 'bun:test';
 import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SessionSettingsMenu } from '../SessionSettingsMenu';
 
+// SessionSettingsMenu enables the `fetchSessionPrLink` query as soon as the
+// menu opens. Without a fetch-level stub, every test that opens the menu
+// fires a real, unmocked network request that resolves/rejects after the
+// test's assertions already ran, making the suite non-deterministic.
+const originalFetch = globalThis.fetch;
+const mockFetch = mock(() =>
+  Promise.resolve(
+    new Response(JSON.stringify({ prUrl: null, branchName: 'test-branch', orgRepo: null }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  )
+);
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} });
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
 afterEach(() => {
   cleanup();
+  mockFetch.mockClear();
 });
 
 function renderMenu(props: Partial<React.ComponentProps<typeof SessionSettingsMenu>> = {}) {

--- a/packages/client/src/components/sessions/__tests__/SessionSettingsMenu.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/SessionSettingsMenu.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach } from 'bun:test';
-import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SessionSettingsMenu } from '../SessionSettingsMenu';
 
@@ -7,26 +7,63 @@ afterEach(() => {
   cleanup();
 });
 
+function renderMenu(props: Partial<React.ComponentProps<typeof SessionSettingsMenu>> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SessionSettingsMenu
+        sessionId="test-session"
+        worktreePath="/path/to/worktree"
+        isMainWorktree={false}
+        onMenuAction={() => {}}
+        {...props}
+      />
+    </QueryClientProvider>
+  );
+}
+
 describe('SessionSettingsMenu', () => {
   it('should have aria-label="Session settings" on the trigger button', () => {
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false },
-      },
-    });
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <SessionSettingsMenu
-          sessionId="test-session"
-          worktreePath="/path/to/worktree"
-          isMainWorktree={false}
-          onMenuAction={() => {}}
-        />
-      </QueryClientProvider>
-    );
+    renderMenu();
 
     const button = screen.getByRole('button', { name: 'Session settings' });
     expect(button).toBeTruthy();
+  });
+
+  describe('pauseDisabled (Issue #1247)', () => {
+    it('disables the Pause menu entry and does not fire onMenuAction when clicked', async () => {
+      const onMenuAction = mock(() => {});
+      renderMenu({ pauseDisabled: true, onMenuAction });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Session settings' }));
+      });
+
+      const pauseButton = screen.getByRole('button', { name: /Pause/ });
+      expect((pauseButton as HTMLButtonElement).disabled).toBe(true);
+
+      fireEvent.click(pauseButton);
+      expect(onMenuAction).not.toHaveBeenCalled();
+    });
+
+    it('leaves the Pause menu entry enabled by default', async () => {
+      const onMenuAction = mock(() => {});
+      renderMenu({ onMenuAction });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Session settings' }));
+      });
+
+      const pauseButton = screen.getByRole('button', { name: /Pause/ });
+      expect((pauseButton as HTMLButtonElement).disabled).toBe(false);
+
+      fireEvent.click(pauseButton);
+      expect(onMenuAction).toHaveBeenCalledWith('pause');
+    });
   });
 });

--- a/packages/client/src/contexts/root-contexts.ts
+++ b/packages/client/src/contexts/root-contexts.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react';
 import type { UseWorktreeCreationTasksReturn } from '../hooks/useWorktreeCreationTasks';
 import type { UseWorktreeDeletionTasksReturn } from '../hooks/useWorktreeDeletionTasks';
+import type { UseSessionStopTasksReturn } from '../hooks/useSessionStopTasks';
 import type { Session, AgentActivityState } from '@agent-console/shared';
 
 /**
@@ -63,6 +64,26 @@ export function useWorktreeDeletionTasksContext(): UseWorktreeDeletionTasksRetur
   const context = useContext(WorktreeDeletionTasksContext);
   if (!context) {
     throw new Error('useWorktreeDeletionTasksContext must be used within WorktreeDeletionTasksContext.Provider');
+  }
+  return context;
+}
+
+/**
+ * Context for in-flight Stop/Pause session tasks.
+ * This allows child routes (Dashboard, SessionPage) to add tasks and scope
+ * the pending/error UI to the affected session instead of a modal that
+ * freezes the whole app.
+ */
+export const SessionStopTasksContext = createContext<UseSessionStopTasksReturn | null>(null);
+
+/**
+ * Hook to access session stop/pause tasks context.
+ * Must be used within a route that is a child of __root.
+ */
+export function useSessionStopTasksContext(): UseSessionStopTasksReturn {
+  const context = useContext(SessionStopTasksContext);
+  if (!context) {
+    throw new Error('useSessionStopTasksContext must be used within SessionStopTasksContext.Provider');
   }
   return context;
 }

--- a/packages/client/src/hooks/__tests__/useSessionSideEffects.test.ts
+++ b/packages/client/src/hooks/__tests__/useSessionSideEffects.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createElement } from 'react';
 import type {
@@ -8,8 +8,11 @@ import type {
 } from '@agent-console/shared';
 import type { UseWorktreeCreationTasksReturn } from '../useWorktreeCreationTasks';
 import type { UseWorktreeDeletionTasksReturn } from '../useWorktreeDeletionTasks';
+import type { UseSessionStopTasksReturn, SessionStopTask } from '../useSessionStopTasks';
 import { useSessionSideEffects } from '../useSessionSideEffects';
 import { clearDraftsForSession, _getDraftsMap } from '../useDraftMessage';
+import { _reset as resetWebSocket } from '../../lib/app-websocket';
+import { MockWebSocket, installMockWebSocket } from '../../test/mock-websocket';
 
 // --- Helpers ---
 
@@ -48,6 +51,17 @@ function createMockWorktreeDeletionTasks(): UseWorktreeDeletionTasksReturn {
   };
 }
 
+function createMockSessionStopTasks(overrides: Partial<UseSessionStopTasksReturn> = {}): UseSessionStopTasksReturn {
+  return {
+    tasks: [],
+    addTask: mock(() => true),
+    removeTask: mock(() => {}),
+    getTask: mock(() => undefined),
+    markAsFailed: mock(() => {}),
+    ...overrides,
+  };
+}
+
 interface DefaultOptions {
   handleSessionsSync: ReturnType<typeof mock>;
   handleSessionCreated: ReturnType<typeof mock>;
@@ -59,6 +73,7 @@ interface DefaultOptions {
   workerActivityStates: Record<string, Record<string, AgentActivityState>>;
   worktreeCreationTasks: UseWorktreeCreationTasksReturn;
   worktreeDeletionTasks: UseWorktreeDeletionTasksReturn;
+  sessionStopTasks: UseSessionStopTasksReturn;
 }
 
 function createDefaultOptions(overrides: Partial<DefaultOptions> = {}): DefaultOptions {
@@ -73,6 +88,7 @@ function createDefaultOptions(overrides: Partial<DefaultOptions> = {}): DefaultO
     workerActivityStates: {},
     worktreeCreationTasks: createMockWorktreeCreationTasks(),
     worktreeDeletionTasks: createMockWorktreeDeletionTasks(),
+    sessionStopTasks: createMockSessionStopTasks(),
     ...overrides,
   };
 }
@@ -164,5 +180,123 @@ describe('useSessionSideEffects', () => {
 
     // Clean up
     draftsMap.clear();
+  });
+});
+
+/**
+ * Tests for Issue #1247 -- session stop/pause task removal is event-driven off
+ * server truth. These tests simulate real WebSocket frames (via MockWebSocket,
+ * the same infrastructure useAppWs.test.ts uses) rather than calling the
+ * wrapped handlers directly, so the assertions exercise the actual
+ * useAppWsEvent -> useSessionSideEffects wiring, not a hand-rolled shortcut.
+ */
+describe('useSessionSideEffects - session stop task removal (Issue #1247)', () => {
+  let restoreWebSocket: () => void;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    restoreWebSocket = installMockWebSocket();
+    Object.defineProperty(window, 'location', {
+      value: { protocol: 'http:', host: 'localhost:3000' },
+      writable: true,
+    });
+    resetWebSocket();
+  });
+
+  afterEach(() => {
+    restoreWebSocket();
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  function stopTask(overrides: Partial<SessionStopTask> = {}): SessionStopTask {
+    return {
+      sessionId: 'session-1',
+      action: 'stop',
+      error: null,
+      ...overrides,
+    };
+  }
+
+  it('removes a stop task whose session left the sessions-sync list', () => {
+    const sessionStopTasks = createMockSessionStopTasks({
+      tasks: [stopTask({ sessionId: 'session-gone', action: 'stop' })],
+    });
+    const options = createDefaultOptions({ sessionStopTasks });
+    renderWithQueryClient(options);
+
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+      ws?.simulateMessage(JSON.stringify({ type: 'sessions-sync', sessions: [], activityStates: [] }));
+    });
+
+    expect(sessionStopTasks.removeTask).toHaveBeenCalledWith('session-gone');
+  });
+
+  it('removes a pause task whose session is present but status is inactive', () => {
+    const sessionStopTasks = createMockSessionStopTasks({
+      tasks: [stopTask({ sessionId: 'session-1', action: 'pause' })],
+    });
+    const options = createDefaultOptions({ sessionStopTasks });
+    renderWithQueryClient(options);
+
+    const session = createMockSession({ id: 'session-1', status: 'inactive', activationState: 'running', isShared: false, recoveryState: 'healthy' });
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+      ws?.simulateMessage(JSON.stringify({ type: 'sessions-sync', sessions: [session], activityStates: [] }));
+    });
+
+    expect(sessionStopTasks.removeTask).toHaveBeenCalledWith('session-1');
+  });
+
+  it('does NOT remove a stop task whose session is still present and active (no resurrection on a mid-flight sync)', () => {
+    const sessionStopTasks = createMockSessionStopTasks({
+      tasks: [stopTask({ sessionId: 'session-1', action: 'stop' })],
+    });
+    const options = createDefaultOptions({ sessionStopTasks });
+    renderWithQueryClient(options);
+
+    const session = createMockSession({ id: 'session-1', status: 'active', activationState: 'running', isShared: false, recoveryState: 'healthy' });
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+      ws?.simulateMessage(JSON.stringify({ type: 'sessions-sync', sessions: [session], activityStates: [] }));
+    });
+
+    expect(sessionStopTasks.removeTask).not.toHaveBeenCalled();
+  });
+
+  it('removes the task unconditionally on a session-deleted event', () => {
+    const sessionStopTasks = createMockSessionStopTasks();
+    const options = createDefaultOptions({ sessionStopTasks });
+    renderWithQueryClient(options);
+
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+      ws?.simulateMessage(JSON.stringify({ type: 'session-deleted', sessionId: 'session-1' }));
+    });
+
+    expect(sessionStopTasks.removeTask).toHaveBeenCalledWith('session-1');
+  });
+
+  it('removes the task unconditionally on a session-paused event', () => {
+    const sessionStopTasks = createMockSessionStopTasks();
+    const options = createDefaultOptions({ sessionStopTasks });
+    renderWithQueryClient(options);
+
+    const session = createMockSession({ id: 'session-1', status: 'inactive', activationState: 'hibernated', isShared: false, recoveryState: 'healthy', pausedAt: '2026-01-01T00:00:00Z' });
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+      ws?.simulateMessage(JSON.stringify({ type: 'session-paused', session }));
+    });
+
+    expect(sessionStopTasks.removeTask).toHaveBeenCalledWith('session-1');
   });
 });

--- a/packages/client/src/hooks/__tests__/useSessionStopTasks.test.ts
+++ b/packages/client/src/hooks/__tests__/useSessionStopTasks.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+import { useSessionStopTasks } from '../useSessionStopTasks';
+
+describe('useSessionStopTasks', () => {
+  it('addTask adds a new task and returns true', () => {
+    const { result } = renderHook(() => useSessionStopTasks());
+
+    let added = false;
+    act(() => {
+      added = result.current.addTask({ sessionId: 'session-1', action: 'stop', sessionTitle: 'My Session' });
+    });
+
+    expect(added).toBe(true);
+    expect(result.current.tasks).toEqual([
+      { sessionId: 'session-1', action: 'stop', sessionTitle: 'My Session', error: null },
+    ]);
+  });
+
+  it('addTask returns false and does not create a duplicate for an existing sessionId', () => {
+    const { result } = renderHook(() => useSessionStopTasks());
+
+    act(() => {
+      result.current.addTask({ sessionId: 'session-1', action: 'stop' });
+    });
+
+    let secondAdded = true;
+    act(() => {
+      // Even a different action for the same sessionId must be rejected --
+      // at most one task per session, regardless of action.
+      secondAdded = result.current.addTask({ sessionId: 'session-1', action: 'pause' });
+    });
+
+    expect(secondAdded).toBe(false);
+    expect(result.current.tasks.length).toBe(1);
+    expect(result.current.tasks[0].action).toBe('stop');
+  });
+
+  it('removeTask removes the task', () => {
+    const { result } = renderHook(() => useSessionStopTasks());
+
+    act(() => {
+      result.current.addTask({ sessionId: 'session-1', action: 'stop' });
+    });
+    expect(result.current.tasks.length).toBe(1);
+
+    act(() => {
+      result.current.removeTask('session-1');
+    });
+
+    expect(result.current.tasks).toEqual([]);
+  });
+
+  it('markAsFailed sets the error and keeps the task', () => {
+    const { result } = renderHook(() => useSessionStopTasks());
+
+    act(() => {
+      result.current.addTask({ sessionId: 'session-1', action: 'pause' });
+    });
+
+    act(() => {
+      result.current.markAsFailed('session-1', 'Network error');
+    });
+
+    expect(result.current.tasks).toEqual([
+      { sessionId: 'session-1', action: 'pause', sessionTitle: undefined, error: 'Network error' },
+    ]);
+  });
+
+  it('getTask returns undefined for an unknown sessionId', () => {
+    const { result } = renderHook(() => useSessionStopTasks());
+
+    expect(result.current.getTask('unknown-session')).toBeUndefined();
+  });
+});

--- a/packages/client/src/hooks/useSessionSideEffects.ts
+++ b/packages/client/src/hooks/useSessionSideEffects.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { Session, AgentActivityState, WorkerActivityInfo, WorktreeDeletionCompletedPayload } from '@agent-console/shared';
 import type { UseWorktreeCreationTasksReturn } from './useWorktreeCreationTasks';
 import type { UseWorktreeDeletionTasksReturn } from './useWorktreeDeletionTasks';
+import type { UseSessionStopTasksReturn } from './useSessionStopTasks';
 import { useAppWsEvent } from './useAppWs';
 import { worktreeKeys, sessionKeys } from '../lib/query-keys';
 import { disconnectSession } from '../lib/worker-websocket';
@@ -20,6 +21,7 @@ interface UseSessionSideEffectsOptions {
   workerActivityStates: Record<string, Record<string, AgentActivityState>>;
   worktreeCreationTasks: UseWorktreeCreationTasksReturn;
   worktreeDeletionTasks: UseWorktreeDeletionTasksReturn;
+  sessionStopTasks: UseSessionStopTasksReturn;
 }
 
 /**
@@ -43,6 +45,7 @@ export function useSessionSideEffects({
   workerActivityStates,
   worktreeCreationTasks,
   worktreeDeletionTasks,
+  sessionStopTasks,
 }: UseSessionSideEffectsOptions): void {
   const queryClient = useQueryClient();
 
@@ -61,17 +64,34 @@ export function useSessionSideEffects({
     clearDraftsForSession(sessionId);
     handleSessionDeleted(sessionId);
     invalidateValidation();
-  }, [handleSessionDeleted, invalidateValidation]);
+    // A stop/pause task's target session is gone -- remove it unconditionally
+    // (harmless no-op if no task exists for this session).
+    sessionStopTasks.removeTask(sessionId);
+  }, [handleSessionDeleted, invalidateValidation, sessionStopTasks]);
 
   const handleSessionUpdatedWithValidation = useCallback((...args: Parameters<typeof handleSessionUpdated>) => {
     handleSessionUpdated(...args);
     invalidateValidation();
   }, [handleSessionUpdated, invalidateValidation]);
 
-  const handleSessionsSyncWithValidation = useCallback((...args: Parameters<typeof handleSessionsSync>) => {
-    handleSessionsSync(...args);
+  // Removes stop/pause tasks whose session-side truth (from the sessions-sync
+  // snapshot) indicates the task is complete: a `stop` task's session left the
+  // list entirely, or a `pause` task's session is present but now `inactive`.
+  // This makes WS-reconnect self-healing -- the task-removal side effect does
+  // not depend on the `session-deleted`/`session-paused` events having been
+  // observed by this client.
+  const handleSessionsSyncWithValidation = useCallback((sessions: Session[], activityStates: WorkerActivityInfo[]) => {
+    handleSessionsSync(sessions, activityStates);
     invalidateValidation();
-  }, [handleSessionsSync, invalidateValidation]);
+    for (const task of sessionStopTasks.tasks) {
+      const session = sessions.find((s) => s.id === task.sessionId);
+      if (!session) {
+        sessionStopTasks.removeTask(task.sessionId);
+      } else if (task.action === 'pause' && session.status === 'inactive') {
+        sessionStopTasks.removeTask(task.sessionId);
+      }
+    }
+  }, [handleSessionsSync, invalidateValidation, sessionStopTasks]);
 
   // Wrap session paused handler to also disconnect lingering worker WebSocket connections
   const handleSessionPausedWithCleanup = useCallback((session: Session) => {
@@ -80,7 +100,8 @@ export function useSessionSideEffects({
     // no longer exists in server memory.
     disconnectSession(session.id);
     handleSessionPaused(session);
-  }, [handleSessionPaused]);
+    sessionStopTasks.removeTask(session.id);
+  }, [handleSessionPaused, sessionStopTasks]);
 
   // Wrap worktree deletion completed handler to also invalidate worktree queries
   const handleWorktreeDeletionCompleted = useCallback((payload: WorktreeDeletionCompletedPayload) => {

--- a/packages/client/src/hooks/useSessionStopTasks.ts
+++ b/packages/client/src/hooks/useSessionStopTasks.ts
@@ -1,0 +1,97 @@
+import { useState, useRef, useCallback } from 'react';
+
+export type SessionStopTaskAction = 'stop' | 'pause';
+
+export interface SessionStopTask {
+  sessionId: string;
+  action: SessionStopTaskAction;
+  sessionTitle?: string;
+  error: string | null;
+}
+
+export interface UseSessionStopTasksReturn {
+  /** Current list of in-flight stop/pause tasks */
+  tasks: SessionStopTask[];
+  /**
+   * Add a new task when a stop/pause request is initiated.
+   * Returns `false` (structural no-op, no task created) if a task for this
+   * `sessionId` already exists -- at most one task per session.
+   */
+  addTask: (params: { sessionId: string; action: SessionStopTaskAction; sessionTitle?: string }) => boolean;
+  /** Remove a task (used when the server confirms completion, or on manual dismiss) */
+  removeTask: (sessionId: string) => void;
+  /** Get the task for a given session, if any */
+  getTask: (sessionId: string) => SessionStopTask | undefined;
+  /** Mark a task as failed (for immediate API errors) */
+  markAsFailed: (sessionId: string, error: string) => void;
+}
+
+/**
+ * Hook to manage in-flight Stop/Pause session tasks on the client side.
+ *
+ * This scopes the pending/error UI for Stop and Pause to the affected session
+ * (dashboard row + session page banner) instead of freezing the whole app
+ * behind a modal for the server round-trip. Mirrors `useWorktreeDeletionTasks`'s
+ * shape/lifecycle.
+ *
+ * Task removal is event-driven off server truth (see `useSessionSideEffects`):
+ * a `stop` task is removed when its session disappears from the sessions sync
+ * (or an explicit `session-deleted` event arrives); a `pause` task is removed
+ * when its session's status becomes `'inactive'`.
+ *
+ * Note: Tasks are lost on page refresh (client-side only).
+ */
+export function useSessionStopTasks(): UseSessionStopTasksReturn {
+  const [tasks, setTasks] = useState<SessionStopTask[]>([]);
+  // Ref mirror so `addTask`'s at-most-one-per-session check (and the resulting
+  // mutation) is readable synchronously by the caller in the same tick. A plain
+  // `setTasks(prev => ...)` functional updater is not reliably synchronous for
+  // this purpose -- callers need `if (!addTask(...)) return;` to correctly guard
+  // against a double-fire race.
+  const tasksRef = useRef<SessionStopTask[]>([]);
+
+  const addTask = useCallback(
+    (params: { sessionId: string; action: SessionStopTaskAction; sessionTitle?: string }): boolean => {
+      if (tasksRef.current.some((t) => t.sessionId === params.sessionId)) {
+        return false;
+      }
+      const newTask: SessionStopTask = {
+        sessionId: params.sessionId,
+        action: params.action,
+        sessionTitle: params.sessionTitle,
+        error: null,
+      };
+      tasksRef.current = [...tasksRef.current, newTask];
+      setTasks(tasksRef.current);
+      return true;
+    },
+    []
+  );
+
+  const removeTask = useCallback((sessionId: string) => {
+    tasksRef.current = tasksRef.current.filter((t) => t.sessionId !== sessionId);
+    setTasks(tasksRef.current);
+  }, []);
+
+  const getTask = useCallback(
+    (sessionId: string) => {
+      return tasks.find((t) => t.sessionId === sessionId);
+    },
+    [tasks]
+  );
+
+  const markAsFailed = useCallback((sessionId: string, error: string) => {
+    tasksRef.current = tasksRef.current.map((t) =>
+      t.sessionId === sessionId ? { ...t, error } : t
+    );
+    setTasks(tasksRef.current);
+  }, []);
+
+  return {
+    tasks,
+    addTask,
+    removeTask,
+    getTask,
+    markAsFailed,
+  };
+}

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -18,11 +18,12 @@ import { useSidebarState } from '../hooks/useSidebarState';
 import { useActiveSessionsWithActivity } from '../hooks/useActiveSessionsWithActivity';
 import { useWorktreeCreationTasks } from '../hooks/useWorktreeCreationTasks';
 import { useWorktreeDeletionTasks } from '../hooks/useWorktreeDeletionTasks';
+import { useSessionStopTasks } from '../hooks/useSessionStopTasks';
 import { useSessionFilter, matchesUserFilter } from '../hooks/useSessionFilter';
 import type { Session } from '@agent-console/shared';
 import { useAuth } from '../lib/auth';
 import { logger } from '../lib/logger';
-import { SessionDataContext, WorktreeCreationTasksContext, WorktreeDeletionTasksContext } from '../contexts/root-contexts';
+import { SessionDataContext, WorktreeCreationTasksContext, WorktreeDeletionTasksContext, SessionStopTasksContext } from '../contexts/root-contexts';
 import type { SessionDataContextValue } from '../contexts/root-contexts';
 
 // Re-export contexts for backward compatibility
@@ -33,6 +34,8 @@ export {
   useWorktreeCreationTasksContext,
   WorktreeDeletionTasksContext,
   useWorktreeDeletionTasksContext,
+  SessionStopTasksContext,
+  useSessionStopTasksContext,
 } from '../contexts/root-contexts';
 export type { SessionDataContextValue } from '../contexts/root-contexts';
 
@@ -91,6 +94,9 @@ function RootLayout() {
   // Worktree deletion task management
   const worktreeDeletionTasks = useWorktreeDeletionTasks();
 
+  // In-flight Stop/Pause session task management (scoped pending/error UI)
+  const sessionStopTasks = useSessionStopTasks();
+
   // Wire up cross-cutting side effects (validation, cache cleanup, favicon, WebSocket subscription)
   useSessionSideEffects({
     handleSessionsSync,
@@ -103,6 +109,7 @@ function RootLayout() {
     workerActivityStates,
     worktreeCreationTasks,
     worktreeDeletionTasks,
+    sessionStopTasks,
   });
 
   // Keep the embedded-agent registry query cache fresh regardless of route
@@ -173,6 +180,7 @@ function RootLayout() {
     <SessionDataContext.Provider value={sessionDataContextValue}>
     <WorktreeCreationTasksContext.Provider value={worktreeCreationTasks}>
       <WorktreeDeletionTasksContext.Provider value={worktreeDeletionTasks}>
+      <SessionStopTasksContext.Provider value={sessionStopTasks}>
         <div className="h-dvh flex flex-col">
           <header className="px-4 py-2 border-b border-slate-700 bg-[#0f172a] flex items-center shrink-0 relative">
             <div className="flex items-center gap-1.5">
@@ -281,6 +289,7 @@ function RootLayout() {
             </main>
           </div>
         </div>
+      </SessionStopTasksContext.Provider>
       </WorktreeDeletionTasksContext.Provider>
     </WorktreeCreationTasksContext.Provider>
     </SessionDataContext.Provider>

--- a/packages/client/src/routes/__tests__/index.test.tsx
+++ b/packages/client/src/routes/__tests__/index.test.tsx
@@ -208,6 +208,18 @@ function createMockSessionStopTasks(overrides: Partial<UseSessionStopTasksReturn
   };
 }
 
+// Provider that exercises the REAL useSessionStopTasks hook (not a mock), so
+// production task-state transitions (addTask / markAsFailed / getTask) flow
+// through to consumers and re-render them as they would in the app.
+function RealSessionStopTasksProvider({ children }: { children: React.ReactNode }) {
+  const sessionStopTasks = useSessionStopTasks();
+  return (
+    <SessionStopTasksContext.Provider value={sessionStopTasks}>
+      {children}
+    </SessionStopTasksContext.Provider>
+  );
+}
+
 // --- Render helper ---
 
 async function renderDashboard(
@@ -731,15 +743,6 @@ describe('SessionCard / Issue #1247 scoped pending state', () => {
     // Uses the REAL useSessionStopTasks hook so the disabled-control guard is
     // exercised against production task state, not a mock that always reports
     // "no task".
-    function RealSessionStopTasksProvider({ children }: { children: React.ReactNode }) {
-      const sessionStopTasks = useSessionStopTasks();
-      return (
-        <SessionStopTasksContext.Provider value={sessionStopTasks}>
-          {children}
-        </SessionStopTasksContext.Provider>
-      );
-    }
-
     const session = createMockQuickSession();
     await renderWithRouter(
       <RealSessionStopTasksProvider>
@@ -781,14 +784,6 @@ describe('SessionCard / Issue #1247 scoped pending state', () => {
 
     // Exercise the REAL useSessionStopTasks hook (not a mock) so markAsFailed's
     // state update actually flows through to `getTask` and re-renders the card.
-    function RealSessionStopTasksProvider({ children }: { children: React.ReactNode }) {
-      const sessionStopTasks = useSessionStopTasks();
-      return (
-        <SessionStopTasksContext.Provider value={sessionStopTasks}>
-          {children}
-        </SessionStopTasksContext.Provider>
-      );
-    }
     await renderWithRouter(
       <RealSessionStopTasksProvider>
         <SessionCard session={session} />

--- a/packages/client/src/routes/__tests__/index.test.tsx
+++ b/packages/client/src/routes/__tests__/index.test.tsx
@@ -15,13 +15,15 @@
  */
 import { describe, it, expect, mock, beforeEach, afterEach, afterAll, spyOn } from 'bun:test';
 import { screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
 
-import { DashboardPage } from '../index';
-import { SessionDataContext, WorktreeDeletionTasksContext, WorktreeCreationTasksContext } from '../../contexts/root-contexts';
+import { DashboardPage, SessionCard, WorktreeRow } from '../index';
+import { SessionDataContext, WorktreeDeletionTasksContext, WorktreeCreationTasksContext, SessionStopTasksContext } from '../../contexts/root-contexts';
 import { renderWithRouter } from '../../test/renderWithRouter';
-import type { Repository } from '@agent-console/shared';
+import type { Repository, Session } from '@agent-console/shared';
 import type { UseWorktreeDeletionTasksReturn } from '../../hooks/useWorktreeDeletionTasks';
 import type { UseWorktreeCreationTasksReturn } from '../../hooks/useWorktreeCreationTasks';
+import { useSessionStopTasks, type UseSessionStopTasksReturn } from '../../hooks/useSessionStopTasks';
 import * as useAppWsModule from '../../hooks/useAppWs';
 import * as capabilitiesModule from '../../lib/capabilities';
 
@@ -67,6 +69,15 @@ interface FetchResponses {
    * `deleteRepositoryCalls`.
    */
   deleteRepositoryBodies?: unknown[];
+  /**
+   * Recorded DELETE /api/sessions/:id calls (Issue #1247 SessionCard tests).
+   */
+  deleteSessionCalls?: string[];
+  /**
+   * When set, DELETE /api/sessions/:id rejects with this message instead of
+   * resolving 204 (Issue #1247 SessionCard error-surfacing tests).
+   */
+  deleteSessionError?: string;
 }
 
 let fetchResponses: FetchResponses = {
@@ -127,6 +138,17 @@ const mockFetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
     return new Response(null, { status: 204 });
   }
 
+  // DELETE /api/sessions/:id  (Stop Session flow, Issue #1247)
+  if (method === 'DELETE' && /\/api\/sessions\/[^/]+$/.test(url)) {
+    const match = url.match(/\/api\/sessions\/([^/]+)$/);
+    const sessionId = match?.[1] ?? '';
+    fetchResponses.deleteSessionCalls?.push(sessionId);
+    if (fetchResponses.deleteSessionError) {
+      return Promise.reject(new Error(fetchResponses.deleteSessionError));
+    }
+    return new Response(null, { status: 204 });
+  }
+
   // Default: empty success response (covers branches lookups, etc.)
   return new Response(JSON.stringify({}), {
     status: 200,
@@ -175,6 +197,17 @@ function createMockCreationContext(): UseWorktreeCreationTasksReturn {
   };
 }
 
+function createMockSessionStopTasks(overrides: Partial<UseSessionStopTasksReturn> = {}): UseSessionStopTasksReturn {
+  return {
+    tasks: [],
+    addTask: mock(() => true),
+    removeTask: mock(() => {}),
+    getTask: mock(() => undefined),
+    markAsFailed: mock(() => {}),
+    ...overrides,
+  };
+}
+
 // --- Render helper ---
 
 async function renderDashboard(
@@ -183,6 +216,10 @@ async function renderDashboard(
     deleteRepositoryResponses?: Record<string, { status: number; body?: unknown }>;
     deleteRepositoryCalls?: string[];
     deleteRepositoryBodies?: unknown[];
+    sessionStopTasks?: UseSessionStopTasksReturn;
+    sessions?: Session[];
+    deleteSessionCalls?: string[];
+    deleteSessionError?: string;
   }
 ) {
   fetchResponses = {
@@ -191,10 +228,12 @@ async function renderDashboard(
     deleteRepositoryResponses: options?.deleteRepositoryResponses,
     deleteRepositoryCalls: options?.deleteRepositoryCalls,
     deleteRepositoryBodies: options?.deleteRepositoryBodies,
+    deleteSessionCalls: options?.deleteSessionCalls,
+    deleteSessionError: options?.deleteSessionError,
   };
 
   const sessionDataValue = {
-    sessions: [],
+    sessions: options?.sessions ?? [],
     wsInitialized: true,
     workerActivityStates: {},
   };
@@ -203,7 +242,9 @@ async function renderDashboard(
     <SessionDataContext.Provider value={sessionDataValue}>
       <WorktreeCreationTasksContext.Provider value={createMockCreationContext()}>
         <WorktreeDeletionTasksContext.Provider value={createMockDeletionContext()}>
-          <DashboardPage />
+          <SessionStopTasksContext.Provider value={options?.sessionStopTasks ?? createMockSessionStopTasks()}>
+            <DashboardPage />
+          </SessionStopTasksContext.Provider>
         </WorktreeDeletionTasksContext.Provider>
       </WorktreeCreationTasksContext.Provider>
     </SessionDataContext.Provider>
@@ -618,5 +659,291 @@ describe('DashboardPage / Unregister Repository — source-repo cleanup checkbox
       expect(screen.getByRole('heading', { name: 'Unregister Repository' })).toBeTruthy();
     });
     expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(false);
+  });
+});
+
+/**
+ * Tests for Issue #1247 -- Stop Session no longer holds a modal open while the
+ * server round-trip is in flight, for the Dashboard's quick-session card. The
+ * "no optimistic update" boundary (the session list only changes via
+ * sessions-sync / session-deleted) is covered by useSessionSideEffects.test.ts;
+ * these tests only pin SessionCard's own confirm-handler behavior.
+ */
+describe('SessionCard / Issue #1247 scoped pending state', () => {
+  function createMockQuickSession(overrides: Partial<Session> = {}): Session {
+    return {
+      id: 'quick-1',
+      type: 'quick',
+      title: 'My Quick Session',
+      locationPath: '/tmp/quick-1',
+      status: 'active',
+      activationState: 'running',
+      createdAt: new Date().toISOString(),
+      workers: [],
+      isShared: false,
+      recoveryState: 'healthy',
+      ...overrides,
+    } as Session;
+  }
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    fetchResponses = {
+      repositories: [],
+      worktreesByRepoId: {},
+      deleteSessionCalls: [],
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('closes the ConfirmDialog synchronously on confirm, without awaiting deleteSession', async () => {
+    const session = createMockQuickSession();
+    await renderWithRouter(
+      <SessionStopTasksContext.Provider value={createMockSessionStopTasks()}>
+        <SessionCard session={session} />
+      </SessionStopTasksContext.Provider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    await waitFor(() => {
+      expect(screen.getByRole('alertdialog')).toBeTruthy();
+    });
+
+    const dialog = screen.getByRole('alertdialog');
+    const confirmButton = screen.getAllByRole('button', { name: 'Stop' })
+      .find((btn) => dialog.contains(btn));
+    expect(confirmButton).toBeTruthy();
+
+    fireEvent.click(confirmButton!);
+
+    // Assert synchronously, before awaiting/flushing the deleteSession fetch call.
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+
+    await waitFor(() => {
+      expect(fetchResponses.deleteSessionCalls).toEqual(['quick-1']);
+    });
+  });
+
+  it('disables the trigger button once a task exists, so a second click cannot fire a second deleteSession call', async () => {
+    // Uses the REAL useSessionStopTasks hook so the disabled-control guard is
+    // exercised against production task state, not a mock that always reports
+    // "no task".
+    function RealSessionStopTasksProvider({ children }: { children: React.ReactNode }) {
+      const sessionStopTasks = useSessionStopTasks();
+      return (
+        <SessionStopTasksContext.Provider value={sessionStopTasks}>
+          {children}
+        </SessionStopTasksContext.Provider>
+      );
+    }
+
+    const session = createMockQuickSession();
+    await renderWithRouter(
+      <RealSessionStopTasksProvider>
+        <SessionCard session={session} />
+      </RealSessionStopTasksProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    await waitFor(() => {
+      expect(screen.getByRole('alertdialog')).toBeTruthy();
+    });
+
+    const dialog = screen.getByRole('alertdialog');
+    const confirmButton = screen.getAllByRole('button', { name: 'Stop' })
+      .find((btn) => dialog.contains(btn));
+    fireEvent.click(confirmButton!);
+
+    await waitFor(() => {
+      expect(fetchResponses.deleteSessionCalls).toEqual(['quick-1']);
+    });
+
+    // The dialog is gone; the card's own trigger button now shows the
+    // disabled "Stopping..." indicator instead of "Stop".
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+    const triggerButton = screen.getByText('Stopping...').closest('button');
+    expect(triggerButton).toBeTruthy();
+    expect((triggerButton as HTMLButtonElement).disabled).toBe(true);
+
+    // Clicking the disabled trigger does not reopen the confirm dialog, and
+    // no second deleteSession call fires.
+    fireEvent.click(triggerButton!);
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+    expect(fetchResponses.deleteSessionCalls).toEqual(['quick-1']);
+  });
+
+  it('renders the error and Dismiss control when deleteSession rejects, and Dismiss clears it', async () => {
+    fetchResponses.deleteSessionError = 'Network error';
+    const session = createMockQuickSession();
+
+    // Exercise the REAL useSessionStopTasks hook (not a mock) so markAsFailed's
+    // state update actually flows through to `getTask` and re-renders the card.
+    function RealSessionStopTasksProvider({ children }: { children: React.ReactNode }) {
+      const sessionStopTasks = useSessionStopTasks();
+      return (
+        <SessionStopTasksContext.Provider value={sessionStopTasks}>
+          {children}
+        </SessionStopTasksContext.Provider>
+      );
+    }
+    await renderWithRouter(
+      <RealSessionStopTasksProvider>
+        <SessionCard session={session} />
+      </RealSessionStopTasksProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    await waitFor(() => {
+      expect(screen.getByRole('alertdialog')).toBeTruthy();
+    });
+    const dialog = screen.getByRole('alertdialog');
+    const confirmButton = screen.getAllByRole('button', { name: 'Stop' })
+      .find((btn) => dialog.contains(btn));
+    fireEvent.click(confirmButton!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Network error')).toBeNull();
+    });
+  });
+});
+
+/**
+ * Tests for Issue #1247 -- the Dashboard's worktree row shows a read-only
+ * Stopping.../Pausing... indicator (and error+Dismiss) while a stop/pause task
+ * targets its session, without disturbing Open/Pull/Delete. Worktree deletion
+ * itself is untouched (out of scope).
+ */
+describe('WorktreeRow / Issue #1247 stop/pause task indicator', () => {
+  function createMockWorktree(overrides: Partial<{ path: string; branch: string; isMain: boolean; repositoryId: string }> = {}) {
+    return {
+      path: '/tmp/worktree-1',
+      branch: 'feature/foo',
+      isMain: false,
+      repositoryId: 'repo-1',
+      ...overrides,
+    };
+  }
+
+  function createMockWorktreeSession(overrides: Partial<Session> = {}): Session {
+    return {
+      id: 'session-1',
+      type: 'worktree',
+      title: 'My Worktree Session',
+      locationPath: '/tmp/worktree-1',
+      status: 'active',
+      activationState: 'running',
+      createdAt: new Date().toISOString(),
+      workers: [],
+      isShared: false,
+      recoveryState: 'healthy',
+      repositoryId: 'repo-1',
+      repositoryName: 'repo',
+      worktreeId: 'feature/foo',
+      isMainWorktree: false,
+      ...overrides,
+    } as Session;
+  }
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows a "Pausing..." indicator and keeps Open enabled while a pause task targets the session', async () => {
+    const session = createMockWorktreeSession();
+    const sessionStopTasks = createMockSessionStopTasks({
+      tasks: [{ sessionId: session.id, action: 'pause', error: null }],
+      getTask: mock((sessionId: string) => (sessionId === session.id ? { sessionId, action: 'pause' as const, error: null } : undefined)),
+    });
+
+    await renderWithRouter(
+      <WorktreeDeletionTasksContext.Provider value={createMockDeletionContext()}>
+        <SessionStopTasksContext.Provider value={sessionStopTasks}>
+          <WorktreeRow
+            worktree={createMockWorktree()}
+            session={session}
+            repositoryId="repo-1"
+            isPulling={false}
+            onPull={() => {}}
+          />
+        </SessionStopTasksContext.Provider>
+      </WorktreeDeletionTasksContext.Provider>
+    );
+
+    expect(screen.getByText('Pausing...')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Open' })).toBeTruthy();
+  });
+
+  it('renders the error and Dismiss control when the task has an error, and Dismiss clears it', async () => {
+    // Uses the REAL useSessionStopTasks hook (seeded via useEffect on mount) so
+    // the Dismiss click's removeTask call flows through real state and
+    // re-renders reactively -- no manual `rerender()` with a differently-shaped
+    // tree is needed (rerender() replaces the whole render output, including
+    // the router/query-client wrapper renderWithRouter built, and would crash).
+    const session = createMockWorktreeSession();
+
+    function WorktreeRowWithSeededError({ session }: { session: Session }) {
+      const sessionStopTasks = useSessionStopTasks();
+      useEffect(() => {
+        sessionStopTasks.addTask({ sessionId: session.id, action: 'stop' });
+        sessionStopTasks.markAsFailed(session.id, 'Network error');
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- seed once on mount
+      }, []);
+      return (
+        <WorktreeDeletionTasksContext.Provider value={createMockDeletionContext()}>
+          <SessionStopTasksContext.Provider value={sessionStopTasks}>
+            <WorktreeRow
+              worktree={createMockWorktree()}
+              session={session}
+              repositoryId="repo-1"
+              isPulling={false}
+              onPull={() => {}}
+            />
+          </SessionStopTasksContext.Provider>
+        </WorktreeDeletionTasksContext.Provider>
+      );
+    }
+
+    await renderWithRouter(<WorktreeRowWithSeededError session={session} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Network error')).toBeNull();
+    });
+  });
+
+  it('does not render an indicator when no task targets the session', async () => {
+    const session = createMockWorktreeSession();
+    const sessionStopTasks = createMockSessionStopTasks();
+
+    await renderWithRouter(
+      <WorktreeDeletionTasksContext.Provider value={createMockDeletionContext()}>
+        <SessionStopTasksContext.Provider value={sessionStopTasks}>
+          <WorktreeRow
+            worktree={createMockWorktree()}
+            session={session}
+            repositoryId="repo-1"
+            isPulling={false}
+            onPull={() => {}}
+          />
+        </SessionStopTasksContext.Provider>
+      </WorktreeDeletionTasksContext.Provider>
+    );
+
+    expect(screen.queryByText('Stopping...')).toBeNull();
+    expect(screen.queryByText('Pausing...')).toBeNull();
   });
 });

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -25,7 +25,7 @@ import { formatPath } from '../lib/path';
 import { ConfirmDialog } from '../components/ui/confirm-dialog';
 import { ErrorDialog, useErrorDialog } from '../components/ui/error-dialog';
 import { GitHubIcon, VSCodeIcon } from '../components/Icons';
-import { Spinner } from '../components/ui/Spinner';
+import { Spinner, ButtonSpinner } from '../components/ui/Spinner';
 import { hasVSCode } from '../lib/capabilities';
 import {
   AlertDialog,
@@ -38,7 +38,7 @@ import {
 } from '../components/ui/alert-dialog';
 import { AddRepositoryForm, type AddRepositoryFormSubmitData } from '../components/repositories';
 import { CreateWorktreeForm, type CreateWorktreeFormRequest } from '../components/worktrees';
-import { useWorktreeDeletionTasksContext, useSessionDataContext } from './__root';
+import { useWorktreeDeletionTasksContext, useSessionStopTasksContext, useSessionDataContext } from './__root';
 import { repositoryKeys, agentKeys, sessionKeys, worktreeKeys, branchKeys } from '../lib/query-keys';
 import type { Session, Repository, Worktree, AgentActivityState, CreateWorktreeSessionRequest, BranchNameFallback, AgentDefinition, HookCommandResult, WorktreePullCompletedPayload, WorktreePullFailedPayload } from '@agent-console/shared';
 import { logger } from '../lib/logger';
@@ -828,6 +828,8 @@ export function WorktreeRow({ worktree, session, pausedSession, repositoryId, is
   const isDeleting = deletionTasks.some(
     (t) => t.worktreePath === worktree.path && t.status === 'deleting'
   );
+  const { getTask: getStopTask, removeTask: removeStopTask } = useSessionStopTasksContext();
+  const stopTask = session ? getStopTask(session.id) : undefined;
 
   const restoreSessionMutation = useMutation({
     mutationFn: (request: CreateWorktreeSessionRequest) => createSession(request),
@@ -1003,7 +1005,25 @@ export function WorktreeRow({ worktree, session, pausedSession, repositoryId, is
             {isDeleting ? 'Deleting...' : 'Delete'}
           </button>
         )}
+        {stopTask && (
+          <span className="text-xs text-gray-400 flex items-center gap-1">
+            <Spinner size="sm" />
+            {stopTask.action === 'pause' ? 'Pausing...' : 'Stopping...'}
+          </span>
+        )}
       </div>
+
+      {stopTask?.error && (
+        <div className="text-xs text-red-400 bg-red-950/50 p-2 rounded flex items-center justify-between gap-2 md:ml-11">
+          <span>{stopTask.error}</span>
+          <button
+            onClick={() => removeStopTask(stopTask.sessionId)}
+            className="btn text-xs bg-slate-700 hover:bg-slate-600 shrink-0"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       {/* Delete Worktree Confirmation */}
       <ConfirmDialog
@@ -1060,20 +1080,27 @@ interface SessionCardProps {
   session: SessionWithActivity;
 }
 
-function SessionCard({ session }: SessionCardProps) {
-  const queryClient = useQueryClient();
+export function SessionCard({ session }: SessionCardProps) {
+  const { addTask, removeTask, markAsFailed, getTask } = useSessionStopTasksContext();
   const [showStopConfirm, setShowStopConfirm] = useState(false);
+  const task = getTask(session.id);
 
-  const deleteMutation = useMutation({
-    mutationFn: deleteSession,
-    onSuccess: () => {
-      // Emit session-deleted locally for immediate UI update
-      // WebSocket event will arrive later but will be processed idempotently
-      emitSessionDeleted(session.id);
-      queryClient.invalidateQueries({ queryKey: sessionKeys.root() });
-      setShowStopConfirm(false);
-    },
-  });
+  const handleConfirmStop = async () => {
+    const added = addTask({ sessionId: session.id, action: 'stop', sessionTitle: session.title });
+    setShowStopConfirm(false);
+    if (!added) return;
+
+    // Session will be removed from UI when WebSocket broadcast arrives from server
+    // (no optimistic update to avoid race condition/flicker)
+
+    try {
+      await deleteSession(session.id);
+      // Success will be handled via WebSocket (session-deleted / sessions-sync).
+    } catch (err) {
+      // If API call fails immediately (network error), mark task as failed
+      markAsFailed(session.id, err instanceof Error ? err.message : 'Failed to stop session');
+    }
+  };
 
   const statusColor =
     session.status === 'active'
@@ -1107,11 +1134,26 @@ function SessionCard({ session }: SessionCardProps) {
         </Link>
         <button
           onClick={() => setShowStopConfirm(true)}
+          disabled={Boolean(task)}
           className="btn btn-danger text-sm"
         >
-          Stop
+          <ButtonSpinner isPending={Boolean(task)} pendingText={task?.action === 'pause' ? 'Pausing...' : 'Stopping...'}>
+            Stop
+          </ButtonSpinner>
         </button>
       </div>
+
+      {task?.error && (
+        <div className="text-xs text-red-400 bg-red-950/50 p-2 rounded flex items-center justify-between gap-2 mt-2">
+          <span>{task.error}</span>
+          <button
+            onClick={() => removeTask(session.id)}
+            className="btn text-xs bg-slate-700 hover:bg-slate-600 shrink-0"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       <ConfirmDialog
         open={showStopConfirm}
@@ -1120,8 +1162,7 @@ function SessionCard({ session }: SessionCardProps) {
         description="Are you sure you want to stop this session?"
         confirmLabel="Stop"
         variant="danger"
-        onConfirm={() => deleteMutation.mutate(session.id)}
-        isLoading={deleteMutation.isPending}
+        onConfirm={handleConfirmStop}
       />
     </>
   );

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -922,95 +922,101 @@ export function WorktreeRow({ worktree, session, pausedSession, repositoryId, is
       : 'bg-gray-600';     // No session
 
   return (
-    <div className="flex flex-col gap-2 p-2 bg-slate-800 rounded md:flex-row md:items-center md:gap-3">
-      {/* Info section: index, status dot, and content - always horizontal */}
-      <div className="flex items-center gap-3 flex-1 min-w-0">
-        <span className="w-6 text-center text-sm font-mono text-gray-500 shrink-0">
-          {worktree.index !== undefined ? worktree.index : '0'}
-        </span>
-        <span className={`inline-block w-2 h-2 rounded-full ${statusColor} shrink-0`} />
-        <div className="flex-1 min-w-0">
-          <div className="text-sm font-medium flex items-center gap-2">
-            {/* Show title from active session or paused session */}
-            {(session?.title || pausedSession?.title) && (
-              <>
-                <span className="truncate" title={session?.title || pausedSession?.title}>{session?.title || pausedSession?.title}</span>
-                <span className="text-gray-500">-</span>
-              </>
-            )}
-            <span className={(session?.title || pausedSession?.title) ? 'text-gray-400' : ''}>{worktree.branch}</span>
-            {worktree.isMain && (
-              <span className="text-xs text-gray-500">(primary)</span>
-            )}
-            {hasVSCode() && (
-              <button
-                onClick={async (e) => {
-                  e.stopPropagation();
-                  try {
-                    await openInVSCode(worktree.path);
-                  } catch (err) {
-                    logger.error('Failed to open in VS Code:', err);
-                  }
-                }}
-                className="p-1 text-gray-400 hover:text-white hover:bg-slate-700 rounded"
-                title="Open in VS Code"
-              >
-                <VSCodeIcon className="w-4 h-4" />
-              </button>
-            )}
-            {session && <ActivityBadge state={session.activityState} />}
-          </div>
-          <PathLink path={worktree.path} className="text-xs text-gray-500 truncate" />
-        </div>
-      </div>
-      <div className="flex gap-2 shrink-0 pl-11 md:pl-0">
-        {session ? (
-          <Link
-            to="/sessions/$sessionId"
-            params={{ sessionId: session.id }}
-            className="btn btn-primary text-xs no-underline"
-          >
-            Open
-          </Link>
-        ) : pausedSession ? (
-          <button
-            onClick={handleResumeSession}
-            disabled={resumeSessionMutation.isPending}
-            className="btn btn-primary text-xs"
-          >
-            {resumeSessionMutation.isPending ? 'Resuming...' : 'Resume'}
-          </button>
-        ) : (
-          <button
-            onClick={handleRestoreSession}
-            disabled={restoreSessionMutation.isPending}
-            className="btn btn-primary text-xs"
-          >
-            {restoreSessionMutation.isPending ? 'Restoring...' : 'Restore'}
-          </button>
-        )}
-        <button
-          onClick={onPull}
-          disabled={isPulling}
-          className="btn text-xs bg-slate-700 hover:bg-slate-600"
-        >
-          {isPulling ? 'Pulling...' : 'Pull'}
-        </button>
-        {!worktree.isMain && (
-          <button
-            onClick={handleDeleteWorktree}
-            disabled={isDeleting}
-            className="btn btn-danger text-xs"
-          >
-            {isDeleting ? 'Deleting...' : 'Delete'}
-          </button>
-        )}
-        {stopTask && (
-          <span className="text-xs text-gray-400 flex items-center gap-1">
-            <Spinner size="sm" />
-            {stopTask.action === 'pause' ? 'Pausing...' : 'Stopping...'}
+    <div className="flex flex-col gap-2 p-2 bg-slate-800 rounded">
+      {/* Row wrapper: info + actions, horizontal from md: up. The error block
+          below is a sibling of this wrapper (not a flex item within it) so it
+          always renders on its own line instead of being squeezed by the
+          outer container's flex-row layout. */}
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+        {/* Info section: index, status dot, and content - always horizontal */}
+        <div className="flex items-center gap-3 flex-1 min-w-0">
+          <span className="w-6 text-center text-sm font-mono text-gray-500 shrink-0">
+            {worktree.index !== undefined ? worktree.index : '0'}
           </span>
-        )}
+          <span className={`inline-block w-2 h-2 rounded-full ${statusColor} shrink-0`} />
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium flex items-center gap-2">
+              {/* Show title from active session or paused session */}
+              {(session?.title || pausedSession?.title) && (
+                <>
+                  <span className="truncate" title={session?.title || pausedSession?.title}>{session?.title || pausedSession?.title}</span>
+                  <span className="text-gray-500">-</span>
+                </>
+              )}
+              <span className={(session?.title || pausedSession?.title) ? 'text-gray-400' : ''}>{worktree.branch}</span>
+              {worktree.isMain && (
+                <span className="text-xs text-gray-500">(primary)</span>
+              )}
+              {hasVSCode() && (
+                <button
+                  onClick={async (e) => {
+                    e.stopPropagation();
+                    try {
+                      await openInVSCode(worktree.path);
+                    } catch (err) {
+                      logger.error('Failed to open in VS Code:', err);
+                    }
+                  }}
+                  className="p-1 text-gray-400 hover:text-white hover:bg-slate-700 rounded"
+                  title="Open in VS Code"
+                >
+                  <VSCodeIcon className="w-4 h-4" />
+                </button>
+              )}
+              {session && <ActivityBadge state={session.activityState} />}
+              {stopTask && (
+                <span className="text-xs text-gray-400 flex items-center gap-1 shrink-0">
+                  <Spinner size="sm" />
+                  {stopTask.action === 'pause' ? 'Pausing...' : 'Stopping...'}
+                </span>
+              )}
+            </div>
+            <PathLink path={worktree.path} className="text-xs text-gray-500 truncate" />
+          </div>
+        </div>
+        <div className="flex gap-2 shrink-0 pl-11 md:pl-0">
+          {session ? (
+            <Link
+              to="/sessions/$sessionId"
+              params={{ sessionId: session.id }}
+              className="btn btn-primary text-xs no-underline"
+            >
+              Open
+            </Link>
+          ) : pausedSession ? (
+            <button
+              onClick={handleResumeSession}
+              disabled={resumeSessionMutation.isPending}
+              className="btn btn-primary text-xs"
+            >
+              {resumeSessionMutation.isPending ? 'Resuming...' : 'Resume'}
+            </button>
+          ) : (
+            <button
+              onClick={handleRestoreSession}
+              disabled={restoreSessionMutation.isPending}
+              className="btn btn-primary text-xs"
+            >
+              {restoreSessionMutation.isPending ? 'Restoring...' : 'Restore'}
+            </button>
+          )}
+          <button
+            onClick={onPull}
+            disabled={isPulling}
+            className="btn text-xs bg-slate-700 hover:bg-slate-600"
+          >
+            {isPulling ? 'Pulling...' : 'Pull'}
+          </button>
+          {!worktree.isMain && (
+            <button
+              onClick={handleDeleteWorktree}
+              disabled={isDeleting}
+              className="btn btn-danger text-xs"
+            >
+              {isDeleting ? 'Deleting...' : 'Delete'}
+            </button>
+          )}
+        </div>
       </div>
 
       {stopTask?.error && (


### PR DESCRIPTION
## Summary

Stop Session and Pause Session previously held a modal `AlertDialog` open while the server mutation was pending, freezing the **entire app** (sidebar, header, other sessions) for the whole round-trip. This PR converts both flows to the same client-side task pattern already used correctly by worktree deletion (`DeleteWorktreeDialog` + `WorktreeDeletionTasksContext`): the dialog closes synchronously on confirm, and pending/error state is scoped to the affected session only (dashboard row + session-page banner).

This is not a new mechanism — it generalizes an existing, correct in-repo pattern to the three Stop/Pause call sites that had never adopted it. See the architect's Design Ruling in the Issue for the full rationale.

## What changed

- New `SessionStopTasksContext` (`contexts/root-contexts.ts`) + `useSessionStopTasks` hook (`hooks/useSessionStopTasks.ts`), mirroring `WorktreeDeletionTasksContext` / `useWorktreeDeletionTasks`. At most one task per `sessionId`; `addTask` is a structural no-op if a task already exists (closes the double-fire race without relying on React re-render timing — verified via a `useRef` mirror, not a `setState` closure).
- Provider wired in `routes/__root.tsx` alongside its siblings.
- `EndSessionDialog` (quick-session Stop) and `PauseSessionDialog` (worktree-session Pause) converted to the `addTask` → `onOpenChange(false)` (synchronous) → `navigate({ to: '/' })` → `await` the API → `markAsFailed` on rejection ordering, verbatim from `DeleteWorktreeDialog`.
- Dashboard `SessionCard`'s Stop flow (`routes/index.tsx`) converted the same way, minus the navigate (already on `/`). Also **removed** its `emitSessionDeleted(...)` call in `onSuccess` — that was a client-side optimistic-update anti-pattern the new design explicitly forbids (the session list only ever changes via the WS `sessions-sync` / `session-deleted` broadcast).
- Task removal is event-driven off server truth in `useSessionSideEffects`: a `stop` task is removed when its session leaves the `sessions-sync` snapshot (or an explicit `session-deleted` arrives); a `pause` task is removed when its session's status becomes `inactive` (via `session-paused`, or discovered as such in a sync snapshot). This makes WS-reconnect self-healing.
- Scoped pending/error UI:
  - `SessionCard` (Dashboard, quick sessions): Stop button becomes a disabled `Stopping...`/`Pausing...` indicator while a task exists; `Open` stays enabled. Error + Dismiss render inline below.
  - `WorktreeRow` (Dashboard, worktree sessions): a small `Pausing.../Stopping...` badge next to the activity badge, `Open`/`Pull`/`Delete` stay enabled/unchanged. Error + Dismiss render on their own full-width line below the row (see the follow-up commit note below).
  - `SessionPage`: a non-modal banner (pending, or error + Dismiss) shown when a task targets the displayed session, plus the relevant lifecycle menu entry (`Pause` for worktree sessions, `Stop Session` for quick sessions) is disabled while the task exists.
- No toast system introduced (none exists in this repo; out of scope per the Issue).
- No modal is ever mounted while a task is pending, anywhere.

### Follow-up commit: layout fix from Browser QA

The first Browser QA pass (screenshots below) caught a real layout bug: `WorktreeRow`'s outer container became a 3-child `flex-row` (info section, actions, and the new error block) at the `md:` breakpoint with no wrap, so the error block was squeezed off-screen and the in-row pending indicator was clipped next to `Open`/`Pull`/`Delete`. Fixed by restructuring the row (info+actions in an inner row wrapper, error block as a full-width sibling) and moving the pending indicator into the info section next to the activity badge, where there's room. Re-verified visually after the fix (screenshot 2 below is post-fix).

## Design ruling reference

Closes #1247. All 5 architect Design Rulings and the prescriptive Fix Plan in the Issue were followed as specified; no redesign was needed. No architect consultation was required during implementation — the Issue's rulings were sufficiently prescriptive for the remaining implementation-detail decisions (exact banner copy/classes, where to render the worktree-row pending indicator given it has no pre-existing Stop button to "replace"). Those judgment calls: pending/error banner uses the existing yellow/red color conventions already established by `PauseSessionDialog` and `EndSessionDialog`/orphan-delete; the `WorktreeRow` dashboard indicator is a small additive badge rather than a button replacement, since that row's only pre-existing lifecycle action is `Delete` (worktree deletion, untouched/out of scope) — `Pause` has never had a dashboard-row control, only a session-page menu entry.

## Polarity verification (AC requirement)

For both `EndSessionDialog` and `PauseSessionDialog`, the new "dialog closes synchronously without awaiting the mutation" test was run against the pre-conversion (held-open, `useMutation`/`isPending`-gated) implementation first:

- **EndSessionDialog**: the 3 new tests (closes synchronously, double-click fires once, `markAsFailed` on rejection) **failed 3/3** against the pre-conversion file; all 5 pre-existing tests still passed. After conversion: **8/8 pass**.
- **PauseSessionDialog**: identical procedure — **3/3 new tests failed** pre-conversion, **8/8 pass** post-conversion.

## Q10 (shared-type / wire-schema change)

**N/A** — this is a client-only change. No new `AppServerMessage` variant, no valibot schema change, no new WS payload. Task removal is wired entirely off the *existing* `sessions-sync` / `session-deleted` / `session-paused` events; nothing new is broadcast by the server.

## Accepted limitations (documented, no code required per the Issue)

- A page **reload** during a pending stop/pause loses the client-side task set (controls re-enable; the server operation continues in the background; the WS broadcast still lands and updates the session list correctly when it arrives). Verified directly during Browser QA (see below) — reloading mid-pause showed the row plainly re-enabled while the server-side pause was still in flight, and the session correctly flipped to paused once the operation completed.
- A server that never responds leaves the task pending indefinitely — same exposure as today's forever-open modal, minus the app freeze.

## Browser QA

Performed against a throwaway dev instance (`bun run dev` with isolated ports/data dir) with a scratch git repo registered as the test repository (`/tmp/.../qa-repo-1247`), one quick session and one worktree session.

**Technique for capturing the pending window** (per `workflow.md`'s gated-UI rule — documented transparently, fully reverted before every commit): a temporary, uncommitted `await new Promise(resolve => setTimeout(resolve, N))` was added at the top of the server's `DELETE /api/sessions/:id` and `POST /api/sessions/:id/pause` handlers (`packages/server/src/routes/sessions.ts`), just long enough to reliably screenshot the pending state before the operation resolved. Verified via `git diff`/`git status` that the file was back to a clean, unmodified state before every commit in this PR — the delay never touched a committed diff. (An initial attempt used Chrome DevTools' network throttling (`Slow 3G`) instead of a server-side delay, to avoid touching server code at all; it worked for the Stop flow's "dialog gone" screenshot but wasn't reliably slow enough for the multi-step Pause flow, so the server-side delay was used for the remaining captures.)

Screenshots (uploaded as a PR comment via `scripts/upload-qa-screenshots.sh`):

1. **`1-stop-dialog-closed-app-interactive`** — Stop confirmed on a quick session: the confirm dialog is gone, the session row shows a disabled "Stopping..." indicator, and the sidebar/header/rest of the dashboard are fully rendered and interactive (not blocked by any overlay).
2. **`2-dashboard-worktree-row-pausing`** — the worktree session's dashboard row showing the "Pausing..." indicator cleanly next to the activity badge (post layout-fix).
3. **`3-session-page-pausing-banner`** — the session page's non-modal amber banner ("Pausing this session...") when revisited during the pending window, sidebar/header still fully interactive.
4. **`3-session-page-error-banner-dismiss`** — the session page's red error banner + Dismiss button (a real error surfaced during QA — a dev-proxy connection drop from the artificial delay — exercising the actual `markAsFailed` → banner → Dismiss path end-to-end).
5. **`1b-sidebar-nav-works-while-stop-pending`** — supplementary: successfully navigated to a *different* session via the sidebar while the first session's Stop was still pending, demonstrating the rest of the app is not just visually unblocked but actually interactive.

Also manually confirmed: resuming a paused session, dismissing an error re-enables the Pause/Stop control (retry path), and a hard page reload mid-pending drops the local task (control re-enables) while the server-side operation completes correctly in the background and the session transitions as expected once the WS broadcast arrives.

## Verification (Definition of Done)

- `bun run typecheck` — clean (routes touched; `routeTree.gen.ts` deleted and regenerated before each check per the stale-generation caveat).
- `bun run test` (full suite) — `TEST_EXIT: 0` after every commit (feature, layout fix, and nitpick-fix commits). Final: server 3720 pass / 1 skip, client 2107 pass, shared 596 pass, embedded-agent 287 pass, integration 73 pass, scripts/hooks/skills 521 pass — 0 fail.
- `bun run check:mock-module` — clean, 0 new violations (no `mock.module()` used; new context tests use the real `SessionStopTasksContext.Provider` + fetch-level stubs per `testing.md`).
- `node .claude/skills/orchestrator/preflight-check.js` — clean.
- `coderabbit review --agent --base main` — **CLI authentication failed** in this headless sandbox (`automatic_login_failed`), not a rate-limit. Could not run locally; relying on the GitHub-side bot review post-push per `coderabbit-ops`.
- No merge conflicts with current `origin/main` (`git merge-tree` dry run, 0 conflict markers).

## CodeRabbit LOW findings disposition

CodeRabbit's first pass left 5 LOW/Trivial nitpick comments (no CRITICAL/HIGH/MEDIUM, no CHANGES_REQUESTED). Per `coderabbit-ops`, every finding gets an explicit disposition below rather than a blanket severity judgment. 3 were fixed inline (commit `5f62e7d1`); 2 are deferred.

1. **`SessionPage.tsx` — missing `role="alert"` on the error banner.** **Fixed** — added `role="alert"` to the non-modal Stop/Pause error banner div (1-line, no behavior change).
2. **`routes/__tests__/index.test.tsx` — duplicated `RealSessionStopTasksProvider` test helper.** **Fixed** — hoisted to module scope, both call sites now reference the single declaration.
3. **`SessionSettingsMenu.test.tsx` — menu-opening tests fire a real unmocked `fetchSessionPrLink` request.** **Fixed** — added a `globalThis.fetch` stub (same pattern as `EndSessionDialog.test.tsx`/`PauseSessionDialog.test.tsx`) so both menu-opening tests are deterministic.
4. **`SessionSettings.test.tsx` — `renderWithRouterAndContext`'s 4 positional params could be an options object.** **Deferred** — a pure test-helper API style preference; would touch every call site in the file for a refactor with no behavior or coverage change. Out of scope for this PR; a good target for a future test-infra cleanup pass if the helper gains more params.
5. **`createMockSessionStopTasks` duplicated across 7 test files.** **Deferred** — a legitimate DRY observation, but extracting a shared test factory (e.g. `src/test/session-stop-tasks.ts`) touches 7 files for a non-functional change. Out of scope for this PR; worth doing as a small follow-up once the pattern is confirmed stable (this PR is the first consumer of the shape).

## Merge disposition note (2026-07-30)

**CR state**: commit `b26a20bc` got a genuine walkthrough at 03:33 UTC (5 LOW/Trivial nitpicks, all dispositioned above). The follow-up nitpick-fix commit `5f62e7d1` (3-file diff: 1-line `role="alert"`, test-helper hoist, fetch stub — all test/a11y-only, no application-logic change) shows commit-status `CodeRabbit=success` but `description: "Review rate limited"` — the bot did not actually review this commit (verified via `gh api .../commits/<sha>/status`, per `coderabbit-ops`'s "fourth surface" caveat, not the rollup state alone). The local CLI remains unavailable for this session (headless-worktree auth failure, documented above) — both channels are unavailable for this specific commit.

**Fallback disposition applied** (`coderabbit-ops` "headless auth-fail AND GitHub bot rate-limited for the same commit" case): substitute verification via Architect independent code-appropriateness audit of the `5f62e7d1` delta + Orchestrator acceptance = dual-clean. This is the next step in this PR's review flow regardless, so no additional wait was introduced.

## Test plan

- [x] New context/hook unit tests (`useSessionStopTasks.test.ts`)
- [x] `useSessionSideEffects` task-removal reactions (sync/session-deleted/session-paused, including the no-resurrection boundary case)
- [x] `EndSessionDialog` / `PauseSessionDialog` polarity + double-fire + error-path tests
- [x] `SessionCard` / `WorktreeRow` scoped pending/error UI tests
- [x] `SessionSettingsMenu` / `QuickSessionSettingsMenu` disabled-while-pending tests
- [x] Manual Browser QA (see above)

Closes #1247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear in-progress indicators for session stopping and pausing.
  * Prevented duplicate Stop or Pause actions while an operation is underway.
  * Added error messages with dismiss controls when stopping or pausing fails.
  * Session status now updates automatically as operations complete or sessions are removed.

* **Bug Fixes**
  * Stop and Pause actions now close promptly and handle delayed or failed requests more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

