### PR TITLE
docs: add credential-gap proxy legitimacy conditions as Q13 sub-clause

### DIFF
--- a/.claude/rules/pre-pr-completeness.md
+++ b/.claude/rules/pre-pr-completeness.md
@@ -152,6 +152,16 @@ Before opening a PR that introduces a **new skill, script, rule, file type, or c
 
     The mechanical counterpart is `acceptance-check.js` Q12 (Shipping-Path Verification Match), which re-asks the same questions at audit time; this rule text is the issuance-side duty and the rationale layer.
 
+    **When a verification is blocked by a credential you cannot legitimately obtain.** Occasionally the mandated verification needs a credential that is not available to you and cannot be made available cheaply (an OS password, a third-party account, a hardware token). Substituting the credential-issuance step is permitted, but only as a **recorded** decision meeting all three of:
+
+    1. **Upstream and outside.** The mechanism you substitute sits upstream of, and outside, the chain under test — replacing it changes how you *arrive* at the thing being verified, never the thing itself. If the substituted mechanism is part of what the AC claims to verify, this is not available to you.
+    2. **Genuinely provisioned.** The artifact your substitute produces is created the way production creates it, through real code paths, from real state — not hand-assembled to look right. (Worked example: a session JWT minted with the same signing call and payload shape as the login endpoint, whose subject came from a real `upsertByOsUid()` against the instance's own database, rather than a hand-written token.)
+    3. **Recorded as a proxy, next to the result.** The evidence states what was substituted, why it is outside the chain under test, and what remained production-real — in the same place as the result, not a footnote. An unrecorded proxy is the failure mode this question exists to catch; a recorded one is simply an honest verification.
+
+    Missing any of the three makes it a **bypass**, not a workaround: stubbing the mechanism under test, hand-writing the artifact, or relaxing the setting whose behavior is being verified are never permitted, however convenient. When in doubt, consult before improvising — the consultation is cheap and the wrong substitution invalidates the whole verification silently.
+
+    (Lesson: Sprint 2026-08-03, Issue #1004 item 5 — the mandated check needed a real OS login password that the delegate had no legitimate way to obtain. Rather than improvise, they held and consulted; the JWT-mint substitution was approved against these three conditions, and the resulting evidence recorded it alongside the result. The same task's PAM-substitution *also* demonstrated the boundary: it was acceptable precisely because PAM sits outside the MCP caller-identity chain the item verifies.)
+
 ## When to apply
 
 - **Required** for PRs that introduce:

--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -26,7 +26,7 @@ The owner interacts only with you. Neither the Architect nor delegate workers se
 
 ### Model defaults
 
-- **Delegate workers**: `sonnet` (aligns with `memory/feedback_delegate_model_sonnet5.md`). Overrides via `templateVars` when a specific task warrants a higher tier.
+- **Delegate workers**: `sonnet`. Overrides via `templateVars` when a specific task warrants a higher tier.
 - **Architect**: `fable`. Overrides only when the owner pins a different model for a specific consultation.
 
 Reflect these defaults when creating worktrees / spawning workers; do not silently drift to a different model without owner directive.


### PR DESCRIPTION
## Why

Sprint 2026-08-01 retro carryover (item 2): during Issue #1004 item 5, a mandated verification was blocked by a credential the delegate could not legitimately obtain (an OS login password). The delegate held and consulted instead of improvising; the substitution that was then jointly approved (a JWT minted through the real signing path against real DB state) worked precisely because it satisfied three conditions that were never written down. This PR writes them down so the next occurrence is self-serve.

## What

- `.claude/rules/pre-pr-completeness.md`: new sub-clause under Q13 (role-switch self-pass) — a credential-issuance substitute is a legitimate workaround only when it is (1) upstream of and outside the chain under test, (2) genuinely provisioned through production code paths, and (3) recorded as a proxy next to the result. Missing any one makes it a bypass. Text drafted by the Architect; placement ruling: this is the direct continuation of Q13's "production-real or proxy?" question, not workflow.md's E2E section (which governs whether to run a verification, not how to construct a substitute for one already decided).
- `.claude/skills/orchestrator/SKILL.md`: remove a dangling reference to a retired memory file in Model defaults (content already self-contained in the skill text).

## Test plan

- `bun run check:lang` clean (115 files)
- `rule-skill-duplication-check.js` clean
- Docs-only change; language-lint CI validates in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)