### PR TITLE
fix: surface provider-key-store activation failures to the UI

### DIFF
--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -36,7 +36,10 @@ import { getRemoteUrl, GitError } from '../lib/git.js';
 import { createLogger } from '../lib/logger.js';
 import { serverConfig } from '../lib/server-config.js';
 import { resolveRequestUsername } from '../services/resolve-spawn-username.js';
-import { EmbeddedAgentActivationError } from '../services/embedded-agent-worker-service.js';
+import {
+  EmbeddedAgentActivationError,
+  GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE,
+} from '../services/embedded-agent-worker-service.js';
 import {
   McpTokenRegistry,
   resolveMcpAuthMode,
@@ -50,21 +53,6 @@ import type { Session, Worker, AgentActivityState, AppServerMessage } from '@age
 import { isPtyBackedWorker, canReceiveSessionMessages } from '@agent-console/shared';
 
 const logger = createLogger('mcp');
-
-/**
- * Client-visible fallback for an embedded-agent auto-activation failure on
- * the `delegate_to_worktree` path whose message is NOT from the
- * {@link EmbeddedAgentActivationError} allowlist (e.g. provider key loading,
- * spawn username resolution, process spawn, filesystem, DB errors). Mirrors
- * `GENERIC_ACTIVATION_FAILURE_MESSAGE` in `websocket/routes.ts` (the worker
- * WebSocket open handler's equivalent classification for the browser-open
- * activation path). Kept as a separate literal here rather than a shared
- * export -- a future consolidation of the two call sites' error
- * classification is expected; keep the two message strings in sync until
- * then.
- */
-const GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE =
-  'Embedded-agent activation failed. Contact an administrator if this persists.';
 
 // ---------- Response helpers ----------
 

--- a/packages/server/src/routes/__tests__/workers.test.ts
+++ b/packages/server/src/routes/__tests__/workers.test.ts
@@ -23,6 +23,7 @@ import { MAX_MESSAGE_FILES, MAX_TOTAL_FILE_SIZE } from '@agent-console/shared';
 import { McpTokenRegistry } from '../../mcp/mcp-auth.js';
 import { AgentDirectory } from '../../services/agent-directory.js';
 import type { SpawnAsUserFn, SpawnAsUserOpts, SpawnAsUserResult } from '../../services/privilege-elevation.js';
+import { GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE } from '../../services/embedded-agent-worker-service.js';
 
 // Config dir is memfs-only; uploads target a per-uid /tmp dir by spec (see #821).
 // memfs hooks fs/promises so the route's mkdir lands in memfs, which we then
@@ -799,7 +800,11 @@ describe('Workers API', () => {
         expect(res.status).toBe(400);
         const body = (await res.json()) as { error: string };
         expect(body.error).not.toContain('ENOENT');
-        expect(body.error).toContain('Embedded-agent activation failed');
+        // Pins the exact literal via the shared constant workers.ts now
+        // imports from EmbeddedAgentWorkerService (Issue #1259 consolidation),
+        // proving the import is actually wired through end-to-end and not
+        // just type-compatible.
+        expect(body.error).toBe(GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE);
       });
     });
 

--- a/packages/server/src/routes/workers.ts
+++ b/packages/server/src/routes/workers.ts
@@ -19,25 +19,11 @@ import { resolveSpawnUsername } from '../services/resolve-spawn-username.js';
 import {
   EmbeddedAgentActivationError,
   EmbeddedMessageDeliveryError,
+  GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE,
 } from '../services/embedded-agent-worker-service.js';
 import type { WorkerMessage } from '@agent-console/shared';
 
 const logger = createLogger('api:workers');
-
-/**
- * Client-visible fallback for an embedded-agent activation/delivery failure
- * on this REST route whose message is NOT from the
- * {@link EmbeddedAgentActivationError} / {@link EmbeddedMessageDeliveryError}
- * marker allowlist. Mirrors `GENERIC_ACTIVATION_FAILURE_MESSAGE` in
- * `websocket/routes.ts` and `GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE` in
- * `mcp/mcp-server.ts` (the worker WebSocket open handler's and the MCP
- * send_session_message/delegate_to_worktree tools' equivalent
- * classification). Kept as a separate literal here rather than a shared
- * export -- there are now 3 copies to keep in sync; a future consolidation
- * of all three call sites' error classification is tracked as a follow-up.
- */
-const GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE =
-  'Embedded-agent activation failed. Contact an administrator if this persists.';
 
 // Upload directory is per-uid under the OS temp directory so that:
 //   1. Different users on the same host (e.g. Model B service user `agentconsole`

--- a/packages/server/src/services/__tests__/embedded-agent-worker-service.test.ts
+++ b/packages/server/src/services/__tests__/embedded-agent-worker-service.test.ts
@@ -16,6 +16,11 @@ import {
   EmbeddedMessageDeliveryError,
   resolveEmbeddedAgentEntryPath,
 } from '../embedded-agent-worker-service.js';
+import {
+  ProviderKeyStoreError,
+  PROVIDER_KEY_STORE_UI_MESSAGES,
+  type ProviderKeyStoreErrorKind,
+} from '../provider-key-store.js';
 
 const MCP_BASE_URL = 'http://localhost:3457/mcp';
 const ENTRY_PATH = '/install/embedded-agent/src/main.ts';
@@ -492,6 +497,86 @@ describe('EmbeddedAgentWorkerService.activate', () => {
     await expect(h.service.activate(h.sessionId, h.workerId)).rejects.not.toBeInstanceOf(
       EmbeddedAgentActivationError,
     );
+  });
+
+  describe('ProviderKeyStoreError reclassification (Issue #1259)', () => {
+    const ALL_KINDS = Object.keys(PROVIDER_KEY_STORE_UI_MESSAGES) as ProviderKeyStoreErrorKind[];
+    const REF = 'missing';
+    // Sentinels standing in for content that must never leak into the UI-facing
+    // EmbeddedAgentActivationError message -- the real absolute path (or, for
+    // `unreadable`, the underlying fs error text) that ProviderKeyStoreError's
+    // OWN `message` carries for server logs.
+    const SENTINEL_PATH = '/test/config/provider-keys.json#sentinel-real-path';
+    const SENTINEL_FS_MESSAGE = 'ENOENT: sentinel-fs-error-text';
+
+    for (const kind of ALL_KINDS) {
+      it(`wraps a ProviderKeyStoreError(kind='${kind}') into EmbeddedAgentActivationError with the matching UI template`, async () => {
+        const logFacingMessage =
+          kind === 'unreadable'
+            ? `Failed to read provider key store at ${SENTINEL_PATH}: ${SENTINEL_FS_MESSAGE}`
+            : `some log-facing message naming ${SENTINEL_PATH} for kind ${kind}`;
+        const storeError = new ProviderKeyStoreError(logFacingMessage, kind, REF);
+        const throwingLoader = mock(async () => {
+          throw storeError;
+        });
+        const h = setup({
+          definition: buildDefinition({ provider: { baseUrl: 'http://x/v1', model: 'm', apiKeyRef: REF } }),
+          loadProviderKeyFn: throwingLoader,
+        });
+
+        let caught: unknown;
+        try {
+          await h.service.activate(h.sessionId, h.workerId);
+        } catch (err) {
+          caught = err;
+        }
+
+        expect(caught).toBeInstanceOf(EmbeddedAgentActivationError);
+        const activationError = caught as EmbeddedAgentActivationError;
+        expect(activationError.message).toBe(PROVIDER_KEY_STORE_UI_MESSAGES[kind](REF));
+        expect(activationError.message).not.toContain(SENTINEL_PATH);
+        expect(activationError.message).not.toContain(SENTINEL_FS_MESSAGE);
+        // `cause` preserves the original marker for server-side logging --
+        // asserted with `toBe` (same instance), not just `toBeInstanceOf`.
+        expect(activationError.cause).toBe(storeError);
+        expect(h.fake.captured.length).toBe(0);
+      });
+    }
+
+    // Note: the "UI message never contains the key VALUE" lock lives in
+    // provider-key-store.test.ts's PROVIDER_KEY_STORE_UI_MESSAGES suite --
+    // this seam only ever throws (never returns a resolved key), so there is
+    // no key value to assert against here.
+
+    // Allowlist-widening polarity lock (ii) (see .../__tests__/routes-embedded-agent.test.ts
+    // for the WS-layer classification half of this lock): a bare
+    // ProviderKeyStoreError reaching runActivation from OUTSIDE step 2's own
+    // try/catch (e.g. thrown by a step-5 spawn seam, standing in for any
+    // non-step-2 source) must NOT be reclassified into
+    // EmbeddedAgentActivationError. This pins Ruling 1's mechanism choice: the
+    // reclassification is a call-site wrap local to step 2, not a second
+    // allowlisted class the WS/MCP/REST layer would need to know about.
+    it('does NOT reclassify a bare ProviderKeyStoreError thrown from outside step 2 (e.g. the spawn step)', async () => {
+      const storeError = new ProviderKeyStoreError(
+        `Provider key store not found at ${SENTINEL_PATH}; cannot resolve apiKeyRef '${REF}'`,
+        'not-found',
+        REF,
+      );
+      const throwingSpawn = () => {
+        throw storeError;
+      };
+      const h = setup({ spawnAsUserFnOverride: throwingSpawn });
+
+      let caught: unknown;
+      try {
+        await h.service.activate(h.sessionId, h.workerId);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(ProviderKeyStoreError);
+      expect(caught).not.toBeInstanceOf(EmbeddedAgentActivationError);
+    });
   });
 
   it('rejects a session without createdBy without minting or spawning', async () => {

--- a/packages/server/src/services/__tests__/provider-key-store.test.ts
+++ b/packages/server/src/services/__tests__/provider-key-store.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { loadProviderKey } from '../provider-key-store.js';
+import {
+  loadProviderKey,
+  ProviderKeyStoreError,
+  PROVIDER_KEY_STORE_UI_MESSAGES,
+  type ProviderKeyStoreErrorKind,
+} from '../provider-key-store.js';
 
 // NOTE: Fixture I/O uses native `Bun.write` / `Bun.file` (the same layer
 // `loadProviderKey` reads through). Some sibling test files install a global
@@ -51,6 +56,137 @@ describe('loadProviderKey', () => {
   it('throws when the JSON root is not an object', async () => {
     await Bun.write(keyFile, JSON.stringify(['a', 'b']));
     await expect(loadProviderKey('openai', { filePath: keyFile })).rejects.toThrow('JSON object');
+  });
+
+  describe('ProviderKeyStoreError kind + ref (Issue #1259)', () => {
+    it('kind=not-found, ref set, when the file is missing', async () => {
+      const missing = path.join(os.tmpdir(), `absent-${crypto.randomUUID()}.json`);
+      let caught: unknown;
+      try {
+        await loadProviderKey('openai', { filePath: missing });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ProviderKeyStoreError);
+      const err = caught as ProviderKeyStoreError;
+      expect(err.kind).toBe('not-found');
+      expect(err.ref).toBe('openai');
+    });
+
+    it('kind=unreadable when the file exists but cannot be read (permission denied)', async () => {
+      await Bun.write(keyFile, JSON.stringify({ openai: 'sk-test' }));
+      await Bun.spawn(['chmod', '000', keyFile]).exited;
+      let caught: unknown;
+      try {
+        await loadProviderKey('openai', { filePath: keyFile });
+      } catch (err) {
+        caught = err;
+      } finally {
+        // Restore so any later cleanup / assertions on this fixture file don't fail.
+        await Bun.spawn(['chmod', '600', keyFile]).exited;
+      }
+      expect(caught).toBeInstanceOf(ProviderKeyStoreError);
+      expect((caught as ProviderKeyStoreError).kind).toBe('unreadable');
+    });
+
+    it('kind=invalid-json on unparseable content', async () => {
+      await Bun.write(keyFile, '{ not valid json');
+      let caught: unknown;
+      try {
+        await loadProviderKey('openai', { filePath: keyFile });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ProviderKeyStoreError);
+      expect((caught as ProviderKeyStoreError).kind).toBe('invalid-json');
+    });
+
+    it('kind=not-object when the JSON root is not an object', async () => {
+      await Bun.write(keyFile, JSON.stringify(['a', 'b']));
+      let caught: unknown;
+      try {
+        await loadProviderKey('openai', { filePath: keyFile });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ProviderKeyStoreError);
+      expect((caught as ProviderKeyStoreError).kind).toBe('not-object');
+    });
+
+    it('kind=missing-ref, ref set, when the ref is absent', async () => {
+      await Bun.write(keyFile, JSON.stringify({ other: 'k' }));
+      let caught: unknown;
+      try {
+        await loadProviderKey('openai', { filePath: keyFile });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ProviderKeyStoreError);
+      const err = caught as ProviderKeyStoreError;
+      expect(err.kind).toBe('missing-ref');
+      expect(err.ref).toBe('openai');
+    });
+  });
+
+  describe('PROVIDER_KEY_STORE_UI_MESSAGES (Issue #1259)', () => {
+    const ALL_KINDS = Object.keys(PROVIDER_KEY_STORE_UI_MESSAGES) as ProviderKeyStoreErrorKind[];
+
+    it('covers exactly the 5 documented kinds', () => {
+      const expectedKinds: ProviderKeyStoreErrorKind[] = [
+        'invalid-json',
+        'missing-ref',
+        'not-found',
+        'not-object',
+        'unreadable',
+      ];
+      expect([...ALL_KINDS].sort()).toEqual(expectedKinds.sort());
+    });
+
+    it('every template names the file via the literal placeholder, never the real path', async () => {
+      const sentinelRef = 'sentinel-ref-xyz';
+      for (const kind of ALL_KINDS) {
+        const message = PROVIDER_KEY_STORE_UI_MESSAGES[kind](sentinelRef);
+        expect(message).toContain('<AGENT_CONSOLE_HOME>/provider-keys.json');
+        expect(message).not.toContain(keyFile);
+      }
+    });
+
+    it('never leaks a key-value-shaped sentinel or (for unreadable) fs error text, across all kinds', () => {
+      const keySentinel = 'super-secret-key-value-sentinel';
+      const fsErrorSentinel = 'ENOENT: fs-error-text-sentinel';
+      for (const [kind, template] of Object.entries(PROVIDER_KEY_STORE_UI_MESSAGES) as [
+        ProviderKeyStoreErrorKind,
+        (ref: string) => string,
+      ][]) {
+        const message = template('some-ref');
+        expect(message).not.toContain(keySentinel);
+        if (kind === 'unreadable') {
+          expect(message).not.toContain(fsErrorSentinel);
+        }
+      }
+    });
+
+    it('the unreadable message is a fixed sentence excluding the real fs error text end-to-end', async () => {
+      await Bun.write(keyFile, JSON.stringify({ openai: 'sk-test' }));
+      await Bun.spawn(['chmod', '000', keyFile]).exited;
+      let caught: unknown;
+      try {
+        await loadProviderKey('openai', { filePath: keyFile });
+      } catch (err) {
+        caught = err;
+      } finally {
+        await Bun.spawn(['chmod', '600', keyFile]).exited;
+      }
+      const err = caught as ProviderKeyStoreError;
+      expect(err.kind).toBe('unreadable');
+      // The log-facing message DOES carry the real fs error text + path.
+      expect(err.message).toContain(keyFile);
+      // The UI-facing template does NOT.
+      const uiMessage = PROVIDER_KEY_STORE_UI_MESSAGES[err.kind](err.ref);
+      expect(uiMessage).not.toContain(keyFile);
+      expect(uiMessage).not.toContain('EACCES');
+      expect(uiMessage).not.toContain('permission denied');
+    });
   });
 
   it('never includes the key value in a thrown message', async () => {

--- a/packages/server/src/services/embedded-agent-worker-service.ts
+++ b/packages/server/src/services/embedded-agent-worker-service.ts
@@ -45,7 +45,7 @@ import type { SessionDataPathResolver } from '../lib/session-data-path-resolver.
 import type { McpTokenRegistry } from '../mcp/mcp-auth.js';
 import type { WorkerOutputFileManager } from '../lib/worker-output-file.js';
 import { spawnAsUser, shellEscape, type SpawnAsUserFn } from './privilege-elevation.js';
-import { loadProviderKey } from './provider-key-store.js';
+import { loadProviderKey, ProviderKeyStoreError, PROVIDER_KEY_STORE_UI_MESSAGES } from './provider-key-store.js';
 import { createLogger } from '../lib/logger.js';
 import { serverConfig } from '../lib/server-config.js';
 import * as path from 'node:path';
@@ -155,18 +155,34 @@ const STDERR_LOG_CAP = 2048;
 /**
  * Marks the small, enumerable set of `runActivation` failure reasons whose
  * `message` is safe to forward to the client verbatim (session/worker/
- * definition lookup failures, missing `createdBy`). Every other failure in
- * `runActivation` (provider key loading, spawn username resolution, process
- * spawn, output reset, persistence) throws a plain `Error` and must NOT be
- * wrapped in this class -- callers use `instanceof` to decide whether
- * `err.message` is client-safe or must be replaced with a generic fallback.
+ * definition lookup failures, missing `createdBy`, and provider-key-store
+ * failures, whose {@link ProviderKeyStoreError} `kind` is mapped to a fixed
+ * UI template in step 2 below). Every other failure in `runActivation`
+ * (spawn username resolution, process spawn, output reset, persistence)
+ * throws a plain `Error` and must NOT be wrapped in this class -- callers
+ * use `instanceof` to decide whether `err.message` is client-safe or must be
+ * replaced with a generic fallback.
  */
 export class EmbeddedAgentActivationError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'EmbeddedAgentActivationError';
   }
 }
+
+/**
+ * Client-visible fallback for an embedded-agent activation failure whose
+ * message is NOT from the {@link EmbeddedAgentActivationError} allowlist
+ * (e.g. spawn username resolution, process spawn, filesystem, DB errors).
+ * Those errors can carry unbounded/unstructured content, so their real
+ * message stays server-side-only (see each call site's `logger.warn`
+ * alongside this constant's use) and only this fixed string reaches the
+ * client. Single shared export consumed by every classification site
+ * (`websocket/routes.ts`, `mcp/mcp-server.ts`, `routes/workers.ts`) so the
+ * wording cannot drift between copies.
+ */
+export const GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE =
+  'Embedded-agent activation failed. Contact an administrator if this persists.';
 
 /**
  * Marker error wrapping a {@link SendUserMessageResult}'s `{ ok: false }`
@@ -363,9 +379,24 @@ export class EmbeddedAgentWorkerService {
     }
 
     // Step 2: resolve the provider key if referenced (dangling ref fails activation).
+    // ProviderKeyStoreError (developer-authored, enumerable by `kind`) is
+    // reclassified to EmbeddedAgentActivationError via the fixed UI template
+    // table -- this is the ONLY place a ProviderKeyStoreError is caught and
+    // converted. Any other error from this seam (including a misbehaving
+    // injected loadProviderKeyFn) propagates unwrapped.
     let apiKey: string | undefined;
     if (definition.provider.apiKeyRef) {
-      apiKey = await this.loadProviderKeyFn(definition.provider.apiKeyRef);
+      try {
+        apiKey = await this.loadProviderKeyFn(definition.provider.apiKeyRef);
+      } catch (err) {
+        if (err instanceof ProviderKeyStoreError) {
+          throw new EmbeddedAgentActivationError(
+            PROVIDER_KEY_STORE_UI_MESSAGES[err.kind](err.ref),
+            { cause: err },
+          );
+        }
+        throw err;
+      }
     }
 
     // Step 3: mint the MCP token. Requires a session owner so the minted identity

--- a/packages/server/src/services/provider-key-store.ts
+++ b/packages/server/src/services/provider-key-store.ts
@@ -9,8 +9,17 @@
  *
  * Every failure path is explicit and surfaced to the client (a dangling ref
  * fails activation rather than silently falling back to keyless): a missing
- * file, unparseable JSON, or an absent / non-string ref each throw a clear
- * Error. The key value itself is NEVER included in a thrown message or a log.
+ * file, unreadable file, unparseable JSON, non-object root, or an absent /
+ * non-string ref each throw a {@link ProviderKeyStoreError}. The key value
+ * itself is NEVER included in a thrown message or a log.
+ *
+ * `ProviderKeyStoreError.message` is a developer-authored, path-naming string
+ * intended for SERVER LOGS ONLY (real absolute path, and for `unreadable` the
+ * underlying fs error text). The UI-safe, path-placeholder-only text for each
+ * `kind` lives separately in {@link PROVIDER_KEY_STORE_UI_MESSAGES} -- see
+ * `embedded-agent-worker-service.ts` step 2 for how the two are bridged at
+ * the activation call site (structural allowlist wrap, NOT a new WS/MCP/REST-
+ * layer marker class).
  */
 import * as path from 'node:path';
 import { getConfigDir } from '../lib/config.js';
@@ -21,6 +30,57 @@ const logger = createLogger('provider-key-store');
 /** Minimal structural type for the DI logger seam below (matches `pino.Logger['warn']`). */
 type WarnLogger = { warn: (obj: Record<string, unknown>, msg: string) => void };
 
+/** Discriminates the 5 explicit failure paths in {@link loadProviderKey}. */
+export type ProviderKeyStoreErrorKind =
+  | 'not-found'
+  | 'unreadable'
+  | 'invalid-json'
+  | 'not-object'
+  | 'missing-ref';
+
+/**
+ * Thrown by {@link loadProviderKey} for each of its 5 explicit failure paths.
+ * `message` keeps the real absolute path (and, for `unreadable`, the
+ * underlying fs error text) -- that content is for SERVER LOGS ONLY. Client-
+ * facing surfacing must go through {@link PROVIDER_KEY_STORE_UI_MESSAGES},
+ * never `message` directly.
+ */
+export class ProviderKeyStoreError extends Error {
+  constructor(
+    message: string,
+    public readonly kind: ProviderKeyStoreErrorKind,
+    public readonly ref: string,
+  ) {
+    super(message);
+    this.name = 'ProviderKeyStoreError';
+  }
+}
+
+/**
+ * Fixed, UI-safe message templates keyed by {@link ProviderKeyStoreErrorKind}.
+ * Each template takes ONLY `ref` as input -- by construction this guarantees
+ * (a) the key value can never appear in a surfaced message (templates never
+ * receive it), and (b) the `unreadable` template can never carry the
+ * underlying fs error's own text (its template is a fixed sentence pointing
+ * to the server log, not an interpolation of any dynamic content). The file
+ * is named via the literal placeholder `<AGENT_CONSOLE_HOME>/provider-keys.json`
+ * -- never the resolved absolute path, never the bare basename -- and the
+ * wording does NOT branch on `AUTH_MODE` (uniform across single-user and
+ * multi-user deployments).
+ */
+export const PROVIDER_KEY_STORE_UI_MESSAGES: Record<ProviderKeyStoreErrorKind, (ref: string) => string> = {
+  'not-found': (ref) =>
+    `Provider key store <AGENT_CONSOLE_HOME>/provider-keys.json was not found, so apiKeyRef '${ref}' could not be resolved. Create the file (see the multi-user setup guide) or remove the apiKeyRef from this agent's provider configuration.`,
+  unreadable: () =>
+    `Provider key store <AGENT_CONSOLE_HOME>/provider-keys.json could not be read. Check the server log for details and verify the file's permissions.`,
+  'invalid-json': () =>
+    `Provider key store <AGENT_CONSOLE_HOME>/provider-keys.json is not valid JSON. Fix the file's contents (it must be a JSON object of "<ref>": "<key>" pairs).`,
+  'not-object': () =>
+    `Provider key store <AGENT_CONSOLE_HOME>/provider-keys.json must be a JSON object of "<ref>": "<key>" pairs. Fix the file's contents.`,
+  'missing-ref': (ref) =>
+    `Provider key ref '${ref}' is not present as a non-empty string in <AGENT_CONSOLE_HOME>/provider-keys.json. Add the ref to the key store or remove it from this agent's provider configuration.`,
+};
+
 /**
  * Resolve a provider key by its reference name.
  *
@@ -29,8 +89,9 @@ type WarnLogger = { warn: (obj: Record<string, unknown>, msg: string) => void };
  *   `<AGENT_CONSOLE_HOME>/provider-keys.json`.
  * @param opts.logger Override for the mode-warning logger (test seam). Defaults to
  *   the module's structured logger.
- * @throws Error when the file is missing, unparseable, or the ref does not map
- *   to a non-empty string. The key value is never included in the message.
+ * @throws {@link ProviderKeyStoreError} when the file is missing, unreadable,
+ *   unparseable, not a JSON object, or the ref does not map to a non-empty
+ *   string. The key value is never included in the message.
  */
 export async function loadProviderKey(
   ref: string,
@@ -41,8 +102,10 @@ export async function loadProviderKey(
 
   const file = Bun.file(filePath);
   if (!(await file.exists())) {
-    throw new Error(
+    throw new ProviderKeyStoreError(
       `Provider key store not found at ${filePath}; cannot resolve apiKeyRef '${ref}'`,
+      'not-found',
+      ref,
     );
   }
 
@@ -52,8 +115,10 @@ export async function loadProviderKey(
   try {
     raw = await file.text();
   } catch (err) {
-    throw new Error(
+    throw new ProviderKeyStoreError(
       `Failed to read provider key store at ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      'unreadable',
+      ref,
     );
   }
 
@@ -61,21 +126,27 @@ export async function loadProviderKey(
   try {
     parsed = JSON.parse(raw);
   } catch {
-    throw new Error(
+    throw new ProviderKeyStoreError(
       `Provider key store at ${filePath} is not valid JSON`,
+      'invalid-json',
+      ref,
     );
   }
 
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-    throw new Error(
+    throw new ProviderKeyStoreError(
       `Provider key store at ${filePath} must be a JSON object of { "<ref>": "<key>" }`,
+      'not-object',
+      ref,
     );
   }
 
   const value = (parsed as Record<string, unknown>)[ref];
   if (typeof value !== 'string' || value.length === 0) {
-    throw new Error(
+    throw new ProviderKeyStoreError(
       `Provider key ref '${ref}' is not present as a non-empty string in ${filePath}`,
+      'missing-ref',
+      ref,
     );
   }
 

--- a/packages/server/src/websocket/__tests__/routes-embedded-agent.test.ts
+++ b/packages/server/src/websocket/__tests__/routes-embedded-agent.test.ts
@@ -28,6 +28,7 @@ import { SqliteUserRepository } from '../../repositories/sqlite-user-repository.
 import { setupWebSocketRoutes, EMBEDDED_USER_MESSAGE_MAX_BYTES } from '../routes.js';
 import type { AppContext } from '../../app-context.js';
 import { McpTokenRegistry } from '../../mcp/mcp-auth.js';
+import { PROVIDER_KEY_STORE_UI_MESSAGES } from '../../services/provider-key-store.js';
 
 const TEST_CONFIG_DIR = '/test/config';
 
@@ -373,6 +374,43 @@ describe('Worker WebSocket: embedded-agent branch', () => {
     expect(mockWs.closeCalls.length).toBe(0);
     // The throwing spawn call is consumed (not recorded as a successful
     // capture), and no further spawn was attempted.
+    expect(fake.captured.length).toBe(0);
+  });
+
+  it('surfaces a dangling provider apiKeyRef as its specific UI template, WITHOUT closing the socket or leaking the real path (Issue #1259)', async () => {
+    // No provider-keys.json exists at TEST_CONFIG_DIR on the REAL filesystem
+    // (memfs mocks node:fs only; loadProviderKey reads via Bun.file -- see
+    // this file's Bun.file/Bun.write NOTE in provider-key-store.test.ts), so
+    // an apiKeyRef-bearing definition drives loadProviderKey down its real
+    // 'not-found' path through the actual EmbeddedAgentWorkerService step 2
+    // wrap -- no injected seam needed.
+    const definition = await embeddedAgentManager.createEmbeddedAgent(
+      { name: 'Keyed model', provider: { baseUrl: 'http://localhost:11434/v1', model: 'qwen3:32b', apiKeyRef: 'openai' } },
+      sessionOwnerUserId,
+    );
+    const session = await sessionManager.createSession(
+      { type: 'quick', locationPath: '/test/path' },
+      { createdBy: sessionOwnerUserId },
+    );
+    const worker = await sessionManager.createWorker(session.id, {
+      type: 'embedded-agent',
+      embeddedAgentId: definition.id,
+    });
+
+    const { mockWs } = openConnection(session.id, worker!.id);
+
+    await waitFor(() => mockWs.sentMessages.length > 0);
+
+    const errorMsg = JSON.parse(mockWs.sentMessages[0]);
+    expect(errorMsg.type).toBe('error');
+    expect(errorMsg.code).toBe('ACTIVATION_FAILED');
+    expect(errorMsg.message).toBe(PROVIDER_KEY_STORE_UI_MESSAGES['not-found']('openai'));
+    expect(errorMsg.message).toContain('<AGENT_CONSOLE_HOME>/provider-keys.json');
+    expect(errorMsg.message).not.toContain(TEST_CONFIG_DIR);
+
+    // Same activation-failure contract as the other classification tests
+    // above: the socket stays open and no spawn was attempted.
+    expect(mockWs.closeCalls.length).toBe(0);
     expect(fake.captured.length).toBe(0);
   });
 

--- a/packages/server/src/websocket/routes.ts
+++ b/packages/server/src/websocket/routes.ts
@@ -24,7 +24,10 @@ import { BufferedWebSocketSender } from './buffered-ws-sender.js';
 import { WebSocketConnectionRegistry } from './connection-registry.js';
 import { withRepositoryRemote } from '../lib/repository-remote.js';
 import { resolveSpawnUsername } from '../services/resolve-spawn-username.js';
-import { EmbeddedAgentActivationError } from '../services/embedded-agent-worker-service.js';
+import {
+  EmbeddedAgentActivationError,
+  GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE,
+} from '../services/embedded-agent-worker-service.js';
 
 const logger = createLogger('websocket');
 
@@ -63,17 +66,6 @@ const currentServerPid = getServerPid();
  * reused for consistency across both directions of the channel.
  */
 export const EMBEDDED_USER_MESSAGE_MAX_BYTES = 262144; // 256 KiB
-
-/**
- * Client-visible fallback for an activation failure whose message is NOT
- * from the {@link EmbeddedAgentActivationError} allowlist (e.g. provider key
- * loading, spawn username resolution, process spawn, filesystem, DB errors).
- * Those errors can carry unbounded/unstructured content, so their real
- * `message` stays server-side-only (see the `logger.warn` call alongside
- * this constant's use site) and only this fixed string reaches the client.
- */
-const GENERIC_ACTIVATION_FAILURE_MESSAGE =
-  'Embedded-agent activation failed. Contact an administrator if this persists.';
 
 /**
  * Length cap for an embedded-agent `embedded-user-message.clientMessageId`.
@@ -882,7 +874,7 @@ export async function setupWebSocketRoutes(
                 const message =
                   err instanceof EmbeddedAgentActivationError
                     ? err.message
-                    : GENERIC_ACTIVATION_FAILURE_MESSAGE;
+                    : GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE;
                 logger.warn({ sessionId, workerId, err }, 'Embedded-agent activation failed');
                 if (!connectionClosed) {
                   sendWorkerError(ws, message, 'ACTIVATION_FAILED');


### PR DESCRIPTION
## Summary

Implements Issue #1259 per its 4 binding architect rulings: provider-key-store activation failures (missing file, unreadable, invalid JSON, non-object root, dangling ref) now surface a specific, actionable message in the UI instead of the generic activation-failure fallback, while the key value and any unbounded filesystem content are structurally prevented from ever reaching the client.

- `packages/server/src/services/provider-key-store.ts` gains `ProviderKeyStoreError` (fields: `kind` — one of `not-found` / `unreadable` / `invalid-json` / `not-object` / `missing-ref` — and `ref`). All 5 existing throw sites in `loadProviderKey` now throw this typed error with their existing message text unchanged (real absolute path, and for `unreadable` the underlying fs error text — server-log-only content, contract unchanged).
- `PROVIDER_KEY_STORE_UI_MESSAGES`, a fixed template table keyed by `kind` and taking **only `ref`** as input, lives alongside it. By construction (not by inspecting current strings) this guarantees the key value can never appear in a surfaced message, and the `unreadable` template can never carry the underlying fs error text. Every template names the file via the literal placeholder `<AGENT_CONSOLE_HOME>/provider-keys.json` — never the resolved absolute path, never the bare basename, uniform across `AUTH_MODE` (no branching).
- `EmbeddedAgentWorkerService.runActivation` step 2 catches `ProviderKeyStoreError` **specifically** and rethrows `new EmbeddedAgentActivationError(PROVIDER_KEY_STORE_UI_MESSAGES[err.kind](err.ref), { cause: err })`. Any other error from the `loadProviderKeyFn` seam (including a misbehaving injected test double) propagates unwrapped, staying outside the allowlist. This is the *only* place a `ProviderKeyStoreError` is reclassified — the WS/MCP/REST layer keeps its existing single-class structural allowlist (`EmbeddedAgentActivationError`); a second allowlisted class was explicitly rejected by the architect.
- `EmbeddedAgentActivationError` gained an optional `ErrorOptions`/`{ cause }` constructor param (native `Error` cause chaining) so the original `ProviderKeyStoreError` (with its real-path message) survives into the server log unchanged.
- No new `WorkerErrorCode` — `code: 'ACTIVATION_FAILED'` is unchanged (Ruling 3; `WorkerErrorCode` is a wire-crossing shared union, so adding a code would trigger the full Q10 schema chain for no current client consumer).
- **Consolidation**: the previously-duplicated `GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE` literal (3 copies: `websocket/routes.ts`, `mcp/mcp-server.ts`, `routes/workers.ts` — `workers.ts`'s own comment anticipated this exact follow-up) is now a single export from `embedded-agent-worker-service.ts`, consumed by all 3 classification sites.

## Verification

- `bun run typecheck && bun run test` (full suite, independently re-run after reviewing the diff): server 3769 pass / 1 skip (pre-existing, environment-gated) / 0 fail, client 2107 pass, shared 597 pass, integration 73 pass, embedded-agent 295 pass, scripts/hooks 521 pass. `TEST_EXIT: 0`.
- `bun run typecheck`: clean across all workspaces, exit 0.
- **Positive-polarity check**: the implementing agent ran the new test files against `git stash`-ed production changes (tests kept). All 3 new/modified test files failed to even load (`SyntaxError: Export named 'ProviderKeyStoreError'/'PROVIDER_KEY_STORE_UI_MESSAGES' not found in module`) — a maximally strong polarity signal. Restoring the production changes brought the full suite back to green.
- `node .claude/skills/orchestrator/preflight-check.js`: exit-clean, 3/3 tracked production files covered (`provider-key-store.ts`, `embedded-agent-worker-service.ts`, `routes/workers.ts` — the last one closed via a small follow-up commit pinning `workers.ts`'s consolidated-import literal to an exact-match assertion). One advisory (non-blocking) "Integration test gap" note for `routes/workers.ts` as an API route — **N/A per Q10**: no wire schema / shared-type field changed (the response shape is the existing `{ error: string }`; only the string's *content* differs by classification), and the full REST request→response path is already exercised end-to-end by `workers.test.ts`'s `app.request()`-driven test plus the live E2E below.
- **AC checklist** (all items from the Issue):
  - Each of the 5 kinds surfaces its own placeholder-bearing message — covered per-kind in `provider-key-store.test.ts` (kind/ref) and `embedded-agent-worker-service.test.ts` (wrap → `EmbeddedAgentActivationError` with the exact template text), plus one kind (`not-found`) exercised end-to-end through the real WS activation path in `routes-embedded-agent.test.ts`.
  - Key value never appears in any surfaced message — `provider-key-store.test.ts`'s `PROVIDER_KEY_STORE_UI_MESSAGES` suite asserts this across all 5 kinds via `Object.entries`, not spot-checked.
  - Genuinely unbounded activation failures (spawn / fs outside the key store / DB) still degrade to the generic message — the pre-existing `'rejects a dangling apiKeyRef without spawning'` test (plain `Error`, not `ProviderKeyStoreError`) is left unmodified and still asserts `.not.toBeInstanceOf(EmbeddedAgentActivationError)`.
  - **Allowlist-widening polarity lock (ii)** (a bare, unwrapped `ProviderKeyStoreError` reaching the WS layer must NOT be reclassified): split across two tests — `embedded-agent-worker-service.test.ts`'s `'does NOT reclassify a bare ProviderKeyStoreError thrown from outside step 2'` proves the reclassification is scoped to step 2 only (a `ProviderKeyStoreError` thrown from the spawn step propagates as itself, not as `EmbeddedAgentActivationError`); the pre-existing `routes-embedded-agent.test.ts` generic-fallback test proves the WS layer's `instanceof EmbeddedAgentActivationError` check (not `instanceof ProviderKeyStoreError`) is what gates verbatim forwarding. Together they pin Ruling 1's mechanism choice end-to-end.
  - Server-side logging unchanged, full error + cause chain intact — verified live below (server log shows `caused by: ProviderKeyStoreError: ... /home/.../provider-keys.json ...` with the real absolute path), and asserted in tests via `activationError.cause` `toBe` (same instance) the original `ProviderKeyStoreError`.
  - No wire/shared-type change — confirmed, Q10 N/A.
  - Generic-message literal consolidated to a single shared export — confirmed via `grep -rn "GENERIC_ACTIVATION_FAILURE_MESSAGE\|GENERIC_EMBEDDED_ACTIVATION_FAILURE_MESSAGE\|Contact an administrator" packages/server/src` (only the new single export + its usage sites + one test-fixture literal remain).

## Live E2E on isolated instance

Per the established pattern (PR #1262 / #1265's "Live E2E on isolated instance" section) — an isolated single-user instance was started from this worktree, custom ports, fresh `AGENT_CONSOLE_HOME`, the shared dev server (3457/5173/6340) was never touched:

```
mkdir -p ~/.agent-console-dev-1259
PORT=27380 CLIENT_PORT=27381 AGENT_CONSOLE_HOME=~/.agent-console-dev-1259 bun run dev
```

Created an embedded-agent definition with `apiKeyRef: 'nonexistent-ref'` and no `provider-keys.json` at all in the fresh `AGENT_CONSOLE_HOME` (drives the real `loadProviderKey` down its `not-found` path with no injected seam). Started a Quick Session with that agent through the actual browser UI (Chrome DevTools MCP) — the worker tab's chat panel rendered:

> Provider key store `<AGENT_CONSOLE_HOME>/provider-keys.json` was not found, so apiKeyRef 'nonexistent-ref' could not be resolved. Create the file (see the multi-user setup guide) or remove the apiKeyRef from this agent's provider configuration.

— the literal placeholder, no real path, no key value, `Retry` action available (the pre-existing UI affordance). The server log for the same activation attempt shows the full chain unchanged:

```
"message": "Provider key store <AGENT_CONSOLE_HOME>/provider-keys.json was not found, ...: Provider key store not found at /home/ms2sato/.agent-console-dev-1259/provider-keys.json; cannot resolve apiKeyRef 'nonexistent-ref'"
...
caused by: ProviderKeyStoreError: Provider key store not found at /home/ms2sato/.agent-console-dev-1259/provider-keys.json; cannot resolve apiKeyRef 'nonexistent-ref'
    at loadProviderKey (.../packages/server/src/services/provider-key-store.ts:105:15)
```

confirming the real absolute path + cause chain reach the server log unchanged while the UI only ever saw the placeholder text.

**Teardown**: killed the isolated instance's full process tree (server, vite) and confirmed via `ss -tlnp` that ports 27380/27381 are free. `~/.agent-console-dev-1259` data dir left in place (throwaway, not shared state — same convention as prior isolated-instance verifications).

## CodeRabbit disposition

**Local CLI**: `coderabbit auth status` reports `signed out` in this headless worktree — same structural limitation as PR #1262 / #1265 (not a rate-limit, will not self-resolve by waiting).

**GitHub-side bot — 3-layer verdict, confirmed clean**, checked at commit `870f01df`:

1. **Pre-merge checks**: ✅ 5/5 passed (Description Check, Title check, Docstring Coverage 100%, Linked Issues check, Out of Scope Changes check).
2. **`reviewDecision`**: empty — this bot only ever submits `COMMENTED`-state reviews in this repo, never a formal top-level `APPROVED`/`CHANGES_REQUESTED` event (same pattern as PR #1265), so empty here is expected, not a signal the bot hasn't run.
3. **Inline comments**: 0 actionable — "No actionable comments were generated in the recent review. 🎉"
4. **4th surface (commit-status `description`, per `coderabbit-ops` skill)**: `state: success`, `description: "Review completed"` — a genuine full walkthrough ran (not the "Review rate limited" string seen when the bot's full pass is throttled), confirmed via `gh api repos/.../commits/<sha>/status`.

Per the `coderabbit-ops` walkthrough-exists rubric (genuine walkthrough + 0 actionable inline comments + `reviewDecision` empty → clean-equivalent), this PR is clean. The bot's own summary also surfaced "Possibly related PRs" (#1010, #1141, #1265) as informational overlap notes on the shared activation-failure-messaging area — no actionable finding, consistent with this PR's explicit consolidation of the #1265-introduced 3rd literal copy.

## Design decisions / architect consultation

No direct architect consultation was needed for this PR — the Issue's 4 rulings plus its bulleted addendum (generic-message consolidation) were unambiguous and implemented as specified, with no design ambiguity requiring a scope or AC clarification.

Closes #1259


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded-agent activation errors with clearer, UI-safe messages for missing, unreadable, invalid, or malformed provider key files.
  * Prevented sensitive file paths, API keys, and filesystem details from appearing in client-facing errors.
  * Standardized generic activation-failure messaging across server and WebSocket responses.
  * Ensured failed activations do not start an embedded-agent subprocess.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
