### PR TITLE
feat(client): group sidebar sessions by repository with collapsible groups

### DIFF
--- a/packages/client/src/components/sidebar/ActiveSessionsSidebar.tsx
+++ b/packages/client/src/components/sidebar/ActiveSessionsSidebar.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useLocation } from '@tanstack/react-router';
-import { useRef, useCallback, useEffect, useState } from 'react';
+import { useRef, useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import type { AgentActivityState, WorktreeCreationTask, WorktreeDeletionTask, Session } from '@agent-console/shared';
 import type { SessionFilterMode } from '../../types/session-filter';
@@ -11,6 +11,8 @@ import { ConfirmDialog } from '../ui/confirm-dialog';
 import { Spinner } from '../ui/Spinner';
 import { ActivityIndicator } from './ActivityIndicator';
 import type { SessionWithActivity } from '../../hooks/useActiveSessionsWithActivity';
+import { groupSessionsByRepository, getGroupAggregateActivityState } from './group-sessions-by-repository';
+import { getPersistedGroupCollapsed, persistGroupCollapsed } from './session-group-collapse-storage';
 import {
   SIDEBAR_MIN_WIDTH,
   SIDEBAR_MAX_WIDTH,
@@ -392,6 +394,28 @@ export function ActiveSessionsSidebar({
   const [isResizing, setIsResizing] = useState(false);
   const [pausedExpanded, setPausedExpanded] = useState(false);
   const sidebarRef = useRef<HTMLDivElement>(null);
+
+  // Repository grouping. `sessions` is already the mine/shared-filtered
+  // list by the time it reaches this component (see routes/__root.tsx), so
+  // grouping here is inherently filter-then-group: a repository with zero
+  // visible sessions never produces a group.
+  const sessionGroups = useMemo(() => groupSessionsByRepository(sessions), [sessions]);
+  const [groupCollapsedOverrides, setGroupCollapsedOverrides] = useState<Record<string, boolean>>({});
+  const isGroupCollapsed = useCallback(
+    (groupKey: string): boolean =>
+      groupKey in groupCollapsedOverrides
+        ? groupCollapsedOverrides[groupKey]
+        : getPersistedGroupCollapsed(groupKey),
+    [groupCollapsedOverrides]
+  );
+  const toggleGroup = useCallback((groupKey: string) => {
+    setGroupCollapsedOverrides((prev) => {
+      const current = groupKey in prev ? prev[groupKey] : getPersistedGroupCollapsed(groupKey);
+      const next = !current;
+      persistGroupCollapsed(groupKey, next);
+      return { ...prev, [groupKey]: next };
+    });
+  }, []);
   const currentWidthRef = useRef(width);
   // Keep ref in sync with prop (no useEffect needed for simple ref sync)
   currentWidthRef.current = width;
@@ -685,7 +709,11 @@ export function ActiveSessionsSidebar({
           !collapsed && (
             <div className="p-3 text-gray-500 text-sm">No active sessions</div>
           )
-        ) : (
+        ) : collapsed || sessionGroups.length <= 1 ? (
+          // R5: collapsed sidebar always renders a flat icon list.
+          // R6: a single group (counting the quick group) degrades to a flat
+          // list with no header, keeping single-repository sidebars
+          // byte-identical to the pre-grouping render.
           sessions.map(({ session, activityState }) => (
             <SessionItem
               key={session.id}
@@ -695,6 +723,57 @@ export function ActiveSessionsSidebar({
               onClick={() => handleSessionClick(session.id)}
             />
           ))
+        ) : (
+          sessionGroups.map((group) => {
+            const groupCollapsed = isGroupCollapsed(group.key);
+            const controlsId = `session-group-${group.key}-list`;
+            // M5: only compute/show the aggregate indicator while collapsed
+            // — expanded groups already show each session's own indicator.
+            const aggregateState = groupCollapsed
+              ? getGroupAggregateActivityState(group.sessions)
+              : null;
+
+            return (
+              <div key={group.key}>
+                <button
+                  onClick={() => toggleGroup(group.key)}
+                  aria-expanded={!groupCollapsed}
+                  aria-controls={controlsId}
+                  className="w-full px-3 py-2 flex items-center justify-between text-gray-500 hover:text-gray-400 transition-colors"
+                >
+                  <span className="flex items-center gap-1.5 min-w-0 text-xs font-medium uppercase tracking-wider">
+                    <span className="truncate">{group.label}</span>
+                    {aggregateState && (
+                      <ActivityIndicator
+                        state={aggregateState}
+                        className="shrink-0"
+                      />
+                    )}
+                  </span>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <span className="text-xs bg-slate-800 text-gray-500 px-1.5 py-0.5 rounded">
+                      {group.sessions.length}
+                    </span>
+                    <ChevronDownIcon
+                      className={`w-3.5 h-3.5 transition-transform ${groupCollapsed ? '-rotate-90' : ''}`}
+                    />
+                  </div>
+                </button>
+                <div id={controlsId}>
+                  {!groupCollapsed &&
+                    group.sessions.map(({ session, activityState }) => (
+                      <SessionItem
+                        key={session.id}
+                        sessionWithActivity={{ session, activityState }}
+                        collapsed={collapsed}
+                        isActive={session.id === currentSessionId}
+                        onClick={() => handleSessionClick(session.id)}
+                      />
+                    ))}
+                </div>
+              </div>
+            );
+          })
         )}
         {/* Paused sessions section */}
         {pausedSessions.length > 0 && (

--- a/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
+++ b/packages/client/src/components/sidebar/__tests__/ActiveSessionsSidebar.test.tsx
@@ -3,6 +3,7 @@ import { screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { renderWithRouter } from '../../../test/renderWithRouter';
 import { ActiveSessionsSidebar } from '../ActiveSessionsSidebar';
+import { QUICK_SESSIONS_GROUP_KEY } from '../group-sessions-by-repository';
 import {
   SIDEBAR_COLLAPSED_WIDTH,
   SIDEBAR_DEFAULT_WIDTH,
@@ -1116,6 +1117,262 @@ describe('ActiveSessionsSidebar', () => {
       await waitFor(() => {
         expect(screen.getByText('Restarted 3 agents.')).toBeTruthy();
       });
+    });
+  });
+
+  describe('Repository grouping (Issue #1292)', () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it('renders a header per group with session counts when 2+ groups exist', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a1', repositoryId: 'repo-a', repositoryName: 'Repo A' }),
+          'idle'
+        ),
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a2', repositoryId: 'repo-a', repositoryName: 'Repo A' }),
+          'idle'
+        ),
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'b1', repositoryId: 'repo-b', repositoryName: 'Repo B' }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} sessions={sessions} />);
+
+      const headerA = document.querySelector('[aria-controls="session-group-repo-a-list"]');
+      const headerB = document.querySelector('[aria-controls="session-group-repo-b-list"]');
+      expect(headerA).toBeTruthy();
+      expect(headerB).toBeTruthy();
+      expect(headerA?.textContent).toContain('Repo A');
+      expect(headerA?.textContent).toContain('2');
+      expect(headerB?.textContent).toContain('Repo B');
+      expect(headerB?.textContent).toContain('1');
+    });
+
+    it('collapsing a group header hides its sessions but keeps the count badge visible', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a1', repositoryId: 'repo-a', repositoryName: 'Repo A', title: 'branch-a1' }),
+          'idle'
+        ),
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'b1', repositoryId: 'repo-b', repositoryName: 'Repo B', title: 'branch-b1' }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} sessions={sessions} />);
+
+      expect(screen.getByText('branch-a1')).toBeTruthy();
+
+      const headerA = document.querySelector('[aria-controls="session-group-repo-a-list"]') as HTMLButtonElement;
+      fireEvent.click(headerA);
+
+      expect(screen.queryByText('branch-a1')).toBeNull();
+      expect(headerA.textContent).toContain('1');
+      expect(headerA.getAttribute('aria-expanded')).toBe('false');
+      // The sibling group is unaffected by collapsing this one.
+      expect(screen.getByText('branch-b1')).toBeTruthy();
+    });
+
+    it('persists group collapse state to localStorage on toggle and restores it on the next mount', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a1', repositoryId: 'repo-a', repositoryName: 'Repo A' }),
+          'idle'
+        ),
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'b1', repositoryId: 'repo-b', repositoryName: 'Repo B' }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} sessions={sessions} />);
+
+      const headerA = document.querySelector('[aria-controls="session-group-repo-a-list"]') as HTMLButtonElement;
+      expect(headerA.getAttribute('aria-expanded')).toBe('true'); // default expanded (M3)
+      fireEvent.click(headerA);
+
+      expect(localStorage.getItem('agent-console:sidebar-group-collapsed:repo-a')).toBe('true');
+
+      cleanup();
+
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} sessions={sessions} />);
+      const restoredHeaderA = document.querySelector('[aria-controls="session-group-repo-a-list"]');
+      expect(restoredHeaderA?.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('renders flat with no group header when exactly one group exists (R6 single-group degradation)', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a1', repositoryId: 'repo-a', repositoryName: 'Repo A' }),
+          'idle'
+        ),
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a2', repositoryId: 'repo-a', repositoryName: 'Repo A' }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} sessions={sessions} />);
+
+      expect(document.querySelectorAll('[aria-controls^="session-group-"]')).toHaveLength(0);
+      // Both sessions still render, just without a header.
+      expect(screen.getAllByText('Repo A')).toHaveLength(2);
+    });
+
+    it('renders a flat icon list with no group headers when the sidebar is collapsed, even with multiple repositories (R5)', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a1', repositoryId: 'repo-a', repositoryName: 'Repo A' }),
+          'idle'
+        ),
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'b1', repositoryId: 'repo-b', repositoryName: 'Repo B' }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(
+        <ActiveSessionsSidebar {...defaultProps()} collapsed={true} sessions={sessions} />
+      );
+
+      expect(document.querySelectorAll('[aria-controls^="session-group-"]')).toHaveLength(0);
+      // Still one activity indicator per session (flat icon list).
+      expect(screen.getAllByLabelText(/^Activity:/)).toHaveLength(2);
+    });
+
+    it('R7: does not render an empty header once filtering removes every session for a repository', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a1', repositoryId: 'repo-a', repositoryName: 'Repo A' }),
+          'idle'
+        ),
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'b1', repositoryId: 'repo-b', repositoryName: 'Repo B' }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} sessions={sessions} />);
+      expect(document.querySelector('[aria-controls="session-group-repo-b-list"]')).toBeTruthy();
+      cleanup();
+
+      // Simulate the mine/shared filter (applied upstream in routes/__root.tsx,
+      // BEFORE `sessions` reaches this component) having removed every
+      // repo-b session. Filter-then-group composition (R7): the component
+      // must never fabricate a lingering empty header for repo-b.
+      const filteredSessions = sessions.filter(
+        (s) => s.session.type === 'worktree' && s.session.repositoryId === 'repo-a'
+      );
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} sessions={filteredSessions} />);
+
+      expect(document.querySelector('[aria-controls="session-group-repo-b-list"]')).toBeNull();
+      // Down to a single group -> R6 degradation also applies, no header at all.
+      expect(document.querySelectorAll('[aria-controls^="session-group-"]')).toHaveLength(0);
+    });
+
+    it('M5: shows an activity indicator on a collapsed group header when it contains a non-idle session', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a1', repositoryId: 'repo-a', repositoryName: 'Repo A' }),
+          'asking'
+        ),
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'b1', repositoryId: 'repo-b', repositoryName: 'Repo B' }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} sessions={sessions} />);
+
+      const headerA = document.querySelector('[aria-controls="session-group-repo-a-list"]') as HTMLButtonElement;
+      const headerB = document.querySelector('[aria-controls="session-group-repo-b-list"]') as HTMLButtonElement;
+
+      // Collapse both: repo-a has an attention-worthy (asking) session, repo-b is idle-only.
+      fireEvent.click(headerA);
+      fireEvent.click(headerB);
+
+      expect(headerA.querySelector('[aria-label="Activity: asking"]')).toBeTruthy();
+      expect(headerB.querySelector('[aria-label^="Activity:"]')).toBeNull();
+    });
+
+    it('does not show the collapsed-group activity indicator while the group is expanded', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a1', repositoryId: 'repo-a', repositoryName: 'Repo A' }),
+          'asking'
+        ),
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'b1', repositoryId: 'repo-b', repositoryName: 'Repo B' }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} sessions={sessions} />);
+
+      const headerA = document.querySelector('[aria-controls="session-group-repo-a-list"]') as HTMLButtonElement;
+      // Still expanded (default) — the session's own indicator is visible
+      // inline; the header itself must not duplicate it.
+      expect(headerA.querySelector('[aria-label="Activity: asking"]')).toBeNull();
+    });
+
+    it('renders quick sessions under a dedicated "Quick sessions" group, ordered after repository groups', async () => {
+      const sessions = [
+        createSessionWithActivity(createMockQuickSession({ id: 'q1' }), 'idle'),
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a1', repositoryId: 'repo-a', repositoryName: 'Repo A' }),
+          'idle'
+        ),
+      ];
+
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} sessions={sessions} />);
+
+      const quickHeader = document.querySelector(`[aria-controls="session-group-${QUICK_SESSIONS_GROUP_KEY}-list"]`);
+      expect(quickHeader).toBeTruthy();
+      expect(quickHeader?.textContent).toContain('Quick sessions');
+
+      const headers = Array.from(document.querySelectorAll('[aria-controls^="session-group-"]'));
+      const headerIds = headers.map((h) => h.getAttribute('aria-controls'));
+      expect(headerIds.indexOf('session-group-repo-a-list')).toBeLessThan(
+        headerIds.indexOf(`session-group-${QUICK_SESSIONS_GROUP_KEY}-list`)
+      );
+    });
+
+    it('invariant: the paused section still renders below the grouped session list (grouping does not swallow it)', async () => {
+      const sessions = [
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'a1', repositoryId: 'repo-a', repositoryName: 'Repo A' }),
+          'idle'
+        ),
+        createSessionWithActivity(
+          createMockWorktreeSession({ id: 'b1', repositoryId: 'repo-b', repositoryName: 'Repo B' }),
+          'idle'
+        ),
+      ];
+      const pausedSessions = [
+        createMockWorktreeSession({ pausedAt: new Date().toISOString(), repositoryName: 'paused-repo' }),
+      ];
+
+      await renderWithRouter(
+        <ActiveSessionsSidebar {...defaultProps()} sessions={sessions} pausedSessions={pausedSessions} />
+      );
+
+      // Exactly the 2 repository groups — the paused section is not folded
+      // into the grouped region as a third group.
+      expect(document.querySelectorAll('[aria-controls^="session-group-"]')).toHaveLength(2);
+      expect(screen.getByText('Paused')).toBeTruthy();
+    });
+
+    it('invariant: "No active sessions" still renders when the session list is empty, unaffected by grouping', async () => {
+      await renderWithRouter(<ActiveSessionsSidebar {...defaultProps()} sessions={[]} />);
+
+      expect(screen.getByText('No active sessions')).toBeTruthy();
+      expect(document.querySelectorAll('[aria-controls^="session-group-"]')).toHaveLength(0);
     });
   });
 });

--- a/packages/client/src/components/sidebar/__tests__/group-sessions-by-repository.test.ts
+++ b/packages/client/src/components/sidebar/__tests__/group-sessions-by-repository.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  groupSessionsByRepository,
+  getGroupAggregateActivityState,
+  QUICK_SESSIONS_GROUP_KEY,
+  QUICK_SESSIONS_GROUP_LABEL,
+} from '../group-sessions-by-repository';
+import type { SessionWithActivity } from '../../../hooks/useActiveSessionsWithActivity';
+import type { AgentActivityState, WorktreeSession, QuickSession } from '@agent-console/shared';
+
+function worktreeSession(overrides: Partial<Omit<WorktreeSession, 'type'>> = {}): WorktreeSession {
+  return {
+    id: `session-${Math.random().toString(36).slice(2)}`,
+    type: 'worktree',
+    repositoryId: 'repo-1',
+    repositoryName: 'my-repo',
+    worktreeId: 'wt-1',
+    isMainWorktree: false,
+    locationPath: '/path/to/worktree',
+    title: 'test-branch',
+    status: 'active',
+    activationState: 'running',
+    createdAt: new Date().toISOString(),
+    workers: [],
+    isShared: false,
+    recoveryState: 'healthy',
+    ...overrides,
+  };
+}
+
+function quickSession(overrides: Partial<Omit<QuickSession, 'type'>> = {}): QuickSession {
+  return {
+    id: `session-${Math.random().toString(36).slice(2)}`,
+    type: 'quick',
+    locationPath: '/some/path',
+    status: 'active',
+    activationState: 'running',
+    createdAt: new Date().toISOString(),
+    workers: [],
+    isShared: false,
+    recoveryState: 'healthy',
+    ...overrides,
+  };
+}
+
+function withActivity(
+  session: SessionWithActivity['session'],
+  activityState: AgentActivityState = 'idle'
+): SessionWithActivity {
+  return { session, activityState };
+}
+
+describe('groupSessionsByRepository', () => {
+  it('returns an empty array for empty input', () => {
+    expect(groupSessionsByRepository([])).toEqual([]);
+  });
+
+  it('returns a single group for a single session', () => {
+    const session = worktreeSession({ id: 's1', repositoryId: 'repo-a', repositoryName: 'repo-a-name' });
+    const groups = groupSessionsByRepository([withActivity(session)]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('repo-a');
+    expect(groups[0].label).toBe('repo-a-name');
+    expect(groups[0].sessions).toHaveLength(1);
+  });
+
+  it('puts multiple sessions from one repository into a single group, preserving order', () => {
+    const s1 = worktreeSession({ id: 's1', repositoryId: 'repo-a', repositoryName: 'repo-a-name' });
+    const s2 = worktreeSession({ id: 's2', repositoryId: 'repo-a', repositoryName: 'repo-a-name' });
+    const s3 = worktreeSession({ id: 's3', repositoryId: 'repo-a', repositoryName: 'repo-a-name' });
+
+    const groups = groupSessionsByRepository([withActivity(s2), withActivity(s3), withActivity(s1)]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].sessions.map((s) => s.session.id)).toEqual(['s2', 's3', 's1']);
+  });
+
+  it('creates a separate group per repository, sorted by label localeCompare', () => {
+    const zulu = worktreeSession({ id: 'z', repositoryId: 'repo-z', repositoryName: 'zulu' });
+    const alpha = worktreeSession({ id: 'a', repositoryId: 'repo-alpha', repositoryName: 'alpha' });
+    const mike = worktreeSession({ id: 'm', repositoryId: 'repo-mike', repositoryName: 'mike' });
+
+    const groups = groupSessionsByRepository([
+      withActivity(zulu),
+      withActivity(alpha),
+      withActivity(mike),
+    ]);
+
+    expect(groups.map((g) => g.label)).toEqual(['alpha', 'mike', 'zulu']);
+  });
+
+  it('groups quick sessions under the QUICK_SESSIONS sentinel key/label', () => {
+    const q1 = quickSession({ id: 'q1' });
+    const groups = groupSessionsByRepository([withActivity(q1)]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe(QUICK_SESSIONS_GROUP_KEY);
+    expect(groups[0].label).toBe(QUICK_SESSIONS_GROUP_LABEL);
+  });
+
+  it('places the quick group last, after all repository groups regardless of label sort order', () => {
+    const q1 = quickSession({ id: 'q1' });
+    const alpha = worktreeSession({ id: 'a', repositoryId: 'repo-alpha', repositoryName: 'alpha' });
+    const zulu = worktreeSession({ id: 'z', repositoryId: 'repo-z', repositoryName: 'zulu' });
+
+    // Quick session listed first in the input to prove ordering is not
+    // input-position-dependent.
+    const groups = groupSessionsByRepository([
+      withActivity(q1),
+      withActivity(zulu),
+      withActivity(alpha),
+    ]);
+
+    expect(groups.map((g) => g.key)).toEqual(['repo-alpha', 'repo-z', QUICK_SESSIONS_GROUP_KEY]);
+  });
+
+  it('does not split a group when sessions sharing a repositoryId disagree on repositoryName; first occurrence wins (M1)', () => {
+    const first = worktreeSession({ id: 's1', repositoryId: 'repo-a', repositoryName: 'old-name' });
+    const stale = worktreeSession({ id: 's2', repositoryId: 'repo-a', repositoryName: 'renamed-name' });
+
+    const groups = groupSessionsByRepository([withActivity(first), withActivity(stale)]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe('old-name');
+    expect(groups[0].sessions).toHaveLength(2);
+  });
+
+  it('mixes quick and worktree sessions into their respective groups', () => {
+    const wt = worktreeSession({ id: 'wt1', repositoryId: 'repo-a', repositoryName: 'repo-a' });
+    const q = quickSession({ id: 'q1' });
+
+    const groups = groupSessionsByRepository([withActivity(wt), withActivity(q)]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.key)).toEqual(['repo-a', QUICK_SESSIONS_GROUP_KEY]);
+  });
+
+  it('R7: never produces a group for a repository absent from the (already-filtered) input', () => {
+    // Simulates the mine/shared filter (applied upstream, before this
+    // function ever sees the list) having removed every session belonging
+    // to repo-b. The pure function only ever sees repo-a's sessions, so it
+    // must not fabricate an empty repo-b header.
+    const onlyRepoA = [
+      withActivity(worktreeSession({ id: 's1', repositoryId: 'repo-a', repositoryName: 'repo-a' })),
+    ];
+
+    const groups = groupSessionsByRepository(onlyRepoA);
+
+    expect(groups).toHaveLength(1);
+    expect(groups.map((g) => g.key)).toEqual(['repo-a']);
+    expect(groups.find((g) => g.key === 'repo-b')).toBeUndefined();
+  });
+});
+
+describe('getGroupAggregateActivityState', () => {
+  const s = (activityState: AgentActivityState) => withActivity(worktreeSession(), activityState);
+
+  it('returns null for an empty group', () => {
+    expect(getGroupAggregateActivityState([])).toBeNull();
+  });
+
+  it('returns null when every session is idle', () => {
+    expect(getGroupAggregateActivityState([s('idle'), s('idle')])).toBeNull();
+  });
+
+  it('returns "active" when the only non-idle session is active', () => {
+    expect(getGroupAggregateActivityState([s('idle'), s('active')])).toBe('active');
+  });
+
+  it('returns "asking" when the only non-idle session is asking', () => {
+    expect(getGroupAggregateActivityState([s('idle'), s('asking')])).toBe('asking');
+  });
+
+  it('prefers "asking" over "active" when both are present (asking is higher attention priority)', () => {
+    expect(getGroupAggregateActivityState([s('active'), s('idle'), s('asking')])).toBe('asking');
+  });
+});

--- a/packages/client/src/components/sidebar/__tests__/group-sessions-by-repository.test.ts
+++ b/packages/client/src/components/sidebar/__tests__/group-sessions-by-repository.test.ts
@@ -175,4 +175,12 @@ describe('getGroupAggregateActivityState', () => {
   it('prefers "asking" over "active" when both are present (asking is higher attention priority)', () => {
     expect(getGroupAggregateActivityState([s('active'), s('idle'), s('asking')])).toBe('asking');
   });
+
+  it('returns null for an unknown-only group ("unknown" is a transient initial state, excluded from the attention set)', () => {
+    expect(getGroupAggregateActivityState([s('idle'), s('unknown')])).toBeNull();
+  });
+
+  it('ignores "unknown" sessions when computing the aggregate — "active" still wins over an unknown+active mix', () => {
+    expect(getGroupAggregateActivityState([s('unknown'), s('active')])).toBe('active');
+  });
 });

--- a/packages/client/src/components/sidebar/group-sessions-by-repository.ts
+++ b/packages/client/src/components/sidebar/group-sessions-by-repository.ts
@@ -1,0 +1,95 @@
+import type { AgentActivityState } from '@agent-console/shared';
+import type { SessionWithActivity } from '../../hooks/useActiveSessionsWithActivity';
+
+/**
+ * repositoryId values are UUIDs (see packages/shared/src/types/repository.ts),
+ * so this literal sentinel can never collide with a real repository group key.
+ */
+export const QUICK_SESSIONS_GROUP_KEY = 'quick';
+export const QUICK_SESSIONS_GROUP_LABEL = 'Quick sessions';
+
+export interface SessionGroup {
+  /** repositoryId for worktree groups, QUICK_SESSIONS_GROUP_KEY for the quick group */
+  key: string;
+  /** repositoryName for worktree groups, QUICK_SESSIONS_GROUP_LABEL for the quick group */
+  label: string;
+  sessions: SessionWithActivity[];
+}
+
+/**
+ * Groups sessions by repository (mode 1 of the grouping-mode frame; see
+ * the sidebar grouping design discussion for the other modes). Pure
+ * function: sessions in, ordered groups out. Callers are
+ * responsible for filtering the input first (mine/shared filter) — this
+ * function never produces a group for a repository that has zero sessions
+ * in its input, so filter-then-group composition never leaves an empty
+ * header behind.
+ *
+ * Ordering: repository groups sorted by label (localeCompare), quick group
+ * always last. Within a group, the relative order of the incoming
+ * `sessions` array is preserved (partition, not re-sort).
+ *
+ * Group key is always `repositoryId` (rename-stable); label is
+ * `repositoryName`. If sessions sharing a `repositoryId` disagree on
+ * `repositoryName` (stale data), the first occurrence's name wins.
+ */
+export function groupSessionsByRepository(sessions: SessionWithActivity[]): SessionGroup[] {
+  const groupsByKey = new Map<string, SessionGroup>();
+
+  for (const item of sessions) {
+    const { session } = item;
+    const key = session.type === 'worktree' ? session.repositoryId : QUICK_SESSIONS_GROUP_KEY;
+
+    let group = groupsByKey.get(key);
+    if (!group) {
+      const label = session.type === 'worktree' ? session.repositoryName : QUICK_SESSIONS_GROUP_LABEL;
+      group = { key, label, sessions: [] };
+      groupsByKey.set(key, group);
+    }
+    group.sessions.push(item);
+  }
+
+  const repoGroups: SessionGroup[] = [];
+  let quickGroup: SessionGroup | undefined;
+
+  for (const group of groupsByKey.values()) {
+    if (group.key === QUICK_SESSIONS_GROUP_KEY) {
+      quickGroup = group;
+    } else {
+      repoGroups.push(group);
+    }
+  }
+
+  repoGroups.sort((a, b) => a.label.localeCompare(b.label));
+
+  return quickGroup ? [...repoGroups, quickGroup] : repoGroups;
+}
+
+const ATTENTION_PRIORITY: Partial<Record<AgentActivityState, number>> = {
+  asking: 0,
+  active: 1,
+};
+
+/**
+ * Returns the highest-priority non-idle activity state present in a group,
+ * or null when every session in the group is idle. Used to surface a
+ * minimal aggregate indicator on a collapsed group header (M5) — without
+ * it, a session waiting on input becomes invisible behind a header.
+ */
+export function getGroupAggregateActivityState(
+  sessions: SessionWithActivity[]
+): AgentActivityState | null {
+  let best: AgentActivityState | null = null;
+  let bestPriority = Infinity;
+
+  for (const { activityState } of sessions) {
+    const priority = ATTENTION_PRIORITY[activityState];
+    if (priority === undefined) continue; // idle (or any future non-attention state)
+    if (priority < bestPriority) {
+      best = activityState;
+      bestPriority = priority;
+    }
+  }
+
+  return best;
+}

--- a/packages/client/src/components/sidebar/group-sessions-by-repository.ts
+++ b/packages/client/src/components/sidebar/group-sessions-by-repository.ts
@@ -65,16 +65,31 @@ export function groupSessionsByRepository(sessions: SessionWithActivity[]): Sess
   return quickGroup ? [...repoGroups, quickGroup] : repoGroups;
 }
 
-const ATTENTION_PRIORITY: Partial<Record<AgentActivityState, number>> = {
+/**
+ * Exhaustive over AgentActivityState (`satisfies` makes a future state
+ * added to the union a compile error here, instead of silently falling
+ * into either default). Lower number = higher attention priority; `null`
+ * means the state never drives the M5 indicator.
+ * - `idle`: nothing needs attention.
+ * - `unknown`: transient initial state (see worker.ts) that
+ *   useActiveSessionsWithActivity.ts already excludes from the sidebar's
+ *   `sessions` prop before this function ever sees it — currently
+ *   unreachable here, kept explicit rather than silently inherited if
+ *   that upstream filter ever changes.
+ */
+const ATTENTION_PRIORITY = {
   asking: 0,
   active: 1,
-};
+  idle: null,
+  unknown: null,
+} satisfies Record<AgentActivityState, number | null>;
 
 /**
- * Returns the highest-priority non-idle activity state present in a group,
- * or null when every session in the group is idle. Used to surface a
- * minimal aggregate indicator on a collapsed group header (M5) — without
- * it, a session waiting on input becomes invisible behind a header.
+ * Returns the highest-priority attention-worthy activity state present in
+ * a group, or null when none of its sessions are attention-worthy. Used
+ * to surface a minimal aggregate indicator on a collapsed group header
+ * (M5) — without it, a session waiting on input becomes invisible behind
+ * a header.
  */
 export function getGroupAggregateActivityState(
   sessions: SessionWithActivity[]
@@ -84,7 +99,7 @@ export function getGroupAggregateActivityState(
 
   for (const { activityState } of sessions) {
     const priority = ATTENTION_PRIORITY[activityState];
-    if (priority === undefined) continue; // idle (or any future non-attention state)
+    if (priority === null) continue;
     if (priority < bestPriority) {
       best = activityState;
       bestPriority = priority;

--- a/packages/client/src/components/sidebar/session-group-collapse-storage.ts
+++ b/packages/client/src/components/sidebar/session-group-collapse-storage.ts
@@ -1,0 +1,26 @@
+const GROUP_COLLAPSED_KEY_PREFIX = 'agent-console:sidebar-group-collapsed:';
+
+/**
+ * Per-group collapsed state, persisted following useSidebarState's exact
+ * pattern (agent-console:-prefixed key, try/catch around every localStorage
+ * access, default expanded). One localStorage key per group (keyed by M1's
+ * group key — repositoryId or the quick-sessions sentinel). Stale keys from
+ * deleted repositories may accumulate; this is an accepted trade-off (see
+ * the sidebar grouping acceptance criteria) — no pruning is implemented.
+ */
+export function getPersistedGroupCollapsed(groupKey: string): boolean {
+  try {
+    const stored = localStorage.getItem(`${GROUP_COLLAPSED_KEY_PREFIX}${groupKey}`);
+    return stored ? (JSON.parse(stored) as boolean) === true : false;
+  } catch {
+    return false;
+  }
+}
+
+export function persistGroupCollapsed(groupKey: string, collapsed: boolean): void {
+  try {
+    localStorage.setItem(`${GROUP_COLLAPSED_KEY_PREFIX}${groupKey}`, JSON.stringify(collapsed));
+  } catch {
+    // Ignore localStorage errors
+  }
+}


### PR DESCRIPTION
## Summary

Implements mode 1 (repository grouping) of the sidebar's grouping-mode frame, per the Acceptance Criteria in #1292.

- Sessions in `ActiveSessionsSidebar` are grouped by `repositoryId` (label `repositoryName`), with quick sessions in a dedicated "Quick sessions" group ordered last (R3).
- Grouping is a pure function (`groupSessionsByRepository` in `group-sessions-by-repository.ts`) that partitions the incoming `sessions` array without re-sorting within a group (M2). Group key/label disagreement within a `repositoryId` resolves to first-occurrence-wins (M1).
- 2+ groups render a collapsible header (button + count badge + chevron), mirroring the existing paused-section idiom (M4). Exactly one group total (including the quick group) renders flat with no header, keeping single-repository sidebars byte-identical to before (R6).
- The 48px collapsed sidebar always renders a flat icon list regardless of group count (R5).
- A collapsed group with at least one attention-worthy session shows a minimal aggregate `ActivityIndicator` dot on its header, so a session waiting on input never becomes invisible behind a collapsed header (M5). See "M5 activity-state mapping" below for the exact per-state decision — this went through an Architect ruling after a CodeRabbit review comment.
- Per-group collapse state persists to `localStorage` under `agent-console:sidebar-group-collapsed:<groupKey>`, following `useSidebarState`'s exact pattern (try/catch per access, default expanded) (M3).
- The three non-session blocks (creation tasks, deletion tasks, paused section) are untouched and remain outside the grouped region (R4).
- Task blocks / paused section / empty state (`sessions.length === 0`) are unmodified — grouping never wraps or swallows them.

### M5 activity-state mapping

`AgentActivityState` has 4 values. The AC's "(non-idle)" gloss is two-value shorthand for a four-value union; `ATTENTION_PRIORITY` in `group-sessions-by-repository.ts` now states the mapping exhaustively (`satisfies Record<AgentActivityState, number | null>`) rather than leaving it an open map that silently omits states:

| State | Drives the M5 dot? | Why |
|---|---|---|
| `asking` | Yes (highest priority) | Waiting for user input — the exact case M5 exists for. |
| `active` | Yes | Agent is working autonomously; still worth surfacing under a collapsed header. |
| `idle` | No | Nothing needs attention. |
| `unknown` | No | Transient initial state every worker passes through (see `worker.ts`); `useActiveSessionsWithActivity.ts` already excludes `unknown`-state sessions before `ActiveSessionsSidebar`'s `sessions` prop is populated, so this is currently unreachable at this function — kept explicit rather than silently inherited if that upstream filter ever changes. Treating it as attention-worthy would put a dot on every freshly-created session, which is the noise M5 exists to prevent, not cause. |

This was CodeRabbit's one actionable finding on this PR (inline comment on `group-sessions-by-repository.ts:87`, proposing to add `unknown` as attention-worthy). The literal AC text ("non-idle") supports either reading, so I consulted the Architect directly rather than resolve it unilaterally — full ruling and reasoning is in the [CodeRabbit thread reply](https://github.com/ms2sato/agent-console/pull/1296#discussion_r3772158395). Ruling: `unknown` stays excluded (intent-based reading); the fix was making the mapping exhaustive/explicit rather than changing its behavior.

## Scope

Client-only, per M6: `repositoryId` / `repositoryName` / `type` are already on the wire (`WorktreeSession` / `QuickSession` in `packages/shared/src/types/session.ts`). No server change, no schema change.

**`pre-pr-completeness.md` Q10 is N/A** — nothing new crosses the server/client wire in this PR; the fields consumed by grouping already exist on `Session`.

## Test classification

Per `testing.md`'s test-category table:

**New-mechanism contract** (must fail against the flat implementation — verified: reverted the grouping branch in the component and confirmed these fail):
- All `group-sessions-by-repository.test.ts` cases (empty/single/one-repo-many/multi-repo/quick-only/mixed/M1 first-occurrence-wins/R7 filter-then-group).
- `getGroupAggregateActivityState` cases, including the 2 tests locking the `unknown`-exclusion contract (unknown-only group → no indicator; unknown+active mix → active still wins, unknown ignored) added after the Architect ruling above.
- `ActiveSessionsSidebar.test.tsx` "Repository grouping" describe block: headers-per-group-with-counts, collapse-hides-items, persistence write-on-toggle + restore-on-mount, R6 single-group degradation, R5 collapsed-sidebar flat render, R7 composition (header disappears once a repo's sessions are filtered out upstream), M5 indicator (shown when collapsed + non-idle, absent when idle-only or expanded), quick-group ordering.

**Invariant-preservation** (both-worlds-pass is correct; each still guards against a specific plausible wrong implementation):
- "the paused section still renders below the grouped session list" — guards against a wrong implementation that folds the paused section into the grouped region (e.g. computing groups from `[...sessions, ...pausedSessions]`) instead of keeping grouping scoped to the active `sessions` list only (R4).
- ""No active sessions" still renders when the session list is empty, unaffected by grouping" — guards against a wrong implementation that lets an empty `sessionGroups` array (or a stray always-rendered header container) leak an empty state into the DOM even with zero sessions.
- All pre-existing tests in `ActiveSessionsSidebar.test.tsx` (task blocks, filter toggle, activity indicators, orphaned sessions, restart-all, etc.) — unmodified, continue to pass, and regression-guard against grouping accidentally changing behavior in those unrelated code paths.

## Verification

- `bun run typecheck` — passes (all packages).
- `bun run test` — full suite green (client 2146/2146, server 3821/3821 + 1 skip, shared 606/606, integration 75/75, embedded-agent 295/295, scripts 528/528).
- `node .claude/skills/orchestrator/preflight-check.js` — clean (coverage covered, no rule/skill duplication, language check clean, no new Issue/PR blame-shift references). The "no integration test changes" advisory is expected per the Q10 N/A note above.
- Manual local CodeRabbit CLI review could not complete (headless browser-auth login times out in this sandboxed environment — a known limitation, not specific to this PR); relying on the GitHub-side CodeRabbit bot review on this PR. The bot's single actionable finding was addressed (see "M5 activity-state mapping" above) and replied to in-thread with the Architect's ruling.

### Browser QA (true-path, per workflow.md)

Verified against a disposable dev instance (`AGENT_CONSOLE_HOME` under `/tmp`, custom ports) seeded with two registered repositories (`Hello-World`, `test_guardian`) plus a quick session, so the true grouped-state path was exercised end-to-end (not the default/hidden state):

1. **Multi-repo groups + quick group**: `HELLO-WORLD` (2), `TEST_GUARDIAN` (1), `QUICK SESSIONS` (1) — headers, counts, chevrons all rendering per M4.
2. **M5 collapsed-group indicator**: sent a real message to a Hello-World session, disabled auto-mode to get a permission prompt (`asking` activity state), collapsed the `HELLO-WORLD` group — a yellow "Activity: asking" dot renders on the header.
3. **Persistence across reload**: reloaded the page — the collapsed `HELLO-WORLD` group (and its M5 indicator) survived.
4. **48px collapsed sidebar**: flat icon list, no group headers, all 4 session icons visible including the asking-state dot leading the list (R5).
5. **Single-group degradation**: removed the `test_guardian` and quick sessions, leaving only Hello-World's 2 sessions — sidebar renders flat with no header (R6).

All throwaway repositories/worktrees/branches and the temp dev instance were cleaned up after QA; no state was left in the shared source-repos tree.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (full suite)
- [x] `preflight-check.js`
- [x] Browser QA true-path screenshots (5 states above)
- [x] CI green
- [x] CodeRabbit review addressed (1 actionable finding, resolved via Architect ruling + in-thread reply)

Closes #1292

## Merge disposition note (2026-08-13)

**CR state**: genuine walkthrough on `0b06c337` produced 1 actionable finding (M5 `unknown` handling), addressed and withdrawn by the bot in-thread. Fix commit `440c5af9` carries commit-status `Review rate limited` (03:24:17Z) — no bot review of the fix diff. Local CLI unavailable throughout this PR: `coderabbit review --agent --base main` hit a headless browser-auth timeout (`automatic_login_failed` / `authentication_failed`), a structural sandbox limitation, not a rate-limit. inline: 1 (resolved), reviewDecision: empty.

**Fallback disposition applied** (`coderabbit-ops` skill, headless-auth-unavailable + bot rate-limited on the same commit): architect independent audit of the uncovered fix diff (`group-sessions-by-repository.ts` + its test file, ~30 lines) + Orchestrator acceptance = dual-clean gate. Merge authority unchanged — this is a logic change, so it remains owner-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions are now grouped by repository in the sidebar.
  * Groups display session counts and activity indicators.
  * Groups can be collapsed or expanded, with preferences preserved between visits.
  * Quick sessions appear in a dedicated group.
  * The sidebar retains a flat layout when collapsed or when grouping is unnecessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->