### PR TITLE
fix: invalidate worktree queries on worktree session-created events

### DIFF
--- a/packages/client/src/hooks/__tests__/useSessionSideEffects.test.ts
+++ b/packages/client/src/hooks/__tests__/useSessionSideEffects.test.ts
@@ -9,7 +9,8 @@ import type {
 import type { UseWorktreeCreationTasksReturn } from '../useWorktreeCreationTasks';
 import type { UseWorktreeDeletionTasksReturn } from '../useWorktreeDeletionTasks';
 import type { UseSessionStopTasksReturn, SessionStopTask } from '../useSessionStopTasks';
-import { useSessionSideEffects } from '../useSessionSideEffects';
+import { useSessionSideEffects, worktreeInvalidationKeyFor } from '../useSessionSideEffects';
+import { worktreeKeys } from '../../lib/query-keys';
 import { clearDraftsForSession, _getDraftsMap } from '../useDraftMessage';
 import { _reset as resetWebSocket } from '../../lib/app-websocket';
 import { MockWebSocket, installMockWebSocket } from '../../test/mock-websocket';
@@ -298,5 +299,187 @@ describe('useSessionSideEffects - session stop task removal (Issue #1247)', () =
     });
 
     expect(sessionStopTasks.removeTask).toHaveBeenCalledWith('session-1');
+  });
+});
+
+/**
+ * Tests for Issue #1266 -- a worktree-type session-created event must
+ * invalidate that repository's worktree queries so the dashboard repository
+ * card picks up worktrees created outside the REST form flow (e.g. MCP
+ * delegate_to_worktree, which never fires worktree-creation-completed).
+ */
+describe('useSessionSideEffects - worktree query invalidation on session-created (Issue #1266)', () => {
+  let restoreWebSocket: () => void;
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    restoreWebSocket = installMockWebSocket();
+    Object.defineProperty(window, 'location', {
+      value: { protocol: 'http:', host: 'localhost:3000' },
+      writable: true,
+    });
+    resetWebSocket();
+  });
+
+  afterEach(() => {
+    restoreWebSocket();
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  function worktreeSession(overrides: Partial<Session> = {}): Session {
+    return createMockSession({
+      type: 'worktree',
+      repositoryId: 'repo-1',
+      repositoryName: 'repo-one',
+      worktreeId: 'feature-branch',
+      isMainWorktree: false,
+      isShared: false,
+      recoveryState: 'healthy',
+      activationState: 'running',
+      ...overrides,
+    } as Partial<Session>);
+  }
+
+  it('invalidates the repository worktree query on a worktree session-created event', () => {
+    const handleSessionCreated = mock(() => {});
+    const options = createDefaultOptions({ handleSessionCreated });
+    const { invalidateSpy } = renderWithQueryClient(options);
+
+    const session = worktreeSession({ id: 'session-wt-1' });
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+      ws?.simulateMessage(JSON.stringify({ type: 'session-created', session }));
+    });
+
+    expect(handleSessionCreated).toHaveBeenCalledWith(session);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: worktreeKeys.byRepository('repo-1') });
+  });
+
+  it('does NOT invalidate worktree queries on a quick session-created event', () => {
+    const handleSessionCreated = mock(() => {});
+    const options = createDefaultOptions({ handleSessionCreated });
+    const { invalidateSpy } = renderWithQueryClient(options);
+
+    const session = createMockSession({ id: 'session-quick-1', type: 'quick', isShared: false, recoveryState: 'healthy', activationState: 'running' } as Partial<Session>);
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+      ws?.simulateMessage(JSON.stringify({ type: 'session-created', session }));
+    });
+
+    expect(handleSessionCreated).toHaveBeenCalledWith(session);
+    const worktreeInvalidations = invalidateSpy.mock.calls.filter(
+      ([arg]) => Array.isArray((arg as { queryKey?: unknown[] })?.queryKey) && (arg as { queryKey: unknown[] }).queryKey[0] === 'worktrees',
+    );
+    expect(worktreeInvalidations).toHaveLength(0);
+  });
+
+  it('a malformed worktree session-created message (missing repositoryId) is rejected at the wire and never invalidates or throws', () => {
+    // repositoryId is required by WorktreeSessionSchema, so this shape cannot
+    // legitimately arrive over the wire -- it is rejected by app-websocket's
+    // schema parse before onSessionCreated is ever invoked. This test proves
+    // the AC's "no invalidation, no throw" boundary holds for the full pipeline;
+    // the wrapper's own defensive guard (for callers other than the wire) is
+    // covered directly by the worktreeInvalidationKeyFor unit tests below.
+    const handleSessionCreated = mock(() => {});
+    const options = createDefaultOptions({ handleSessionCreated });
+    const { invalidateSpy } = renderWithQueryClient(options);
+
+    const session = worktreeSession({ id: 'session-wt-2', repositoryId: undefined } as Partial<Session>);
+    const ws = MockWebSocket.getLastInstance();
+    expect(() => {
+      act(() => {
+        ws?.simulateOpen();
+        ws?.simulateMessage(JSON.stringify({ type: 'session-created', session }));
+      });
+    }).not.toThrow();
+
+    expect(handleSessionCreated).not.toHaveBeenCalled();
+    const worktreeInvalidations = invalidateSpy.mock.calls.filter(
+      ([arg]) => Array.isArray((arg as { queryKey?: unknown[] })?.queryKey) && (arg as { queryKey: unknown[] }).queryKey[0] === 'worktrees',
+    );
+    expect(worktreeInvalidations).toHaveLength(0);
+  });
+
+  it('invalidates independently for two worktree sessions created in rapid succession', () => {
+    const handleSessionCreated = mock(() => {});
+    const options = createDefaultOptions({ handleSessionCreated });
+    const { invalidateSpy } = renderWithQueryClient(options);
+
+    const sessionA = worktreeSession({ id: 'session-wt-a', repositoryId: 'repo-a' });
+    const sessionB = worktreeSession({ id: 'session-wt-b', repositoryId: 'repo-b' });
+    const ws = MockWebSocket.getLastInstance();
+    act(() => {
+      ws?.simulateOpen();
+      ws?.simulateMessage(JSON.stringify({ type: 'session-created', session: sessionA }));
+      ws?.simulateMessage(JSON.stringify({ type: 'session-created', session: sessionB }));
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: worktreeKeys.byRepository('repo-a') });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: worktreeKeys.byRepository('repo-b') });
+  });
+});
+
+describe('worktreeInvalidationKeyFor (Issue #1266)', () => {
+  it('returns the repository worktree key for a worktree session with a repositoryId', () => {
+    const session = createMockSession({
+      type: 'worktree',
+      repositoryId: 'repo-1',
+      repositoryName: 'repo-one',
+      worktreeId: 'feature-branch',
+      isMainWorktree: false,
+      isShared: false,
+      recoveryState: 'healthy',
+      activationState: 'running',
+    } as Partial<Session>);
+
+    expect(worktreeInvalidationKeyFor(session)).toEqual(worktreeKeys.byRepository('repo-1'));
+  });
+
+  it('returns null and does not throw for a quick session', () => {
+    const session = createMockSession({ type: 'quick', isShared: false, recoveryState: 'healthy', activationState: 'running' } as Partial<Session>);
+
+    expect(() => worktreeInvalidationKeyFor(session)).not.toThrow();
+    expect(worktreeInvalidationKeyFor(session)).toBeNull();
+  });
+
+  it('returns null and does not throw for a worktree session without a repositoryId', () => {
+    // Defensive boundary: repositoryId is required by the WorktreeSession type
+    // and by the wire schema, but the guard must stay safe against a runtime
+    // value (e.g. an unsafe cast) that omits it.
+    const session = createMockSession({
+      type: 'worktree',
+      repositoryId: undefined,
+      repositoryName: 'repo-one',
+      worktreeId: 'feature-branch',
+      isMainWorktree: false,
+      isShared: false,
+      recoveryState: 'healthy',
+      activationState: 'running',
+    } as Partial<Session>);
+
+    expect(() => worktreeInvalidationKeyFor(session)).not.toThrow();
+    expect(worktreeInvalidationKeyFor(session)).toBeNull();
+  });
+
+  it('returns null and does not throw for a worktree session with an empty-string repositoryId', () => {
+    const session = createMockSession({
+      type: 'worktree',
+      repositoryId: '',
+      repositoryName: 'repo-one',
+      worktreeId: 'feature-branch',
+      isMainWorktree: false,
+      isShared: false,
+      recoveryState: 'healthy',
+      activationState: 'running',
+    } as Partial<Session>);
+
+    expect(() => worktreeInvalidationKeyFor(session)).not.toThrow();
+    expect(worktreeInvalidationKeyFor(session)).toBeNull();
   });
 });

--- a/packages/client/src/hooks/useSessionSideEffects.ts
+++ b/packages/client/src/hooks/useSessionSideEffects.ts
@@ -10,6 +10,19 @@ import { disconnectSession } from '../lib/worker-websocket';
 import { clearDraftsForSession } from './useDraftMessage';
 import { updateFavicon, hasAnyAskingWorker } from '../lib/favicon-manager';
 
+/**
+ * Query key to invalidate for a session-created event, or null if this
+ * session-created event carries no worktree-cache implication (a quick
+ * session, or a worktree session that -- despite `repositoryId` being a
+ * required field on the wire schema -- was constructed without one).
+ */
+export function worktreeInvalidationKeyFor(session: Session): ReturnType<typeof worktreeKeys.byRepository> | null {
+  if (session.type === 'worktree' && session.repositoryId) {
+    return worktreeKeys.byRepository(session.repositoryId);
+  }
+  return null;
+}
+
 interface UseSessionSideEffectsOptions {
   handleSessionsSync: (sessions: Session[], activityStates: WorkerActivityInfo[]) => void;
   handleSessionCreated: (session: Session) => void;
@@ -58,7 +71,15 @@ export function useSessionSideEffects({
   const handleSessionCreatedWithValidation = useCallback((...args: Parameters<typeof handleSessionCreated>) => {
     handleSessionCreated(...args);
     invalidateValidation();
-  }, [handleSessionCreated, invalidateValidation]);
+    // A worktree-type session may have been created outside the REST form flow
+    // (e.g. MCP delegate_to_worktree), which never fires worktree-creation-completed.
+    // React to the authoritative session-created fact instead of relying on that
+    // task event, so the dashboard repository card sees the new worktree row.
+    const queryKey = worktreeInvalidationKeyFor(args[0]);
+    if (queryKey) {
+      queryClient.invalidateQueries({ queryKey });
+    }
+  }, [handleSessionCreated, invalidateValidation, queryClient]);
 
   const handleSessionDeletedWithValidation = useCallback((sessionId: string) => {
     clearDraftsForSession(sessionId);


### PR DESCRIPTION
## Summary

MCP-created worktrees (`delegate_to_worktree`) never fired `worktree-creation-completed` (that event is only fired by the REST route), so the Dashboard repository card stayed stale until an unrelated refetch. Per the architect's ruling on this Issue, the fix reacts to the authoritative fact instead: `session-created` broadcasts unconditionally regardless of how the worktree was created, so `useSessionSideEffects` now wraps `handleSessionCreated` to also invalidate that repository's worktree query cache for `worktree`-type sessions. Server is unchanged — no new event, no wire-schema change.

- Quick sessions do not invalidate (containment).
- A worktree session's `repositoryId` is required by both the TypeScript type and the wire schema (`WorktreeSessionSchema`), so the guard's "no repositoryId" branch is unreachable over the wire; it exists purely as defense-in-depth against a bad runtime cast. Verified directly via a pure exported helper (`worktreeInvalidationKeyFor`), not just inferred.

## Pre-change (TDD polarity) check

Stashed only `packages/client/src/hooks/useSessionSideEffects.ts` (the fix), keeping the new/modified test file in place, and ran the hook test file against unmodified `main`:

```
$ bun test --preload ./src/test/setup.ts src/hooks/__tests__/useSessionSideEffects.test.ts
SyntaxError: Export named 'worktreeInvalidationKeyFor' not found in module '.../useSessionSideEffects.ts'.
0 pass / 1 fail / 1 error
```

The whole test file fails to even load without the fix (missing export used by the new tests). Restoring the fix: all 17 tests pass (`17 pass / 0 fail`). No partial polarity — every new assertion depends on behavior introduced by this change.

## Q10 (shared-type / wire-schema change)

N/A — this is a client-only reaction to an existing, unchanged wire event (`session-created`). No shared type or schema was added or modified.

## REST-flow idempotency

Existing REST form flow (`worktree-creation-completed` handling, task removal, fallback/setup-result dialogs) is untouched and its existing tests are green.

For a REST-created worktree, both `session-created` and `worktree-creation-completed` fire. Traced `useWorktreeCreationTasks.handleWorktreeCreationCompleted` (the REST path's completion handler): it only updates local sidebar task-list state (`status`, `sessionId`, `sessionTitle` on the in-memory task) — it never touched `queryClient`/`worktreeKeys` before or after this change. The worktree query-cache invalidation added here is fired exactly once, from `session-created`, regardless of which path created the worktree. There is no double-invalidation of the same cache key to reason about; the two events operate on disjoint state (local task list vs. TanStack Query cache).

**Restore/resume boundary (explicit):** a `session-created` event for a worktree the client already has cached (e.g. a restore/resume of an existing session) still fires the invalidation. This is accepted as harmless — it is just an extra `queryKey` refetch of already-fresh data — and is intentionally not special-cased to detect "already cached" and skip invalidation.

## Shipping-path verification

Per the AC, verified on an isolated dev instance (outside `~/.agent-console*`: `AGENT_CONSOLE_HOME=/tmp/agent-console-1266-verify`, ports 13457/15173, since the shared default ports were already in use by another running instance):

1. Registered a throwaway local git repo as a Repository.
2. Opened the Dashboard in Chrome DevTools MCP — repository card showed 0 worktrees.
3. Called the isolated instance's MCP endpoint directly (`POST http://localhost:13457/mcp`, `tools/call` → `delegate_to_worktree`) — the real production MCP tool-call code path, invoked via raw JSON-RPC since the pre-registered `agent-console-dev`/`agent-console` MCP clients in this environment point at different (shared) instances.
4. Re-snapshotted the Dashboard **without any manual refetch or reload** — the new worktree row (branch `chore/echo-hello`, session in the sidebar) was present.
5. Confirmed via the network log that this was invalidation-driven, not stale-time coincidence: a fresh `GET /api/repositories/<id>/worktrees` request appears immediately after the MCP call, matching `worktreeInvalidationKeyFor`'s query key.

Evidence (DOM snapshot + network trace of the post-MCP-delegate Dashboard state): see PR comments below.

Cleaned up afterward: removed the throwaway repo/session data, shut down the isolated instance, and deleted its data root — no artifacts left in the shared environment.

## CodeRabbit

Local CLI cannot authenticate in this headless worktree (structural auth-fail, not a quota condition). GitHub-side bot's commit-status description reads "Review rate limited" (rollup shows `CodeRabbit=SUCCESS`, which is not itself a verdict — see `coderabbit-ops` "the fourth surface"); `reviewDecision` is empty. Both channels are unavailable for this commit — see PR comments for the full disposition note; this needs the Architect + Orchestrator dual-clean disposition before merge per `coderabbit-ops` troubleshooting.

## Test plan

- [x] `bun run test` — full suite, second clean run: `TEST_EXIT: 0` (first run had 1 unrelated flake in `terminal-store-paging.test.ts`, unrelated to this change, confirmed non-reproducing on isolated re-runs and on a clean second full run).
- [x] `bun run typecheck` — clean.
- [x] `node .claude/skills/orchestrator/preflight-check.js` — clean (test coverage, rule/skill duplication, language check, blame-shift check all pass).
- [x] Shipping-path E2E via MCP on an isolated dev instance (see above).

Closes #1266

