### PR TITLE
docs: sprint retrospective improvements (2026-08-05)

### DIFF
--- a/.claude/rules/pre-pr-completeness.md
+++ b/.claude/rules/pre-pr-completeness.md
@@ -162,6 +162,26 @@ Before opening a PR that introduces a **new skill, script, rule, file type, or c
 
     (Lesson: Sprint 2026-08-03, Issue #1004 item 5 — the mandated check needed a real OS login password that the delegate had no legitimate way to obtain. Rather than improvise, they held and consulted; the JWT-mint substitution was approved against these three conditions, and the resulting evidence recorded it alongside the result. The same task's PAM-substitution *also* demonstrated the boundary: it was acceptable precisely because PAM sits outside the MCP caller-identity chain the item verifies.)
 
+    **Where you record a correction is part of the correction.** When you discover that a claim in a PR body, an Issue, or a design doc overstates its evidence, correct it *there*. A note in a session memo, a chat message, or a report to the requester does not reach the person who reads the artifact six months from now — and the artifact is what they will act on. A memo is transient; a PR body is durable. This applies with particular force to observations recorded under the proxy rules above: an observation whose strength was overstated in a durable place, and corrected only in a transient one, is still overstated as far as every future reader is concerned. (Lesson: Sprint 2026-08-05 PR [#1283](https://github.com/ms2sato/agent-console/pull/1283) — the PR body reported "the alias form was accepted at spawn", evidenced only by the process still being alive ~2s later. The Orchestrator noticed the gap between that evidence and that claim, explained the distinction in the owner memo, and considered it handled. The Architect required the PR body itself be fixed before merge: the memo would be gone, the body would not.)
+
+14. **Rollback-resource question — for PRs that add a resource acquisition inside a function that already has failure rollback:**
+
+    When this PR makes a function acquire something new — spawn a subprocess, mint a token, open a handle, create a file, take a lock — and that function already has a failure path that cleans up (a `catch` that kills workers, deletes state, restores a previous status), ask one question:
+
+    > **Does that existing rollback release the resource I just added?**
+
+    It usually does not. Rollback code enumerates what existed when it was written; a new acquisition is invisible to it. The failure is silent — the happy path is unaffected, the rollback still "succeeds", and the leak only appears under a failure that tests rarely exercise.
+
+    Check three things at the code, not from the caller:
+
+    1. **Read every rollback path in the function**, not just the one nearest your change. A function with two `catch` blocks needs both updated; fixing one leaves the same hole half-open.
+    2. **Confirm the cleanup call actually reaches your resource type.** A shared cleanup helper may silently ignore it — a `killWorker` gated on `worker.type === 'agent' || 'terminal'` no-ops on anything else, so appending your worker to its list looks correct and does nothing.
+    3. **Confirm the ordering.** Cleanup that runs after the lookup structure is torn down cannot find the resource. Deactivating a worker *after* `deleteSession` removes it from the session map is a no-op, and the resource becomes permanently unreachable rather than merely leaked.
+
+    Then add a test per rollback path: acquisition succeeds, a *later* step fails, the resource is released. A test that only exercises "my own acquisition failed" does not cover this.
+
+    (Lesson: Sprint 2026-08-05 PR [#1276](https://github.com/ms2sato/agent-console/pull/1276) — session-resume gained an embedded-agent activation inside a function whose two rollback paths killed only PTY workers. On a later PTY failure or a DB-persist failure, the activated subprocess and its minted MCP token survived the rollback, and the subsequent `deleteSession` made them unreachable, so each retry compounded the leak. CodeRabbit found it in a review body; the Architect's own audit had missed it, and named the gap precisely: they had required exactly this check of a delegate four days earlier in PR #1237 and did not apply it to their own review. That is the role-switch blind spot Q13 describes, in its most direct form.)
+
 ## When to apply
 
 - **Required** for PRs that introduce:
@@ -174,6 +194,7 @@ Before opening a PR that introduces a **new skill, script, rule, file type, or c
   - A shared / persistent artifact write (Question 7) — required regardless of whether other criteria match
   - A derived field added to a shared type that crosses the server/client wire (Question 10) — required regardless of whether other criteria match
   - A new worker / agent / execution surface analogous to an existing one, or a new entry in `AGENT_OPERATIONS` / a new agent-operations exposure table (Question 11) — required regardless of whether other criteria match
+- **Question 14 applies to any PR that adds a resource acquisition inside a function with an existing failure-rollback path** — required regardless of whether other criteria match
 - **Question 12 applies to any PR whose AC mandates a real-environment verification** (a smoke script, a dogfood pass, a container / multi-user / real-device check) — required regardless of whether other criteria match, and it runs **before implementation**, not before the PR. It is the one question here that is worthless if asked late.
 - **Question 13 applies at AC / verification-plan issuance and at audit time** — it binds the author and auditor roles, not the implementing delegate.
 - **Optional but encouraged** for any production code PR touching infrastructure or cross-cutting patterns

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -48,13 +48,41 @@ Schema unit tests alone are insufficient. Required: actual form interaction test
 - Test files MUST be named after the production file they test: `foo-bar.ts` -> `__tests__/foo-bar.test.ts`
 - Place test files in the `__tests__/` directory at the same level as the production file
 
+## Test Categories and What "Polarity" Means for Each
+
+`workflow.md` requires a failing-first test for bug fixes. Applied mechanically to every test in a PR, that requirement produces a wrong verdict, because tests come in kinds with different correct behaviors against unmodified code.
+
+| Category | Purpose | Against unmodified code |
+|---|---|---|
+| **Bug-polarity** | Prove the reported defect existed and is now fixed | **Must fail** — no exceptions |
+| **New-mechanism contract** | Pin the behavior a newly added mechanism promises | **Must fail** (the mechanism does not exist yet) |
+| **Invariant-preservation** | Prove existing behavior did *not* change when new code was introduced alongside it | **Passes in both worlds — this is correct** |
+
+The third category is the one that gets misjudged. A test that passes before and after looks like the "passes in both directions" case `workflow.md` warns about, but the two are distinguished by a different question:
+
+> **Would this test fail against a plausible wrong implementation of the new code?**
+
+If yes, it is a real guard and its both-worlds pass is the point. If no — if no realistic mistake in this PR could break it — it is vacuous and should be redesigned or removed.
+
+Worked example: PR [#1283](https://github.com/ms2sato/agent-console/pull/1283) added a `{{var:+prefix}}` template form, and two of its nine new tests asserted that reserved names (`{{prompt:+X}}`, `{{cwd:+X}}`) are *not* expanded through it. Those two passed against the unmodified engine — the reserved-name guard already existed one pass down. They are not vacuous: dropping the guard from the new pass makes `{{prompt:+X}}` expand to the empty string and the placeholder silently disappear, which is exactly the mistake an implementer might make. Seven tests flipped, two did not, and all nine were correct.
+
+**When reporting polarity, state the category per test.** "7 of 9 flipped" invites a partial-polarity finding; "7 bug/contract tests flipped, 2 invariant-preservation tests hold in both worlds and fail against a guard-less implementation" is the same fact, correctly classified.
+
+### Demonstrating polarity without breaking the build
+
+To show a test fails against pre-change code, **comment out only the added block, leaving new exports and signatures intact**, then restore.
+
+Do not use `git stash --patch` to separate an added block from the exports it needs. Splitting hunks interactively is error-prone (a mis-answered prompt leaves a broken intermediate state), and stashing a new export makes the whole test file fail to load — a load error, not a behavioral failure, which proves nothing about the assertion under test and cannot be distinguished from a real polarity result. (Lesson: Sprint 2026-08-05 — PR [#1275](https://github.com/ms2sato/agent-console/pull/1275)'s delegate hit exactly this: a heredoc-driven `stash --patch` stashed a helper's export while leaving its call sites, and the resulting failure was an import error. PR [#1276](https://github.com/ms2sato/agent-console/pull/1276)'s delegate used the comment-out form and got a clean `But it was not called` on precisely the assertions that mattered.)
+
+After restoring, confirm the round trip left nothing behind — `git diff --stat` should match what it was before, and `git status` should be clean of stray edits.
+
 ## Evaluation Criteria
 
 ### Test Validity
 - Tests verify **requirements**, not implementation details
 - Assertions are meaningful and specific
 - Test names clearly describe what is being tested
-- Tests would fail if production code behavior changes
+- Tests would fail if production code behavior changes (see the category table above for what this means for invariant-preservation tests)
 
 ### Coverage
 - Happy path is covered

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -20,7 +20,7 @@ Before completing any code changes, always verify:
    - **Stale `routeTree.gen.ts` caveat:** The presence-only check accepts a stale `routeTree.gen.ts` when route files have been added / renamed / removed but the generated file was not regenerated. After modifying anything under `packages/client/src/routes/`, delete `packages/client/src/routeTree.gen.ts` (or run `bun run build`) before relying on `bun run typecheck`.
 3. **Run CodeRabbit CLI review:** Execute `coderabbit review --agent --base main` and address any CRITICAL / HIGH / MEDIUM severity issues before creating a PR. If the CodeRabbit CLI is not installed locally, skip this step and recommend installation: `curl -fsSL https://cli.coderabbit.ai/install.sh | sh`.
 
-   For the LOW / NITPICK findings policy, the **3-layer clean verdict** (Pre-merge checks / `reviewDecision` / inline comments), and operational case-by-case dispositions (rate-limit fallback, GitHub-side bot unresponsive, both layers simultaneously rate-limited, `CHANGES_REQUESTED` resolution), invoke the [`coderabbit-ops`](../skills/coderabbit-ops/SKILL.md) skill.
+   For the LOW / NITPICK findings policy, the **CodeRabbit verdict-surface checklist** (`coderabbit-ops/SKILL.md` is its single writer — do not restate the surface list elsewhere), and operational case-by-case dispositions (rate-limit fallback, GitHub-side bot unresponsive, both layers simultaneously rate-limited, `CHANGES_REQUESTED` resolution), invoke the [`coderabbit-ops`](../skills/coderabbit-ops/SKILL.md) skill.
 4. **Review test quality:** When tests are added or modified, evaluate adequacy and coverage
 5. **Manual verification (UI changes only):** When modifying UI components and Chrome DevTools MCP is available, perform manual testing through the browser.
 
@@ -53,7 +53,7 @@ A task or PR is "done" only when ALL of the following hold. Reporting "ready for
 5. **Branch is pushed to origin**.
 6. **PR is opened with linked Issue** — the body contains `Closes #NNN` (the title's `(closes #N)` does not auto-close the Issue; only the body's keyword does, and the script `acceptance-check.js` requires the body match).
 7. **CI is fully green** — verified via the rollup, not a single per-run event. Use `gh pr view <PR> --json statusCheckRollup` to confirm. (Issue #699 fixed the per-run vs rollup gap; before that fix the per-run event could falsely report "all passed" while the rollup had failures.)
-8. **CodeRabbit review state is clean** — see [`coderabbit-ops`](../skills/coderabbit-ops/SKILL.md) skill for the 3-layer verdict (Pre-merge checks / `reviewDecision` / inline comments) and any fallback exceptions.
+8. **CodeRabbit review state is clean** — walk the verdict-surface checklist in the [`coderabbit-ops`](../skills/coderabbit-ops/SKILL.md) skill (its single writer) and apply any fallback exceptions documented there.
 
 "Implementation complete" without all eight is **not** done. (Lesson: Sprint 2026-04-27 PR #703 — agent reported "Production ready" with no commit / no push / no PR, requiring three rounds of hand-holding before reaching actual mergeable state.)
 
@@ -64,7 +64,7 @@ When you form a conclusion from a *secondary signal* — a derived, lagging, or 
 | Domain | Secondary signal (do NOT conclude from this alone) | Primary information (verify here) |
 |---|---|---|
 | CI failure | "infra problem" / "rate-limit" / "external service" intuition; the red X without the log | `gh run view <run_id> --log-failed` |
-| CodeRabbit review | absence of new comments; pre-merge checks passing; a stale `CHANGES_REQUESTED`; a rate-limit message; **`CodeRabbit=SUCCESS` in `statusCheckRollup`** | the PR's 3-layer state (Pre-merge checks / `reviewDecision` / inline comments) re-read at decision time, **plus the commit status's `description` string** — `state` is `success` even when the bot never reviewed (see [`coderabbit-ops`](../skills/coderabbit-ops/SKILL.md) "The fourth surface") |
+| CodeRabbit review | absence of new comments; pre-merge checks passing; a stale `CHANGES_REQUESTED`; a rate-limit message; **`CodeRabbit=SUCCESS` in `statusCheckRollup`** | every surface in the [`coderabbit-ops`](../skills/coderabbit-ops/SKILL.md) verdict-surface checklist, re-read at decision time — including the commit status's `description` (`state` is `success` even when the bot never reviewed) and the **body of each formal review** (a finding outside the diff appears there and in no inline comment) |
 | Cross-repo issue | "this symptom looks like the other repo's known bug / shared pattern" | reproduce in *this* repo's own code path before filing, blaming, or claiming applicability |
 | Runtime observation | a dev-server log line / websocket frame / UI render / channel assumption taken as proof a path ran or a notification arrived | the authoritative store / server-side state / a deterministic probe / per-channel confirmation |
 
@@ -117,7 +117,7 @@ The reverse failure mode is also real: CI output that locally would mean "broken
 
 **Inference trap.** Concluding "CodeRabbit is clean" from a secondary signal: pre-merge checks passing (5/5), the absence of *new* inline comments, or a rate-limit message read as "nothing to address". None of these are the review verdict. A stale `CHANGES_REQUESTED` from an earlier push, or a bot that never actually ran because it was rate-limited, both look identical to "clean" if you only glance at one layer.
 
-**Verify procedure.** Re-read the PR's 3-layer state at decision time, not from memory of an earlier read:
+**Verify procedure.** Re-read every verdict surface at decision time, not from memory of an earlier read:
 
 1. **Pre-merge checks** — necessary but not sufficient on their own.
 2. **`reviewDecision`** — `gh pr view <N> --json reviewDecision`. Empty means the bot has not reviewed yet (not "clean"); `CHANGES_REQUESTED` must be resolved, not aged out. The only exception is the documented rate-limit fallback.
@@ -177,6 +177,21 @@ Two shapes seen in Sprint 2026-07-18b:
 4. **When each iteration costs a CI round-trip, go wide, not deep.** Binary search is optimal when probes are cheap and sequential; when a round-trip is the binding cost, put every enumerable variant into a single run.
 
 (Lesson: Sprint 2026-07-18b Issue #1225 — `main` was red for four days. Four single-mechanism hypotheses were disproven in sequence, each with a positive control that made the negatives credible. What resolved it was re-running the last green CI run byte-identically — which exonerated the repository and isolated the runner image as the only changed variable — followed by delta-debugging the real test file. Issue #1211 was settled the same day by the same shape: running the identical config and binary outside Docker. Neither was reached by the hypotheses.)
+
+### Sub-pattern 7: stale state carried across idle
+
+**Inference trap.** A state claim that was verified once, then repeated across many turns without re-verification, until repetition itself makes it feel established. Where the other sub-patterns over-trust a weak signal, this one keeps trusting a signal that was strong *at the time* and has since expired. It hides especially well in status summaries: restating "waiting on X" in every progress report reads as diligence, but no re-reading occurs.
+
+Claims of the form "**still waiting on** X" are the highest-risk shape, because they assert something about the present while being evidenced only by the past. Whatever you are waiting on may have already moved — and if it has, everything you decided *because* you were waiting is also wrong.
+
+**Verify procedure.**
+
+1. **Re-verify any carried-over state claim at the moment you act on it**, not when you first recorded it. Reporting it, escalating on it, or choosing not to act because of it all count as acting on it.
+2. **Ask what would have changed it while you were idle.** A PR merges, a review lands, a gate clears — none of these notify you retroactively, and idle time is exactly when they happen.
+3. **When the claim is about someone else's queue, check for evidence of *output*, not of *state*.** (This is Sub-pattern 5's test, and it applies here too.)
+4. **Keep the wording of any standing reminder — a timer's action text, a checklist item — in sync with what you are actually waiting for.** A reminder describing last week's blocker will fire on schedule and confirm the wrong thing.
+
+(Lessons, both Sprint 2026-08-05: the Architect held "PR #1270 is awaiting owner gate" across two days of intermittent turns, restating it in each status summary without re-reading, then raised an urgent warning that a commit-message keyword would close an Issue on merge — the PR had merged two days earlier and the Issue had closed with it. Separately, the Orchestrator left a self-check timer whose action text still described a PR merged hours before; it fired repeatedly while a delegate's completed PR sat unreviewed for six hours, and the stall was surfaced by the owner asking what the hold-up was, not by the timer.)
 
 ## Commands
 

--- a/.claude/skills/coderabbit-ops/SKILL.md
+++ b/.claude/skills/coderabbit-ops/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: coderabbit-ops
-description: CodeRabbit code review operations playbook + troubleshooting / FAQ. Use when creating a PR, before merge, when handling CodeRabbit issues (rate-limit fallback, GitHub-side bot unresponsive, both layers simultaneously rate-limited), or when interpreting the 3-layer clean verdict (Pre-merge checks / reviewDecision / inline comments). Covers local CLI invocation, GitHub-side bot interpretation, and case-by-case dispositions.
+description: CodeRabbit code review operations playbook + troubleshooting / FAQ. Use when creating a PR, before merge, when handling CodeRabbit issues (rate-limit fallback, GitHub-side bot unresponsive, both layers simultaneously rate-limited), or when interpreting the CodeRabbit verdict surfaces (pre-merge checks / reviewDecision / inline comments / commit-status description / formal review bodies). Covers local CLI invocation, GitHub-side bot interpretation, and case-by-case dispositions.
 ---
 
 # CodeRabbit Ops
 
-This skill is the operational playbook for **CodeRabbit code review** in this project. It covers CLI invocation, the LOW / NITPICK findings policy, and the 3-layer clean verdict. For case-by-case dispositions (rate-limit fallback, unresponsive bot, simultaneous rate-limit), see [`troubleshooting.md`](troubleshooting.md).
+This skill is the operational playbook for **CodeRabbit code review** in this project. It covers CLI invocation, the LOW / NITPICK findings policy, and the verdict-surface checklist (the single writer for that list). For case-by-case dispositions (rate-limit fallback, unresponsive bot, simultaneous rate-limit), see [`troubleshooting.md`](troubleshooting.md).
 
 ## When to invoke
 
 - **PR creation** — to know how to run the local CLI and how to address findings.
-- **Before merge** — to verify the 3-layer clean verdict.
-- **CodeRabbit troubleshooting** — when the local CLI is rate-limited, the GitHub-side bot is unresponsive, both layers are simultaneously rate-limited, or the verdict layers are confusing.
+- **Before merge** — to walk the verdict-surface checklist.
+- **CodeRabbit troubleshooting** — when the local CLI is rate-limited, the GitHub-side bot is unresponsive, both channels are simultaneously rate-limited, or the verdict surfaces disagree.
 - **CI failure diagnosis** — when CodeRabbit-related checks fail and you need the resolution flow.
 
 ## CLI invocation
@@ -30,25 +30,31 @@ Read every finding regardless of severity. For LOW / NITPICK / "minor" findings:
 - **Defer with a one-line note in the PR body** when the fix is non-trivial or out of scope — name the finding and the reason for deferral so the owner can override. Silent skip is not acceptable.
 - **Never mark "addressed" without a code change or an explicit defer note.** "I read it and decided it's fine" is not closure; the absence of either a fix commit or a defer note hides the trade-off.
 
-## 3-layer clean verdict
+## CodeRabbit verdict surfaces (checklist)
 
-GitHub surfaces CodeRabbit info in three distinct layers that are easy to confuse. **All three must be clean** before merge:
+GitHub scatters CodeRabbit information across several unrelated surfaces. **Every surface below must be checked** before merge — none of them alone is the verdict, and a clean-looking subset is the recurring way findings get missed.
 
-| Layer | Verification | Clean state |
-|---|---|---|
-| **Pre-merge checks** (Title / Description / Docstring / Linked Issues / Out-of-Scope) | "5/5 passed" in the GitHub UI | Metadata validation only — **not** code review |
-| **Review state** | `gh pr view <N> --json reviewDecision` | `APPROVED` (or empty under the rate-limit fallback in `troubleshooting.md`) |
-| **Inline comments** | `gh api repos/<owner>/<repo>/pulls/<N>/comments` | Resolved or addressed if actionable |
+This section is the **single writer** for the surface list. Other documents (`workflow.md`, `core-responsibilities.md`) link here rather than restating it; when a new surface is discovered, add it here only.
+
+> **Why this section is not called "the N-layer verdict" anymore.** It was "the 3-layer clean verdict" for months, then a 4th surface was documented in a separate subsection, and then a 5th (below) was found the hard way — a Major finding sat in a place none of the named layers read, on a PR both the Orchestrator and the Architect had already called clean. A name that encodes a count asserts completeness the list does not have, and invites checking "the three" and stopping. Treat the list as open: the next surface is not yet in it.
+
+| # | Surface | Verification | Clean state |
+|---|---|---|---|
+| 1 | **Pre-merge checks** (Title / Description / Docstring / Linked Issues / Out-of-Scope) | "5/5 passed" in the GitHub UI | Metadata validation only — **not** code review |
+| 2 | **Review state** | `gh pr view <N> --json reviewDecision` | `APPROVED` (or empty under the rate-limit fallback in `troubleshooting.md`) |
+| 3 | **Inline comments** | `gh api repos/<owner>/<repo>/pulls/<N>/comments` | Resolved or addressed if actionable |
+| 4 | **Commit-status `description`** | see "The commit-status surface" below | `Review completed` — `state` is `success` even when no review ran |
+| 5 | **Formal review bodies** | see "The review-body surface" below | No unaddressed findings in any review's `body` |
 
 An empty `reviewDecision` means the bot has not yet reviewed and the PR is **not** yet clean — wait for the bot to submit, do not merge. (Exception 1: under the rate-limit fallback in `troubleshooting.md`, an empty state may persist; in that exception path, follow the fallback's verification steps before merge. Exception 2: a completed walkthrough with 0 actionable inline comments can also leave `reviewDecision` empty — CodeRabbit does not always submit a formal review event when it finds nothing to flag. See "the walkthrough-exists rubric" in `troubleshooting.md` before assuming "not yet reviewed" from an empty field alone.)
 
-**Docs-only PR carve-out (by configuration).** `.coderabbit.yaml` sets `reviews.auto_review.ignore_title_keywords: ["docs:"]`, so PRs titled with the conventional `docs:` prefix are skipped by auto-review ON PURPOSE (quota preservation — docs-only PRs were rate-limiting code PRs during PR-dense sprints). For such PRs an empty `reviewDecision` with no bot activity is the EXPECTED state, not a wait condition: verify the diff is genuinely docs-only (no production code), then treat layer 2 as N/A. When a docs PR warrants a bot pass anyway (e.g. a large design doc), trigger one manually with an `@coderabbitai review` comment — the manual path is unaffected by the title skip. Note the file also carries the review profile (`chill`) previously configured in the web UI, because a repo config file takes precedence over UI settings.
+**Docs-only PR carve-out (by configuration).** `.coderabbit.yaml` sets `reviews.auto_review.ignore_title_keywords: ["docs:"]`, so PRs titled with the conventional `docs:` prefix are skipped by auto-review ON PURPOSE (quota preservation — docs-only PRs were rate-limiting code PRs during PR-dense sprints). For such PRs an empty `reviewDecision` with no bot activity is the EXPECTED state, not a wait condition: verify the diff is genuinely docs-only (no production code), then treat surface 2 as N/A. When a docs PR warrants a bot pass anyway (e.g. a large design doc), trigger one manually with an `@coderabbitai review` comment — the manual path is unaffected by the title skip. Note the file also carries the review profile (`chill`) previously configured in the web UI, because a repo config file takes precedence over UI settings.
 
-"CodeRabbit clean" requires all three. Pre-merge checks alone are insufficient. (Sprint 2026-04-25 PR #694 — agent declared "clean" based on pre-merge 5/5 while review state was `CHANGES_REQUESTED` with 3 actionable issues.)
+"CodeRabbit clean" requires every surface. Pre-merge checks alone are insufficient. (Sprint 2026-04-25 PR #694 — agent declared "clean" based on pre-merge 5/5 while review state was `CHANGES_REQUESTED` with 3 actionable issues.)
 
-### The fourth surface: `statusCheckRollup`'s `CodeRabbit` entry is NOT a verdict
+### The commit-status surface: `statusCheckRollup`'s `CodeRabbit` entry is NOT a verdict
 
-None of the three layers above is the **commit-status context** named `CodeRabbit`. That context nonetheless appears in `gh pr view <N> --json statusCheckRollup` — the command everyone runs to confirm CI — rendered alongside `test`, `preflight`, and the rest as:
+None of surfaces 1-3 is the **commit-status context** named `CodeRabbit`. That context nonetheless appears in `gh pr view <N> --json statusCheckRollup` — the command everyone runs to confirm CI — rendered alongside `test`, `preflight`, and the rest as:
 
 ```
 CodeRabbit=SUCCESS
@@ -66,13 +72,30 @@ Three descriptions observed, all with `state=success`:
 
 | `description` | Meaning | Action |
 |---|---|---|
-| `Review completed` | A real review ran | Proceed to layers 2 and 3 |
+| `Review completed` | A real review ran | Proceed to surfaces 2, 3 and 5 |
 | `Review rate limited` | **The bot never reviewed this commit** | Wait, or apply the `troubleshooting.md` disposition |
-| `Review skipped: ignored keyword in the PR title` | Deliberately skipped by `.coderabbit.yaml` config (the `docs:` carve-out above) | Layer 2 is N/A — verify the diff really is docs-only |
+| `Review skipped: ignored keyword in the PR title` | Deliberately skipped by `.coderabbit.yaml` config (the `docs:` carve-out above) | Surface 2 is N/A — verify the diff really is docs-only |
 
 Note the `updated_at` too: the status is re-issued per head SHA, so **updating a PR branch resets it**. A `Review completed` from before a rebase says nothing about the current head.
 
 (Sprint 2026-07-18b — three PRs (#1227, #1231, #1229) carried `CodeRabbit=SUCCESS` in the rollup while the description read `Review rate limited`. Reading only the rollup state would have merged all three as "CodeRabbit clean" with no review. #1227 in particular later produced a Major finding that a standards document would otherwise have shipped with.)
+
+### The review-body surface: findings that live in no inline comment
+
+A finding CodeRabbit cannot anchor to a changed line — GitHub rejects inline comments outside the diff — is posted in the **body of the formal review** instead. Nothing about it appears in the inline-comment list, so surface 3 reports zero and surface 4 reports `Review completed`: the PR looks reviewed and clean while carrying an unread finding.
+
+Read every review body explicitly:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<N>/reviews \
+  -q '.[] | "\(.submitted_at) \(.user.login) \(.state)\n\(.body)"'
+```
+
+The tell in the body is a `⚠️ Outside diff range comments (N)` block. Its findings carry the same severity markers as inline ones and must be dispositioned the same way — fixed, or deferred with a note.
+
+**Zero inline comments is not evidence of zero findings.** When surface 3 comes back empty, that is precisely when surface 5 must be read, not when the check is over.
+
+(Sprint 2026-08-05 PR #1276 — CodeRabbit posted a formal review whose body held a Major finding: session-resume rollback freed PTY workers but not the embedded-agent worker the same change had just activated, leaking a subprocess and a minted MCP token that became unreachable once the session was deleted. `reviewDecision` was empty, inline comments were 0, and the commit status said `Review completed`. The Orchestrator reported "findings zero" to the owner on that basis; the Architect's independent audit had also missed the rollback asymmetry. It surfaced only because the delegate re-examined the CodeRabbit state on their own initiative and reported the ambiguity rather than accepting the Orchestrator's summary. A process that depends on a delegate doubting the Orchestrator is not a process — this section is what replaces it.)
 
 ## Case-by-case dispositions
 

--- a/.claude/skills/coderabbit-ops/troubleshooting.md
+++ b/.claude/skills/coderabbit-ops/troubleshooting.md
@@ -1,6 +1,6 @@
 # CodeRabbit Ops — Troubleshooting / FAQ
 
-Case-by-case dispositions for CodeRabbit issues. The 3-layer clean verdict definition, CLI invocation, and LOW / NITPICK findings policy live in [`SKILL.md`](SKILL.md); this file covers the exception paths.
+Case-by-case dispositions for CodeRabbit issues. The verdict-surface checklist, CLI invocation, and LOW / NITPICK findings policy live in [`SKILL.md`](SKILL.md); this file covers the exception paths.
 
 ## Q: The local CodeRabbit CLI is rate-limited. What do I do?
 
@@ -34,7 +34,7 @@ Conflating the two in a PR body misleads whoever reads it later: an auth failure
 
 **No. Abandon the wait, do not over-engineer.** If the GitHub-side bot posts a rate-limit warning at PR open and a subsequent `@coderabbitai review` re-trigger does not produce a review submission within ~10-15 minutes, abandon the wait. CodeRabbit's "incremental review" policy can treat the rate-limit warning event as "already reviewed" and refuse to re-review the same commit. **Do not push trivial commits to force a re-trigger** — that bends the workflow around CodeRabbit's quirks at the cost of CI cycles and review log noise.
 
-Instead, when the local CodeRabbit CLI is clean (0 findings), add the rate-limit fallback note (above) to the PR body, treat that as the documented exception path, and proceed to merge after the rest of the "clean" 3-layer condition is satisfied. (Sprint 2026-04-30 PR #738 — bot unresponsive 60+ min after re-trigger while PR #737 in the same flow returned APPROVED in 3 min; owner guidance: do not bend the process for CodeRabbit, abandon the wait early.)
+Instead, when the local CodeRabbit CLI is clean (0 findings), add the rate-limit fallback note (above) to the PR body, treat that as the documented exception path, and proceed to merge after the remaining verdict surfaces are satisfied. (Sprint 2026-04-30 PR #738 — bot unresponsive 60+ min after re-trigger while PR #737 in the same flow returned APPROVED in 3 min; owner guidance: do not bend the process for CodeRabbit, abandon the wait early.)
 
 ## Q: I retriggered `@coderabbitai review` and got "Review finished... does not re-review already reviewed commits." Does that count as clean?
 
@@ -95,7 +95,7 @@ The simultaneous-rate-limit case does not relax PR Merge Authority — it remove
    gh pr view <N> --json reviews,latestReviews
    ```
    If the latest review is `APPROVED`, the rollup field is just laggy and a UI refresh / `gh pr view` re-query usually flips it.
-3. **If the latest review is still `CHANGES_REQUESTED` despite all comments resolved**, the bot has not submitted the follow-up positive review. Treat the 3-layer clean verdict as satisfied: pre-merge checks SUCCESS + 0 unresolved actionable inline comments + no outstanding CodeRabbit ask. The stale `reviewDecision` does not block merge under PR Merge Authority. Add a one-line note to the PR body / merge confirmation:
+3. **If the latest review is still `CHANGES_REQUESTED` despite all comments resolved**, the bot has not submitted the follow-up positive review. Treat the verdict-surface checklist as satisfied: pre-merge checks SUCCESS + 0 unresolved actionable inline comments + no unaddressed finding in any review body + no outstanding CodeRabbit ask. The stale `reviewDecision` does not block merge under PR Merge Authority. Add a one-line note to the PR body / merge confirmation:
    ```
    CodeRabbit reviewDecision is `CHANGES_REQUESTED` (stale UX) — all comments are marker-closed; merging under existing PR Merge Authority.
    ```
@@ -110,7 +110,7 @@ Recommended sequence per push:
 
 1. **Run the local CLI** (`coderabbit review --agent --base main`). Address every CRITICAL / HIGH / MEDIUM finding. Re-push if you make code changes from CLI feedback.
 2. **Wait for the GitHub-side bot review.** It may take 3-12 minutes typically, longer under rate-limit. Do not push trivial commits to retrigger (per "abandon-the-wait" above).
-3. **Merge when `reviewDecision: APPROVED` and CLI is clean.** Both layers form the 3-layer clean verdict.
+3. **Merge when `reviewDecision: APPROVED` and CLI is clean.** Both feed the verdict-surface checklist in `SKILL.md`.
 
 This pattern is robust against the GitHub bot being temporarily rate-limited: the CLI gives you a verifiable clean signal you can act on while the bot recovers. When the bot eventually submits, it serves as confirmation rather than the only data point. (Lesson: Sprint 2026-06-26 — observed across PRs #892 / #897. Both pushed multiple times during a CodeRabbit rate-limit window; CLI ran clean on every push and caught Major findings the bot would later have flagged. The bot's APPROVED arrived after rate-limit lifted, confirming the CLI verdict. Without the CLI pass, both PRs would have been merge-blocked on the bot's rate-limit recovery or proceeded with no review at all.)
 

--- a/.claude/skills/dev-environment-quirks/SKILL.md
+++ b/.claude/skills/dev-environment-quirks/SKILL.md
@@ -96,6 +96,28 @@ git -C <serving-checkout> log -1 --format='%ci %h %s'
 
 If the process start time predates the commit time, the server is running old code — restart (or re-rsync / re-bundle) before drawing any verification conclusion from its behavior. (Lesson: Sprint 2026-08-01 — merged PRs #1237/#1241 were believed E2E-verified on the shared dev server, which was in fact running a binary from before the merges; the gap sat undetected for two days. See `.claude/rules/pre-pr-completeness.md` Q13 "Retroactive application".)
 
+## Driving MCP against a throwaway instance you started yourself
+
+Shipping-path verification often needs a disposable instance (`AGENT_CONSOLE_HOME=/tmp/agent-console-<issue>-verify` on a free port — never under `~/.agent-console*`, which a guard protects from cleanup). **The session's pre-registered MCP clients cannot reach it**: those entries point at the shared instances, and rewriting the global `~/.claude.json` to retarget them would disturb every other session on the machine.
+
+Call the instance's own `/mcp` endpoint directly instead — it is the same production transport the registered clients use, so the code path under test is unchanged:
+
+```bash
+# 1. handshake, 2. tools/call — both plain JSON-RPC over HTTP
+curl -s -X POST http://localhost:<port>/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2025-11-25' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
+       "params":{"name":"delegate_to_worktree","arguments":{...}}}'
+```
+
+Then read primary evidence from the OS rather than the tool's reply — e.g. `tr '\0' ' ' < /proc/<pid>/cmdline` for the spawned process's argv, which neither truncates nor reformats the way `ps` output can.
+
+Cleaning up afterward: the sandbox guard rejects recursive and force delete flags even for a temp directory you created. `find <dir> -depth -delete` removes the tree without them (a flagless single-file `rm` is also permitted). Verify removal with a listing rather than assuming.
+
+(Two delegates rediscovered this independently in Sprint 2026-08-05, on PRs [#1275](https://github.com/ms2sato/agent-console/pull/1275) and [#1283](https://github.com/ms2sato/agent-console/pull/1283).)
+
 ## Cross-references
 
 - `scripts/dev.sh` and `scripts/dev-multiuser.sh` — canonical scripts (the prologues are required reading).

--- a/.claude/skills/orchestrator/core-responsibilities.md
+++ b/.claude/skills/orchestrator/core-responsibilities.md
@@ -118,15 +118,22 @@ When a single design or Issue is too large for one PR (e.g., a multi-slice featu
     -F sub_issue_id=$(gh api repos/<owner>/<repo>/issues/<sub> --jq '.id')
   ```
 
-**3-layer cleaning rule (mandatory).** GitHub's auto-close parser scans **three locations** for `closes / fixes / resolves <issue>` keywords. To prevent the parent from auto-closing when a slice merges, all three must be clean:
+**Close-keyword cleaning rule (mandatory).** GitHub's auto-close parser scans **three locations** for `closes / fixes / resolves <issue>` keywords. Every location must be clean for any Issue that must survive the merge:
 
-| Location | Parent (`#parent`) | Sub-issue (`#sub`) |
+| Location | Issue that must stay open | Issue the PR really completes |
 |---|---|---|
-| PR body | `Refs #parent` (no close keyword) | `Closes #sub` |
-| PR title | `Part N of #parent` (no close keyword for parent) | (sub-issue mention optional) |
-| Original commit message (squash source) | `Refs #parent` only | `Closes #sub` (optional) |
+| PR body | `Refs #NNN` (no close keyword) | `Closes #NNN` |
+| PR title | mention without a close keyword (e.g. `Part N of #NNN`) | (mention optional) |
+| Original commit message (squash source) | `Refs #NNN` only | `Closes #NNN` (optional) |
 
-If any of the three carries a close keyword for the parent, the parent auto-closes when the squash merge lands. Recovery requires manual reopen + comment explaining the incident — far more expensive than getting the title right at delegation time. **The orchestrator's delegation prompt MUST set the PR title to `Part N of #parent` style before sending; do not let the agent produce a title that includes parent close keywords.** (Lesson: Sprint 2026-05-03 PR [#764](https://github.com/ms2sato/agent-console/pull/764) — orchestrator's delegation prompt allowed the agent to craft `(closes #678 part 1)`; parent [#678](https://github.com/ms2sato/agent-console/issues/678) auto-closed on merge despite body-level cleanup, requiring manual reopen.)
+If any location carries a close keyword, the Issue auto-closes when the squash merge lands. Recovery requires manual reopen + a comment explaining the incident — far more expensive than getting it right at delegation time. **The orchestrator's delegation prompt MUST state the required form for all three locations before sending; do not let the agent choose.**
+
+**This applies to two distinct cases, not just one.** The rule was written for multi-slice parents, but the same parser closes any Issue named anywhere:
+
+1. **Multi-slice parent** — a slice PR must not close the umbrella Issue. (Lesson: Sprint 2026-05-03 PR [#764](https://github.com/ms2sato/agent-console/pull/764) — the delegation prompt allowed the agent to craft `(closes #678 part 1)`; parent [#678](https://github.com/ms2sato/agent-console/issues/678) auto-closed on merge despite body-level cleanup.)
+2. **Checkpoint-gated Issue** — an Issue whose close condition is a post-merge verification the PR itself cannot perform (a real-machine smoke, an owner dogfood pass). Merging the code is not completing the Issue, so the PR must not close it. (Lesson: Sprint 2026-08-05 PR [#1278](https://github.com/ms2sato/agent-console/pull/1278) — the AC explicitly made an owner real-machine checkpoint the close condition, and the PR body correctly said so and omitted `Closes`. An intermediate commit's subject carried `(closes #1222)`, was inherited into the squash commit body, and closed [#1222](https://github.com/ms2sato/agent-console/issues/1222) one second after merge with the checkpoint still unperformed. Both the delegate and the Orchestrator had verified the PR body and stopped there — the rule above already covered the commit-message location, but neither of us read it as applying outside the parent/sub-issue case.)
+
+When an Issue is checkpoint-gated, say so in the delegation prompt and name the checkpoint, so the agent knows the merge is not the finish line.
 
 ### Paired Backend + Frontend Delegation Pattern
 


### PR DESCRIPTION
## Summary

Eight improvements from the Sprint 2026-08-05 retrospective, approved by the owner (proposals B-3, B-4, D-1, D-3 were reviewed and deliberately deferred; they remain in the triage list).

The sprint's failure modes were all in **reading signals**, not in producing code — push-to-fail was 0% across 55 CI runs, and every fix round came from review rather than a broken push. These changes address the reading side.

## What changed

### CodeRabbit verdict surfaces — `coderabbit-ops/SKILL.md` is now the single writer

- **Retired the "3-layer" name.** A name encoding a count asserts a completeness the list does not have, and invites checking "the three" and stopping. This is precisely how the 5th surface went unread.
- **Documented the review-body surface (new).** A finding CodeRabbit cannot anchor to a changed line is posted in the body of the formal review; it appears in no inline comment. `reviewDecision` empty + 0 inline comments + `Review completed` therefore looks clean while carrying an unread finding. Read `pulls/<N>/reviews` bodies explicitly and look for the `⚠️ Outside diff range comments (N)` block.
- `workflow.md` and `troubleshooting.md` now link to the checklist rather than restating the layers (the drift `rule-skill-duplication-check.js` exists to prevent).

### Close-keyword cleaning rule — generalized (`core-responsibilities.md`)

The commit-message location was **already documented**, but framed entirely around multi-slice parents, so it was not read as applying to checkpoint-gated Issues. Now the rule states the general condition (any Issue that must survive the merge) and names both cases, with the instruction to declare the checkpoint in the delegation prompt so the agent knows the merge is not the finish line.

### `pre-pr-completeness.md`

- **New Q14 (rollback-resource question):** when a PR adds a resource acquisition inside a function that already has failure rollback, does that rollback release the new resource? With the three checks that make the question real: read *every* rollback path, confirm the shared cleanup helper actually reaches your resource type (a type-gated `killWorker` silently no-ops), and confirm ordering (cleanup after the lookup structure is torn down is unreachable, not merely late).
- **Q13 gains a record-durability clause:** correct an overstated claim in the durable artifact, not only in a transient memo.

### `testing.md`

- **Invariant-preservation named as a third test category.** Its correct behavior is to pass in both worlds; the vacuity test is "would it fail against a plausible wrong implementation of the new code?". Prevents mechanically reporting a correct test set as a partial-polarity violation.
- **Comment out the added block instead of `git stash --patch`** when demonstrating polarity — a stashed export produces a load error, which proves nothing about the assertion under test.

### `workflow.md`

- **Sub-pattern 7 (stale state carried across idle):** a state claim verified once and repeated across turns expires; "still waiting on X" asserts the present from past evidence. Re-verify at the moment of acting, and keep standing reminders' wording in sync with what you are actually waiting for.

### `dev-environment-quirks`

- How to drive MCP against a throwaway instance the session's pre-registered clients cannot reach (raw JSON-RPC to its own `/mcp`), read primary evidence from `/proc/<pid>/cmdline`, and clean up under the sandbox guard (`find -depth -delete`). Two delegates rediscovered this independently.

## Sources

Each change is anchored to an incident this sprint: #1276 (rollback leak found in a review body), #1278 (Issue closed by a squash-inherited commit subject), #1283 (overstated observation corrected only in a memo; invariant-preservation tests misread as partial polarity), #1275 (stash --patch broke the polarity demonstration).

## Test plan

- [x] `bun run check:lang` — clean (117 files)
- [x] `rule-skill-duplication-check.js` — clean
- [x] `preflight-check.js` — clean (coverage / duplication / language / blame-shift)
- Docs-only; no production code

Refs #1276, #1278, #1283