### PR TITLE
fix: close spawnAsUser stdin sink at teardown for feeding consumers (closes #1230)

### DIFF
--- a/.claude/rules/elevation-helpers.md
+++ b/.claude/rules/elevation-helpers.md
@@ -105,6 +105,35 @@ The fix is a one-liner; the cost of missing it is a class of bugs that does not 
 
 The `stdin.end()` discipline is structurally similar to "drain stdout/stderr after spawnAsUser if you do not consume them" (also a `spawnAsUser` consumer obligation, addressed in PR #889 via the same conditional-wakeup migration's `drainAndDiscard` helper). Both follow from the primitive piping streams that its long-lived consumers need but that fire-and-forget consumers do not. Future helpers in this family may introduce analogous consumer-side disciplines; the principle is the same: **the primitive's defaults are tuned for its loudest consumer; quieter consumers inherit obligations that the primitive cannot encode**.
 
+### `spawnAsUser`: close stdin at teardown for feeding consumers
+
+The fire-and-forget rule above is written against the shape "never writes to stdin". It is silent about the opposite shape: a **feeding** consumer that writes to stdin across the process's whole lifetime (a long-lived worker fed commands over time). A feeding consumer correctly concludes the fire-and-forget obligation is not theirs -- and then nothing tells them what IS theirs. The obligation does not disappear; it moves from "immediately" to "at teardown".
+
+**Rule**: every teardown path for a feeding `spawnAsUser` consumer -- every place that stops tracking the subprocess (a kill call, a map deletion/clear, an activation-failure cleanup catch) -- must close the stdin `FileSink` via a per-service private `endStdinSafely(stdin)` helper, not merely drop the reference and let GC incidentally reclaim the pipe fd. This is the same reachability argument Issue #1196 established for the PTY master fd: a worker object referenced from a session/worker map stays reachable for the worker's whole life, so "unreachable, therefore GC'd" is not a real release path in production.
+
+The helper is a thin, per-service, private wrapper -- NOT a new elevation primitive (the strict-thin-wrapper contract in this file's "The strict-thin-wrapper contract" section stands; a tolerant "safe end" is *semantics*, and semantics live at the caller). Duplicate it in each consumer once a second consumer needs it, rather than extracting a shared helper before a third consumer exists (see "When to extract a new helper" above). It must tolerate, without throwing into the teardown path:
+
+- `stdin` being `null` (not yet activated / already torn down),
+- an already-exited child (`end()` on a broken pipe),
+- being invoked more than once for the same sink (a defensive property, not necessarily a reachable production sequence -- teardown code should still never assume it is the only caller).
+
+```ts
+function endStdinSafely(stdin: FileSink | null): void {
+  if (!stdin) return;
+  try {
+    stdin.end();
+  } catch (err) {
+    logger.warn({ err }, 'Failed to close subprocess stdin sink at teardown');
+  }
+}
+```
+
+**Ordering matters when a signal is also involved.** If a teardown path both signals the process (SIGTERM/SIGKILL) and closes stdin, signal FIRST, then close -- kill-then-end keeps existing signal-based exit semantics byte-identical, because closing stdin first would give the child an EOF-triggered exit path that races the signal, introducing a second, previously-nonexistent exit mechanism. The end is purely additive resource release once the signal path is already in flight; it must never become alternative exit machinery.
+
+**Ordering matters relative to the reference itself.** Close the sink BEFORE nulling the field that held it (`worker.stdin = null` or equivalent) -- once the reference is dropped, `endStdinSafely` cannot reach the sink to close it.
+
+**Worked example**: Issue [#1230](https://github.com/ms2sato/agent-console/issues/1230) found this gap in both of this codebase's feeding `spawnAsUser` consumers -- `interactive-process-manager.ts` (3 teardown sites: `killProcess()`, the per-session cleanup loop, the shutdown-all path) and `embedded-agent-worker-service.ts` (the exit observer, which is every exit's single choke point, managed or unexpected; and the activation-failure catch, which the exit observer never runs for, since a spawn that fails before the exit observer is registered has no observer to fall back on). `embedded-agent-worker-service.ts`'s own header comment had stated the fire-and-forget exemption correctly but never mentioned the teardown obligation that replaces it -- confident-but-incomplete phrasing hid the gap from a reader auditing for exactly this class of bug.
+
 ### Caller-side pre-filter discipline
 
 When the consumer's existing direct-spawn path applies an env / arg / shape transformation that `runAsUser`'s non-elevated branch does NOT replicate (e.g., `getCleanChildProcessEnv()` stripping `AGENT_CONSOLE_*` / `SERVER_ONLY_ENV_VARS` before spawn), **gate the elevation at the caller** via `shouldElevateForUser(requestUsername)` and keep the legacy direct-spawn branch verbatim for the non-elevated case. Do NOT push the filter into `runAsUser` — that would violate the strict-thin-wrapper contract by adding semantic layering inside the primitive.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check:pty-fd-leak": "bun scripts/smoke/check-pty-fd-leak.ts",
     "check:pty-early-output": "bun scripts/smoke/check-pty-early-output.ts",
     "check:pty-als-data": "bun scripts/smoke/check-pty-als-data.ts",
+    "check:stdin-sink-leak": "bun scripts/smoke/check-stdin-sink-leak.ts",
     "hooks:install": "bun scripts/install-hooks.mjs",
     "preinstall": "bun scripts/check-bun-version.mjs",
     "postinstall": "bun scripts/install-hooks.mjs",

--- a/packages/server/src/services/__tests__/embedded-agent-worker-service.test.ts
+++ b/packages/server/src/services/__tests__/embedded-agent-worker-service.test.ts
@@ -80,6 +80,8 @@ interface FakeSpawn {
   stdinWrites: string[];
   flushCount: () => number;
   killSignals: number[];
+  /** Issue #1230: number of times the fake stdin sink's `end()` was called. */
+  endCount: () => number;
   pushStdout: (s: string) => void;
   pushStderr: (s: string) => void;
   /** Resolve `exited` AND close both streams so the exit observer can complete. */
@@ -90,11 +92,18 @@ interface FakeSpawn {
   setOnStdinWrite: (fn: (chunk: string) => void) => void;
 }
 
-function makeFakeSpawn(): FakeSpawn {
+/**
+ * Issue #1230: options controlling the fake stdin sink's `end()` behavior, so
+ * teardown tests can assert `endStdinSafely` was invoked (via `endCount`) and
+ * that a throwing `end()` (simulating an already-exited child / broken pipe)
+ * does not propagate out of the teardown path.
+ */
+function makeFakeSpawn(opts?: { endThrows?: boolean }): FakeSpawn {
   const captured: SpawnAsUserOpts[] = [];
   const stdinWrites: string[] = [];
   const killSignals: number[] = [];
   let flushes = 0;
+  let ends = 0;
   let onKill: ((signal: number) => void) | undefined;
   // Fired at the exact moment stdin.write is called (Finding 3: lets the
   // append-before-forward test record ordering at call-time, not after await).
@@ -115,7 +124,12 @@ function makeFakeSpawn(): FakeSpawn {
       onStdinWrite?.(s);
       return 0;
     },
-    end: () => {},
+    end: () => {
+      ends += 1;
+      if (opts?.endThrows) {
+        throw new Error('EPIPE: stdin already closed');
+      }
+    },
     flush: () => {
       flushes += 1;
       return 0;
@@ -149,6 +163,7 @@ function makeFakeSpawn(): FakeSpawn {
     stdinWrites,
     flushCount: () => flushes,
     killSignals,
+    endCount: () => ends,
     pushStdout: stdout.push,
     pushStderr: stderr.push,
     simulateExit: (code: number) => {
@@ -223,6 +238,8 @@ function setup(opts?: {
   staleOutputOffset?: number;
   /** Transcript Restore (#1123): readHistoryWithOffset rejects instead of resolving (simulates a persistent I/O error on an existing worker). */
   readHistoryWithOffsetThrows?: boolean;
+  /** Issue #1230: make the fake stdin sink's `end()` throw (simulates an already-exited child / broken pipe at teardown). */
+  spawnEndThrows?: boolean;
 }): Harness {
   const definition = 'definition' in (opts ?? {}) ? opts!.definition : buildDefinition();
   const createdBy = opts && 'createdBy' in opts ? opts.createdBy : 'user-1';
@@ -239,7 +256,7 @@ function setup(opts?: {
     initialPrompt: opts?.initialPrompt,
     initialPromptDelivered: opts?.initialPromptDelivered,
   });
-  const fake = makeFakeSpawn();
+  const fake = makeFakeSpawn({ endThrows: opts?.spawnEndThrows });
 
   const mint = mock(() => TOKEN);
   const revokeByWorker = mock(() => {});
@@ -1045,6 +1062,61 @@ describe('EmbeddedAgentWorkerService exit handling', () => {
     expect(h.revokeByWorker).not.toHaveBeenCalled();
     expect(appendedLines(h.bufferOutput)).not.toContain('{"v":1,"type":"exited","code":1}');
     expect(h.globalExit).not.toHaveBeenCalled();
+  });
+});
+
+// -----------------------------------------------------------------------
+// Issue #1230: feeding spawnAsUser consumers must close the stdin sink at
+// teardown so the OS pipe fd is released deterministically instead of being
+// left for incidental GC (same unsound pattern Issue #1196 flagged for PTY
+// master fds). Two teardown sites: the exit observer (handleExit) and the
+// activation-failure catch in runActivation (for a failure occurring after
+// spawn but before the exit observer is registered).
+// -----------------------------------------------------------------------
+describe('EmbeddedAgentWorkerService stdin sink teardown (Issue #1230)', () => {
+  it('closes the stdin sink exactly once when the subprocess exits (handleExit)', async () => {
+    const h = setup();
+    await h.service.activate(h.sessionId, h.workerId);
+
+    h.fake.simulateExit(0);
+    await waitFor(() => h.worker.subprocess === null);
+
+    expect(h.fake.endCount()).toBe(1);
+  });
+
+  it('completes exit cleanup without throwing when the stdin sink throws on end() (broken pipe)', async () => {
+    const h = setup({ spawnEndThrows: true });
+    await h.service.activate(h.sessionId, h.workerId);
+    h.recorder.onExit.mockClear();
+
+    h.fake.simulateExit(1);
+    await waitFor(() => h.worker.subprocess === null);
+
+    // Cleanup ran to completion (revoke, null fields, fire onExit) despite
+    // the sink throwing on end() -- `endStdinSafely` swallows it internally.
+    expect(h.worker.subprocess).toBeNull();
+    expect(h.worker.stdin).toBeNull();
+    expect(h.revokeByWorker).toHaveBeenCalledWith(h.workerId);
+    expect(h.recorder.onExit).toHaveBeenCalledWith(1, null, 'unexpected');
+    expect(h.fake.endCount()).toBe(1);
+  });
+
+  it('closes the spawned stdin sink when a post-spawn step fails before the exit observer is registered', async () => {
+    // The init command write (runActivation Step 6) is the only step between
+    // assigning the spawned stdin handle and registering the exit observer
+    // (Step 7). Forcing it to throw exercises the activation-failure catch's
+    // teardown path with a live (never-observed) stdin sink.
+    const h = setup();
+    h.fake.setOnStdinWrite(() => {
+      throw new Error('EPIPE: broken pipe during init write');
+    });
+
+    await expect(h.service.activate(h.sessionId, h.workerId)).rejects.toThrow('EPIPE');
+
+    expect(h.worker.subprocess).toBeNull();
+    expect(h.worker.stdin).toBeNull();
+    expect(h.revokeByWorker).toHaveBeenCalledWith(h.workerId);
+    expect(h.fake.endCount()).toBe(1);
   });
 });
 

--- a/packages/server/src/services/__tests__/interactive-process-manager.test.ts
+++ b/packages/server/src/services/__tests__/interactive-process-manager.test.ts
@@ -251,6 +251,17 @@ describe('InteractiveProcessManager', () => {
     }
 
     /**
+     * Issue #1230: fake `spawnAsUserFn` options controlling the returned
+     * stdin sink's `end()` behavior, so teardown tests can assert
+     * `endStdinSafely` is invoked (via an `endCalls` counter) and that a
+     * throwing `end()` (simulating an already-exited child / broken pipe)
+     * does not propagate out of the teardown path.
+     */
+    interface FakeSpawnAsUserOpts {
+      endThrows?: boolean;
+    }
+
+    /**
      * Subset of Bun's `Subprocess<'pipe','pipe','pipe'>` shape that
      * `interactive-process-manager` actually consumes (`exited`, `stdout`,
      * `stderr`, `stdin`, `kill`). Mirrors the `FakeProc` pattern used in
@@ -269,16 +280,21 @@ describe('InteractiveProcessManager', () => {
      * a controllable FakeSubprocess. The FakeSubprocess exposes
      * `.simulateExit(code)` so tests can drive the lifecycle.
      */
-    function makeFakeSpawnAsUser(captured: CapturedSpawn[]): {
+    function makeFakeSpawnAsUser(
+      captured: CapturedSpawn[],
+      opts?: FakeSpawnAsUserOpts,
+    ): {
       fn: SpawnAsUserFn;
       lastStdinWrites: Array<string | Uint8Array>;
       flushCalls: { count: number };
       killSignals: number[];
+      endCalls: { count: number };
       simulateExit: (code: number) => void;
     } {
       const lastStdinWrites: Array<string | Uint8Array> = [];
       const flushCalls = { count: 0 };
       const killSignals: number[] = [];
+      const endCalls = { count: 0 };
       let resolveExited: ((code: number) => void) | null = null;
       const exited = new Promise<number>((resolve) => {
         resolveExited = resolve;
@@ -289,7 +305,12 @@ describe('InteractiveProcessManager', () => {
           lastStdinWrites.push(chunk);
           return 0;
         },
-        end: () => {},
+        end: () => {
+          endCalls.count++;
+          if (opts?.endThrows) {
+            throw new Error('EPIPE: stdin already closed');
+          }
+        },
         flush: () => {
           flushCalls.count++;
           return Promise.resolve(0);
@@ -338,6 +359,7 @@ describe('InteractiveProcessManager', () => {
         lastStdinWrites,
         flushCalls,
         killSignals,
+        endCalls,
         simulateExit: (code: number) => resolveExited?.(code),
       };
     }
@@ -476,6 +498,147 @@ describe('InteractiveProcessManager', () => {
       // Resolve to avoid hanging promises in afterEach
       fake.simulateExit(143);
       elevatedManager.disposeAll();
+    });
+
+    // -----------------------------------------------------------------------
+    // Issue #1230: close the stdin sink at each of the 3 teardown sites so the
+    // OS pipe fd is released deterministically (not left for incidental GC,
+    // same unsound pattern Issue #1196 flagged for PTY master fds). Nested
+    // inside this describe block so the tests can reuse `makeFakeSpawnAsUser`.
+    // -----------------------------------------------------------------------
+    describe('stdin sink teardown (Issue #1230)', () => {
+      it('killProcess closes the stdin sink exactly once', async () => {
+        const captured: CapturedSpawn[] = [];
+        const fake = makeFakeSpawnAsUser(captured);
+        const elevatedManager = new InteractiveProcessManager(
+          onOutput,
+          onExit,
+          { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+          onResponse,
+          fake.fn,
+        );
+
+        const info = await elevatedManager.runProcess({
+          sessionId: 'session-1',
+          workerId: 'worker-1',
+          command: 'sleep 60',
+        });
+
+        elevatedManager.killProcess(info.id);
+        expect(fake.endCalls.count).toBe(1);
+
+        fake.simulateExit(143);
+      });
+
+      it('deleteProcessesBySession closes the stdin sink exactly once per deleted process', async () => {
+        const captured: CapturedSpawn[] = [];
+        const fake = makeFakeSpawnAsUser(captured);
+        const elevatedManager = new InteractiveProcessManager(
+          onOutput,
+          onExit,
+          { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+          onResponse,
+          fake.fn,
+        );
+
+        await elevatedManager.runProcess({
+          sessionId: 'session-1',
+          workerId: 'worker-1',
+          command: 'sleep 60',
+        });
+
+        const deleted = elevatedManager.deleteProcessesBySession('session-1');
+        expect(deleted).toBe(1);
+        expect(fake.endCalls.count).toBe(1);
+
+        fake.simulateExit(143);
+      });
+
+      it('disposeAll closes the stdin sink exactly once per disposed process', async () => {
+        const captured: CapturedSpawn[] = [];
+        const fake = makeFakeSpawnAsUser(captured);
+        const elevatedManager = new InteractiveProcessManager(
+          onOutput,
+          onExit,
+          { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+          onResponse,
+          fake.fn,
+        );
+
+        await elevatedManager.runProcess({
+          sessionId: 'session-1',
+          workerId: 'worker-1',
+          command: 'sleep 60',
+        });
+
+        elevatedManager.disposeAll();
+        expect(fake.endCalls.count).toBe(1);
+
+        fake.simulateExit(143);
+      });
+
+      it('killProcess still returns true and removes the process when the stdin sink throws on end() (broken pipe)', async () => {
+        const captured: CapturedSpawn[] = [];
+        const fake = makeFakeSpawnAsUser(captured, { endThrows: true });
+        const elevatedManager = new InteractiveProcessManager(
+          onOutput,
+          onExit,
+          { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+          onResponse,
+          fake.fn,
+        );
+
+        const info = await elevatedManager.runProcess({
+          sessionId: 'session-1',
+          workerId: 'worker-1',
+          command: 'sleep 60',
+        });
+
+        const killed = elevatedManager.killProcess(info.id);
+        expect(killed).toBe(true);
+        expect(elevatedManager.getProcess(info.id)).toBeUndefined();
+        expect(fake.endCalls.count).toBe(1);
+
+        fake.simulateExit(143);
+      });
+
+      it('tolerates end() being invoked more than once on the same stdin sink without throwing', async () => {
+        // Two processes spawned through the SAME fake spawnAsUserFn share the
+        // identical underlying fake stdin sink object (the fake's `stdin`
+        // closure variable is created once and reused across calls). Killing
+        // both exercises `endStdinSafely` twice against the same sink through
+        // two separate, real teardown-path invocations (killProcess x2),
+        // demonstrating the double-teardown tolerance without fabricating an
+        // artificial call sequence.
+        const captured: CapturedSpawn[] = [];
+        const fake = makeFakeSpawnAsUser(captured);
+        const elevatedManager = new InteractiveProcessManager(
+          onOutput,
+          onExit,
+          { injectPtyMessage: mockInjectPtyMessage, writePtyData: mockWritePtyData },
+          onResponse,
+          fake.fn,
+        );
+
+        const infoA = await elevatedManager.runProcess({
+          sessionId: 'session-1',
+          workerId: 'worker-1',
+          command: 'sleep 60',
+        });
+        const infoB = await elevatedManager.runProcess({
+          sessionId: 'session-1',
+          workerId: 'worker-1',
+          command: 'sleep 61',
+        });
+
+        expect(() => {
+          elevatedManager.killProcess(infoA.id);
+          elevatedManager.killProcess(infoB.id);
+        }).not.toThrow();
+        expect(fake.endCalls.count).toBe(2);
+
+        fake.simulateExit(143);
+      });
     });
   });
 

--- a/packages/server/src/services/embedded-agent-worker-service.ts
+++ b/packages/server/src/services/embedded-agent-worker-service.ts
@@ -14,6 +14,16 @@
  * over time), so the fire-and-forget `stdin.end()` obligation does NOT apply.
  * The drain obligation is satisfied by the stdout / stderr readers, whose
  * completion is tracked via `streamsDone` (never fire-and-forget).
+ *
+ * Staying open for the process lifetime is not staying open forever: at
+ * teardown the stdin sink must still be closed explicitly, or the OS pipe fd
+ * is left for incidental GC -- the same unsound pattern previously flagged
+ * as unacceptable for the PTY master-fd handle. `endStdinSafely` (a private
+ * method on this class) is called from both teardown points -- the exit
+ * observer (`handleExit`) and the activation-failure catch in
+ * `runActivation` -- so every path that stops owning a live stdin sink
+ * closes it deterministically. See `.claude/rules/elevation-helpers.md`'s
+ * "feeding-consumer teardown obligation".
  */
 import type { Subprocess, FileSink } from 'bun';
 import * as v from 'valibot';
@@ -339,6 +349,7 @@ export class EmbeddedAgentWorkerService {
     // in the registry forever — the exit observer (its only other revoker)
     // never runs when the subprocess failed to spawn or was never observed.
     let spawned: PipedSubprocess | null = null;
+    let spawnedStdin: FileSink | null = null;
     try {
       // Step 4: attempt restore before resetting (Transcript Restore, #1123),
       // unless this is the worker's first-ever activation (nothing to
@@ -437,6 +448,7 @@ export class EmbeddedAgentWorkerService {
         cwd: session.locationPath,
       });
       spawned = subprocess;
+      spawnedStdin = stdin;
       worker.subprocess = subprocess;
       worker.stdin = stdin;
 
@@ -508,6 +520,7 @@ export class EmbeddedAgentWorkerService {
       if (spawned) {
         this.safeKill(spawned, 9);
       }
+      this.endStdinSafely(spawnedStdin);
       worker.subprocess = null;
       worker.stdin = null;
       // Safe to delete unconditionally: the in-flight activation guard prevents
@@ -937,6 +950,7 @@ export class EmbeddedAgentWorkerService {
     // Append the server-authored exited row so the on-disk log is complete.
     this.appendEvent(ctx, { v: 1, type: 'exited', code: code ?? null });
 
+    this.endStdinSafely(worker.stdin);
     worker.subprocess = null;
     worker.stdin = null;
     this.deps.mcpTokenRegistry.revokeByWorker(workerId);
@@ -970,6 +984,22 @@ export class EmbeddedAgentWorkerService {
       subprocess.kill(signal);
     } catch {
       // Process may have already exited.
+    }
+  }
+
+  /**
+   * Close a subprocess's stdin sink at teardown so the OS pipe fd is
+   * released deterministically rather than left for incidental GC -- see
+   * the class-level JSDoc's "feeding-consumer teardown obligation" note.
+   * Tolerates: no sink, an already-exited child (broken pipe on `end()`),
+   * and being invoked more than once for the same sink.
+   */
+  private endStdinSafely(stdin: FileSink | null): void {
+    if (!stdin) return;
+    try {
+      stdin.end();
+    } catch (err) {
+      logger.warn({ err }, 'Failed to close subprocess stdin sink at teardown');
     }
   }
 

--- a/packages/server/src/services/interactive-process-manager.ts
+++ b/packages/server/src/services/interactive-process-manager.ts
@@ -7,6 +7,25 @@ const logger = createLogger('interactive-process-manager');
 
 export const MAX_PROCESSES_PER_SESSION = 10;
 
+/**
+ * Close a subprocess's stdin sink at teardown so the OS pipe fd is released
+ * deterministically rather than left for incidental GC. Mirrors the
+ * discipline `.claude/rules/elevation-helpers.md`'s "feeding-consumer
+ * teardown obligation" documents for `spawnAsUser` consumers that feed stdin
+ * over the process's lifetime -- the same unsound GC-reliance pattern
+ * previously flagged as unacceptable for PTY master-fd handles. Tolerates:
+ * no sink, an already-exited child (broken pipe on `end()`), and being
+ * invoked more than once for the same sink.
+ */
+function endStdinSafely(stdin: FileSink | null): void {
+  if (!stdin) return;
+  try {
+    stdin.end();
+  } catch (err) {
+    logger.warn({ err }, 'Failed to close subprocess stdin sink at teardown');
+  }
+}
+
 interface StoredProcess {
   info: InteractiveProcessInfo;
   subprocess: Subprocess<'pipe', 'pipe', 'pipe'>;
@@ -262,6 +281,7 @@ export class InteractiveProcessManager {
     } catch {
       // Process may have already exited
     }
+    endStdinSafely(stored.stdin);
 
     stored.info.status = 'exited';
     this.processes.delete(processId);
@@ -294,6 +314,7 @@ export class InteractiveProcessManager {
         } catch {
           // Process may have already exited
         }
+        endStdinSafely(stored.stdin);
         this.processes.delete(id);
         count += 1;
       }
@@ -316,6 +337,7 @@ export class InteractiveProcessManager {
       } catch {
         // Process may have already exited
       }
+      endStdinSafely(stored.stdin);
     }
     const count = this.processes.size;
     this.processes.clear();

--- a/scripts/smoke/check-stdin-sink-leak.ts
+++ b/scripts/smoke/check-stdin-sink-leak.ts
@@ -1,0 +1,279 @@
+#!/usr/bin/env bun
+/**
+ * Post-deploy smoke test for the stdin-sink fd leak fixed in Issue #1230.
+ *
+ * Long-lived `spawnAsUser` consumers that feed a subprocess's stdin over its
+ * lifetime (`InteractiveProcessManager`, `EmbeddedAgentWorkerService`) must
+ * close the returned `FileSink` explicitly at teardown, or the underlying
+ * pipe write-end fd is left for incidental GC -- the same unsound pattern
+ * Issue #1196 established as unacceptable for the PTY master-fd handle
+ * (`check-pty-fd-leak.ts` is the sibling smoke for that fix).
+ * `endStdinSafely` (a private helper duplicated in each consumer, per
+ * `.claude/rules/elevation-helpers.md`'s "feeding-consumer teardown
+ * obligation") is the production fix.
+ *
+ * This script imports the PRODUCTION `InteractiveProcessManager` directly
+ * (no reimplementation) and drives real spawn/kill cycles through its public
+ * `runProcess` / `killProcess` API against the actual OS, using the DEFAULT
+ * (real, non-elevated-bypass) `spawnAsUser` -- no fake is injected for the
+ * spawn shape itself, so `sh -c <command>` is spawned for real via
+ * `Bun.spawn`. A thin recording wrapper around `spawnAsUser` is passed via
+ * `InteractiveProcessManager`'s existing `spawnAsUserFn` DI param solely so
+ * this script can reach the raw subprocess handles for final SIGKILL
+ * cleanup (see "Test command shape" below) -- it does not alter spawn
+ * behavior.
+ *
+ * Coverage note: only `InteractiveProcessManager` is exercised here.
+ * `EmbeddedAgentWorkerService` needs session/DB scaffolding that isn't worth
+ * standing up for a filesystem-descriptor smoke; its stdin-sink teardown is
+ * covered instead by the unit tests in
+ * `packages/server/src/services/__tests__/embedded-agent-worker-service.test.ts`
+ * (a deliberate, already-decided substitution -- see Issue #1230).
+ *
+ * Test command shape -- why the spawned child ignores SIGTERM and never
+ * reads stdin:
+ * ------------------------------------------------------------------------
+ * `killProcess()` always sends `SIGTERM` to the child (unchanged behavior,
+ * not part of this fix). Empirically, once a child actually exits and Bun
+ * reaps it, Bun's own subprocess-lifecycle cleanup closes ALL of that
+ * child's associated pipe fds (stdin/stdout/stderr) on OUR side too --
+ * completely independent of whether `stdin.end()` was ever called. Using an
+ * ordinary child (e.g. `cat`, which also exits on EOF) therefore makes the
+ * pre-fix and post-fix fd counts converge to the same value once the child
+ * dies, masking the exact defect this smoke exists to catch (verified
+ * empirically while developing this script: a `cat`-based version passed
+ * identically with the production fix reverted).
+ *
+ * To isolate the deterministic `stdin.end()` effect from that confound, the
+ * test command (`trap '' TERM; exec sleep <N>`) is deliberately immune to
+ * BOTH triggers that would otherwise reap it during the measurement window:
+ *   - `trap '' TERM` sets SIGTERM to be ignored, and POSIX preserves an
+ *     ignored (SIG_IGN) disposition across `exec`, so the exec'd `sleep`
+ *     stays immune -- `killProcess()`'s `kill(15)` cannot terminate it.
+ *   - `sleep` never reads stdin, so closing stdin's write end (whether via
+ *     the fix or incidentally) has no effect on the child's lifetime either
+ *     (unlike `cat`, which would exit on the resulting EOF).
+ * The child is therefore still alive when fds are counted after the cycle
+ * loop, in BOTH the fixed and unfixed case. Its stdout+stderr pipe fds
+ * legitimately stay open the whole time (nothing in this fix touches them);
+ * only the stdin fd's fate differs between fixed and unfixed code. The
+ * assertion below is bounded accordingly (see EXPECTED_SURVIVING_FDS below)
+ * rather than asserting a full return to baseline, and every spawned
+ * subprocess is force-killed with SIGKILL (uncatchable) at the end of the
+ * script so nothing is left running on the host.
+ *
+ * IMPORTANT -- unlike `check-pty-fd-leak.ts`, this script does NOT call
+ * `Bun.gc()` anywhere. The deterministic-release contract under test here IS
+ * "the pipe write-end fd is closed at `killProcess()` call time, with no GC
+ * involved" -- forcing (or masking) GC would hide exactly the defect this
+ * smoke exists to catch. A short bounded poll after the cycle loop accounts
+ * only for the small asynchronous tail between `killProcess()` returning and
+ * the kernel reflecting the closed fd (mirrors `check-pty-fd-leak.ts`'s
+ * `waitUntil` helper) -- it is not a GC wait, since the test children never
+ * exit during the measurement window (see above).
+ *
+ * GC-timing nondeterminism and why the pre-fix signal is still trustworthy:
+ * even with no explicit `Bun.gc()` call, Bun's own incidental garbage
+ * collection can still run during the cycle loop (allocation pressure from
+ * 50 spawned subprocesses/streams) and may reclaim -- and thus close -- some
+ * unfixed (leaked) stdin sinks purely by chance. This means a pre-fix run's
+ * fd count is a LOWER BOUND on the true leak, not an exact count: one
+ * observed pre-fix run measured `baseline=3, after=129` (delta=126 over 50
+ * cycles, ~2.52/cycle) rather than the theoretical maximum of ~153
+ * (delta=150, exactly 3/cycle) that zero incidental GC would produce --
+ * some leaked sinks were already reclaimed by the time the count ran. This
+ * is exactly why `SLACK_FDS` (10) is kept small relative to
+ * `CYCLE_COUNT * EXPECTED_SURVIVING_FDS_PER_CYCLE` (50 * 2 = 100): a real
+ * per-cycle stdin leak adds up to `CYCLE_COUNT` extra fds (50) even after
+ * incidental GC reclaims some of them, which is far larger than the 10-fd
+ * slack margin -- so the bounded assertion below still reliably fails on a
+ * regression despite this noise. None of this contradicts the "no GC
+ * needed" point above: the fixed path's release is unconditional and
+ * synchronous at `killProcess()` time regardless of whether GC ever runs;
+ * this note only explains why the UNFIXED path's failure signal remains a
+ * reliable (if conservative) lower bound even though incidental GC is
+ * outside this script's control.
+ *
+ * Usage:
+ *   bun scripts/smoke/check-stdin-sink-leak.ts
+ *
+ * Exit codes:
+ *   0  all assertions passed
+ *   1  one or more assertions failed (details on stderr)
+ *   2  bad usage / cannot run (e.g. not on Linux -- /proc is unavailable)
+ */
+
+import { InteractiveProcessManager } from '../../packages/server/src/services/interactive-process-manager.js';
+import { spawnAsUser, type SpawnAsUserResult } from '../../packages/server/src/services/privilege-elevation.js';
+
+if (process.platform !== 'linux') {
+  console.error('This smoke depends on /proc (Linux-only). Skipping on', process.platform);
+  process.exit(2);
+}
+
+const CYCLE_COUNT = 50;
+// Immune to SIGTERM (ignored, preserved across exec) and never reads stdin,
+// so the child stays alive for the whole measurement window regardless of
+// whether the stdin-sink fix is present -- see the file header.
+const IMMORTAL_COMMAND = `trap '' TERM; exec sleep 100`;
+// The child staying alive means its stdout+stderr pipe fds legitimately stay
+// open in BOTH the fixed and unfixed case (nothing in this fix touches
+// them) -- only the stdin fd differs. `+1` per cycle of slack absorbs minor
+// kernel-side counting jitter without weakening the assertion: an actual
+// stdin leak would add a full extra fd per cycle (50), far outside this
+// margin.
+const EXPECTED_SURVIVING_FDS_PER_CYCLE = 2;
+const SLACK_FDS = 10;
+
+// Every subprocess handle spawned during this run, kept ONLY so the script
+// can force-kill (SIGKILL, uncatchable) every immortal test child before
+// exiting -- not for defeating GC (see file header; the fixed path never
+// relies on GC to begin with).
+const spawnedSubprocesses: SpawnAsUserResult['subprocess'][] = [];
+function recordingSpawnAsUser(opts: Parameters<typeof spawnAsUser>[0]): SpawnAsUserResult {
+  const result = spawnAsUser(opts);
+  spawnedSubprocesses.push(result.subprocess);
+  return result;
+}
+
+function killAllSpawned(): void {
+  for (const subprocess of spawnedSubprocesses) {
+    try {
+      subprocess.kill(9);
+    } catch {
+      // Already gone.
+    }
+  }
+}
+
+// Counts via a spawned child process reading `/proc/<pid>/fd` (a same-user
+// child can read its parent's fd table, the same mechanism `lsof` relies on
+// for same-user processes without root). `Bun.spawnSync` is a native Bun API
+// unaffected by any `node:fs` mocking elsewhere in the process. Mirrors
+// `check-pty-fd-leak.ts`'s `countPtmxFds`.
+//
+// Matches both `pipe:[...]` (anonymous pipes, the typical bare-metal Linux
+// shape for `Bun.spawn({ stdio: 'pipe' })`) and `socket:[...]` (some
+// container/sandbox runtimes implement stdio piping via `socketpair(2)`
+// instead of `pipe(2)` -- verified empirically in this repo's own sandboxed
+// dev environment, where every spawned child's 3 stdio fds show up as
+// `socket:[N]` rather than `pipe:[N]`).
+function countPipeFds(pid: number = process.pid): number {
+  const script = `for fd in /proc/${pid}/fd/*; do readlink "$fd" 2>/dev/null; done | grep -cE '^(pipe|socket):'`;
+  const result = Bun.spawnSync(['sh', '-c', script]);
+  const parsed = Number.parseInt(result.stdout.toString().trim(), 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+/**
+ * Prove countPipeFds() can actually detect a live pipe fd before trusting it
+ * for the regression assertion below. If the counting mechanism itself is
+ * broken (sh missing, /proc unreadable, readlink absent), before/after would
+ * both silently read 0 and the assertion below would vacuously pass without
+ * verifying anything (Issue #1200). Also doubles as the warm-up cycle:
+ * `InteractiveProcessManager` logs via pino on every spawn/kill, and pino's
+ * transport lazily opens a couple of extra fds the first time it is
+ * actually used (a one-time initialization cost, not a per-cycle leak) --
+ * running it here, before the real baseline is captured, keeps that cost
+ * out of the main loop's measurement.
+ */
+async function selfCheckAndWarmUp(manager: InteractiveProcessManager, earlyBaseline: number): Promise<void> {
+  const info = await manager.runProcess({
+    sessionId: 'stdin-leak-smoke-selfcheck',
+    workerId: 'w',
+    command: IMMORTAL_COMMAND,
+  });
+  const count = countPipeFds();
+  manager.killProcess(info.id);
+  if (!(count > earlyBaseline)) {
+    console.error(
+      `Self-check failed: countPipeFds() reported ${count} with a live subprocess held open (baseline=${earlyBaseline}) -- counting infrastructure is broken, cannot verify`,
+    );
+    killAllSpawned();
+    process.exit(2);
+  }
+  // Let the kernel settle after the self-check's own kill/close before the
+  // real baseline is captured.
+  await new Promise((resolve) => setTimeout(resolve, 300));
+}
+
+async function runCycle(manager: InteractiveProcessManager): Promise<void> {
+  const info = await manager.runProcess({
+    sessionId: 'stdin-leak-smoke',
+    workerId: 'w',
+    command: IMMORTAL_COMMAND,
+  });
+  const killed = manager.killProcess(info.id);
+  if (!killed) {
+    console.error('killProcess unexpectedly returned false mid-run -- cannot verify');
+    killAllSpawned();
+    process.exit(2);
+  }
+}
+
+/**
+ * Poll `read()` until `isDone(value)` or `timeoutMs` elapses, returning the
+ * last observed value either way. This accounts for the small asynchronous
+ * tail between `killProcess()` returning and the kernel reflecting the
+ * closed stdin fd -- NOT for the test children exiting (they never do, by
+ * design -- see file header) and NOT for GC.
+ */
+async function waitUntil<T>(read: () => T, isDone: (value: T) => boolean, timeoutMs = 2000): Promise<T> {
+  const start = Date.now();
+  let value = read();
+  while (!isDone(value) && Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    value = read();
+  }
+  return value;
+}
+
+const manager = new InteractiveProcessManager(
+  () => {},
+  () => {},
+  undefined,
+  undefined,
+  recordingSpawnAsUser,
+);
+
+const earlyBaseline = countPipeFds();
+await selfCheckAndWarmUp(manager, earlyBaseline);
+
+const baselineFds = countPipeFds();
+
+for (let i = 0; i < CYCLE_COUNT; i++) {
+  await runCycle(manager);
+}
+
+const expectedMax = baselineFds + CYCLE_COUNT * EXPECTED_SURVIVING_FDS_PER_CYCLE + SLACK_FDS;
+const afterFds = await waitUntil(countPipeFds, (v) => v <= expectedMax);
+
+const failures: string[] = [];
+let passes = 0;
+const expect = (cond: boolean, label: string, detail?: string) => {
+  if (cond) {
+    console.log(`  OK    ${label}`);
+    passes++;
+  } else {
+    console.error(`  FAIL  ${label}${detail ? ` -- ${detail}` : ''}`);
+    failures.push(label);
+  }
+};
+
+console.log(`==> ran ${CYCLE_COUNT} spawn/kill cycles via InteractiveProcessManager.runProcess/killProcess`);
+console.log('==> pipe/socket fd count (this process, via /proc/<pid>/fd)');
+expect(
+  afterFds <= expectedMax,
+  `fd count bounded by surviving-child stdout+stderr only, no stdin leak (baseline=${baselineFds}, after=${afterFds}, expectedMax=${expectedMax})`,
+  `baseline=${baselineFds} after=${afterFds} expectedMax=${expectedMax} (an actual stdin leak would add ~${CYCLE_COUNT} more, one per cycle)`,
+);
+
+console.log();
+manager.disposeAll();
+killAllSpawned();
+if (failures.length > 0) {
+  console.error(`FAILED: ${failures.length} assertion(s) failed`);
+  process.exit(1);
+}
+console.log(`PASSED: ${passes} assertion(s) passed`);
+process.exit(0);


### PR DESCRIPTION
## Summary

Two long-lived `spawnAsUser` consumers — `InteractiveProcessManager` and `EmbeddedAgentWorkerService` — feed a subprocess's stdin over the process's whole lifetime and never closed the returned `FileSink` at teardown. The reference was just dropped and left for incidental GC to release the pipe fd — the same unsound pattern Issue #1196 established as unacceptable for the PTY master-fd handle.

Each service adds its own tiny private `endStdinSafely(stdin)` helper (duplicate-until-third-consumer per `elevation-helpers.md`'s extraction ruling — no new elevation primitive):

- `interactive-process-manager.ts` (3 sites: `killProcess()`, the per-session cleanup loop, `disposeAll()`): kill-then-end order preserved exactly — signal first, stdin close purely additive, so an EOF-triggered exit path never races the signal.
- `embedded-agent-worker-service.ts` (2 sites): the exit observer (`handleExit`, the single choke point every exit — managed or unexpected — passes through) and the activation-failure catch in `runActivation` (which the exit observer never runs for, since a spawn failing before the observer is registered has no observer to fall back on). Closed before nulling the field in both cases.

Completeness grep confirmed exactly these 5 drop sites across both files (`stdin = null` / `processes.delete` / `processes.clear` / activation-failure catches) — no extras found.

Also fixes `embedded-agent-worker-service.ts`'s header comment, which correctly stated the fire-and-forget `stdin.end()` exemption for feeding consumers but never mentioned the teardown obligation that replaces it — confident-but-incomplete phrasing that hid the gap. `elevation-helpers.md` gets a new "feeding-consumer teardown obligation" subsection as a sibling to the existing fire-and-forget rule.

No change to `spawnAsUser` / `privilege-elevation.ts` itself, and no behavior change to signal escalation, the shutdown-command write, or exit-reason classification — all pre-existing tests for those paths are unchanged and green.

## Deviation from Ruling 4 (architect-approved)

The architect's Ruling 4 specified a `cat`-based stdin-reading child + exact `readlink → pipe:[...]` match for the real-fd smoke. Implementing that revealed a genuine empirical finding that changes the smoke's design (approved by the architect, session 56b4d446, before this PR was opened):

**Finding**: once a child process actually exits and Bun reaps it, Bun's own subprocess-lifecycle cleanup closes ALL of that child's associated stdio pipe fds on the parent side — independent of whether `stdin.end()` was ever called. A `cat`-based child (which exits on stdin EOF, and also exits on the `SIGTERM` `killProcess()` sends) therefore converges to the same fd count in both the fixed and unfixed case, masking the exact defect the smoke exists to catch. Verified empirically both ways.

**Redesign**: the smoke's test command is `trap '' TERM; exec sleep 100` — immune to `killProcess()`'s `SIGTERM` (ignored, and POSIX preserves `SIG_IGN` across `exec`) and never reads stdin (so closing/leaking it has no effect on the child's lifetime either). The child survives the whole measurement window in both fixed and unfixed cases, isolating the stdin fd's fate as the only variable. The assertion is bounded (`baseline + CYCLE_COUNT*2 + slack`, covering the surviving child's legitimate stdout+stderr fds) rather than an exact-baseline return.

**Precise severity note** (architect's framing, not to be overclaimed): this shows the leak's real-world manifestation is (a) a `spawnAsUser`-fed child that outlives `killProcess()`'s `SIGTERM` — and since `killProcess()` sends `kill(15)` with no `SIGKILL` escalation, a `SIGTERM`-ignoring child is a genuine production path, not a test contrivance — combined with (b) GC-timing nondeterminism for the reaped case. The fix is unconditional and deterministic regardless of this framing (Issue #1196's standard); this note only refines what the smoke's specific failure mode demonstrates.

**Two additional empirical notes baked into the smoke's header** (also required by the architect's riders):
- This sandboxed dev environment's `Bun.spawn({ stdio: 'pipe' })` shows up as `socket:[...]` (socketpair) rather than `pipe:[...]` in `/proc/self/fd` — the counting regex matches `^(pipe|socket):`.
- The pre-fix fd count is a *lower bound* on the true leak, not an exact count — incidental GC can reclaim some leaked sinks mid-run even with no explicit `Bun.gc()` call (our own pre-fix run measured a delta of ~126-144 over 50 cycles rather than the theoretical max of 150 if zero were GC'd). This is why the slack margin (10) is kept small relative to `CYCLE_COUNT * EXPECTED_SURVIVING_FDS_PER_CYCLE` (100) — a real per-cycle leak still reliably exceeds the bound despite this noise.

All test-child cleanup uses `SIGKILL` (uncatchable, since the test children ignore `SIGTERM` by construction), called on every exit path (0/1/2), verified no orphaned processes are left behind.

## Verification

### TDD polarity (per-path unit tests)

Both new test blocks were verified to fail against the unfixed code (stashed the production diff for each file, ran the new tests, confirmed failure for the right reason — `end()` never called — then restored):
- `interactive-process-manager.test.ts`: 5 new tests, all failed pre-fix with `expected 1/2, received 0`.
- `embedded-agent-worker-service.test.ts`: 3 new tests, same failure shape pre-fix.

### Real-fd smoke (`bun run check:stdin-sink-leak`)

**Pre-fix** (production diff for `interactive-process-manager.ts` reverted, smoke script kept) — reproduced independently by me as the reviewing agent:

```
==> ran 50 spawn/kill cycles via InteractiveProcessManager.runProcess/killProcess
==> pipe/socket fd count (this process, via /proc/<pid>/fd)
  FAIL  fd count bounded by surviving-child stdout+stderr only, no stdin leak (baseline=8, after=152, expectedMax=118) -- baseline=8 after=152 expectedMax=118 (an actual stdin leak would add ~50 more, one per cycle)

FAILED: 1 assertion(s) failed
error: script "check:stdin-sink-leak" exited with code 1
```

**Post-fix** (restored) — reproduced independently by me:

```
==> ran 50 spawn/kill cycles via InteractiveProcessManager.runProcess/killProcess
==> pipe/socket fd count (this process, via /proc/<pid>/fd)
  OK    fd count bounded by surviving-child stdout+stderr only, no stdin leak (baseline=2, after=102, expectedMax=112)

PASSED: 1 assertion(s) passed
```
Exit code 0. Stable across multiple consecutive re-runs (implementer ran 3 additional times post-fix: consistently `baseline=7, after=107, expectedMax=117`, exactly the expected `50*2=100` fd delta with zero stdin leak).

`EmbeddedAgentWorkerService` is not separately fd-smoked (needs DB/session scaffolding not worth standing up for this) — its coverage is the per-path unit-test layer plus the mechanism proven once by the shared `InteractiveProcessManager` smoke. This substitution was decided jointly in the architect's AC, not silently by the implementer.

### `bun run check:pty-fd-leak` (adjacent to `pty-provider.ts`, run out of caution)

```
==> ran 100 spawn/kill cycles via bunTerminalProvider
==> ptmx fd count (this process, via /proc/<pid>/fd)
  OK    ptmx fd count non-increasing (before=0, after=0)
==> kernel pty counter (/proc/sys/kernel/pty/nr)
  OK    kernel pty counter non-increasing (before=40, after=40)

PASSED: 2 assertion(s) passed
```
Exit code 0 — unaffected by this change, as expected.

### Full suite (typecheck + test)

`bun run test` (full monorepo suite via `bun run --filter '*' test`, includes typecheck): shared 596/596, integration 73/73, server 3728/3728 (+1 pre-existing unrelated skip: memfs-isolation), embedded-agent 287/287, client 2107/2107, scripts 521/521 — all `0 fail`. `TEST_EXIT: 0`.

`bun run typecheck`: all 4 packages pass.

### Preflight

`node .claude/skills/orchestrator/preflight-check.js` — clean (test coverage, rule/skill duplication, language check, blame-shift check all green). `PREFLIGHT_EXIT: 0`.

### CodeRabbit CLI

Attempted `coderabbit review --agent --base main` from this headless worktree session — authentication failed as expected in this environment (`automatic_login_failed`, browser-based OAuth cannot complete headlessly). Per `.claude/skills/coderabbit-ops`, relying on the GitHub-side bot review (post-push) for this PR.

## Design ruling reference

Implements the architect's finalized Ruling 1-5 + AC from Issue #1230 (2026-07-30) verbatim, with the one architect-approved smoke-design deviation documented above. No design was re-derived by the implementer.

Closes #1230


## Merge disposition note (2026-07-30)

**CR state**: initial walkthrough at 06:51 UTC was `Review rate limited` (state=success in `statusCheckRollup`, actual description read via `gh api .../status`). Local CLI at 06:51 UTC returned `automatic_login_failed` (headless-worktree auth cannot complete, structural, not a quota condition). inline: 0, reviewDecision: empty.

**Fallback disposition applied** (`coderabbit-ops` skill, headless-auth-unavailable + GitHub-bot-rate-limited-same-commit): Architect independent code-appropriateness audit substituted as the third verification layer. Architect audit (session 56b4d446) verdict: **CLEAN** — production conforms to Rulings 1/2 exactly, `elevation-helpers.md` addition exceeds spec, all 3 smoke-deviation riders verified, per-path tests are genuine polarity against unfixed code. This dual-clean gate (Architect audit + Orchestrator acceptance, pending) satisfies the "CodeRabbit clean" precondition per PR Merge Authority.
