### PR TITLE
chore: add packages/server/src/mcp/** to preflight COVERAGE_PATTERNS

### DIFF
--- a/.claude/rules/test-trigger.md
+++ b/.claude/rules/test-trigger.md
@@ -2,6 +2,7 @@
 globs:
   - "packages/server/src/routes/**/*.ts"
   - "packages/server/src/services/**/*.ts"
+  - "packages/server/src/mcp/**/*.ts"
   - "packages/client/src/hooks/**/*.ts"
   - "packages/client/src/components/**/*.tsx"
   - "packages/shared/src/**/*.ts"
@@ -23,6 +24,7 @@ When modifying production files matching these patterns, corresponding test file
 |-------------|------------------------|
 | `packages/server/src/routes/**/*.ts` | `.../__tests__/*.test.ts` or sibling `*.test.ts` |
 | `packages/server/src/services/**/*.ts` | `.../__tests__/*.test.ts` or sibling `*.test.ts` |
+| `packages/server/src/mcp/**/*.ts` | `.../__tests__/*.test.ts` or sibling `*.test.ts` |
 | `packages/client/src/hooks/**/*.ts` | `.../__tests__/*.test.ts(x)` or sibling `*.test.ts(x)` |
 | `packages/client/src/components/**/*.tsx` | `.../__tests__/*.test.tsx` or sibling `*.test.tsx` (a JSX-free pure-logic test may instead use `*.test.ts`, e.g. `SessionPage.test.ts` alongside `SessionPage.tsx`) |
 | `packages/shared/src/**/*.ts` | `.../__tests__/*.test.ts` or sibling `*.test.ts` |

--- a/.claude/skills/orchestrator/check-utils.js
+++ b/.claude/skills/orchestrator/check-utils.js
@@ -79,6 +79,7 @@ export function categorizeFiles(files) {
 export const COVERAGE_PATTERNS = [
   /^packages\/server\/src\/routes\/.+\.ts$/,
   /^packages\/server\/src\/services\/.+\.ts$/,
+  /^packages\/server\/src\/mcp\/.+\.ts$/,
   /^packages\/client\/src\/hooks\/.+\.ts$/,
   /^packages\/client\/src\/components\/.+\.tsx$/,
   /^packages\/shared\/src\/.+\.ts$/,


### PR DESCRIPTION
## Summary

Adds `packages/server/src/mcp/**/*.ts` to the preflight sibling-test coverage gate. The gate never fired for MCP server code because the pattern was missing from `COVERAGE_PATTERNS`. This is a process-tooling-only change: no production code changed, no tests added — the 4 existing files under `packages/server/src/mcp/` (`mcp-server.ts`, `mcp-auth.ts`, `agent-operations-mcp.ts`, `agent-operations-embedded.ts`) already have sibling tests in `mcp/__tests__/`, so the new pattern starts fully satisfied.

## Changes

- `.claude/skills/orchestrator/check-utils.js`: added `/^packages\/server\/src\/mcp\/.+\.ts$/` to `COVERAGE_PATTERNS` (canonical regex shape required by `check-mirror-drift.js`).
- `.claude/rules/test-trigger.md`: mirrored the same pattern in both the YAML `globs:` frontmatter and the markdown "Expected Test File Locations" table.

## Verification

### Mirror-drift check

```
$ node .claude/skills/orchestrator/check-mirror-drift.js
✅ COVERAGE_PATTERNS and test-trigger.md are in sync.
$ echo $?
0
```

### Gate polarity (load-bearing item)

A temporary probe (`void 0;` inserted into `getMcpCallerIdentity()` in `packages/server/src/mcp/mcp-auth.ts`, a real code-line change, not comment-only) was committed, preflight run, then reverted.

**Run 1 — probe present, no sibling-test change (expected: FAIL):**

```
$ node .claude/skills/orchestrator/preflight-check.js
## Test Coverage Check

### Missing Tests (1)

- ❌ packages/server/src/mcp/mcp-auth.ts — expected: packages/server/src/mcp/__tests__/mcp-auth.test.ts

**1 production file(s) missing test coverage.**

---
## Rule/Skill Duplication Check
✅ No rule paragraphs found verbatim in any skill file.
---
## Language Check (public artifacts)
✅ All public artifacts use Latin / Greek / Cyrillic scripts only.
---
## Source-Comment Blame-Shift Check
✅ No new Issue / PR / dated CodeRabbit references in source comments.

$ echo $?
1
```

**Run 2 — probe reverted (expected: PASS):**

```
$ git reset --hard HEAD~1   # drops the probe commit
$ node .claude/skills/orchestrator/preflight-check.js
## Test Coverage Check

No production files matching coverage patterns were changed.

---
## Rule/Skill Duplication Check
✅ No rule paragraphs found verbatim in any skill file.
---
## Language Check (public artifacts)
✅ All public artifacts use Latin / Greek / Cyrillic scripts only.
---
## Source-Comment Blame-Shift Check
✅ No new Issue / PR / dated CodeRabbit references in source comments.

$ echo $?
0
```

**`git status` confirming zero probe residue after revert:**

```
$ git status --porcelain
(no output)
```

### Containment (isTestFile() negation still applies)

The same shape of probe (`void 0; // TEMP PROBE ...`, a real code-line, not comment-only) was applied only to `packages/server/src/mcp/__tests__/mcp-auth.test.ts` (a test file, no production file touched), committed, and preflight run:

```
$ node .claude/skills/orchestrator/preflight-check.js
## Test Coverage Check

No production files matching coverage patterns were changed.

---
## Rule/Skill Duplication Check
✅ No rule paragraphs found verbatim in any skill file.
---
## Language Check (public artifacts)
✅ All public artifacts use Latin / Greek / Cyrillic scripts only.
---
## Source-Comment Blame-Shift Check
✅ No new Issue / PR / dated CodeRabbit references in source comments.

$ echo $?
0
```

The test-file-only probe was then reverted (`git reset --hard HEAD~1`), confirmed clean via `git status --porcelain` (no output), before the final commit was pushed.

### Full test suite

```
[36m│[0m  2107 pass / 0 fail (client)
[36m│[0m  597 pass / 0 fail (shared)
[36m│[0m  73 pass / 0 fail (integration)
[36m│[0m  3788 pass / 1 skip / 0 fail (server)
[36m│[0m  295 pass / 0 fail (embedded-agent)
 522 pass / 0 fail (scripts, .claude/hooks, .claude/skills/*/__tests__ — includes check-utils.js / preflight-check.js coverage)
TEST_EXIT: 0
```

(Full untruncated output available on request; final line was `TEST_EXIT: 0`.)

### CodeRabbit

Skipped: the local CodeRabbit CLI cannot authenticate in this headless worktree (no interactive browser auth available). Per `coderabbit-ops` skill fallback, GitHub-side bot review will run once the PR is open.

## Scope note

No file under `packages/server/src/mcp/` needed an exception (bare `types.ts`, `.gen.ts`, etc.) — all 4 existing production files already had sibling tests before this PR.

Closes #1263


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated test coverage checks to include server MCP components.
  * Documented expected test locations for MCP-related code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->