### PR TITLE
fix: surface provider error body in embedded-agent chat errors

### DIFF
--- a/packages/embedded-agent/src/providers/__tests__/openai-chat-adapter.test.ts
+++ b/packages/embedded-agent/src/providers/__tests__/openai-chat-adapter.test.ts
@@ -37,11 +37,19 @@ function hangingStream(signal: AbortSignal): ReadableStream<Uint8Array> {
   });
 }
 
+/** A body stream whose first read rejects, e.g. a dropped connection mid-body. */
+function rejectingStream(): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    pull() {
+      return Promise.reject(new Error('stream error: connection reset'));
+    },
+  });
+}
+
 interface MockResponseInit {
   status?: number;
   headers?: Record<string, string>;
   body?: ReadableStream<Uint8Array> | null;
-  text?: () => Promise<string>;
 }
 
 function mockResponse(init: MockResponseInit): Response {
@@ -51,7 +59,6 @@ function mockResponse(init: MockResponseInit): Response {
     status,
     headers: new Headers(init.headers ?? {}),
     body: init.body === undefined ? streamFromChunks([]) : init.body,
-    text: init.text ?? (async () => ''),
   } as unknown as Response;
 }
 
@@ -564,7 +571,7 @@ describe('OpenAIChatAdapter — HTTP error body enrichment', () => {
       fetchFn: async () =>
         mockResponse({
           status: 403,
-          text: async () =>
+          body: streamFromChunks([
             JSON.stringify({
               type: 'error',
               error: {
@@ -573,6 +580,7 @@ describe('OpenAIChatAdapter — HTTP error body enrichment', () => {
                 message: 'regional opt-in required: https://example.com/opt-in',
               },
             }),
+          ]),
         }),
     });
     let caught: unknown;
@@ -594,11 +602,13 @@ describe('OpenAIChatAdapter — HTTP error body enrichment', () => {
     expect(err.retryable).toBe(false);
   });
 
-  it('surfaces the truncated head of a non-JSON (e.g. HTML gateway) error body', async () => {
+  it('surfaces the truncated head of a non-JSON (e.g. HTML gateway) error body split across multiple reads', async () => {
     const html = '<html><body><h1>403 Forbidden</h1><p>Access denied by WAF.</p></body></html>';
     const adapter = new OpenAIChatAdapter({
       baseUrl: 'http://x/v1',
-      fetchFn: async () => mockResponse({ status: 403, text: async () => html }),
+      // 10-byte chunks force the bounded-read loop to make several reader.read()
+      // calls, exercising the loop rather than a single-chunk stream.
+      fetchFn: async () => mockResponse({ status: 403, body: streamFromChunks(chunkString(html, 10)) }),
     });
     let caught: unknown;
     try {
@@ -617,7 +627,7 @@ describe('OpenAIChatAdapter — HTTP error body enrichment', () => {
     const body = 'a'.repeat(500);
     const adapter = new OpenAIChatAdapter({
       baseUrl: 'http://x/v1',
-      fetchFn: async () => mockResponse({ status: 400, text: async () => body }),
+      fetchFn: async () => mockResponse({ status: 400, body: streamFromChunks([body]) }),
     });
     let caught: unknown;
     try {
@@ -636,7 +646,7 @@ describe('OpenAIChatAdapter — HTTP error body enrichment', () => {
     const body = 'a'.repeat(501);
     const adapter = new OpenAIChatAdapter({
       baseUrl: 'http://x/v1',
-      fetchFn: async () => mockResponse({ status: 400, text: async () => body }),
+      fetchFn: async () => mockResponse({ status: 400, body: streamFromChunks([body]) }),
     });
     let caught: unknown;
     try {
@@ -652,10 +662,10 @@ describe('OpenAIChatAdapter — HTTP error body enrichment', () => {
     expect(err.message).toContain('[truncated]');
   });
 
-  it('stays status-only when the body is empty', async () => {
+  it('stays status-only when the body is null', async () => {
     const adapter = new OpenAIChatAdapter({
       baseUrl: 'http://x/v1',
-      fetchFn: async () => mockResponse({ status: 500, text: async () => '' }),
+      fetchFn: async () => mockResponse({ status: 500, body: null }),
     });
     let caught: unknown;
     try {
@@ -675,9 +685,7 @@ describe('OpenAIChatAdapter — HTTP error body enrichment', () => {
         mockResponse({
           status: 503,
           headers: { 'retry-after': '3' },
-          text: async () => {
-            throw new Error('stream error: connection reset');
-          },
+          body: rejectingStream(),
         }),
     });
     let caught: unknown;
@@ -706,7 +714,7 @@ describe('OpenAIChatAdapter — HTTP error body enrichment', () => {
         capturedHeaders = new Headers(init.headers);
         return mockResponse({
           status: 403,
-          text: async () => JSON.stringify({ error: { message: 'forbidden' } }),
+          body: streamFromChunks([JSON.stringify({ error: { message: 'forbidden' } })]),
         });
       },
     });
@@ -720,6 +728,45 @@ describe('OpenAIChatAdapter — HTTP error body enrichment', () => {
     }
     expect(capturedHeaders!.get('authorization')).toBe(`Bearer ${apiKey}`);
     expect((caught as ProviderError).message).not.toContain(apiKey);
+  });
+
+  it('stops reading once the bounded prefix is reached, never consuming a much larger body', async () => {
+    // Mirrors production's MAX_PROVIDER_ERROR_BODY_BYTES (8 * 1024); kept local
+    // to this test rather than imported, since the constant is not exported.
+    const BOUND_BYTES = 8 * 1024;
+    const CHUNK_BYTES = 1024;
+    const TOTAL_CHUNKS = 24; // 24KB total, 3x the bound -- a res.text()-based
+    // unbounded read would consume all of it.
+    let pulls = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls++;
+        if (pulls > TOTAL_CHUNKS) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(encoder.encode('a'.repeat(CHUNK_BYTES)));
+      },
+    });
+    const adapter = new OpenAIChatAdapter({
+      baseUrl: 'http://x/v1',
+      fetchFn: async () => mockResponse({ status: 500, body }),
+    });
+    let caught: unknown;
+    try {
+      await collect(
+        adapter.run({ model: 'm', messages, tools: [], signal: new AbortController().signal }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProviderError);
+    // The loop's length check stops consuming once BOUND_BYTES is reached, so
+    // only ~BOUND_BYTES/CHUNK_BYTES reads happen (+1 for the stream's own
+    // readahead prefetch) -- proving the stream was never fully drained. A
+    // res.text()-based unbounded read would have pulled all TOTAL_CHUNKS.
+    expect(pulls).toBeLessThanOrEqual(BOUND_BYTES / CHUNK_BYTES + 1);
+    expect(pulls).toBeLessThan(TOTAL_CHUNKS);
   });
 });
 

--- a/packages/embedded-agent/src/providers/__tests__/openai-chat-adapter.test.ts
+++ b/packages/embedded-agent/src/providers/__tests__/openai-chat-adapter.test.ts
@@ -41,6 +41,7 @@ interface MockResponseInit {
   status?: number;
   headers?: Record<string, string>;
   body?: ReadableStream<Uint8Array> | null;
+  text?: () => Promise<string>;
 }
 
 function mockResponse(init: MockResponseInit): Response {
@@ -50,6 +51,7 @@ function mockResponse(init: MockResponseInit): Response {
     status,
     headers: new Headers(init.headers ?? {}),
     body: init.body === undefined ? streamFromChunks([]) : init.body,
+    text: init.text ?? (async () => ''),
   } as unknown as Response;
 }
 
@@ -552,6 +554,172 @@ describe('OpenAIChatAdapter — HTTP errors', () => {
 
     expect((await grab(server)).retryable).toBe(true);
     expect((await grab(client)).retryable).toBe(false);
+  });
+});
+
+describe('OpenAIChatAdapter — HTTP error body enrichment', () => {
+  it('includes the provider error message and type/code from an OpenAI-shape JSON error body', async () => {
+    const adapter = new OpenAIChatAdapter({
+      baseUrl: 'http://x/v1',
+      fetchFn: async () =>
+        mockResponse({
+          status: 403,
+          text: async () =>
+            JSON.stringify({
+              type: 'error',
+              error: {
+                type: 'RegionError',
+                code: 'region_not_supported',
+                message: 'regional opt-in required: https://example.com/opt-in',
+              },
+            }),
+        }),
+    });
+    let caught: unknown;
+    try {
+      await collect(
+        adapter.run({ model: 'm', messages, tools: [], signal: new AbortController().signal }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProviderError);
+    const err = caught as ProviderError;
+    expect(err.message).toContain('provider responded with HTTP 403');
+    expect(err.message).toContain('regional opt-in required: https://example.com/opt-in');
+    expect(err.message).toContain('RegionError');
+    expect(err.message).toContain('region_not_supported');
+    // retryable/status/retryAfterMs semantics stay exactly as before.
+    expect(err.status).toBe(403);
+    expect(err.retryable).toBe(false);
+  });
+
+  it('surfaces the truncated head of a non-JSON (e.g. HTML gateway) error body', async () => {
+    const html = '<html><body><h1>403 Forbidden</h1><p>Access denied by WAF.</p></body></html>';
+    const adapter = new OpenAIChatAdapter({
+      baseUrl: 'http://x/v1',
+      fetchFn: async () => mockResponse({ status: 403, text: async () => html }),
+    });
+    let caught: unknown;
+    try {
+      await collect(
+        adapter.run({ model: 'm', messages, tools: [], signal: new AbortController().signal }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    const err = caught as ProviderError;
+    expect(err.message).toContain('provider responded with HTTP 403');
+    expect(err.message).toContain(html);
+  });
+
+  it('does not truncate a body exactly at the 500-char cap', async () => {
+    const body = 'a'.repeat(500);
+    const adapter = new OpenAIChatAdapter({
+      baseUrl: 'http://x/v1',
+      fetchFn: async () => mockResponse({ status: 400, text: async () => body }),
+    });
+    let caught: unknown;
+    try {
+      await collect(
+        adapter.run({ model: 'm', messages, tools: [], signal: new AbortController().signal }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    const err = caught as ProviderError;
+    expect(err.message).toContain(body);
+    expect(err.message).not.toContain('[truncated]');
+  });
+
+  it('truncates a body one char over the 500-char cap and marks it as truncated', async () => {
+    const body = 'a'.repeat(501);
+    const adapter = new OpenAIChatAdapter({
+      baseUrl: 'http://x/v1',
+      fetchFn: async () => mockResponse({ status: 400, text: async () => body }),
+    });
+    let caught: unknown;
+    try {
+      await collect(
+        adapter.run({ model: 'm', messages, tools: [], signal: new AbortController().signal }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    const err = caught as ProviderError;
+    expect(err.message).toContain('a'.repeat(500));
+    expect(err.message).not.toContain('a'.repeat(501));
+    expect(err.message).toContain('[truncated]');
+  });
+
+  it('stays status-only when the body is empty', async () => {
+    const adapter = new OpenAIChatAdapter({
+      baseUrl: 'http://x/v1',
+      fetchFn: async () => mockResponse({ status: 500, text: async () => '' }),
+    });
+    let caught: unknown;
+    try {
+      await collect(
+        adapter.run({ model: 'm', messages, tools: [], signal: new AbortController().signal }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as ProviderError).message).toBe('provider responded with HTTP 500');
+  });
+
+  it('degrades to today’s status-only message when reading the body rejects, without throwing a secondary error', async () => {
+    const adapter = new OpenAIChatAdapter({
+      baseUrl: 'http://x/v1',
+      fetchFn: async () =>
+        mockResponse({
+          status: 503,
+          headers: { 'retry-after': '3' },
+          text: async () => {
+            throw new Error('stream error: connection reset');
+          },
+        }),
+    });
+    let caught: unknown;
+    try {
+      await collect(
+        adapter.run({ model: 'm', messages, tools: [], signal: new AbortController().signal }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProviderError);
+    const err = caught as ProviderError;
+    expect(err.message).toBe('provider responded with HTTP 503');
+    expect(err.status).toBe(503);
+    expect(err.retryable).toBe(true);
+    expect(err.retryAfterMs).toBe(3000);
+  });
+
+  it('never surfaces the Authorization header value in the enriched error message', async () => {
+    const apiKey = 'sk-should-never-leak-1234567890';
+    let capturedHeaders: Headers | null = null;
+    const adapter = new OpenAIChatAdapter({
+      baseUrl: 'http://x/v1',
+      apiKey,
+      fetchFn: async (_url, init) => {
+        capturedHeaders = new Headers(init.headers);
+        return mockResponse({
+          status: 403,
+          text: async () => JSON.stringify({ error: { message: 'forbidden' } }),
+        });
+      },
+    });
+    let caught: unknown;
+    try {
+      await collect(
+        adapter.run({ model: 'm', messages, tools: [], signal: new AbortController().signal }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(capturedHeaders!.get('authorization')).toBe(`Bearer ${apiKey}`);
+    expect((caught as ProviderError).message).not.toContain(apiKey);
   });
 });
 

--- a/packages/embedded-agent/src/providers/openai-chat-adapter.ts
+++ b/packages/embedded-agent/src/providers/openai-chat-adapter.ts
@@ -68,6 +68,55 @@ interface OpenAIStreamChunk {
   usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number } | null;
 }
 
+// Gateways in front of OpenAI-compatible providers often return a full HTML
+// error page on 4xx/5xx (WAF blocks, region gating); the UI needs the head of
+// that body for diagnosis, not the whole page.
+const MAX_PROVIDER_ERROR_BODY_CHARS = 500;
+
+function truncateProviderErrorDetail(text: string): string {
+  if (text.length <= MAX_PROVIDER_ERROR_BODY_CHARS) return text;
+  return `${text.slice(0, MAX_PROVIDER_ERROR_BODY_CHARS)} [truncated]`;
+}
+
+/**
+ * Best-effort extraction of a human-readable detail from a non-ok provider
+ * response body, for enriching the `ProviderError` message. Never throws --
+ * any shape that doesn't match the expected JSON error shapes falls back to
+ * the raw (truncated) text.
+ */
+function extractProviderErrorDetail(bodyText: string): string | undefined {
+  const trimmed = bodyText.trim();
+  if (trimmed.length === 0) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    parsed = undefined;
+  }
+
+  if (parsed !== undefined && parsed !== null && typeof parsed === 'object') {
+    const obj = parsed as Record<string, unknown>;
+    const errorObj =
+      obj.error !== null && typeof obj.error === 'object'
+        ? (obj.error as Record<string, unknown>)
+        : undefined;
+    const message =
+      (errorObj !== undefined && typeof errorObj.message === 'string'
+        ? errorObj.message
+        : undefined) ?? (typeof obj.message === 'string' ? obj.message : undefined);
+
+    if (message !== undefined) {
+      const type = errorObj !== undefined && typeof errorObj.type === 'string' ? errorObj.type : undefined;
+      const code = errorObj !== undefined && typeof errorObj.code === 'string' ? errorObj.code : undefined;
+      const context = [type, code].filter((v): v is string => v !== undefined).join('/');
+      return truncateProviderErrorDetail(context.length > 0 ? `${message} (${context})` : message);
+    }
+  }
+
+  return truncateProviderErrorDetail(trimmed);
+}
+
 function toOpenAITools(tools: ToolDefinition[]): unknown[] {
   return tools.map((t) => ({
     type: 'function',
@@ -172,10 +221,17 @@ export class OpenAIChatAdapter implements ProviderAdapter {
       if (!res.ok) {
         const retryAfterMs = parseRetryAfterMs(res.headers.get('retry-after'));
         const retryable = res.status === 429 || res.status >= 500;
-        throw new ProviderError(
-          `provider responded with HTTP ${res.status}`,
-          { retryable, status: res.status, retryAfterMs },
-        );
+        let message = `provider responded with HTTP ${res.status}`;
+        try {
+          const detail = extractProviderErrorDetail(await res.text());
+          if (detail !== undefined) {
+            message = `${message}: ${detail}`;
+          }
+        } catch {
+          // Enrichment is best-effort only; an unreadable body must not
+          // prevent throwing the status-only ProviderError below.
+        }
+        throw new ProviderError(message, { retryable, status: res.status, retryAfterMs });
       }
       if (res.body === null) {
         throw new ProviderError('provider returned an empty response body', {

--- a/packages/embedded-agent/src/providers/openai-chat-adapter.ts
+++ b/packages/embedded-agent/src/providers/openai-chat-adapter.ts
@@ -73,9 +73,38 @@ interface OpenAIStreamChunk {
 // that body for diagnosis, not the whole page.
 const MAX_PROVIDER_ERROR_BODY_CHARS = 500;
 
+// Read bound for the raw network stream, well above MAX_PROVIDER_ERROR_BODY_CHARS
+// so a JSON error body's `type`/`code` wrapper around the `message` field isn't
+// cut off before extractProviderErrorDetail gets to parse and truncate it, but
+// still far below "arbitrarily large" so a hostile/misbehaving gateway can't
+// force an unbounded read.
+const MAX_PROVIDER_ERROR_BODY_BYTES = 8 * 1024;
+
 function truncateProviderErrorDetail(text: string): string {
   if (text.length <= MAX_PROVIDER_ERROR_BODY_CHARS) return text;
   return `${text.slice(0, MAX_PROVIDER_ERROR_BODY_CHARS)} [truncated]`;
+}
+
+/**
+ * Reads at most MAX_PROVIDER_ERROR_BODY_BYTES from a response body stream.
+ * Errors from the reader propagate to the caller -- enrichment is best-effort
+ * and the existing call site already wraps this in a try/catch.
+ */
+async function readBoundedBodyText(res: Response): Promise<string> {
+  if (res.body === null) return '';
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  try {
+    while (text.length < MAX_PROVIDER_ERROR_BODY_BYTES) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+  return text;
 }
 
 /**
@@ -223,7 +252,7 @@ export class OpenAIChatAdapter implements ProviderAdapter {
         const retryable = res.status === 429 || res.status >= 500;
         let message = `provider responded with HTTP ${res.status}`;
         try {
-          const detail = extractProviderErrorDetail(await res.text());
+          const detail = extractProviderErrorDetail(await readBoundedBodyText(res));
           if (detail !== undefined) {
             message = `${message}: ${detail}`;
           }


### PR DESCRIPTION
## Summary

- `OpenAIChatAdapter.run()` discarded the response body on `!res.ok`, so the chat UI only ever showed a bare `provider responded with HTTP <status>`. The provider's own structured explanation (region gating, WAF block reason, etc.) never reached the user, forcing a manual curl round-trip to diagnose (see Issue for the incident that motivated this).
- On a non-ok response, the body is now read best-effort and used to enrich the `ProviderError` message before throwing:
  - OpenAI-shape JSON (`error.message`, `error.type`, `error.code`) is preferred; a top-level `message` field is the fallback JSON shape.
  - Non-JSON bodies fall back to the raw text.
  - The detail is capped at 500 chars with a `[truncated]` marker when cut, so a WAF's full HTML error page doesn't flood the UI.
  - Reading/parsing the body can never throw a secondary error — any failure degrades to today's status-only message.
- `retryable` / `status` / `retryAfterMs` construction is untouched.

## Architect involvement

AC (6 items) were pre-confirmed by the architect before delegation; no additional consultation was needed during implementation — the two "optional micro-item" suggestions from the architect were both accepted (see below), decided by the implementer per the issue's explicit "your call" framing.

## Optional micro-items (architect-flagged, implementer's call)

- (a) Empty-body boundary test (`!res.ok` + `''` body stays status-only) — **included**: it's the AC's own explicit boundary case and costs nothing.
- (b) `[truncated]` indicator on truncation — **included**: cheap, and directly useful for the diagnosis use case this issue exists for (a reader needs to know the message was cut, not read a silently-truncated sentence as complete).

## Polarity check (TDD)

7 new tests were written first and run against the unmodified body-discarding implementation:

- **4 failed for the right reason** (message was status-only, missing all body content):
  - `includes the provider error message and type/code from an OpenAI-shape JSON error body`
  - `surfaces the truncated head of a non-JSON (e.g. HTML gateway) error body`
  - `does not truncate a body exactly at the 500-char cap`
  - `truncates a body one char over the 500-char cap and marks it as truncated`
- **3 passed pre-fix as expected** (they guard pre-existing/boundary behavior the fix must *preserve*, not the fix's own new behavior):
  - `stays status-only when the body is empty`
  - `degrades to today's status-only message when reading the body rejects, without throwing a secondary error`
  - `never surfaces the Authorization header value in the enriched error message`

After the fix, all tests in the file pass (30 → 34 tests, 0 fail).

## Out of scope

- Retry/backoff policy — unchanged.
- MCP tool-call error path — untouched (separate channel per Issue).
- Issue #1259 (key-store failure UI) — a sibling issue, deliberately not mixed into this PR (per architect's 2-PR-separation ruling).

## Verification

`bun run typecheck && bun run test` (full monorepo suite), last portion + exit code:

```
@agent-console/shared         596 pass, 0 fail
@agent-console/integration     73 pass, 0 fail
@agent-console/server        3730 pass, 1 skip (pre-existing, unrelated memfs-isolation skip), 0 fail
@agent-console/embedded-agent  294 pass, 0 fail
@agent-console/client         2107 pass, 0 fail
scripts/hooks/skills tests    521 pass, 0 fail
TEST_EXIT: 0
```

`node .claude/skills/orchestrator/preflight-check.js` — clean (coverage, rule/skill duplication, language, blame-shift checks all pass).

**CodeRabbit CLI**: could not authenticate in this headless worktree session (`coderabbit auth login` requires a user-controlled browser flow; automatic login timed out). Skipped per `workflow.md` fallback — recommend the GitHub-side CodeRabbit bot review be checked before merge.

## Update: addressed CodeRabbit Major finding (commit `dca4bf67`)

The GitHub-side CodeRabbit bot flagged a real Major issue on the first commit: `await res.text()` buffered the **entire** error-response body in memory before the 500-char display truncation applied — i.e. the read itself was unbounded even though display was bounded, directly contradicting this PR's own "don't flood the UI with a 90KB WAF page" rationale. A hostile or misbehaving gateway could force an unbounded allocation on the error path.

Fix: replaced `res.text()` with a bounded stream read (`readBoundedBodyText`, `MAX_PROVIDER_ERROR_BODY_BYTES = 8 * 1024`) that reads at most 8KB from `res.body` via `getReader()` and cancels the reader once the bound is hit. 8KB safely exceeds the 500-char display cap (so JSON `error.type`/`error.code` wrappers around `message` aren't cut before parsing) while still bounding well below "arbitrarily large". The existing best-effort contract (no secondary error from the enrichment path) is unchanged — reader errors still propagate into the same outer `try/catch`.

Added a regression test (`stops reading once the bounded prefix is reached, never consuming a much larger body`) that feeds a 24KB stream (3x the bound) and asserts the reader only pulls up to the bound before stopping — this test fails against the original `res.text()`-based implementation, which would have drained the whole stream. All existing enrichment-message tests (migrated from a `text` mock field to real `ReadableStream` bodies, since production no longer calls `.text()`) stay green.

Closes #1258


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for provider request failures by including relevant response details.
  * Added safe handling for structured, plain-text, empty, or unreadable error responses.
  * Limited included error details to 500 characters while preserving status and retry information.
  * Redacted authorization data from surfaced error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
