### PR TITLE
test: convert remaining fetch stub casts to Object.assign preconnect pattern

### DIFF
--- a/packages/client/src/__tests__/routes/agents/index.test.tsx
+++ b/packages/client/src/__tests__/routes/agents/index.test.tsx
@@ -76,7 +76,7 @@ const mockFetch = mock(async (input: RequestInfo | URL, init?: RequestInit): Pro
 let useAppWsStateSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
-  globalThis.fetch = mockFetch as unknown as typeof fetch;
+  globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
   mockFetch.mockClear();
   agentsResponse = { agents: [] };
   embeddedAgentsResponse = { embeddedAgents: [] };

--- a/packages/client/src/components/__tests__/SessionSettings.test.tsx
+++ b/packages/client/src/components/__tests__/SessionSettings.test.tsx
@@ -149,7 +149,7 @@ describe('SessionSettings', () => {
       return Promise.resolve(new Response());
     });
 
-    globalThis.fetch = mockFetch as unknown as typeof fetch;
+    globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
     defaultProps.onBranchChange.mockClear();
     defaultProps.onSessionRestart.mockClear();
   });

--- a/packages/client/src/components/header/__tests__/NavLinks.test.tsx
+++ b/packages/client/src/components/header/__tests__/NavLinks.test.tsx
@@ -48,7 +48,7 @@ const mockFetch = mock(async (input: RequestInfo | URL): Promise<Response> => {
 });
 
 beforeEach(() => {
-  globalThis.fetch = mockFetch as unknown as typeof fetch;
+  globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
   reviewQueueResponse = [];
   validateSessionsResponse = { hasIssues: false, results: [] };
   logoutCalled = false;

--- a/packages/client/src/components/repositories/__tests__/CloneFromUrlForm.test.tsx
+++ b/packages/client/src/components/repositories/__tests__/CloneFromUrlForm.test.tsx
@@ -58,7 +58,7 @@ function installScriptedFetch(opts: {
     });
   });
 
-  globalThis.fetch = scripted as unknown as typeof fetch;
+  globalThis.fetch = Object.assign(scripted, { preconnect: () => {} }) as typeof fetch;
   return { calls, scripted };
 }
 

--- a/packages/client/src/components/repositories/__tests__/EditRepositoryForm.test.tsx
+++ b/packages/client/src/components/repositories/__tests__/EditRepositoryForm.test.tsx
@@ -8,7 +8,7 @@ import { EditRepositoryForm } from '../EditRepositoryForm';
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
 const mockFetch = mock((_input: RequestInfo | URL, _init?: RequestInit) => Promise.resolve(new Response()));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 // Default mock for Slack integration (returns 404 - not found)
 function createSlackNotFoundResponse() {

--- a/packages/client/src/components/repositories/__tests__/RepositoryList.test.tsx
+++ b/packages/client/src/components/repositories/__tests__/RepositoryList.test.tsx
@@ -8,7 +8,7 @@ import type { Repository } from '@agent-console/shared';
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
 const mockFetch = mock((_input: RequestInfo | URL, _init?: RequestInit) => Promise.resolve(new Response()));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 afterAll(() => {
   globalThis.fetch = originalFetch;

--- a/packages/client/src/components/repositories/hooks/__tests__/use-clone-repository.test.tsx
+++ b/packages/client/src/components/repositories/hooks/__tests__/use-clone-repository.test.tsx
@@ -55,7 +55,7 @@ function installScriptedFetch(opts: {
       headers: { 'Content-Type': 'application/json' },
     });
   });
-  globalThis.fetch = scripted as unknown as typeof fetch;
+  globalThis.fetch = Object.assign(scripted, { preconnect: () => {} }) as typeof fetch;
   return { calls, scripted };
 }
 

--- a/packages/client/src/components/sessions/__tests__/QuickSessionForm.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/QuickSessionForm.test.tsx
@@ -8,7 +8,7 @@ import { setSharedAccountsAvailable, _reset as resetAuth } from '../../../lib/au
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
 const mockFetch = mock((_input: RequestInfo | URL) => Promise.resolve(new Response()));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 afterAll(() => {
   globalThis.fetch = originalFetch;

--- a/packages/client/src/components/sessions/__tests__/RestartSessionDialog.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/RestartSessionDialog.test.tsx
@@ -7,7 +7,7 @@ import { RestartSessionDialog, type RestartSessionDialogProps } from '../Restart
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
 const mockFetch = mock(() => Promise.resolve(new Response()));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 afterAll(() => {
   globalThis.fetch = originalFetch;

--- a/packages/client/src/components/sessions/hooks/__tests__/useSessionPageState.test.ts
+++ b/packages/client/src/components/sessions/hooks/__tests__/useSessionPageState.test.ts
@@ -71,7 +71,7 @@ const mockFetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
 })
 
 // Install fetch mock at module level (consistent with useTabManagement.test.ts)
-globalThis.fetch = mockFetch as unknown as typeof fetch
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch
 
 afterAll(() => {
   globalThis.fetch = originalFetch

--- a/packages/client/src/components/sessions/hooks/__tests__/useTabManagement.test.ts
+++ b/packages/client/src/components/sessions/hooks/__tests__/useTabManagement.test.ts
@@ -73,7 +73,7 @@ const mockFetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
   return new Response('Not Found', { status: 404 });
 });
 
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 afterAll(() => {
   globalThis.fetch = originalFetch;

--- a/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
+++ b/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
@@ -1059,16 +1059,19 @@ describe('ActiveSessionsSidebar', () => {
 
     beforeEach(() => {
       restartAllResponse = { restarted: 0, failed: 0, results: [] };
-      globalThis.fetch = mock(async (input: RequestInfo | URL): Promise<Response> => {
-        const url = input instanceof Request ? input.url : String(input);
-        if (url.includes('/restart-all-agents')) {
-          return new Response(JSON.stringify(restartAllResponse), {
-            status: 200,
-            headers: { 'content-type': 'application/json' },
-          });
-        }
-        return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
-      }) as unknown as typeof fetch;
+      globalThis.fetch = Object.assign(
+        mock(async (input: RequestInfo | URL): Promise<Response> => {
+          const url = input instanceof Request ? input.url : String(input);
+          if (url.includes('/restart-all-agents')) {
+            return new Response(JSON.stringify(restartAllResponse), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            });
+          }
+          return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+        }),
+        { preconnect: () => {} },
+      ) as typeof fetch;
     });
 
     afterEach(() => {

--- a/packages/client/src/components/ui/__tests__/WebhookConfigBanner.test.tsx
+++ b/packages/client/src/components/ui/__tests__/WebhookConfigBanner.test.tsx
@@ -40,7 +40,7 @@ describe('WebhookConfigBanner', () => {
     localStorage.clear();
     // Set up fetch-level mock
     mockFetch = vi.fn();
-    globalThis.fetch = mockFetch as unknown as typeof fetch;
+    globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
   });
 
   afterEach(() => {

--- a/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx
@@ -8,7 +8,7 @@ import { CreateWorktreeForm } from '../CreateWorktreeForm';
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
 const mockFetch = mock((_input: RequestInfo | URL) => Promise.resolve(new Response()));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 // Restore original fetch after all tests
 afterAll(() => {

--- a/packages/client/src/components/worktrees/__tests__/FromIssueTab.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/FromIssueTab.test.tsx
@@ -7,7 +7,7 @@ import { FromIssueTab } from '../FromIssueTab';
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
 const mockFetch = mock((_input: RequestInfo | URL) => Promise.resolve(new Response()));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 afterAll(() => {
   globalThis.fetch = originalFetch;

--- a/packages/client/src/components/worktrees/__tests__/QuickWorktreeDialog.test.tsx
+++ b/packages/client/src/components/worktrees/__tests__/QuickWorktreeDialog.test.tsx
@@ -18,7 +18,7 @@ let useCreateWorktreeSpy: ReturnType<typeof spyOn>;
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
 const mockFetch = mock((_input: RequestInfo | URL) => Promise.resolve(new Response()));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 afterAll(() => {
   globalThis.fetch = originalFetch;

--- a/packages/client/src/hooks/__tests__/useCreateWorktree.test.ts
+++ b/packages/client/src/hooks/__tests__/useCreateWorktree.test.ts
@@ -34,7 +34,7 @@ const mockFetch = mock((_input: RequestInfo | URL, _init?: RequestInit) =>
     headers: { 'Content-Type': 'application/json' },
   }))
 );
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 afterAll(() => {
   globalThis.fetch = originalFetch;

--- a/packages/client/src/lib/__tests__/api.test.ts
+++ b/packages/client/src/lib/__tests__/api.test.ts
@@ -29,7 +29,7 @@ const expect = (value: unknown) => bunExpect(value);
 // Save original fetch and set up mock
 const originalFetch = globalThis.fetch;
 const mockFetch = mock(() => Promise.resolve(new Response()));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 // Restore original fetch after all tests
 afterAll(() => {

--- a/packages/client/src/routes/__tests__/index.test.tsx
+++ b/packages/client/src/routes/__tests__/index.test.tsx
@@ -156,7 +156,7 @@ const mockFetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
   });
 });
 
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 afterAll(() => {
   globalThis.fetch = originalFetch;

--- a/packages/client/src/routes/settings/repositories/$repositoryId/__tests__/index.test.tsx
+++ b/packages/client/src/routes/settings/repositories/$repositoryId/__tests__/index.test.tsx
@@ -89,7 +89,7 @@ const mockFetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
   throw new Error(`Unhandled fetch request in RepositoryDetailView test: ${method} ${url}`);
 });
 
-globalThis.fetch = mockFetch as unknown as typeof fetch;
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
 
 afterAll(() => {
   globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary

Five (measured 2026-07-30 at Issue filing time; 20 measured at implementation time — main had grown more sites in between) client test files stubbed `globalThis.fetch` via the double cast `mockFetch as unknown as typeof fetch`. This PR converts every remaining occurrence to the cleaner structural pattern already established elsewhere in the codebase (`AgentSelector.test.tsx`, `AgentForm` and `EndSessionDialog` test files):

```ts
globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
```

Bun's `typeof fetch` includes a `preconnect` member that plain mock functions lack; the clean pattern supplies it structurally instead of casting past it through `unknown`.

## Files converted (20)

- `packages/client/src/__tests__/routes/agents/index.test.tsx`
- `packages/client/src/components/__tests__/SessionSettings.test.tsx`
- `packages/client/src/components/header/__tests__/NavLinks.test.tsx`
- `packages/client/src/components/repositories/__tests__/CloneFromUrlForm.test.tsx`
- `packages/client/src/components/repositories/__tests__/EditRepositoryForm.test.tsx`
- `packages/client/src/components/repositories/__tests__/RepositoryList.test.tsx`
- `packages/client/src/components/repositories/hooks/__tests__/use-clone-repository.test.tsx`
- `packages/client/src/components/sessions/__tests__/QuickSessionForm.test.tsx`
- `packages/client/src/components/sessions/__tests__/RestartSessionDialog.test.tsx`
- `packages/client/src/components/sessions/hooks/__tests__/useSessionPageState.test.ts`
- `packages/client/src/components/sessions/hooks/__tests__/useTabManagement.test.ts`
- `packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx`
- `packages/client/src/components/ui/__tests__/WebhookConfigBanner.test.tsx`
- `packages/client/src/components/worktrees/__tests__/CreateWorktreeForm.test.tsx`
- `packages/client/src/components/worktrees/__tests__/FromIssueTab.test.tsx`
- `packages/client/src/components/worktrees/__tests__/QuickWorktreeDialog.test.tsx`
- `packages/client/src/hooks/__tests__/useCreateWorktree.test.ts`
- `packages/client/src/lib/__tests__/api.test.ts`
- `packages/client/src/routes/__tests__/index.test.tsx`
- `packages/client/src/routes/settings/repositories/$repositoryId/__tests__/index.test.tsx`

Scope note: the Issue title said five files, but the Issue body's stated grep is authoritative ("Re-run the grep at implementation time for the authoritative list"). `grep -rl "as unknown as typeof fetch" packages/` on current main (5c3ae3eb) returned 20 files; all 20 are converted here. `useSessionSideEffects.test.ts` and all other client-hooks/server-services files are untouched (two sibling PRs are in flight there).

Diffstat note: 19 files are single-line conversions (+1/-1 each). `packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx` is 13/10 because its stub is a multi-line inline `mock(...)` call, so the conversion wraps the whole expression in `Object.assign(...)` and re-indents the body — not a uniform 1:1 edit. `git diff -w` on that file confirms the mock body is byte-identical modulo indentation; the only semantic change is the same `Object.assign(..., { preconnect })` wrap as everywhere else.

## Verification

Empty grep post-conversion:
```
$ grep -rn "as unknown as typeof fetch" packages/
(no output, exit 1)
```

Full suite (`bun run test`, i.e. typecheck + all packages), pasted per workflow.md:

```
[36m│[0m [0m[32m 2107 pass[0m
[36m│[0m [0m[2m 0 fail[0m
[36m│[0m  4428 expect() calls
[36m│[0m Ran 2107 tests across 144 files. [49.20s]
[1m@agent-console/shared[0m test $ bun test src/
[36m│[0m [0m[32m 597 pass[0m
[36m│[0m [0m[2m 0 fail[0m
Ran 597 tests across 22 files. [1.92s]
[1m@agent-console/integration[0m test $ bun test --preload ./src/setup.ts src/
[36m│[0m [0m[32m 73 pass[0m
[36m│[0m [0m[2m 0 fail[0m
Ran 73 tests across 27 files. [3.42s]
[1m@agent-console/server[0m test $ bun test src/
[36m│[0m [0m[32m 3788 pass[0m
[36m│[0m  [33m1 skip[0m
[36m│[0m [0m[2m 0 fail[0m
Ran 3789 tests across 165 files. [75.03s]
[1m@agent-console/embedded-agent[0m test $ bun test src/
[36m│[0m [0m[32m 295 pass[0m
[36m│[0m [0m[2m 0 fail[0m
Ran 295 tests across 26 files. [8.27s]
[1m@agent-console/client[0m test $ bun test --preload ./src/test/setup.ts src/
[36m│[0m [0m[32m 2107 pass[0m
[36m│[0m [0m[2m 0 fail[0m
Ran 2107 tests across 144 files. [49.24s]
$ bun test scripts/ ./.claude/hooks/__tests__/ ./.claude/skills/*/__tests__/
[0m[32m 522 pass[0m
[0m[2m 0 fail[0m
Ran 522 tests across 17 files.
TEST_EXIT: 0
```

`bun run typecheck` ran as part of `bun run test` (exit 0, part of the same run above).

`node .claude/skills/orchestrator/preflight-check.js` exit 0 (no production files changed; no rule/skill duplication; language check clean; no blame-shift comment references).

## Notes

- Test-only refactor: zero production code changes, zero behavior/assertion changes. Only the fetch-stub-installation line's cast shape changes per site.
- Do not merge — merge disposition is the Orchestrator's call.

## Note on CodeRabbit

Both local CodeRabbit CLI (headless-worktree auth failure — structural, not a quota condition) and the GitHub-side bot (rate limited at PR open; a manual `@coderabbitai review` retrigger by the owner returned the "does not re-review already reviewed commits" reply while the commit status still read `Review rate limited`, i.e. no genuine walkthrough was ever posted for this commit — `coderabbit-ops` troubleshooting.md Q39's rate-limit-only shape, not clean) were unavailable for this PR's sole commit.

Per `coderabbit-ops` troubleshooting.md Q61, the Architect performed an independent code-appropriateness audit as the substitute verification layer. Verdict: **CLEAN**. The Architect mechanically confirmed 20 files changed / 20 `Object.assign` sites added / zero added lines containing `as unknown` (no half-converted casts), and reviewed the `ActiveSessionsSidebar.test.tsx` diffstat asymmetry noted above. This dual-clean (CI green + Architect audit) satisfies the "CodeRabbit clean" precondition for merge; final merge classification remains the Orchestrator's under existing PR Merge Authority.

Closes #1253
