### PR TITLE
docs: add I-9 No Silent Drop of Pre-Attach Events to the invariants catalog

### DIFF
--- a/.claude/skills/architectural-invariants/SKILL.md
+++ b/.claude/skills/architectural-invariants/SKILL.md
@@ -302,6 +302,53 @@ Issue [#728](https://github.com/ms2sato/agent-console/issues/728) surfaced the b
 
 ---
 
+## I-9. No Silent Drop of Pre-Attach Events
+
+**Rule.** Data or events that arrive while no handler/listener is attached yet must be **buffered** (bounded, flushed on first attach) or **fail loudly** (throw, ERROR log). A guard that silently discards them — `if (listener) { deliver } // else: nothing` — is prohibited.
+
+**Why it matters.** The failure mode is **silent and timing-sensitive**. The guard looks defensive when written; in reality it converts an early event into an unobservable non-event. The code works in every environment where the producer is slower than the consumer's attach (slow spawn chains, loaded machines, synthetic tests that emit after attaching), and fails only where the producer is fast (a direct spawn emitting within milliseconds) — presenting as "the event never happened" with zero diagnostic signal. No error is logged, nothing crashes, downstream state simply never advances.
+
+Two structural traps make this worse than an ordinary race:
+
+1. **A synchronous JS span cannot close the window when the callback is registered natively.** If the callback is passed as an argument to the creation call itself (`Bun.spawn({ terminal: { data } })`, a constructor option, an FFI registration), the native side holds it *before the creation call returns*, while the wrapper object the callback consults is assigned only *after*. "There are no awaits between spawn and attach" is then an argument about the wrong window — its safety rests on an unverifiable assumption about when the native layer may invoke the callback (`os-environment-coupling.md`'s forbidden should-work reasoning).
+2. **The correct implementation often already exists for a sibling event on the same object.** One event type gets late-attach replay because a hang was noticed; another gets the silent guard because a drop was not. The asymmetry hides in plain sight.
+
+### Domains where this applies
+
+| Domain | Producer | Pre-attach window |
+|---|---|---|
+| PTY / subprocess output | native `data` callback | between spawn and adapter/listener attach |
+| Process exit events | `exited` promise / exit callback | between exit and `onExit` attach (the solved sibling — replay pattern) |
+| WebSocket / socket messages | `message` events | between open and `onmessage` attach |
+| Event emitters with replace semantics | single-listener `on*` setters | between construction and first setter call |
+| Queue / stream consumers | delivery callbacks | between subscribe-at-create and handler wiring |
+
+### Detection heuristics
+
+1. **Grep the guard shape.** `if (listener)` / `if (handler)` / `handler?.(...)` inside a delivery callback, with no else-branch that stores the payload, is the signature. Ask: where does the payload go when the guard is false?
+2. **Callback-as-creation-argument.** Any callback passed into the creating call itself is live before your wrapper exists. Trace what it consults, and what happens while that is still null/undefined.
+3. **Sibling-event comparison (the discovery path that found the incident below).** For every event type on the same object (`data` / `exit` / `error` / `close`), compare their late-attach handling side by side — `grep` sibling call sites in the same file. One replaying while another drops is the bug, and the replaying one is your in-file reference implementation for the fix.
+4. **"Works on the slow path, fails on the fast path" reports.** An environment asymmetry where the failing configuration has the *shorter* producer startup (direct vs elevated spawn, local vs remote, warm vs cold) is this invariant's field signature.
+
+### Resolution patterns
+
+- **Bounded buffer, flush on first attach.** A capped buffer (keep the FIRST bytes — early data is usually the valuable data — count what is dropped past the cap) shared by every window, flushed in arrival order through the same decode path as live data on the first attach only; freed on flush and on dispose. **Copy payloads at buffer time** if the producer may reuse its callback buffer (`.slice()`, not `.subarray()` — a view can be corrupted before flush).
+- **Synchronous replay-on-attach** for one-shot events (exit): if the event already fired, invoke the newly attached listener immediately, with a double-fire guard.
+- **Loud failure** where buffering is genuinely wrong: throw or ERROR-log so the drop is observable.
+- **Watchdog for the residual.** Where downstream silently waits on the event (a gate that swallows output until a sentinel), add a bounded timer that converts indefinite silence into an ERROR carrying delivery diagnostics.
+
+### Example: caught (late) by this invariant
+
+Issue [#1242](https://github.com/ms2sato/agent-console/issues/1242), fixed in PR [#1243](https://github.com/ms2sato/agent-console/pull/1243). The default PTY provider's `data` callback (passed as a `Bun.spawn` argument — trap 1) dropped chunks while `adapter === null`, and the adapter's `_emitData` dropped them again while `dataListener === null`. The same adapter's `onExit` **already implemented late-attach replay with a double-fire guard** — the correct pattern for the sibling event lived in the same file (trap 2), found by the sibling-grep heuristic. Production symptom: MCP `delegate_to_worktree` on macOS created every resource but the agent never started — the login-shell sentinel was emitted within milliseconds on the direct spawn path and lost in the pre-attach window, leaving a 0-byte output log with no error anywhere. The same code passed 3/3 on Ubuntu, where the elevated spawn chain's login-shell init delays the sentinel past every window. Fix: a shared bounded pre-attach buffer created *before* `Bun.spawn` (closing both windows with one flush), copy-on-push after a review round found the buffered views could alias the producer's reusable buffer, plus a sentinel watchdog. The owner-environment checkpoint confirmed the windows were the cause.
+
+**Review question that would have caught it mechanically:** *"For every event callback this change registers or consumes: what happens to an event that fires before the first handler is attached — buffered, replayed, or silently dropped? Do all sibling events on the same object answer the same way?"*
+
+### Suggested acceptance criterion template
+
+- [ ] For each event/data callback introduced or consumed, pre-attach delivery is either buffered (bounded, copy-on-push, flush-on-first-attach, freed on dispose) or loudly rejected — never silently dropped; a deterministic test emits before attach and asserts byte-identical delivery after attach (and fails against a silently-dropping implementation); sibling events on the same object are audited for late-attach symmetry
+
+---
+
 ## How to Add New Invariants
 
 A new entry to this catalog should satisfy all of:

--- a/.claude/skills/orchestrator/suggest-criteria.js
+++ b/.claude/skills/orchestrator/suggest-criteria.js
@@ -208,6 +208,30 @@ export const MATCHING_RULES = {
     relevance:
       'artifact written to a shared / persistent location — embedded references must resolve via globally-stable anchors, not cwd or per-worktree paths',
   },
+  'I-9': {
+    keywords: [
+      'onData',
+      'onExit',
+      'onMessage',
+      'listener',
+      'event callback',
+      'data callback',
+      'attach',
+      'pre-attach',
+      'subscribe',
+      'pty',
+      'terminal',
+      'subprocess output',
+      'websocket message',
+      'event emitter',
+      'buffer',
+      'replay',
+      'sentinel',
+    ],
+    pathFragments: ['pty-provider', 'worker-manager', 'websocket/', 'worker-websocket', 'app-websocket'],
+    relevance:
+      'event/data callbacks with a pre-attach window — payloads arriving before the first handler attach must be buffered (bounded, flush-on-first-attach) or fail loudly, never silently dropped; audit sibling events on the same object for late-attach symmetry',
+  },
 };
 
 function usage() {


### PR DESCRIPTION
## Why

Issue #1242's root cause — silent discard of PTY output arriving before the first `onData` attach — is a cross-cutting bug class, not a one-off: the same guard shape (`if (listener) { deliver }` with no else) can appear in any event-callback consumer, its failure mode is silent and timing-sensitive (works wherever the producer is slow, fails where it is fast), and the correct handling already existed for the sibling `exit` event in the same file. That combination (cross-cutting / high-leverage detection / named failure mode / concrete incident) meets all four criteria in the catalog's "How to Add New Invariants" section.

This entry was ruled during the #1242 AC review (architect homework, activated on the issue's close after the owner checkpoint confirmed the windows were the cause) and follows the agreed three-part structure: the norm, the exit-replay vs data-drop asymmetry as the worked example, and the sibling-grep discovery path recorded as a detection heuristic — the discovery route is deliberately part of the entry, since "grep the sibling events on the same object" is more reusable for the next reader than the norm alone.

## Content

- **Rule**: pre-attach data/events are buffered (bounded, copy-on-push, flush-on-first-attach) or fail loudly — never silently dropped.
- **Two structural traps**: natively-registered callbacks (passed into the creation call itself) are live before the wrapper object exists, so synchronous-span reasoning addresses the wrong window; and the correct late-attach handling often already exists for a sibling event nearby.
- **Detection heuristics** including the sibling-event comparison that found #1242's asymmetry, and the "works on the slow path, fails on the fast path" field signature.
- **Resolution patterns**: bounded buffer + flush-on-first-attach (with the copy-on-push aliasing lesson from PR #1243's review round), replay-on-attach for one-shot events, loud failure, watchdog for the residual.
- **Worked example**: the full #1242 / PR #1243 narrative including the Ubuntu-vs-macOS timing asymmetry and the owner-checkpoint confirmation.

## Test plan

Docs-only (`.claude/skills/**`). `bun run check:lang` exit 0 (115 files scanned) run locally in this worktree; the `language-lint` workflow covers it in CI. No production or test code touched.

Refs #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)