### PR TITLE
fix: auto-activate embedded-agent initial workers on the delegate_to_worktree path

### DIFF
--- a/packages/server/src/mcp/__tests__/delegate-embedded-agent-activation.test.ts
+++ b/packages/server/src/mcp/__tests__/delegate-embedded-agent-activation.test.ts
@@ -1,0 +1,481 @@
+/**
+ * Issue #1260 PR-1: `delegate_to_worktree` with an embedded initial worker
+ * must activate it (subprocess spawn + init handshake + initialPrompt
+ * delivery) as part of the tool call itself, with NO worker WebSocket
+ * connection ever involved. This file drives the REAL `createMcpApp`
+ * `delegate_to_worktree` handler chain -> real `SessionManager` -> a fake
+ * loop subprocess injected via the `spawnAsUserFn` seam (mirrors
+ * `websocket/__tests__/routes-embedded-agent.test.ts`'s `makeFakeSpawn`).
+ *
+ * Production path requirement (self-pass, see Issue #1260 AC): the test
+ * below calls the real MCP tool handler via `callTool`, NOT
+ * `sessionManager.activateEmbeddedAgentWorker` directly. No
+ * `setupWebSocketRoutes` / worker WS `onOpen` is imported or invoked
+ * anywhere in this file -- activation is caused ONLY by the
+ * `delegate_to_worktree` tool call, which is the AC's core assertion.
+ *
+ * `delegate_to_worktree` has no dedicated `embeddedAgentId` tool parameter
+ * -- an embedded agent is targeted via `agentId` (or `agentName`), resolved
+ * cross-registry by `agentDirectory.resolve()` (see `mcp-server.ts`'s
+ * `delegate_to_worktree` handler). The tests below pass the embedded
+ * agent's definition id as `agentId`, exactly as a real MCP caller would.
+ *
+ * Polarity requirement (self-pass): against the pre-fix implementation, the
+ * first test below fails at `expect(fake.captured.length).toBe(1)` because
+ * `delegate_to_worktree` never calls `activateEmbeddedAgentWorker` for an
+ * embedded-agent initial worker -- this is Issue #1260 Gap 1 itself.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Hono } from 'hono';
+import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
+import { createMockPtyFactory } from '../../__tests__/utils/mock-pty.js';
+import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
+import { resetGitMocks } from '../../__tests__/utils/mock-git-helper.js';
+import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
+import { JobQueue } from '../../jobs/job-queue.js';
+import { registerJobHandlers } from '../../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
+import { SessionManager } from '../../services/session-manager.js';
+import { RepositoryManager } from '../../services/repository-manager.js';
+import { AgentManager, CLAUDE_CODE_AGENT_ID } from '../../services/agent-manager.js';
+import { SqliteAgentRepository } from '../../repositories/sqlite-agent-repository.js';
+import { JsonSessionRepository } from '../../repositories/index.js';
+import { SqliteRepositoryRepository } from '../../repositories/sqlite-repository-repository.js';
+import { SqliteUserRepository } from '../../repositories/sqlite-user-repository.js';
+import { WorktreeService } from '../../services/worktree-service.js';
+import { TimerManager } from '../../services/timer-manager.js';
+import { ConditionalWakeupManager } from '../../services/conditional-wakeup-manager.js';
+import { InteractiveProcessManager } from '../../services/interactive-process-manager.js';
+import { AnnotationService } from '../../services/annotation-service.js';
+import { InterSessionMessageService } from '../../services/inter-session-message-service.js';
+import { SingleUserMode } from '../../services/user-mode.js';
+import { EmbeddedAgentManager } from '../../services/embedded-agent-manager.js';
+import { SqliteEmbeddedAgentRepository } from '../../repositories/sqlite-embedded-agent-repository.js';
+import { createMcpApp } from '../mcp-server.js';
+import { McpTokenRegistry } from '../mcp-auth.js';
+import { createWorktreeWithSession } from '../../services/worktree-creation-service.js';
+import { deleteWorktree } from '../../services/worktree-deletion-service.js';
+import { AgentDirectory } from '../../services/agent-directory.js';
+import type { SpawnAsUserFn, SpawnAsUserOpts, SpawnAsUserResult } from '../../services/privilege-elevation.js';
+import type { runAsUser } from '../../services/privilege-elevation.js';
+import { initializeMcp, callTool, parseToolResult } from './mcp-protocol-test-helpers.js';
+
+const TEST_CONFIG_DIR = '/test/config-1260';
+const TEST_REPO_PATH = '/test/repo-1260';
+const TEST_REPO_ID = 'repo-1260';
+
+/** Minimal subset of Bun's FileSink consumed by EmbeddedAgentWorkerService (write/end/flush). */
+interface FakeFileSink {
+  write: (chunk: string | Uint8Array) => number;
+  end: () => void;
+  flush: () => number;
+}
+
+/**
+ * Fake spawnAsUser for the embedded-agent loop subprocess, with a `pushLine`
+ * hook to emit NDJSON events on stdout (unlike routes-embedded-agent.test.ts's
+ * `makeFakeSpawn`, which never emits stdout on its own -- this file needs to
+ * simulate a `ready` event to exercise `maybeDeliverInitialPrompt`).
+ * Single-shot (one spawn per fake instance), matching the existing pattern.
+ */
+function makeFakeEmbeddedSpawn(): {
+  fn: SpawnAsUserFn;
+  captured: SpawnAsUserOpts[];
+  stdinWrites: string[];
+  pushLine: (obj: unknown) => void;
+  simulateExit: (code: number) => void;
+  throwOnNextSpawn: Error | null;
+} {
+  const captured: SpawnAsUserOpts[] = [];
+  const stdinWrites: string[] = [];
+
+  let stdoutCtrl!: ReadableStreamDefaultController<Uint8Array>;
+  let stderrCtrl!: ReadableStreamDefaultController<Uint8Array>;
+  const stdout = new ReadableStream<Uint8Array>({ start(c) { stdoutCtrl = c; } });
+  const stderr = new ReadableStream<Uint8Array>({ start(c) { stderrCtrl = c; } });
+
+  let resolveExited!: (code: number) => void;
+  const exited = new Promise<number>((resolve) => { resolveExited = resolve; });
+  let exitSimulated = false;
+  const simulateExit = (code: number) => {
+    if (exitSimulated) return;
+    exitSimulated = true;
+    resolveExited(code);
+    stdoutCtrl.close();
+    stderrCtrl.close();
+  };
+
+  const encoder = new TextEncoder();
+  const pushLine = (obj: unknown) => {
+    stdoutCtrl.enqueue(encoder.encode(`${JSON.stringify(obj)}\n`));
+  };
+
+  const stdin: FakeFileSink = {
+    write: (chunk) => {
+      stdinWrites.push(typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk));
+      return 0;
+    },
+    end: () => {},
+    flush: () => 0,
+  };
+
+  const subprocess = {
+    pid: 9999,
+    exited,
+    stdin,
+    stdout,
+    stderr,
+    kill: () => {},
+  };
+
+  const state = { throwOnNextSpawn: null as Error | null };
+
+  const fn: SpawnAsUserFn = (opts) => {
+    if (state.throwOnNextSpawn) {
+      const err = state.throwOnNextSpawn;
+      state.throwOnNextSpawn = null;
+      throw err;
+    }
+    captured.push(opts);
+    return { subprocess, stdin, elevated: false } as unknown as SpawnAsUserResult;
+  };
+
+  return {
+    fn,
+    captured,
+    stdinWrites,
+    pushLine,
+    simulateExit,
+    get throwOnNextSpawn() {
+      return state.throwOnNextSpawn;
+    },
+    set throwOnNextSpawn(err: Error | null) {
+      state.throwOnNextSpawn = err;
+    },
+  };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out');
+    await new Promise((r) => setTimeout(r, 2));
+  }
+}
+
+/**
+ * Always-success fake for WorkerManager's `runAsUser`-shaped elevation calls
+ * (prompt-file write for an agent-worker initialPrompt, mirrors
+ * mcp-server.test.ts's `fakeRunAsUserAlwaysSuccess`). Not AUTH_MODE-gated --
+ * needed even in single-user mode for the terminal-agent regression test
+ * below, which has a non-empty `initialPrompt`.
+ */
+const fakeRunAsUserAlwaysSuccess: typeof runAsUser = async () => ({
+  stdout: '',
+  stderr: '',
+  exitCode: 0,
+  timedOut: false,
+});
+
+describe('delegate_to_worktree: embedded-agent auto-activation (Issue #1260 PR-1)', () => {
+  const ptyFactory = createMockPtyFactory();
+  let app: Hono;
+  let sessionManager: SessionManager;
+  let repositoryManager: RepositoryManager;
+  let agentManager: AgentManager;
+  let embeddedAgentManager: EmbeddedAgentManager;
+  let worktreeService: WorktreeService;
+  let userRepository: SqliteUserRepository;
+  let testJobQueue: JobQueue;
+  let mcpSessionId: string;
+  let fake: ReturnType<typeof makeFakeEmbeddedSpawn>;
+  let nextId: number;
+
+  beforeEach(async () => {
+    await closeDatabase();
+    setupMemfs({
+      [`${TEST_CONFIG_DIR}/.keep`]: '',
+      [`${TEST_REPO_PATH}/.git/HEAD`]: 'ref: refs/heads/main',
+    });
+    process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+
+    await initializeDatabase(':memory:');
+    testJobQueue = new JobQueue(getDatabase(), { concurrency: 1 });
+    registerJobHandlers(testJobQueue, new WorkerOutputFileManager());
+
+    resetProcessMock();
+    mockProcess.markAlive(process.pid);
+    ptyFactory.reset();
+    resetGitMocks();
+
+    fake = makeFakeEmbeddedSpawn();
+
+    const db = getDatabase();
+    agentManager = await AgentManager.create(new SqliteAgentRepository(db));
+    embeddedAgentManager = await EmbeddedAgentManager.create(new SqliteEmbeddedAgentRepository(db));
+    userRepository = new SqliteUserRepository(db);
+
+    const sessionRepository = new JsonSessionRepository(`${TEST_CONFIG_DIR}/sessions.json`);
+    sessionManager = await SessionManager.create({
+      userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
+      pathExists: async () => true,
+      sessionRepository,
+      jobQueue: testJobQueue,
+      agentManager,
+      embeddedAgentManager,
+      mcpTokenRegistry: new McpTokenRegistry(),
+      annotationService: new AnnotationService(),
+      runAsUserImpl: fakeRunAsUserAlwaysSuccess,
+      spawnAsUserFn: fake.fn,
+      userRepository,
+      repositoryLookup: { getRepositorySlug: (id: string) => repositoryManager?.getRepositorySlug(id) },
+      repositoryEnvLookup: {
+        getRepositoryInfo: (id: string) => {
+          const r = repositoryManager?.getRepository(id);
+          return r ? { name: r.name, path: r.path, envVars: r.envVars } : undefined;
+        },
+        getWorktreeIndexNumber: async () => 0,
+      },
+    });
+
+    const sqliteRepoRepo = new SqliteRepositoryRepository(db);
+    await sqliteRepoRepo.save({
+      id: TEST_REPO_ID,
+      name: 'test-repo',
+      path: TEST_REPO_PATH,
+      createdAt: new Date().toISOString(),
+      clonedSourceRepoPath: null,
+    });
+    repositoryManager = await RepositoryManager.create({ repository: sqliteRepoRepo, jobQueue: testJobQueue });
+
+    worktreeService = new WorktreeService({
+      db,
+      runAsUserImpl: async (opts) => {
+        const tokens = Array.from(opts.command.matchAll(/'([^']*)'/g)).map((m) => m[1]);
+        const wtPath = tokens.find((t) => t.includes('/worktrees/wt-'));
+        if (wtPath) {
+          const fs = await import('fs');
+          fs.mkdirSync(wtPath, { recursive: true });
+        }
+        return { stdout: '', stderr: '', exitCode: 0, timedOut: false };
+      },
+    });
+
+    const agentDirectory = new AgentDirectory({ terminal: agentManager, embedded: embeddedAgentManager });
+    const mcpApp = createMcpApp({
+      sessionManager,
+      repositoryManager,
+      agentManager,
+      agentDirectory,
+      timerManager: new TimerManager(() => {}),
+      conditionalWakeupManager: new ConditionalWakeupManager(() => {}),
+      interactiveProcessManager: new InteractiveProcessManager(() => {}, () => {}),
+      worktreeService,
+      annotationService: new AnnotationService(),
+      interSessionMessageService: new InterSessionMessageService(),
+      suggestSessionMetadata: async () => ({ branch: 'unused', title: 'unused' }),
+      createWorktreeWithSession,
+      deleteWorktree,
+      userRepository,
+      broadcastToApp: () => {},
+      findOpenPullRequest: async () => null,
+      fetchPullRequestUrl: async () => null,
+    });
+    app = new Hono();
+    app.route('', mcpApp);
+    mcpSessionId = await initializeMcp(app);
+    nextId = 10;
+  });
+
+  afterEach(async () => {
+    if (sessionManager) {
+      for (const session of sessionManager.getAllSessions()) {
+        for (const worker of session.workers) {
+          if (worker.type === 'embedded-agent' && worker.activated) {
+            const deactivatePromise = sessionManager.deactivateEmbeddedAgentWorker(session.id, worker.id);
+            fake.simulateExit(0);
+            await deactivatePromise;
+          }
+        }
+      }
+    }
+    await testJobQueue.stop();
+    await closeDatabase();
+    cleanupMemfs();
+  });
+
+  async function createEmbeddedAgentDef(): Promise<string> {
+    const def = await embeddedAgentManager.createEmbeddedAgent(
+      { name: 'Stub embedded agent', provider: { baseUrl: 'http://localhost:9/v1', model: 'stub-model' } },
+      'creator-user-id',
+    );
+    return def.id;
+  }
+
+  it('activates the embedded-agent worker via the real delegate_to_worktree handler chain, with no worker WebSocket ever opened', async () => {
+    const embeddedAgentId = await createEmbeddedAgentDef();
+    const alice = await userRepository.upsertByOsUid(5001, 'alice', '/home/alice');
+    const parentSession = await sessionManager.createSession(
+      { type: 'quick', locationPath: TEST_REPO_PATH },
+      { createdBy: alice.id },
+    );
+
+    const activityBroadcasts: Array<{ sessionId: string; workerId: string; state: string }> = [];
+    sessionManager.setGlobalActivityCallback((sessionId, workerId, state) => {
+      activityBroadcasts.push({ sessionId, workerId, state });
+    });
+
+    expect(fake.captured.length).toBe(0);
+
+    const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+      repositoryId: TEST_REPO_ID,
+      prompt: 'Do the thing',
+      branch: 'feat/1260-pr1-child',
+      baseBranch: 'main',
+      useRemote: false,
+      // `delegate_to_worktree` has no dedicated `embeddedAgentId` param --
+      // an embedded agent is targeted via `agentId`, resolved cross-registry
+      // by `agentDirectory.resolve()`.
+      agentId: embeddedAgentId,
+      parentSessionId: parentSession.id,
+      parentWorkerId: 'parent-worker-id',
+      skipMessageCallbackPrompt: true,
+    }, nextId++);
+
+    expect(response.result?.isError).toBeUndefined();
+    const data = parseToolResult(response) as { sessionId: string; workerId: string };
+
+    // --- AC core: subprocess spawned as part of the delegate call itself.
+    // No worker WebSocket route is set up anywhere in this file (no
+    // setupWebSocketRoutes import, no onOpen call) -- the delegate call is
+    // the ONLY thing that could have triggered this spawn. ---
+    expect(fake.captured.length).toBe(1);
+    expect(fake.captured[0].command).toContain('bun');
+    expect(fake.stdinWrites.length).toBeGreaterThanOrEqual(1);
+    const initCommand = JSON.parse(fake.stdinWrites[0]);
+    expect(initCommand.type).toBe('init');
+
+    const internalWorker = sessionManager.getWorker(data.sessionId, data.workerId);
+    expect(internalWorker?.type === 'embedded-agent' && internalWorker.subprocess).not.toBeNull();
+
+    // --- Gap 2: aggregated activity is 'idle', asserted at the state/sync
+    // layer (direct query + the broadcast the app-level sync state relies
+    // on), NOT by rendering the sidebar. ---
+    expect(sessionManager.getWorkerActivityState(data.sessionId, data.workerId)).toBe('idle');
+    expect(
+      activityBroadcasts.some(
+        (b) => b.sessionId === data.sessionId && b.workerId === data.workerId && b.state === 'idle',
+      ),
+    ).toBe(true);
+
+    // --- initialPrompt delivery: loop reports `ready` -> maybeDeliverInitialPrompt
+    // -> sendUserMessage over the SAME fake stdin -> session.initialPromptDelivered flips. ---
+    fake.pushLine({ v: 1, type: 'ready' });
+    await waitFor(() => sessionManager.getSession(data.sessionId)?.initialPromptDelivered === true);
+    const userMessageWrite = fake.stdinWrites.map((w) => JSON.parse(w)).find((c) => c.type === 'user-message');
+    expect(userMessageWrite).toBeDefined();
+    expect(userMessageWrite.text).toBe('Do the thing');
+
+    // --- Idempotency lock: a subsequent worker-WebSocket open would call the
+    // SAME entry point (websocket/routes.ts:875) -- simulate it directly and
+    // confirm it's a no-op: no second spawn, no epoch re-mint. ---
+    const epochBefore = internalWorker?.type === 'embedded-agent' ? internalWorker.epoch : undefined;
+    await sessionManager.activateEmbeddedAgentWorker(data.sessionId, data.workerId);
+    expect(fake.captured.length).toBe(1);
+    const internalWorkerAfter = sessionManager.getWorker(data.sessionId, data.workerId);
+    expect(internalWorkerAfter?.type === 'embedded-agent' ? internalWorkerAfter.epoch : undefined).toBe(epochBefore);
+  });
+
+  it('scope containment: a UI/REST-created embedded session (bypassing delegate_to_worktree) is NOT auto-activated', async () => {
+    const embeddedAgentId = await createEmbeddedAgentDef();
+    const session = await sessionManager.createSession({ type: 'quick', locationPath: TEST_REPO_PATH });
+    await sessionManager.createWorker(session.id, { type: 'embedded-agent', embeddedAgentId });
+
+    const persisted = sessionManager.getSession(session.id);
+    const embeddedWorker = persisted?.workers.find((w) => w.type === 'embedded-agent');
+    expect(embeddedWorker).toBeDefined();
+    expect(embeddedWorker?.type === 'embedded-agent' && embeddedWorker.activated).toBe(false);
+    expect(fake.captured.length).toBe(0);
+  });
+
+  it('activation failure (missing session.createdBy, marker-classified) fails the tool call verbatim; worktree/session persist (no rollback)', async () => {
+    const embeddedAgentId = await createEmbeddedAgentDef();
+
+    const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+      repositoryId: TEST_REPO_ID,
+      prompt: 'Do the thing',
+      branch: 'feat/1260-pr1-no-createdby',
+      baseBranch: 'main',
+      useRemote: false,
+      agentId: embeddedAgentId,
+      // No parentSessionId -> session.createdBy stays undefined -> the mint
+      // step in EmbeddedAgentWorkerService.runActivation throws
+      // EmbeddedAgentActivationError('...has no createdBy...') (marker).
+    }, nextId++);
+
+    expect(response.result?.isError).toBe(true);
+    const data = parseToolResult(response) as { error: string };
+    expect(data.error).toContain('has no createdBy');
+    expect(fake.captured.length).toBe(0); // never reached the spawn step
+
+    expect(sessionManager.getAllSessions().length).toBe(1);
+    const worktrees = await worktreeService.listWorktrees(TEST_REPO_PATH, TEST_REPO_ID);
+    expect(worktrees.length).toBe(1);
+  });
+
+  it('activation failure (spawn throws, non-marker) fails the tool call with the generic message, not the raw error', async () => {
+    const embeddedAgentId = await createEmbeddedAgentDef();
+    const bob = await userRepository.upsertByOsUid(5002, 'bob', '/home/bob');
+    const parentSession = await sessionManager.createSession(
+      { type: 'quick', locationPath: TEST_REPO_PATH },
+      { createdBy: bob.id },
+    );
+
+    fake.throwOnNextSpawn = new Error('ENOENT: unstructured internal detail nobody should see client-side');
+
+    const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+      repositoryId: TEST_REPO_ID,
+      prompt: 'Do the thing',
+      branch: 'feat/1260-pr1-generic-failure',
+      baseBranch: 'main',
+      useRemote: false,
+      agentId: embeddedAgentId,
+      parentSessionId: parentSession.id,
+      parentWorkerId: 'parent-worker-id',
+      skipMessageCallbackPrompt: true,
+    }, nextId++);
+
+    expect(response.result?.isError).toBe(true);
+    const data = parseToolResult(response) as { error: string };
+    expect(data.error).not.toContain('ENOENT');
+    expect(data.error).toContain('Embedded-agent activation failed');
+
+    // Unlike the "missing createdBy" test above (no parentSessionId, so only
+    // the delegated session exists), this test creates a parent session
+    // (bob's) in addition to the delegated session -- 2 total.
+    expect(sessionManager.getAllSessions().length).toBe(2);
+  });
+
+  it('regression: terminal-agent delegate flow is unaffected (embedded spawn seam never touched)', async () => {
+    const carol = await userRepository.upsertByOsUid(5003, 'carol', '/home/carol');
+    const parentSession = await sessionManager.createSession(
+      { type: 'quick', locationPath: TEST_REPO_PATH },
+      { createdBy: carol.id },
+    );
+
+    const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+      repositoryId: TEST_REPO_ID,
+      prompt: 'Do the thing',
+      branch: 'feat/1260-pr1-terminal-agent',
+      baseBranch: 'main',
+      useRemote: false,
+      agentId: CLAUDE_CODE_AGENT_ID,
+      parentSessionId: parentSession.id,
+      parentWorkerId: 'parent-worker-id',
+      skipMessageCallbackPrompt: true,
+    }, nextId++);
+
+    expect(response.result?.isError).toBeUndefined();
+    expect(fake.captured.length).toBe(0);
+  });
+});

--- a/packages/server/src/mcp/__tests__/mcp-protocol-test-helpers.ts
+++ b/packages/server/src/mcp/__tests__/mcp-protocol-test-helpers.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared MCP JSON-RPC session helpers, extracted for
+ * delegate-embedded-agent-activation.test.ts (Issue #1260 PR-1) from the
+ * pattern already inlined in mcp-server.test.ts, to avoid a second inline
+ * copy of the same boilerplate in this new file.
+ */
+import type { Hono } from 'hono';
+
+/**
+ * Initialize MCP session by sending the initialize request and
+ * notifications/initialized. Returns the Mcp-Session-Id header value.
+ */
+export async function initializeMcp(app: Hono): Promise<string> {
+  const res = await app.request('/mcp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'test', version: '1.0.0' },
+      },
+      id: 1,
+    }),
+  });
+
+  const sessionId = res.headers.get('mcp-session-id') ?? '';
+
+  await app.request('/mcp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      'Mcp-Session-Id': sessionId,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    }),
+  });
+
+  return sessionId;
+}
+
+/** Call an MCP tool and return the parsed JSON-RPC response. */
+export async function callTool(
+  app: Hono,
+  sessionId: string,
+  name: string,
+  args: Record<string, unknown>,
+  id: number = 2,
+): Promise<{ result?: { content: Array<{ type: string; text: string }>; isError?: boolean }; error?: unknown }> {
+  const res = await app.request('/mcp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      'Mcp-Session-Id': sessionId,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name, arguments: args },
+      id,
+    }),
+  });
+
+  return (await res.json()) as {
+    result?: { content: Array<{ type: string; text: string }>; isError?: boolean };
+    error?: unknown;
+  };
+}
+
+/** Extract the parsed text content from a tool call result. */
+export function parseToolResult(response: Awaited<ReturnType<typeof callTool>>): unknown {
+  const text = response.result?.content?.[0]?.text;
+  if (!text) return undefined;
+  return JSON.parse(text);
+}

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -37,7 +37,7 @@ import { deleteWorktree, _getDeletionsInProgress } from '../../services/worktree
 import type { SuggestSessionMetadataFn } from '../../services/session-metadata-suggester.js';
 import { AgentDirectory } from '../../services/agent-directory.js';
 import type { AgentDirectoryEntry, EmbeddedAgentDefinition } from '@agent-console/shared';
-import type { runAsUser } from '../../services/privilege-elevation.js';
+import type { runAsUser, SpawnAsUserFn, SpawnAsUserOpts, SpawnAsUserResult } from '../../services/privilege-elevation.js';
 
 // Mock session-metadata-suggester to avoid spawning real agent processes.
 // Declaring the parameter type makes `mock.calls` typed correctly so the
@@ -99,6 +99,77 @@ const fakeRunAsUserAlwaysSuccess: typeof runAsUser = async (opts) => {
     timedOut: false,
   };
 };
+
+/** Minimal subset of Bun's FileSink consumed by EmbeddedAgentWorkerService (write/end/flush). */
+interface McpDelegateFakeFileSink {
+  write: (chunk: string | Uint8Array) => number;
+  end: () => void;
+  flush: () => number;
+}
+
+/**
+ * Fake spawnAsUser for the embedded-agent loop subprocess (Issue #1260
+ * PR-1). Needed because `delegate_to_worktree` now eagerly activates an
+ * embedded-agent initial worker as part of the tool call itself -- without
+ * this seam, the two `should create an embedded-agent initial worker...`
+ * tests below would hit the REAL `spawnAsUser` and attempt a real `bun`
+ * subprocess spawn. Mirrors `websocket/__tests__/routes-embedded-agent.test.ts`'s
+ * `makeFakeSpawn` (never emits stdout on its own -- these tests only assert
+ * that activation was attempted, not on the loop's own event stream).
+ * Reset in `beforeEach`; deactivated in `afterEach` via `simulateExit` so no
+ * activated worker's `subprocess.exited` await / stdout reader outlives the
+ * test.
+ */
+function makeFakeEmbeddedAgentDelegateSpawn(): {
+  fn: SpawnAsUserFn;
+  captured: SpawnAsUserOpts[];
+  stdinWrites: string[];
+  simulateExit: (code: number) => void;
+} {
+  const captured: SpawnAsUserOpts[] = [];
+  const stdinWrites: string[] = [];
+
+  let stdoutCtrl!: ReadableStreamDefaultController<Uint8Array>;
+  let stderrCtrl!: ReadableStreamDefaultController<Uint8Array>;
+  const stdout = new ReadableStream<Uint8Array>({ start(c) { stdoutCtrl = c; } });
+  const stderr = new ReadableStream<Uint8Array>({ start(c) { stderrCtrl = c; } });
+
+  let resolveExited!: (code: number) => void;
+  const exited = new Promise<number>((resolve) => { resolveExited = resolve; });
+  let exitSimulated = false;
+  const simulateExit = (code: number) => {
+    if (exitSimulated) return;
+    exitSimulated = true;
+    resolveExited(code);
+    stdoutCtrl.close();
+    stderrCtrl.close();
+  };
+
+  const stdin: McpDelegateFakeFileSink = {
+    write: (chunk) => {
+      stdinWrites.push(typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk));
+      return 0;
+    },
+    end: () => {},
+    flush: () => 0,
+  };
+
+  const subprocess = {
+    pid: 8765,
+    exited,
+    stdin,
+    stdout,
+    stderr,
+    kill: () => {},
+  };
+
+  const fn: SpawnAsUserFn = (opts) => {
+    captured.push(opts);
+    return { subprocess, stdin, elevated: false } as unknown as SpawnAsUserResult;
+  };
+
+  return { fn, captured, stdinWrites, simulateExit };
+}
 
 // Test config directory
 const TEST_CONFIG_DIR = '/test/config';
@@ -257,6 +328,9 @@ describe('MCP Server Tools', () => {
   let mcpSessionId: string;
   // Track unique IDs for tool calls to avoid collisions in the shared transport
   let nextId: number;
+  // Issue #1260 PR-1: embedded-agent loop subprocess fake, see
+  // `makeFakeEmbeddedAgentDelegateSpawn` above.
+  let fakeEmbeddedSpawn: ReturnType<typeof makeFakeEmbeddedAgentDelegateSpawn>;
 
   /**
    * Capture of the `runAsUser` invocation made by the injected stub on the
@@ -363,6 +437,12 @@ describe('MCP Server Tools', () => {
     // Create AnnotationService
     annotationService = new AnnotationService();
 
+    // Issue #1260 PR-1: fresh fake for each test (see declaration comment
+    // above); `delegate_to_worktree` now eagerly activates an embedded-agent
+    // initial worker, so this seam is required even though most tests never
+    // exercise it.
+    fakeEmbeddedSpawn = makeFakeEmbeddedAgentDelegateSpawn();
+
     // Create SessionManager directly
     sessionManager = await SessionManager.create({
       userMode: new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' }),
@@ -373,6 +453,7 @@ describe('MCP Server Tools', () => {
       annotationService,
       mcpTokenRegistry: new McpTokenRegistry(),
       runAsUserImpl: fakeRunAsUserAlwaysSuccess,
+      spawnAsUserFn: fakeEmbeddedSpawn.fn,
       repositoryLookup: { getRepositorySlug: (id: string) => repositoryManager?.getRepositorySlug(id) },
       repositoryEnvLookup: {
         getRepositoryInfo: (id: string) => {
@@ -475,6 +556,20 @@ describe('MCP Server Tools', () => {
   }
 
   afterEach(async () => {
+    // Issue #1260 PR-1: deactivate any embedded-agent worker `delegate_to_worktree`
+    // activated during the test (mirrors routes-embedded-agent.test.ts's afterEach)
+    // so the fake subprocess's `exited` await / stdout reader don't outlive the test.
+    if (sessionManager) {
+      for (const session of sessionManager.getAllSessions()) {
+        for (const worker of session.workers) {
+          if (worker.type === 'embedded-agent' && worker.activated) {
+            const deactivatePromise = sessionManager.deactivateEmbeddedAgentWorker(session.id, worker.id);
+            fakeEmbeddedSpawn.simulateExit(0);
+            await deactivatePromise;
+          }
+        }
+      }
+    }
     timerManager.disposeAll();
     conditionalWakeupManager.disposeAll();
     interactiveProcessManager.disposeAll();
@@ -2214,11 +2309,24 @@ describe('MCP Server Tools', () => {
     it('should create an embedded-agent initial worker when agentId matches an embedded agent', async () => {
       await setupDelegateEnvironment('feat/embedded-by-id');
 
+      // Issue #1260 PR-1: `delegate_to_worktree` now eagerly activates an
+      // embedded-agent initial worker, which requires the created session to
+      // have a `createdBy` (to mint the worker's MCP caller identity). A
+      // parent session provides that via the standard delegate inheritance
+      // path (see "should inherit createdBy from parent session" above).
+      const parentSession = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: TEST_REPO_PATH,
+      }, { createdBy: 'parent-user-embedded-by-id' });
+
       const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
         repositoryId: 'test-repo',
         prompt: 'Test embedded agent selection by id',
         branch: 'feat/embedded-by-id',
         agentId: TEST_EMBEDDED_AGENT_DEF.id,
+        parentSessionId: parentSession.id,
+        parentWorkerId: 'parent-worker-id',
+        skipMessageCallbackPrompt: true,
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2231,17 +2339,28 @@ describe('MCP Server Tools', () => {
       expect(worker!.type).toBe('embedded-agent');
       if (worker!.type === 'embedded-agent') {
         expect(worker!.embeddedAgentId).toBe(TEST_EMBEDDED_AGENT_DEF.id);
+        // Auto-activated by the delegate path itself (Issue #1260 Gap 1).
+        expect(worker!.activated).toBe(true);
       }
+      expect(fakeEmbeddedSpawn.captured.length).toBe(1);
     });
 
     it('should create an embedded-agent initial worker when agentName matches an embedded agent', async () => {
       await setupDelegateEnvironment('feat/embedded-by-name');
+
+      const parentSession = await sessionManager.createSession({
+        type: 'quick',
+        locationPath: TEST_REPO_PATH,
+      }, { createdBy: 'parent-user-embedded-by-name' });
 
       const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
         repositoryId: 'test-repo',
         prompt: 'Test embedded agent selection by name',
         branch: 'feat/embedded-by-name',
         agentName: TEST_EMBEDDED_AGENT_DEF.name,
+        parentSessionId: parentSession.id,
+        parentWorkerId: 'parent-worker-id',
+        skipMessageCallbackPrompt: true,
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2254,7 +2373,9 @@ describe('MCP Server Tools', () => {
       expect(worker!.type).toBe('embedded-agent');
       if (worker!.type === 'embedded-agent') {
         expect(worker!.embeddedAgentId).toBe(TEST_EMBEDDED_AGENT_DEF.id);
+        expect(worker!.activated).toBe(true);
       }
+      expect(fakeEmbeddedSpawn.captured.length).toBe(1);
     });
 
     it('should return error when agentName matches both a terminal agent and an embedded agent', async () => {

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -36,6 +36,7 @@ import { getRemoteUrl, GitError } from '../lib/git.js';
 import { createLogger } from '../lib/logger.js';
 import { serverConfig } from '../lib/server-config.js';
 import { resolveRequestUsername } from '../services/resolve-spawn-username.js';
+import { EmbeddedAgentActivationError } from '../services/embedded-agent-worker-service.js';
 import {
   McpTokenRegistry,
   resolveMcpAuthMode,
@@ -49,6 +50,21 @@ import type { Session, Worker, AgentActivityState, AppServerMessage } from '@age
 import { isPtyBackedWorker, canReceiveSessionMessages } from '@agent-console/shared';
 
 const logger = createLogger('mcp');
+
+/**
+ * Client-visible fallback for an embedded-agent auto-activation failure on
+ * the `delegate_to_worktree` path whose message is NOT from the
+ * {@link EmbeddedAgentActivationError} allowlist (e.g. provider key loading,
+ * spawn username resolution, process spawn, filesystem, DB errors). Mirrors
+ * `GENERIC_ACTIVATION_FAILURE_MESSAGE` in `websocket/routes.ts` (the worker
+ * WebSocket open handler's equivalent classification for the browser-open
+ * activation path). Kept as a separate literal here rather than a shared
+ * export -- a future consolidation of the two call sites' error
+ * classification is expected; keep the two message strings in sync until
+ * then.
+ */
+const GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE =
+  'Embedded-agent activation failed. Contact an administrator if this persists.';
 
 // ---------- Response helpers ----------
 
@@ -913,6 +929,39 @@ export function createMcpApp(deps: McpDependencies): Hono {
         );
         if (!agentWorker) {
           return errorResult('Session created but no agent worker was found');
+        }
+
+        // Delegate-path-only activation: the delegate path is the only place
+        // that knows no browser tab is coming for this worker, so it activates an
+        // embedded-agent initial worker itself here, through the SAME
+        // idempotent entry point the worker WebSocket open handler uses
+        // (`activateEmbeddedAgentWorker` -> websocket/routes.ts). A later
+        // browser open on this worker hits that entry's existing
+        // already-activated no-op guard -- no second activation entry point,
+        // no new activation semantics. Terminal-agent workers are unaffected:
+        // they already spawn their PTY at session-creation time
+        // (worker-lifecycle-manager.ts).
+        if (agentWorker.type === 'embedded-agent') {
+          try {
+            await sessionManager.activateEmbeddedAgentWorker(session.id, agentWorker.id);
+          } catch (err) {
+            // Only the enumerable, developer-authored reasons (marked by
+            // EmbeddedAgentActivationError) are safe to forward verbatim --
+            // identical classification to websocket/routes.ts. The created
+            // worktree/session are NOT rolled back: this is the delegate
+            // path's only failure channel, and the resulting state (session
+            // exists, its agent failed to start) mirrors what a UI-created
+            // activation failure already leaves behind.
+            const message =
+              err instanceof EmbeddedAgentActivationError ? err.message : GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE;
+            logger.warn(
+              { sessionId: session.id, workerId: agentWorker.id, err },
+              'Embedded-agent auto-activation failed on delegate path',
+            );
+            return errorResult(
+              `Session ${session.id} was created but its embedded agent failed to activate: ${message}`,
+            );
+          }
         }
 
         const delegateResult: DelegateResult = {


### PR DESCRIPTION
## Summary

Implements PR-1 of Issue #1260 (Gaps 1+2 only) per the architect's binding Ruling A: **delegate-path-only activation**, not spawn-at-creation parity.

- `delegate_to_worktree`'s handler now activates an embedded-agent initial worker itself, right after `createWorktreeWithSession` returns, by calling the SAME idempotent entry point the worker WebSocket open handler already uses (`sessionManager.activateEmbeddedAgentWorker`). No new activation entry point, no new activation semantics.
- This also resolves Gap 2 (sidebar invisibility) for free, since activation broadcasts `activityState: 'idle'`, which is what lets the sidebar's `unknown`-state hard-exclude pass.
- Activation failure fails the MCP tool call with a classified message (marker `EmbeddedAgentActivationError` messages forwarded verbatim; everything else replaced with a generic fallback, mirroring `websocket/routes.ts`'s existing classification for the browser-open path). The created worktree/session are **not** rolled back on activation failure — documented residual, same partial state a UI-created activation failure already leaves.
- UI/REST-created embedded sessions (i.e. anything that does not go through `delegate_to_worktree`) are **unaffected** — they stay deactivated until a browser opens the worker tab, per Ruling A's explicit rejection of spawn-at-creation parity.

**Out of scope** (separate PRs per the issue's decomposition): PR-2 (`send_session_message` embedded-agent target support / Gap 3) and PR-3 (worktree query invalidation staleness fix).

## Design decisions / consultation

No new architect consultation was needed for this PR — Issue #1260 already contains the architect's (session 56b4d446) binding Ruling A/B/C and the finalized PR-1 acceptance criteria, and this PR implements Ruling A verbatim (delegate-path-only activation via the existing `activateEmbeddedAgentWorker` entry, no spawn-at-creation parity, no new activation entry point). One implementation-time decision surfaced and was resolved without needing architect input: `delegate_to_worktree` has no dedicated `embeddedAgentId` tool parameter — an embedded agent is targeted via `agentId`/`agentName` resolved cross-registry by `agentDirectory.resolve()` — so the new tests pass the embedded agent's definition id as `agentId`, exactly as a real MCP caller would.

## Changes

- `packages/server/src/mcp/mcp-server.ts` — the activation block described above, plus a local `GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE` constant. This intentionally duplicates the wording of `GENERIC_ACTIVATION_FAILURE_MESSAGE` in `websocket/routes.ts` rather than extracting a shared export — Issue #1259 (not yet landed) is the designated future PR for consolidating the two call sites' error classification; a code comment cross-references this and both message strings are kept in sync.
- `packages/server/src/mcp/__tests__/delegate-embedded-agent-activation.test.ts` (new) — the AC's core E2E-shaped integration test suite (5 tests), driving the REAL `createMcpApp` → `delegate_to_worktree` handler chain → real `SessionManager` → a fake loop subprocess injected via the `spawnAsUserFn` seam (mirrors `websocket/__tests__/routes-embedded-agent.test.ts`'s `makeFakeSpawn` pattern). No `setupWebSocketRoutes` / worker-WS `onOpen` is imported or invoked anywhere in this file — activation is caused **only** by the `delegate_to_worktree` tool call, which is the AC's core assertion.
- `packages/server/src/mcp/__tests__/mcp-protocol-test-helpers.ts` (new) — small shared MCP JSON-RPC session helpers extracted for the new test file, to avoid a second inline copy of boilerplate already in `mcp-server.test.ts` (workflow.md duplication check).
- `packages/server/src/mcp/__tests__/mcp-server.test.ts` — updated the two pre-existing "should create an embedded-agent initial worker when agentId/agentName matches..." tests to give the delegated session a `createdBy` (via a parent session) and assert auto-activation now happens; added a `spawnAsUserFn` fake to the shared `SessionManager.create()` setup (previously this file never exercised embedded-agent activation) plus `afterEach` deactivation cleanup.

## Verification (self-pass, per Issue #1260 AC)

- **Production path**: the main test calls the real MCP tool handler via `callTool` against a real `createMcpApp`, not a direct `sessionManager.activateEmbeddedAgentWorker()` call.
- **Polarity**: against the unmodified pre-fix code, the main test failed exactly at `expect(fake.captured.length).toBe(1)` (received `0`) — i.e. no subprocess ever spawns, which is Issue #1260 Gap 1 itself. Confirmed by re-running the test against `mcp-server.ts` before the production edit was applied.
- **AC checklist covered by the new test file**:
  - Subprocess spawned + init handshake delivered + `initialPrompt` delivered through the ready-gated mechanism + `session.initialPromptDelivered` flipped — all with no worker WebSocket ever opened (no `setupWebSocketRoutes` import/usage anywhere in the file).
  - Gap 2: `sessionManager.getWorkerActivityState(...)` is `'idle'` after the tool call, asserted at the state/sync layer (not by rendering the sidebar), plus the `'idle'` broadcast via `setGlobalActivityCallback` is asserted directly.
  - Idempotency lock: a simulated subsequent worker-WebSocket open (calling the same `activateEmbeddedAgentWorker` entry point directly) is a no-op — no second spawn, no epoch re-mint.
  - Scope containment (Ruling A pin lock): a UI/REST-created embedded session (bypassing `delegate_to_worktree`) stays deactivated — this test fails if someone implements spawn-at-creation parity instead.
  - Activation failure, marker-classified (missing `session.createdBy`): tool call fails with the verbatim marker message; worktree/session persist (no rollback).
  - Activation failure, non-marker (spawn throws a plain `Error`): tool call fails with the generic fallback message, not the raw error text.
  - Regression: terminal-agent delegate flow is unaffected (embedded spawn seam never touched).
- **Q10 (schema-type parallel maintenance)**: N/A — no shared-type / wire-schema change in this PR.

## Test plan

- [x] `bun run test` (full suite): 3735+295+596+73+2107+521 pass, 1 skip, 0 fail, exit 0 (re-verified independently after rebasing onto latest `origin/main`).
- [x] `bun run typecheck`: exit 0, all packages.
- [x] `node .claude/skills/orchestrator/preflight-check.js`: clean (no production files under this PR match the mechanical coverage-pattern regexes — `packages/server/src/mcp/**` is not currently in `COVERAGE_PATTERNS`; new test files added anyway per the Issue's explicit AC). Rule/skill duplication, language, and blame-shift checks all clean.
- [x] CodeRabbit CLI (`coderabbit review --agent --base main`): CLI is installed (v0.7.1) but `coderabbit auth status` reports `signed out` — headless-worktree auth failure (no browser available for the OAuth flow), not a rate-limit. See "Note on CodeRabbit" below.
- [x] Final E2E dogfood — see "Live E2E on isolated instance" below.

## Live E2E on isolated instance

Per Orchestrator direction: the shared dev server (port 3457/5173, `/var/lib/agent-console/source-repos/agent-console`, 13-day uptime) was NOT touched/restarted — instead, an isolated single-user instance was started from this worktree's own fixed build, following the same pattern established in PR #1243's "Dev-server regression evidence" section.

**Setup** (all throwaway, isolated, torn down after):
```
mkdir -p ~/.agent-console-dev-1260
PORT=17260 CLIENT_PORT=17261 AGENT_CONSOLE_HOME=~/.agent-console-dev-1260 bun run dev
```
- A from-scratch local git repo (`/tmp/ac-1260-repo`, one commit) registered via `POST /api/repositories`.
- An embedded-agent definition (`POST /api/embedded-agents`) pointed at a small inert-but-responsive stub OpenAI-compatible provider on `:17262` (returns one short SSE completion, no tool calls — per Orchestrator guidance this is not a proxy-vs-production violation since the mechanism under test is activation/delivery, not LLM response quality; the loop still spawns as a real subprocess and consumes the real `initialPrompt`).
- A parent session created via `POST /api/sessions` (single-user default identity auto-assigns `createdBy`).

**Step 1-2: `delegate_to_worktree` via raw MCP JSON-RPC** (`curl` against `POST /mcp`, replicating exactly what a real MCP client sends — no browser, no worker WebSocket connection made anywhere in this session):
```json
{"jsonrpc":"2.0","method":"tools/call","params":{"name":"delegate_to_worktree","arguments":{
  "repositoryId":"5fb5dade-...","prompt":"Say hello for the Issue 1260 PR-1 dogfood check.",
  "branch":"feat/1260-dogfood-child","baseBranch":"main","useRemote":false,
  "agentId":"ee4c1899-...","parentSessionId":"450c7f31-...","parentWorkerId":"a5a87f60-...",
  "skipMessageCallbackPrompt":true}},"id":2}
```
→ returned success (no `isError`), with `sessionId`/`workerId`/`worktreePath`/`branch`.

**Step 3a — subprocess spawned without any browser interaction, real OS process, `initialPrompt` consumed:**
```
$ ps -eo pid,ppid,cmd | grep main.ts
10223 8192  sh -c 'bun' '.../packages/embedded-agent/src/main.ts'
10224 10223 bun .../packages/embedded-agent/src/main.ts
```
`GET /api/sessions/<id>` on the delegated session: `"activated": true`, `"initialPromptDelivered": true`. The stub provider's own log confirms the loop actually dialed it (`[stub-provider] chat.completions request received`) — proof the full pipeline ran end-to-end: spawn → real MCP init handshake → `ready` → `initialPrompt` delivered as a user-message → turn processed against a real (if inert) network provider → back to idle.

**Step 3b — Gap 2, activity not `unknown` (sidebar-visible), via `get_session_status` (app-level state, not the sidebar itself):**
```json
{"workers":[{"id":"a00a9957-...","type":"embedded-agent","activityState":"idle"}]}
```

**Step 3c — no worker WebSocket ever opened:** structurally true (no WS client was ever constructed in this session) and confirmed against the server log: `grep -c "ws/session" dev.log` → `0`; the only 3 log lines mentioning this workerId are `Worker created` / `worker-output-file` reset / `embedded-agent-worker-service` activation — no WS route log line at all.

**Scope-containment cross-check (Ruling A), same isolated instance:** created a second quick session and added an embedded-agent worker directly via `POST /api/sessions/:id/workers` (bypassing `delegate_to_worktree` entirely) → `"activated": false`, confirming the delegate-only scoping live, not just in unit tests.

**Teardown:** killed the isolated instance's process tree (root pid, cascaded) and the stub provider; verified via `ps` that every pid in the tree (server, vite, esbuild, the embedded-agent subprocess, the stub provider) was gone, and `ss -tln` showed ports 17260/17261/17262 free. `~/.agent-console-dev-1260` data dir left in place (not deleted) per instruction.

## Note on CodeRabbit

Local CLI: headless-worktree auth failure (`signed out`), not a rate-limit — will not self-resolve by waiting. GitHub-side bot: `statusCheckRollup` shows `CodeRabbit=SUCCESS`, but the commit status `description` is `Review rate limited` (checked via the commit-status API, not just the rollup) — no real review has run for this commit yet. Both channels are currently unavailable for this commit. Per the `coderabbit-ops` skill's "headless auth-fail AND GitHub bot rate-limited" disposition, this needs either (a) a wait for the bot's rate-limit window to clear and a real review to land, or (b) an Architect independent code-appropriateness audit + Orchestrator acceptance as the dual-clean substitute, before merge — that decision belongs to the Orchestrator, not this delegate.

Closes: none (intentionally — `Refs #1260`, not `Closes`, since PR-2 and PR-3 remain open against the same Issue).

Refs #1260


