### PR TITLE
feat: add setup-shared-account.sh operator script for shared sessions

### DIFF
--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -1080,7 +1080,7 @@ than subscription-based. See `docs/glossary.md` for the term.
 ### 1. Provision the OS account
 
 ```bash
-sudo scripts/setup-shared-account.sh project-sa
+sudo scripts/setup-shared-account.sh agent-console-shared
 ```
 
 The script is idempotent (safe to re-run) and accepts `--group <name>`,
@@ -1110,7 +1110,7 @@ sudo systemctl edit agent-console
 
 ```ini
 [Service]
-Environment=AGENT_CONSOLE_SHARED_USERNAME=project-sa
+Environment=AGENT_CONSOLE_SHARED_USERNAME=agent-console-shared
 ```
 
 Then restart and verify:
@@ -1135,7 +1135,7 @@ Example for AWS Bedrock with a long-term Bedrock API key, keeping the
 rotating secret in its own file so rotation is a one-file overwrite:
 
 ```bash
-sudo -u project-sa -i
+sudo -u agent-console-shared -i
 
 cat >> ~/.profile <<'EOF'
 export CLAUDE_CODE_USE_BEDROCK=1
@@ -1163,10 +1163,10 @@ hazard (`packages/server/src/services/env-filter.ts`).
 
 ```bash
 # Vendor auth works for the account itself
-sudo -u project-sa -i claude -p "hello"
+sudo -u agent-console-shared -i claude -p "hello"
 
 # Full elevation chain delivers the login-init env (see Post-deploy Verification)
-sudo -u agentconsole sh -c 'cd /home/agentconsole/agent-console && NODE_ENV=production /usr/local/bin/bun scripts/smoke/check-multiuser-pty-env.ts project-sa'
+sudo -u agentconsole sh -c 'cd /home/agentconsole/agent-console && NODE_ENV=production /usr/local/bin/bun scripts/smoke/check-multiuser-pty-env.ts agent-console-shared'
 ```
 
 Finally, log in to the web UI as a regular user, create a quick session

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -1139,7 +1139,7 @@ sudo -u agent-console-shared -i
 
 cat >> ~/.profile <<'EOF'
 export CLAUDE_CODE_USE_BEDROCK=1
-export AWS_REGION=ap-northeast-1
+export AWS_REGION=us-east-1
 [ -f ~/.bedrock-key.env ] && . ~/.bedrock-key.env
 EOF
 

--- a/docs/multi-user-setup-guide.md
+++ b/docs/multi-user-setup-guide.md
@@ -588,6 +588,8 @@ target), reference it from the systemd unit with `EnvironmentFile=-`, then
 | `AGENT_CONSOLE_MCP_AUTH` | _(unset)_ | Mode for missing-MCP-token handling on EVERY `/mcp` request (transport-level gate, Issue #1269): `off`, `warn`, or `enforce`. Unset resolves to `warn` for every `AUTH_MODE`, including multi-user (Sprint 2026-07-16; see Issue #1107 for the enforce-by-default restoration path). Setting `enforce` explicitly while `AUTH_MODE` is not `multi-user` fails server startup with a configuration error: `resolveMcpAuthMode` rejects the combination because MCP bearer tokens for terminal-agent workers are only minted when `AUTH_MODE=multi-user` (`worker-manager.ts`'s mint gate — see [Ruling 2](design/embedded-agent-worker.md#transport-level-authn-gate-issue-1269)), so enforcing without it would reject every terminal-agent MCP call outright; this is a deliberate fail-fast, not a bug. See [MCP authentication mode](#mcp-authentication-mode-agent_console_mcp_auth) below — most deployments should leave this unset. |
 | `EMBEDDED_AGENT_BUN_PATH` | `bun` | Absolute path (or bare command name) used to invoke `bun` when spawning the embedded-agent worker's loop subprocess. Default `bun` resolves via PATH, correct for single-user/dev where the spawned process shares the server's shell environment. Multi-user mode MUST set this to an absolute path (e.g. `/usr/local/bin/bun`) because the subprocess runs inside an elevated, non-interactive login shell that does not source `.bashrc` and cannot resolve a user-local `~/.bun/bin/bun` by bare name (Issue #1221; see [`.claude/rules/os-environment-coupling.md`](../.claude/rules/os-environment-coupling.md)). `scripts/setup-multiuser-for-ubuntu.sh` sets this to the SAME value as `ExecStart` (Issue #1222) — the server process and the embedded-agent subprocess always execute the identical file, so drift between them is structurally impossible; re-run the setup script after a `bun upgrade` to refresh which version that shared file is. |
 
+| `AGENT_CONSOLE_SHARED_USERNAME` | _(unset)_ | OS username of the **Shared Account** that runs [SharedSessions](design/shared-orchestrator-session.md). Unset → shared sessions disabled (`/api/config` reports `sharedAccountsAvailable: false`). Set → the server resolves the account at startup and **fails fast** if it does not exist. Honoured only when `AUTH_MODE=multi-user`. Provision the account with `scripts/setup-shared-account.sh`; see [Shared Account Setup](#shared-account-setup-shared-sessions). |
+
 The full list of server variables is defined in
 [`packages/server/src/lib/server-config.ts`](../packages/server/src/lib/server-config.ts).
 
@@ -1065,6 +1067,113 @@ multi-user instance): the helper does read the file and the resulting
 [#1107](https://github.com/ms2sato/agent-console/issues/1107) (restoring
 `enforce` as the multi-user default), not as a gate on general multi-user
 support, and that prerequisite is now satisfied.
+
+## Shared Account Setup (shared sessions)
+
+Optional. A **Shared Account** is a dedicated OS account that runs
+[SharedSessions](design/shared-orchestrator-session.md) — sessions any
+authenticated user can read and write. It is structurally an ordinary
+account (real home, real login shell), distinct from both the service user
+and individual users; its LLM-vendor authentication is API-key-based rather
+than subscription-based. See `docs/glossary.md` for the term.
+
+### 1. Provision the OS account
+
+```bash
+sudo scripts/setup-shared-account.sh project-sa
+```
+
+The script is idempotent (safe to re-run) and accepts `--group <name>`,
+`--shell <path>`, and `--dry-run` (previews without root). It:
+
+- verifies the shared group exists (run the bootstrap script first if not);
+- creates the account with a real home and a login shell the sudoers rule
+  permits (`/bin/bash` by default — zsh and others are rejected because the
+  elevation path invokes the target's login shell and the installed rule
+  only allows `sh`/`bash`);
+- locks the password (the account is a pure execution identity — humans
+  authenticate as themselves; elevation into it is NOPASSWD via the service
+  user's existing rule, so no sudoers change is needed);
+- adds it to the shared group (required for the setgid data-root tree). It
+  deliberately does NOT add the account to `shadow` and does NOT edit
+  sshd_config — blocking SSH login with a `DenyUsers` entry is a
+  recommended manual step the script prints.
+
+### 2. Register the account with the server
+
+Add the username to the systemd unit via a drop-in (survives bootstrap
+re-runs, unlike edits to the generated unit file):
+
+```bash
+sudo systemctl edit agent-console
+```
+
+```ini
+[Service]
+Environment=AGENT_CONSOLE_SHARED_USERNAME=project-sa
+```
+
+Then restart and verify:
+
+```bash
+sudo systemctl restart agent-console
+curl -s http://localhost:<port>/api/config   # expect "sharedAccountsAvailable":true
+```
+
+The server fails fast at startup when the configured username does not
+resolve to an OS account — create the account first, configure second.
+The setting is honoured only under `AUTH_MODE=multi-user`.
+
+### 3. Configure LLM vendor credentials in the account's own home
+
+The elevation path deliberately does not forward server env to spawned
+PTYs, so vendor credentials must come from the shared account's own
+login-shell init. Put exports in `~/.profile` — NOT `~/.bashrc`, which the
+elevated inner shell (dash) never reads.
+
+Example for AWS Bedrock with a long-term Bedrock API key, keeping the
+rotating secret in its own file so rotation is a one-file overwrite:
+
+```bash
+sudo -u project-sa -i
+
+cat >> ~/.profile <<'EOF'
+export CLAUDE_CODE_USE_BEDROCK=1
+export AWS_REGION=ap-northeast-1
+[ -f ~/.bedrock-key.env ] && . ~/.bedrock-key.env
+EOF
+
+umask 077
+cat > ~/.bedrock-key.env <<'EOF'
+export AWS_BEARER_TOKEN_BEDROCK=<long-term Bedrock API key>
+EOF
+
+exit
+```
+
+Use a **long-term** Bedrock API key (short-term keys expire within 12
+hours and will break unattended shared sessions). To rotate, overwrite
+`~/.bedrock-key.env` with the new key and recreate running shared sessions
+(PTYs read env at spawn time). Do NOT put `CLAUDE_CODE_*` or `AWS_*`
+variables on the server's systemd unit — they do not reach elevated PTYs,
+and `CLAUDE_CODE_*` on the server env triggers the direct-path unset-prefix
+hazard (`packages/server/src/services/env-filter.ts`).
+
+### 4. Verify
+
+```bash
+# Vendor auth works for the account itself
+sudo -u project-sa -i claude -p "hello"
+
+# Full elevation chain delivers the login-init env (see Post-deploy Verification)
+sudo -u agentconsole sh -c 'cd /home/agentconsole/agent-console && NODE_ENV=production /usr/local/bin/bun scripts/smoke/check-multiuser-pty-env.ts project-sa'
+```
+
+Finally, log in to the web UI as a regular user, create a quick session
+with **Create as shared session** checked (the checkbox appears only when
+`sharedAccountsAvailable` is true), and confirm `whoami` in the session
+terminal reports the shared account and the agent responds via the
+configured vendor.
 
 ## Post-deploy Verification (smoke tests)
 

--- a/scripts/setup-shared-account.sh
+++ b/scripts/setup-shared-account.sh
@@ -59,7 +59,7 @@ usage() {
   cat <<'EOF'
 Usage: setup-shared-account.sh <username> [--group <name>] [--shell <path>] [--dry-run]
 
-  username        Shared Account OS user to provision (e.g. project-sa).
+  username        Shared Account OS user to provision (e.g. agent-console-shared).
   --group <name>  Shared group to join (default: agent-console-users, or
                   $AGENT_CONSOLE_SERVICE_GROUP if set). Must already exist.
   --shell <path>  Login shell (default: /bin/bash). Must be one of

--- a/scripts/setup-shared-account.sh
+++ b/scripts/setup-shared-account.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+#
+# Provision a Shared Account OS user for Agent Console shared sessions.
+#
+# A Shared Account is a pure execution identity: shared orchestrator sessions
+# run as this account via the service user's privilege elevation (see
+# docs/design/shared-orchestrator-session.md). Humans authenticate as
+# themselves; the account itself never logs in, so its password is locked.
+#
+# Steps (each idempotent):
+#   1. Verify the shared group exists (created by setup-multiuser-for-ubuntu.sh).
+#   2. Create the account if missing (regular account with a real home and a
+#      real login shell — NOT --system: it is an execution identity, not a
+#      daemon). If it exists, verify/repair its login shell and home.
+#   3. Lock the account password.
+#   4. Add the account to the shared group.
+#   5. Print operator next steps (server env, vendor credentials, sshd note,
+#      post-setup smoke verification).
+#
+# This script does NOT touch sudoers (the installed `(ALL,!root)` rule already
+# covers any non-root elevation target), does NOT add the account to the
+# `shadow` group, does NOT write into any other user's home, and does NOT edit
+# sshd_config (.claude/rules/os-environment-coupling.md Discipline 2).
+#
+# Usage:
+#   sudo scripts/setup-shared-account.sh <username>
+#   sudo scripts/setup-shared-account.sh <username> --group <name> --shell <path>
+#   scripts/setup-shared-account.sh <username> --dry-run   # preview, no root needed
+#
+# Idempotent: a second invocation with the same arguments is a no-op.
+#
+# Environment overrides:
+#   AGENT_CONSOLE_SERVICE_GROUP — default group name (overridden by --group).
+#
+# Documentation: docs/design/shared-orchestrator-session.md
+
+set -euo pipefail
+
+DEFAULT_GROUP="${AGENT_CONSOLE_SERVICE_GROUP:-agent-console-users}"
+DEFAULT_SHELL="/bin/bash"
+
+# POSIX username regex (login name): start with a letter or underscore, then
+# letters / digits / hyphen / underscore, max 31 chars total.
+USERNAME_REGEX='^[a-z_][a-z0-9_-]{0,30}$'
+
+# Login shells the deployed sudoers template permits as elevation targets.
+# The elevation helper invokes `sudo -u <user> -i sh -c '...'`, which runs the
+# target's login shell; scripts/sudoers-agent-console.template only allows
+# these four paths. Any other shell (zsh, fish, ...) would make every elevated
+# invocation for this account be denied by sudoers.
+ALLOWED_SHELLS=(/bin/sh /bin/bash /usr/bin/sh /usr/bin/bash)
+
+err() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage: setup-shared-account.sh <username> [--group <name>] [--shell <path>] [--dry-run]
+
+  username        Shared Account OS user to provision (e.g. project-sa).
+  --group <name>  Shared group to join (default: agent-console-users, or
+                  $AGENT_CONSOLE_SERVICE_GROUP if set). Must already exist.
+  --shell <path>  Login shell (default: /bin/bash). Must be one of
+                  /bin/sh, /bin/bash, /usr/bin/sh, /usr/bin/bash — the only
+                  shells the sudoers rule permits for elevation targets.
+  --dry-run       Print all actions; do not modify the system (no root needed).
+  -h, --help      Show this help and exit.
+EOF
+}
+
+if [ "$#" -lt 1 ]; then
+  usage >&2
+  exit 2
+fi
+
+USERNAME=""
+GROUP_NAME=""
+SHELL_PATH=""
+DRY_RUN=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --group)
+      [ "$#" -ge 2 ] || err "--group requires an argument"
+      GROUP_NAME="$2"
+      shift 2
+      ;;
+    --shell)
+      [ "$#" -ge 2 ] || err "--shell requires an argument"
+      SHELL_PATH="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    -*)
+      err "unknown flag: $1"
+      ;;
+    *)
+      if [ -z "$USERNAME" ]; then
+        USERNAME="$1"
+        shift
+      else
+        err "unexpected positional argument: $1"
+      fi
+      ;;
+  esac
+done
+
+[ -n "$USERNAME" ] || { usage >&2; exit 2; }
+GROUP_NAME="${GROUP_NAME:-$DEFAULT_GROUP}"
+SHELL_PATH="${SHELL_PATH:-$DEFAULT_SHELL}"
+
+# Validate identifiers.
+if ! echo "$USERNAME" | grep -Eq "$USERNAME_REGEX"; then
+  err "invalid username '$USERNAME' (must match $USERNAME_REGEX)"
+fi
+if ! echo "$GROUP_NAME" | grep -Eq "$USERNAME_REGEX"; then
+  err "invalid group name '$GROUP_NAME' (must match $USERNAME_REGEX)"
+fi
+
+# Validate the login shell against the sudoers allowlist.
+shell_allowed() {
+  local candidate="$1" s
+  for s in "${ALLOWED_SHELLS[@]}"; do
+    if [ "$candidate" = "$s" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+if ! shell_allowed "$SHELL_PATH"; then
+  err "login shell '$SHELL_PATH' is not permitted: the sudoers rule installed by \
+setup-multiuser-for-ubuntu.sh (scripts/sudoers-agent-console.template) only allows \
+${ALLOWED_SHELLS[*]} as elevation targets' login shells. The elevation helper invokes \
+the target account's login shell, so any other shell (zsh, fish, ...) would make every \
+elevated invocation for this account be denied by sudoers."
+fi
+
+# Require root for real runs; dry-run works unprivileged.
+if [ "$DRY_RUN" -eq 0 ] && [ "$(id -u)" -ne 0 ]; then
+  err "this script must be run as root (sudo scripts/setup-shared-account.sh $USERNAME), or use --dry-run to preview"
+fi
+
+run() {
+  # Print + run, unless --dry-run.
+  echo "+ $*"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    "$@"
+  fi
+}
+
+heading() {
+  echo ""
+  echo "==> $*"
+}
+
+echo "Agent Console shared-account setup"
+echo "----------------------------------"
+echo "  username     : $USERNAME"
+echo "  shared group : $GROUP_NAME"
+echo "  login shell  : $SHELL_PATH"
+echo "  dry run      : $([ "$DRY_RUN" -eq 1 ] && echo yes || echo no)"
+
+# ---------------------------------------------------------------------------
+# Step 1 — precondition: shared group must exist
+# ---------------------------------------------------------------------------
+
+heading "Step 1/4 — shared group '$GROUP_NAME'"
+if getent group "$GROUP_NAME" >/dev/null 2>&1; then
+  echo "    group '$GROUP_NAME' exists."
+else
+  err "group '$GROUP_NAME' does not exist; run scripts/setup-multiuser-for-ubuntu.sh first"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — create the account (or verify existing state)
+# ---------------------------------------------------------------------------
+
+heading "Step 2/4 — account '$USERNAME'"
+if getent passwd "$USERNAME" >/dev/null 2>&1; then
+  echo "    user '$USERNAME' already exists; verifying shell and home"
+  CURRENT_SHELL="$(getent passwd "$USERNAME" | cut -d: -f7)"
+  if shell_allowed "$CURRENT_SHELL"; then
+    echo "    login shell is '$CURRENT_SHELL' (allowed); no change."
+  else
+    echo "    login shell is '$CURRENT_SHELL' (NOT allowed by the sudoers rule); fixing to '$SHELL_PATH'"
+    run usermod -s "$SHELL_PATH" "$USERNAME"
+  fi
+  CURRENT_HOME="$(getent passwd "$USERNAME" | cut -d: -f6)"
+  if [ -d "$CURRENT_HOME" ]; then
+    echo "    home directory '$CURRENT_HOME' exists."
+  else
+    err "user '$USERNAME' has home '$CURRENT_HOME' but the directory does not exist; create it (e.g. 'mkhomedir_helper $USERNAME' or 'install -d -o $USERNAME -g $USERNAME -m 0750 $CURRENT_HOME') and re-run"
+  fi
+else
+  # A regular account, NOT --system: it needs a real home directory (vendor
+  # credentials live there) and a real login shell (the elevation helper
+  # invokes it). It is an execution identity, not a daemon.
+  run useradd --create-home --shell "$SHELL_PATH" "$USERNAME"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — lock the password
+# ---------------------------------------------------------------------------
+#
+# The account is a pure execution identity: humans authenticate as themselves,
+# elevation into this account is NOPASSWD via the service user's sudoers rule,
+# and no password login should ever be possible.
+
+heading "Step 3/4 — lock password for '$USERNAME'"
+if [ "$DRY_RUN" -eq 1 ] && ! getent passwd "$USERNAME" >/dev/null 2>&1; then
+  echo "    (dry-run) user does not exist yet; would lock after creation"
+  run usermod -L "$USERNAME"
+elif PASSWD_STATUS="$(passwd -S "$USERNAME" 2>/dev/null | awk '{print $2}')" && [ "$PASSWD_STATUS" = "L" ]; then
+  echo "    password is already locked; skipping."
+else
+  run usermod -L "$USERNAME"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4 — shared group membership
+# ---------------------------------------------------------------------------
+
+heading "Step 4/4 — membership in '$GROUP_NAME'"
+if [ "$DRY_RUN" -eq 1 ] && ! getent passwd "$USERNAME" >/dev/null 2>&1; then
+  echo "    (dry-run) user does not exist yet; would add to '$GROUP_NAME' after creation"
+  run usermod -aG "$GROUP_NAME" "$USERNAME"
+elif id -nG "$USERNAME" 2>/dev/null | tr ' ' '\n' | grep -Fxq "$GROUP_NAME"; then
+  echo "    '$USERNAME' is already a member of '$GROUP_NAME'."
+else
+  run usermod -aG "$GROUP_NAME" "$USERNAME"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary + next steps (informational only; nothing below is executed)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Done. Next steps (manual):"
+echo ""
+echo "1. Configure the server (create first, configure second — this script"
+echo "   handles the ordering; the server fails fast at startup if the OS"
+echo "   account named below is missing):"
+echo "     Set AGENT_CONSOLE_SHARED_USERNAME=$USERNAME on the server's systemd"
+echo "     unit (an Environment= line in /etc/systemd/system/agent-console.service"
+echo "     or the secrets EnvironmentFile), then:"
+echo "       sudo systemctl daemon-reload && sudo systemctl restart agent-console"
+echo ""
+echo "2. Configure LLM vendor credentials in the account's OWN home (this"
+echo "   script does not write secrets — they are the operator's to place)."
+echo "   For AWS Bedrock, for example:"
+echo "     - export lines in /home/$USERNAME/.profile — NOT ~/.bashrc: the"
+echo "       elevated inner shell is dash and never reads .bashrc"
+echo "     - /home/$USERNAME/.aws/credentials, mode 0600, owned by $USERNAME"
+echo ""
+echo "3. (Recommended, optional) Block SSH login for the account by adding"
+echo "     DenyUsers $USERNAME"
+echo "   to /etc/ssh/sshd_config and reloading sshd. This script deliberately"
+echo "   does NOT edit sshd_config (no unilateral modification of OS state"
+echo "   outside the project's scope; .claude/rules/os-environment-coupling.md)."
+echo ""
+echo "4. Post-setup verification (run as the bootstrap's service user,"
+echo "   default 'agentconsole'):"
+echo "     sudo -u agentconsole bun scripts/smoke/check-multiuser-pty-env.ts $USERNAME"
+echo "     sudo -u agentconsole bun scripts/smoke/check-login-shell-sentinel.ts --elevated $USERNAME"
+echo ""
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "(dry run; no system state was modified)"
+fi

--- a/scripts/setup-shared-account.sh
+++ b/scripts/setup-shared-account.sh
@@ -194,6 +194,7 @@ if getent passwd "$USERNAME" >/dev/null 2>&1; then
     run usermod -s "$SHELL_PATH" "$USERNAME"
   fi
   CURRENT_HOME="$(getent passwd "$USERNAME" | cut -d: -f6)"
+  ACCOUNT_HOME="$CURRENT_HOME"
   if [ -d "$CURRENT_HOME" ]; then
     echo "    home directory '$CURRENT_HOME' exists."
   else
@@ -204,6 +205,11 @@ else
   # credentials live there) and a real login shell (the elevation helper
   # invokes it). It is an execution identity, not a daemon.
   run useradd --create-home --shell "$SHELL_PATH" "$USERNAME"
+  # Resolve the actual home for the next-steps output. Falls back to the
+  # conventional path under dry-run, where useradd did not actually run
+  # (getent then exits non-zero, hence the || true under set -e).
+  ACCOUNT_HOME="$(getent passwd "$USERNAME" 2>/dev/null | cut -d: -f6 || true)"
+  ACCOUNT_HOME="${ACCOUNT_HOME:-/home/$USERNAME}"
 fi
 
 # ---------------------------------------------------------------------------
@@ -256,9 +262,9 @@ echo ""
 echo "2. Configure LLM vendor credentials in the account's OWN home (this"
 echo "   script does not write secrets — they are the operator's to place)."
 echo "   For AWS Bedrock, for example:"
-echo "     - export lines in /home/$USERNAME/.profile — NOT ~/.bashrc: the"
+echo "     - export lines in $ACCOUNT_HOME/.profile — NOT ~/.bashrc: the"
 echo "       elevated inner shell is dash and never reads .bashrc"
-echo "     - /home/$USERNAME/.aws/credentials, mode 0600, owned by $USERNAME"
+echo "     - $ACCOUNT_HOME/.aws/credentials, mode 0600, owned by $USERNAME"
 echo ""
 echo "3. (Recommended, optional) Block SSH login for the account by adding"
 echo "     DenyUsers $USERNAME"


### PR DESCRIPTION
## Summary

Adds `scripts/setup-shared-account.sh`, the operator script that provisions a **Shared Account** OS user for shared sessions, and documents the full shared-account setup flow in `docs/multi-user-setup-guide.md` (new "Shared Account Setup" section + `AGENT_CONSOLE_SHARED_USERNAME` row in the Environment Variables table — the variable previously appeared nowhere in operator docs).

Usage: `scripts/setup-shared-account.sh <username> [--group <name>] [--shell <path>] [--dry-run]`, run as root (dry-run works unprivileged). The username is a required positional argument, so any deployment-specific name works.

Idempotent steps:

1. Verify the shared group exists (points at the bootstrap script if missing).
2. Create the account with a real home and a login shell the installed elevation rule permits (`/bin/bash` default; zsh etc. rejected with an explanatory error — the elevation path invokes the target's login shell and the installed rule only allows `sh`/`bash`). On existing accounts, a disallowed shell is repaired and home existence is verified.
3. Lock the password (pure execution identity — humans authenticate as themselves; elevation into the account is NOPASSWD via the service user's existing rule).
4. Join the shared group (setgid data-root access).

Deliberate non-actions (`.claude/rules/os-environment-coupling.md` Discipline 2): no elevation-config edits (the installed `(ALL,!root)` rule already covers any non-root target), no `shadow` membership, no writes to other users' homes, no sshd_config edits (the SSH `DenyUsers` recommendation is printed as a manual next step).

## Pre-PR completeness (gap-scan)

- Q1 (existing mechanism): `scripts/add-multiuser-user.sh` only adds an existing user to the group; the bootstrap only provisions the service user. This script fills the gap and mirrors their conventions (arg parsing, `run()`/dry-run, username regex, idempotency checks).
- Q2 (canonical invocation documented): the new guide section is added in this PR; the script's next-steps output and the guide cross-reference each other.
- Glossary: `Shared Account` is already defined in `docs/glossary.md`; the script and docs use the term consistently (no new domain concept introduced).

## Test plan

- `bash -n` syntax check: OK.
- Full suite after commit: `bun run typecheck && bun run test` exit 0 (scripts-dir test group: 528 pass / 0 fail; client 2115 pass / 0 fail; server/shared/embedded green in the same run).
- `node .claude/skills/orchestrator/preflight-check.js` after commit: coverage n/a (no production files matching patterns), language check clean, no rule/skill duplication, no blame-shift comments. `scripts/*.sh` has no sibling-test requirement per `test-trigger.md`.
- **Real-machine verification (Linux multi-user host, 2026-08-12)** — shell scripts are only verifiable at runtime (workflow.md Verification Checklist item 7; run on the actual Linux deploy target):
  - Dry-run as non-root: correct `+ command` preview for a not-yet-existing user; both arg orders accepted; error paths verified (missing username → usage/exit 2, invalid username → exit 1, `--shell /bin/zsh` → allowlist explanation/exit 1, real run as non-root → root-required guidance).
  - Real run as root: account created with `/bin/bash` and home; `passwd -S` reports `L`; member of `agent-console-users`.
  - Re-run: all steps skipped ("already exists / already locked / already a member") — idempotency confirmed.
  - End-to-end: `AGENT_CONSOLE_SHARED_USERNAME` set via systemd drop-in → `/api/config` returned `sharedAccountsAvailable: true` → browser-created shared session ran as the provisioned account with AWS Bedrock auth (long-term API key in the account's own login init) → `check-multiuser-pty-env.ts` 9/9 and `check-login-shell-sentinel.ts --elevated` 7/7 passed for the account.

Closes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a setup utility to provision and maintain a shared execution account, including group access, secure password locking, and configuration checks.
  - Added dry-run support and clear follow-up guidance for server, credential, SSH, and smoke-test configuration.

- **Documentation**
  - Added comprehensive guidance for configuring shared accounts, including environment settings, startup validation, system registration, credential rotation, verification, and shared-session checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->