### PR TITLE
fix: require parentSessionId/parentWorkerId for delegate_to_worktree

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -238,6 +238,11 @@ Database field identifying the authenticated user who actually created the sessi
 - **Contrast:** [created_by](#created_by)  
 - **See:** [Schema notes in shared-orchestrator-session.md](design/shared-orchestrator-session.md#schema-notes)
 
+### Delegation Parent — `parentSessionId`, `parentWorkerId`
+The ownership-inheritance chain for a session created via `delegate_to_worktree`: `parentSessionId` and `parentWorkerId` identify the calling session and worker, and are required as of Issue [#1293](https://github.com/ms2sato/agent-console/issues/1293) (previously optional, documented only as a reporting convenience so the delegated agent could call back via `send_session_message`). The parent session's [created_by](#created_by) is inherited as the delegated session's own `created_by` — this is what makes the pair identity-determining rather than a courtesy: a `parentSessionId` that does not resolve to any session, or one that resolves but has no `created_by` (an ownerless/legacy parent), is a hard error at delegation time, because neither can produce a working `created_by` → [requestUsername](#requestusername) chain for the child. `parentWorkerId` is separately resolved against the PARENT session's own workers (never a global lookup) and must name one capable of receiving `send_session_message`.
+- **Contrast:** the verified MCP caller identity ([MCP Caller Token](#mcp-caller-token)'s `userId`) is never the source of `created_by` — it authorizes (`checkCallerOwnsSession`: may this caller act on the claimed session?), the parent session determines ownership. These are deliberately separate questions.
+- **See:** [created_by](#created_by), [requestUsername](#requestusername), [MCP Caller Token](#mcp-caller-token); Issue [#1293](https://github.com/ms2sato/agent-console/issues/1293)
+
 ### Service User
 The dedicated OS account (typically `agentconsole`) that runs the server process.
 - **Aliases:** Server service user, agentconsole service user, server process user

--- a/packages/server/src/mcp/__tests__/delegate-embedded-agent-activation.test.ts
+++ b/packages/server/src/mcp/__tests__/delegate-embedded-agent-activation.test.ts
@@ -398,9 +398,16 @@ describe('delegate_to_worktree: embedded-agent auto-activation (Issue #1260 PR-1
     expect(fake.captured.length).toBe(0);
   });
 
-  it('activation failure (missing session.createdBy, marker-classified) fails the tool call verbatim; worktree/session persist (no rollback)', async () => {
+  it('parentSessionId is schema-required, closing the route that used to reach the "no createdBy" activation failure (Issue #1293)', async () => {
     const embeddedAgentId = await createEmbeddedAgentDef();
 
+    // Before Issue #1293, omitting parentSessionId let a session get created
+    // with createdBy left undefined, and the mint step in
+    // EmbeddedAgentWorkerService.runActivation threw
+    // EmbeddedAgentActivationError('...has no createdBy...') (marker) --
+    // AFTER the worktree/session already existed. parentSessionId is now
+    // schema-required, so this route is closed before the handler runs at
+    // all: no worktree, no session, no spawn attempt.
     const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
       repositoryId: TEST_REPO_ID,
       prompt: 'Do the thing',
@@ -408,19 +415,18 @@ describe('delegate_to_worktree: embedded-agent auto-activation (Issue #1260 PR-1
       baseBranch: 'main',
       useRemote: false,
       agentId: embeddedAgentId,
-      // No parentSessionId -> session.createdBy stays undefined -> the mint
-      // step in EmbeddedAgentWorkerService.runActivation throws
-      // EmbeddedAgentActivationError('...has no createdBy...') (marker).
     }, nextId++);
 
-    expect(response.result?.isError).toBe(true);
-    const data = parseToolResult(response) as { error: string };
-    expect(data.error).toContain('has no createdBy');
+    if (response.error) {
+      expect(response.error).toBeDefined();
+    } else {
+      expect(response.result?.isError).toBe(true);
+    }
     expect(fake.captured.length).toBe(0); // never reached the spawn step
 
-    expect(sessionManager.getAllSessions().length).toBe(1);
+    expect(sessionManager.getAllSessions().length).toBe(0);
     const worktrees = await worktreeService.listWorktrees(TEST_REPO_PATH, TEST_REPO_ID);
-    expect(worktrees.length).toBe(1);
+    expect(worktrees.length).toBe(0);
   });
 
   it('activation failure (spawn throws, non-marker) fails the tool call with the generic message, not the raw error', async () => {
@@ -450,9 +456,9 @@ describe('delegate_to_worktree: embedded-agent auto-activation (Issue #1260 PR-1
     expect(data.error).not.toContain('ENOENT');
     expect(data.error).toContain('Embedded-agent activation failed');
 
-    // Unlike the "missing createdBy" test above (no parentSessionId, so only
-    // the delegated session exists), this test creates a parent session
-    // (bob's) in addition to the delegated session -- 2 total.
+    // Unlike the "no createdBy" test above (which now rejects before any
+    // session is created), this test creates a parent session (bob's) in
+    // addition to the delegated session -- 2 total.
     expect(sessionManager.getAllSessions().length).toBe(2);
   });
 

--- a/packages/server/src/mcp/__tests__/delegate-embedded-agent-activation.test.ts
+++ b/packages/server/src/mcp/__tests__/delegate-embedded-agent-activation.test.ts
@@ -338,7 +338,7 @@ describe('delegate_to_worktree: embedded-agent auto-activation (Issue #1260 PR-1
       // by `agentDirectory.resolve()`.
       agentId: embeddedAgentId,
       parentSessionId: parentSession.id,
-      parentWorkerId: 'parent-worker-id',
+      parentWorkerId: parentSession.workers.find((w) => w.type === 'agent' || w.type === 'embedded-agent')!.id,
       skipMessageCallbackPrompt: true,
     }, nextId++);
 
@@ -447,7 +447,7 @@ describe('delegate_to_worktree: embedded-agent auto-activation (Issue #1260 PR-1
       useRemote: false,
       agentId: embeddedAgentId,
       parentSessionId: parentSession.id,
-      parentWorkerId: 'parent-worker-id',
+      parentWorkerId: parentSession.workers.find((w) => w.type === 'agent' || w.type === 'embedded-agent')!.id,
       skipMessageCallbackPrompt: true,
     }, nextId++);
 
@@ -477,7 +477,7 @@ describe('delegate_to_worktree: embedded-agent auto-activation (Issue #1260 PR-1
       useRemote: false,
       agentId: CLAUDE_CODE_AGENT_ID,
       parentSessionId: parentSession.id,
-      parentWorkerId: 'parent-worker-id',
+      parentWorkerId: parentSession.workers.find((w) => w.type === 'agent' || w.type === 'embedded-agent')!.id,
       skipMessageCallbackPrompt: true,
     }, nextId++);
 

--- a/packages/server/src/mcp/__tests__/mcp-auth.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-auth.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
 import {
   McpTokenRegistry,
   resolveMcpAuthMode,
@@ -329,5 +331,59 @@ describe('checkCallerOwnsSession', () => {
       ctx,
     );
     expect(result?.error).toContain('identity mismatch');
+  });
+});
+
+/**
+ * Grep-based containment check for Issue #1293 R1/S4: `McpCallerIdentity`
+ * is consumed for authorization only (`checkCallerOwnsSession`); ownership
+ * (a session's `createdBy`) must always derive from the parent session,
+ * never from the caller's own identity. See `McpCallerIdentity`'s JSDoc in
+ * ../mcp-auth.ts for the full rationale. This scans production source for
+ * the regression shape a future PR could introduce: assigning
+ * `createdBy` directly from a `.userId` field (the caller identity's own
+ * field name).
+ */
+describe('McpCallerIdentity containment (Issue #1293 S4, grep-based)', () => {
+  const SERVER_SRC = path.resolve(__dirname, '../..');
+
+  function walkFiles(dir: string, acc: string[] = []): string[] {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return acc;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__') continue;
+        if (entry.name === 'node_modules') continue;
+        walkFiles(fullPath, acc);
+      } else if (entry.isFile() && /\.ts$/.test(entry.name)) {
+        acc.push(fullPath);
+      }
+    }
+    return acc;
+  }
+
+  it('no production file derives a session createdBy from an MCP caller identity userId', () => {
+    const offenders: Array<{ file: string; line: number; text: string }> = [];
+    // Matches `createdBy: foo.userId` / `createdBy = foo.userId` -- the
+    // shape of assigning ownership from the caller identity's own field.
+    const pattern = /createdBy\s*[:=]\s*[\w.]*\.userId\b/;
+
+    for (const file of walkFiles(SERVER_SRC)) {
+      const content = fs.readFileSync(file, 'utf-8');
+      if (!pattern.test(content)) continue;
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (pattern.test(lines[i])) {
+          offenders.push({ file: path.relative(SERVER_SRC, file), line: i + 1, text: lines[i].trim() });
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -644,6 +644,25 @@ describe('MCP Server Tools', () => {
     await remountMcpApp();
   }
 
+  /**
+   * Create a real, owned parent session and return the ids `delegate_to_worktree`
+   * now requires (Issue #1293 S1/S3). `createdBy` only needs to be a
+   * non-empty string -- it does not need to resolve in `userRepository` --
+   * since S3(b) only rejects an UNSET `createdBy`, not an orphan UUID.
+   * Tests that specifically exercise parent-resolution edge cases (missing
+   * session, no createdBy, orphan UUID) create their own parent session
+   * inline instead of using this helper.
+   */
+  async function createValidDelegateParent(
+    createdBy = 'delegate-test-parent-user',
+  ): Promise<{ parentSessionId: string; parentWorkerId: string }> {
+    const parent = await sessionManager.createSession(
+      { type: 'quick', locationPath: TEST_REPO_PATH },
+      { createdBy },
+    );
+    return { parentSessionId: parent.id, parentWorkerId: 'parent-worker-id' };
+  }
+
   afterEach(async () => {
     // Issue #1260 PR-1: deactivate any embedded-agent worker `delegate_to_worktree`
     // activated during the test (mirrors routes-embedded-agent.test.ts's afterEach)
@@ -2086,6 +2105,7 @@ describe('MCP Server Tools', () => {
       const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
         repositoryId: 'non-existent-repo',
         prompt: 'Implement feature X',
+        ...(await createValidDelegateParent()),
       }, nextId++);
       const data = parseToolResult(response) as { error: string };
 
@@ -2111,6 +2131,7 @@ describe('MCP Server Tools', () => {
         repositoryId: 'test-repo',
         prompt: 'Do something',
         agentId: 'non-existent-agent',
+        ...(await createValidDelegateParent()),
       }, nextId++);
       const data = parseToolResult(response) as { error: string };
 
@@ -2126,6 +2147,7 @@ describe('MCP Server Tools', () => {
         repositoryId: 'test-repo',
         prompt: 'Implement feature X',
         branch: 'feat/my-feature',
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2182,6 +2204,7 @@ describe('MCP Server Tools', () => {
         repositoryId: 'test-repo',
         prompt: 'Implement automatic branch generation',
         // branch is intentionally omitted
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2205,6 +2228,7 @@ describe('MCP Server Tools', () => {
         repositoryId: 'test-repo',
         prompt: 'Do some work',
         branch: 'my-explicit-branch',
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2225,6 +2249,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Add dark mode support',
         branch: 'feat/titled-task',
         title: 'Dark Mode Feature',
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2250,13 +2275,15 @@ describe('MCP Server Tools', () => {
         prompt: 'Work on remote-based feature',
         branch: 'feat/remote-branch',
         // useRemote is intentionally omitted — should default to true
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
 
       // Verify fetchRemote was called (the baseBranch defaults to 'main').
-      // The 3rd arg is `requestUsername` — null here because no parent
-      // session context is provided in this test (Issue #912).
+      // The 3rd arg is `requestUsername` — null here because the parent
+      // session created by createValidDelegateParent() has a createdBy
+      // that does not resolve in userRepository (Issue #912 / #1293).
       expect(mockGit.fetchRemote).toHaveBeenCalledWith('main', TEST_REPO_PATH, null);
     });
 
@@ -2268,6 +2295,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Work on local-only feature',
         branch: 'feat/local-branch',
         useRemote: false,
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2306,6 +2334,7 @@ describe('MCP Server Tools', () => {
         repositoryId: 'test-repo',
         prompt: 'Try to create duplicate worktree',
         branch: 'existing-branch',
+        ...(await createValidDelegateParent()),
       }, nextId++);
       const data = parseToolResult(response) as { error: string };
 
@@ -2344,6 +2373,7 @@ describe('MCP Server Tools', () => {
         repositoryId: 'test-repo',
         prompt: 'Test orphaned worktree lookup via DB',
         branch: 'feat/ghost-worktree',
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2359,6 +2389,13 @@ describe('MCP Server Tools', () => {
     it('should rollback worktree when session is deleted before delegation completes', async () => {
       await setupDelegateEnvironment('feat/deleted-session');
 
+      // Create the valid parent session BEFORE installing the createSession
+      // override below -- otherwise the override would also delete the
+      // parent session created by createValidDelegateParent(), and the
+      // delegate call would fail at the S3(a) parent-lookup check instead
+      // of reaching the race condition this test actually exercises.
+      const parent = await createValidDelegateParent();
+
       // Intercept createSession: after it creates the session, immediately delete it
       // to simulate a concurrent deletion race condition
       const originalCreateSession = sessionManager.createSession.bind(sessionManager);
@@ -2373,6 +2410,7 @@ describe('MCP Server Tools', () => {
         repositoryId: 'test-repo',
         prompt: 'Test session deleted during delegation',
         branch: 'feat/deleted-session',
+        ...parent,
       }, nextId++);
       const data = parseToolResult(response) as { error: string };
 
@@ -2403,6 +2441,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test repo default agent selection',
         branch: 'feat/repo-default',
         // agentId is intentionally omitted
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2418,6 +2457,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test fallback to claude-code-builtin',
         branch: 'feat/no-default',
         // agentId is intentionally omitted
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       // Success proves claude-code-builtin was used (the only registered agent)
@@ -2446,6 +2486,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test explicit agentId overrides repo default',
         branch: 'feat/explicit-override',
         agentId: explicitAgent.id,
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2473,6 +2514,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test deleted default agent',
         branch: 'feat/deleted-default',
         // agentId is intentionally omitted so the stale defaultAgentId is used
+        ...(await createValidDelegateParent()),
       }, nextId++);
       const data = parseToolResult(response) as { error: string };
 
@@ -2497,6 +2539,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test agentName resolution',
         branch: 'feat/agent-name-test',
         agentName: 'My Custom Agent',
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2511,6 +2554,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test non-existent agentName',
         branch: 'feat/no-match',
         agentName: 'Non-Existent Agent',
+        ...(await createValidDelegateParent()),
       }, nextId++);
       const data = parseToolResult(response) as { error: string };
 
@@ -2535,6 +2579,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test ambiguous agentName',
         branch: 'feat/ambiguous',
         agentName: 'Ambiguous Agent',
+        ...(await createValidDelegateParent()),
       }, nextId++);
       const data = parseToolResult(response) as { error: string };
 
@@ -2561,6 +2606,7 @@ describe('MCP Server Tools', () => {
         branch: 'feat/both-params',
         agentId: agentById.id,
         agentName: 'Agent By Name',
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2670,6 +2716,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test cross-registry ambiguous agentName',
         branch: 'feat/cross-registry-ambiguous',
         agentName: sharedName,
+        ...(await createValidDelegateParent()),
       }, nextId++);
       const data = parseToolResult(response) as { error: string };
 
@@ -2723,12 +2770,13 @@ describe('MCP Server Tools', () => {
     it('should append callback instructions to prompt when parent IDs are provided', async () => {
       await setupDelegateEnvironment('feat/callback-test');
 
+      const parent = await createValidDelegateParent();
 
       const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
         repositoryId: 'test-repo',
         prompt: 'Implement callback feature',
         branch: 'feat/callback-test',
-        parentSessionId: 'caller-session-123',
+        parentSessionId: parent.parentSessionId,
         parentWorkerId: 'caller-worker-456',
       }, nextId++);
 
@@ -2739,7 +2787,7 @@ describe('MCP Server Tools', () => {
 
       // Should contain both the original prompt and callback instructions
       expect(agentPrompt).toContain('Implement callback feature');
-      expect(agentPrompt).toContain('toSessionId: "caller-session-123"');
+      expect(agentPrompt).toContain(`toSessionId: "${parent.parentSessionId}"`);
       expect(agentPrompt).toContain('toWorkerId: "caller-worker-456"');
       expect(agentPrompt).toContain('[Message Callback Instructions]');
 
@@ -2779,12 +2827,13 @@ describe('MCP Server Tools', () => {
     it('should NOT append callback instructions when skipMessageCallbackPrompt is true', async () => {
       await setupDelegateEnvironment('feat/skip-callback');
 
+      const parent = await createValidDelegateParent();
 
       const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
         repositoryId: 'test-repo',
         prompt: 'Implement feature without callback',
         branch: 'feat/skip-callback',
-        parentSessionId: 'caller-session-123',
+        parentSessionId: parent.parentSessionId,
         parentWorkerId: 'caller-worker-456',
         skipMessageCallbackPrompt: true,
       }, nextId++);
@@ -2800,7 +2849,18 @@ describe('MCP Server Tools', () => {
       expect(agentPrompt).not.toContain('toWorkerId');
     });
 
-    it('should return validation error when only parentSessionId is provided', async () => {
+    // -----------------------------------------------------------------------
+    // Issue #1293 T1: parentSessionId/parentWorkerId are now schema-required
+    // (S1), and the old runtime XOR guard is deleted (S2) -- an invalid
+    // combination is unrepresentable at the schema layer instead of being
+    // caught by a handler-level check. These three tests replace the old
+    // "returns a custom XOR error" / "silently succeeds without parent IDs"
+    // tests, whose premises (reaching the handler with a partial or absent
+    // pair) are no longer reachable. Mirrors the dual-branch assertion the
+    // pre-existing "without repositoryId" schema test above uses, since the
+    // MCP SDK may surface a required-field violation as a JSON-RPC-level
+    // error or as a tool-result isError depending on transport specifics.
+    it('should reject the call when only parentSessionId is provided (parentWorkerId missing) -- schema-required (Issue #1293 T1)', async () => {
       await setupDelegateEnvironment('feat/partial-caller');
 
       const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
@@ -2808,49 +2868,49 @@ describe('MCP Server Tools', () => {
         prompt: 'Test partial parent IDs',
         branch: 'feat/partial-caller',
         parentSessionId: 'caller-session-123',
-        // parentWorkerId is intentionally omitted
+        // parentWorkerId is intentionally omitted -- now a schema violation
       }, nextId++);
 
-      expect(response.result?.isError).toBe(true);
-      const data = parseToolResult(response) as { error: string };
-      expect(data.error).toContain('parentSessionId and parentWorkerId must be provided together');
+      if (response.error) {
+        expect(response.error).toBeDefined();
+      } else {
+        expect(response.result?.isError).toBe(true);
+      }
     });
 
-    it('should return validation error when only parentWorkerId is provided', async () => {
+    it('should reject the call when only parentWorkerId is provided (parentSessionId missing) -- schema-required (Issue #1293 T1)', async () => {
       await setupDelegateEnvironment('feat/partial-worker');
 
       const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
         repositoryId: 'test-repo',
         prompt: 'Test partial parent IDs',
         branch: 'feat/partial-worker',
-        // parentSessionId is intentionally omitted
+        // parentSessionId is intentionally omitted -- now a schema violation
         parentWorkerId: 'caller-worker-456',
       }, nextId++);
 
-      expect(response.result?.isError).toBe(true);
-      const data = parseToolResult(response) as { error: string };
-      expect(data.error).toContain('parentSessionId and parentWorkerId must be provided together');
+      if (response.error) {
+        expect(response.error).toBeDefined();
+      } else {
+        expect(response.result?.isError).toBe(true);
+      }
     });
 
-    it('should NOT include callback instructions when parent IDs are not provided', async () => {
+    it('should reject the call when both parentSessionId and parentWorkerId are omitted -- schema-required (Issue #1293 T1)', async () => {
       await setupDelegateEnvironment('feat/no-caller');
-
 
       const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
         repositoryId: 'test-repo',
         prompt: 'Normal delegation without caller IDs',
         branch: 'feat/no-caller',
+        // parentSessionId and parentWorkerId are both intentionally omitted
       }, nextId++);
 
-      expect(response.result?.isError).toBeUndefined();
-
-      const data = parseToolResult(response) as { sessionId: string };
-      const agentPrompt = getAgentPromptForSession(data.sessionId);
-
-      expect(agentPrompt).toContain('Normal delegation without caller IDs');
-      expect(agentPrompt).not.toContain('[Message Callback Instructions]');
-      expect(agentPrompt).not.toContain('toSessionId');
-      expect(agentPrompt).not.toContain('toWorkerId');
+      if (response.error) {
+        expect(response.error).toBeDefined();
+      } else {
+        expect(response.result?.isError).toBe(true);
+      }
     });
 
     it('should inherit createdBy from parent session', async () => {
@@ -2882,6 +2942,30 @@ describe('MCP Server Tools', () => {
       expect(childSession!.createdBy).toBe('parent-user-abc');
     });
 
+    it('errors (S3a) naming the id when parentSessionId does not resolve to any session (Issue #1293 T2)', async () => {
+      await setupDelegateEnvironment('feat/stale-parent');
+
+      const createWorktreeSpy = jest.spyOn(worktreeService, 'createWorktree');
+
+      // Before Issue #1293, a stale/fabricated parentSessionId silently
+      // degraded to a null-owned, dead-agent session -- the incident this
+      // Issue closes. It must now error naming the id, with zero worktree
+      // side effect (the check runs before createWorktree is reached).
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test stale parentSessionId',
+        branch: 'feat/stale-parent',
+        parentSessionId: 'fabricated-parent-session-id',
+        parentWorkerId: 'parent-worker-id',
+      }, nextId++);
+
+      expect(response.result?.isError).toBe(true);
+      const data = parseToolResult(response) as { error: string };
+      expect(data.error).toContain('fabricated-parent-session-id');
+      expect(data.error).toContain('Parent session not found');
+      expect(createWorktreeSpy).not.toHaveBeenCalled();
+    });
+
     // -------------------------------------------------------------------------
     // Issue #844: OS username plumbing through delegate_to_worktree
     // -------------------------------------------------------------------------
@@ -2895,9 +2979,13 @@ describe('MCP Server Tools', () => {
     // The tests below spy on `worktreeService.createWorktree` to capture the
     // exact `requestUsername` argument the MCP path passes through, covering:
     //   1. Resolved username path (parent user exists in userRepository)
-    //   2. No parentSessionId -> null
-    //   3. Parent exists but createdBy is null/undefined -> null
-    //   4. Parent createdBy is a UUID that does not resolve -> null
+    //   2. Parent exists but createdBy is null/undefined -> S3(b) error (Issue #1293)
+    //   3. Parent createdBy is a UUID that does not resolve -> null
+    //
+    // A fourth case existed here previously ("no parentSessionId -> null");
+    // it is now unreachable (parentSessionId is schema-required, Issue #1293
+    // S1) and is covered instead by the "Issue #1293 T1" schema-rejection
+    // tests above.
     describe('Issue #844: OS username plumbing', () => {
       /**
        * Spy on `worktreeService.createWorktree` and return the spy so tests
@@ -2941,30 +3029,14 @@ describe('MCP Server Tools', () => {
         expect(callArgs[4]).toBe('alice');
       });
 
-      it('passes null requestUsername when delegate_to_worktree is called without parentSessionId', async () => {
-        await setupDelegateEnvironment('feat/no-parent-username');
-
-        const createWorktreeSpy = spyCreateWorktree();
-
-        const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
-          repositoryId: 'test-repo',
-          prompt: 'Direct delegation with no parent context',
-          branch: 'feat/no-parent-username',
-          // parentSessionId intentionally omitted
-        }, nextId++);
-
-        expect(response.result?.isError).toBeUndefined();
-
-        expect(createWorktreeSpy).toHaveBeenCalledTimes(1);
-        const callArgs = createWorktreeSpy.mock.calls[0] as unknown[];
-        expect(callArgs[4]).toBeNull();
-      });
-
-      it('passes null requestUsername when parent session has no createdBy (legacy)', async () => {
+      it('errors (S3b) instead of resolving requestUsername when parent session has no createdBy (legacy)', async () => {
         await setupDelegateEnvironment('feat/legacy-parent');
 
         // Create a parent session WITHOUT createdBy - legacy / pre-multi-user
-        // sessions saved before `sessions.created_by` was populated.
+        // sessions saved before `sessions.created_by` was populated. Before
+        // Issue #1293, this silently produced a null requestUsername and a
+        // dead, ownerless delegated session (the incident this Issue
+        // closes); now it must error before ever reaching createWorktree.
         const parentSession = await sessionManager.createSession({
           type: 'quick',
           locationPath: TEST_REPO_PATH,
@@ -2980,11 +3052,12 @@ describe('MCP Server Tools', () => {
           parentWorkerId: 'parent-worker-id',
         }, nextId++);
 
-        expect(response.result?.isError).toBeUndefined();
+        expect(response.result?.isError).toBe(true);
+        const data = parseToolResult(response) as { error: string };
+        expect(data.error).toContain(parentSession.id);
+        expect(data.error).toContain('no createdBy');
 
-        expect(createWorktreeSpy).toHaveBeenCalledTimes(1);
-        const callArgs = createWorktreeSpy.mock.calls[0] as unknown[];
-        expect(callArgs[4]).toBeNull();
+        expect(createWorktreeSpy).not.toHaveBeenCalled();
       });
 
       it('passes null requestUsername when parent createdBy UUID does not resolve to a user', async () => {
@@ -3065,32 +3138,12 @@ describe('MCP Server Tools', () => {
         expect(context?.sshAuthSockFallback).toBe('/home/alice918/.1password/agent.sock');
       });
 
-      it('does NOT populate sshAuthSockFallback when parentSessionId is omitted', async () => {
-        await setupDelegateEnvironment('feat/ssh-no-parent');
-
-        const spy = spyCreateSession();
-
-        const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
-          repositoryId: 'test-repo',
-          prompt: 'Direct delegation with no parent context',
-          branch: 'feat/ssh-no-parent',
-        }, nextId++);
-
-        expect(response.result?.isError).toBeUndefined();
-
-        // Assert the spy was actually invoked before reading the captured
-        // arg, so an accidental refactor that no longer goes through
-        // createSession does not silently vacuous-pass this negative test.
-        expect(spy).toHaveBeenCalled();
-        const lastCall = spy.mock.calls[spy.mock.calls.length - 1] as unknown[];
-        const context = lastCall[1] as { sshAuthSockFallback?: string } | undefined;
-        expect(context?.sshAuthSockFallback).toBeUndefined();
-      });
-
-      it('does NOT populate sshAuthSockFallback when parent has no createdBy (legacy session)', async () => {
+      it('errors (S3b) instead of creating a session when parent has no createdBy (legacy session)', async () => {
         await setupDelegateEnvironment('feat/ssh-legacy');
 
-        // Legacy parent: no createdBy.
+        // Legacy parent: no createdBy. Before Issue #1293 this proceeded
+        // with sshAuthSockFallback left undefined; now S3(b) rejects the
+        // call before createSession is ever reached.
         const parentSession = await sessionManager.createSession({
           type: 'quick',
           locationPath: TEST_REPO_PATH,
@@ -3106,12 +3159,8 @@ describe('MCP Server Tools', () => {
           parentWorkerId: 'parent-worker-id',
         }, nextId++);
 
-        expect(response.result?.isError).toBeUndefined();
-
-        expect(spy).toHaveBeenCalled();
-        const lastCall = spy.mock.calls[spy.mock.calls.length - 1] as unknown[];
-        const context = lastCall[1] as { sshAuthSockFallback?: string } | undefined;
-        expect(context?.sshAuthSockFallback).toBeUndefined();
+        expect(response.result?.isError).toBe(true);
+        expect(spy).not.toHaveBeenCalled();
       });
 
       it('does NOT populate sshAuthSockFallback when parent createdBy UUID does not resolve', async () => {
@@ -3153,10 +3202,13 @@ describe('MCP Server Tools', () => {
     // `task-<timestamp>` branch names). The tests below assert the argument
     // shape `suggestSessionMetadata` is called with, covering:
     //   1. Resolved username -> passed through; LLM-suggested branch is used.
-    //   2. No parentSessionId -> requestUser is null; LLM suggestion still
-    //      succeeds via the default mock and the suggested branch is used.
-    //   3. Orphan parent createdBy -> requestUser is null; suggestion failure
+    //   2. Orphan parent createdBy -> requestUser is null; suggestion failure
     //      falls back to `task-<timestamp>`.
+    //
+    // A third case existed here previously ("no parentSessionId -> requestUser
+    // is null"); it is now unreachable (parentSessionId is schema-required,
+    // Issue #1293 S1) and is covered instead by the "Issue #1293 T1"
+    // schema-rejection tests in the delegate_to_worktree block above.
     describe('Issue #876: suggestSessionMetadata receives resolved OS username', () => {
       // Read the captured `requestUser` argument from the first
       // suggestion call (typed via the top-of-file mock parameter).
@@ -3201,25 +3253,6 @@ describe('MCP Server Tools', () => {
 
         const data = parseToolResult(response) as { branch: string };
         expect(data.branch).toBe('fix/diff-worker-elevation');
-      });
-
-      it('passes null requestUser to suggestSessionMetadata when delegate_to_worktree is called without parentSessionId', async () => {
-        // Default mockSuggestSessionMetadata returns 'feat/auto-generated-branch';
-        // no need to override.
-        await setupDelegateEnvironment('feat/auto-generated-branch');
-
-        const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
-          repositoryId: 'test-repo',
-          prompt: 'Direct delegation with no parent context',
-          // branch and parentSessionId both intentionally omitted
-        }, nextId++);
-
-        expect(response.result?.isError).toBeUndefined();
-
-        expect(readSuggestRequestUser()).toBeNull();
-
-        const data = parseToolResult(response) as { branch: string };
-        expect(data.branch).toBe('feat/auto-generated-branch');
       });
 
       it('passes null requestUser to suggestSessionMetadata when parent createdBy UUID does not resolve to a user', async () => {
@@ -3271,6 +3304,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test with template variables',
         branch: 'feat/template-vars',
         templateVars: { model: 'gpt-4' },
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -3381,12 +3415,13 @@ describe('MCP Server Tools', () => {
     it('should persist parentSessionId and parentWorkerId when delegate_to_worktree is called with them', async () => {
       await setupParentMetadataEnvironment('feat/persist-parent');
 
+      const parent = await createValidDelegateParent();
 
       const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
         repositoryId: 'test-repo',
         prompt: 'Test parent metadata persistence',
         branch: 'feat/persist-parent',
-        parentSessionId: 'parent-sess-abc',
+        parentSessionId: parent.parentSessionId,
         parentWorkerId: 'parent-wkr-xyz',
       }, nextId++);
 
@@ -3403,19 +3438,20 @@ describe('MCP Server Tools', () => {
         parentWorkerId?: string;
       };
 
-      expect(statusData.parentSessionId).toBe('parent-sess-abc');
+      expect(statusData.parentSessionId).toBe(parent.parentSessionId);
       expect(statusData.parentWorkerId).toBe('parent-wkr-xyz');
     });
 
     it('should return parentSessionId and parentWorkerId in list_sessions response', async () => {
       await setupParentMetadataEnvironment('feat/list-parent');
 
+      const parent = await createValidDelegateParent();
 
       const delegateResponse = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
         repositoryId: 'test-repo',
         prompt: 'Test parent metadata in list_sessions',
         branch: 'feat/list-parent',
-        parentSessionId: 'parent-sess-list',
+        parentSessionId: parent.parentSessionId,
         parentWorkerId: 'parent-wkr-list',
       }, nextId++);
 
@@ -3435,35 +3471,14 @@ describe('MCP Server Tools', () => {
 
       const delegatedSession = listData.sessions.find((s) => s.id === delegateData.sessionId);
       expect(delegatedSession).toBeDefined();
-      expect(delegatedSession!.parentSessionId).toBe('parent-sess-list');
+      expect(delegatedSession!.parentSessionId).toBe(parent.parentSessionId);
       expect(delegatedSession!.parentWorkerId).toBe('parent-wkr-list');
     });
 
-    it('should not include parentSessionId/parentWorkerId when not provided', async () => {
-      await setupParentMetadataEnvironment('feat/no-parent-meta');
-
-
-      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
-        repositoryId: 'test-repo',
-        prompt: 'Delegate without parent metadata',
-        branch: 'feat/no-parent-meta',
-      }, nextId++);
-
-      expect(response.result?.isError).toBeUndefined();
-
-      const data = parseToolResult(response) as { sessionId: string };
-
-      const statusResponse = await callTool(app, mcpSessionId, 'get_session_status', {
-        sessionId: data.sessionId,
-      }, nextId++);
-      const statusData = parseToolResult(statusResponse) as {
-        parentSessionId?: string;
-        parentWorkerId?: string;
-      };
-
-      expect(statusData.parentSessionId).toBeUndefined();
-      expect(statusData.parentWorkerId).toBeUndefined();
-    });
+    // Issue #1293: a "not provided" variant existed here previously; it is
+    // now unreachable (parentSessionId/parentWorkerId are schema-required)
+    // and is covered instead by the "Issue #1293 T1" schema-rejection tests
+    // in the delegate_to_worktree block above.
   });
 
   // ===========================================================================
@@ -3524,6 +3539,7 @@ describe('MCP Server Tools', () => {
         repositoryId: 'test-repo',
         prompt: 'Test env var injection',
         branch: 'feat/env-test',
+        ...(await createValidDelegateParent()),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -3087,6 +3087,44 @@ describe('MCP Server Tools', () => {
       expect(data.sessionId).toBeDefined();
     });
 
+    // Invariant-preservation, NOT new-mechanism: this does not flip against
+    // pre-fix code (pre-fix had no parentWorkerId validation at all, so it
+    // passed then and passes now too). `canReceiveSessionMessages` already
+    // accepts `embedded-agent` by its own definition (worker.ts:47), so
+    // nothing here can fail today. Its job is prospective: it is the test
+    // that would fail if `canReceiveSessionMessages` were ever narrowed to
+    // agent-only, or if the S3b guard were rewritten to hardcode
+    // `type === 'agent'` instead of consuming the shared predicate --
+    // either mistake would break embedded-agent delegation silently while
+    // every OTHER test in this file (which all use an 'agent'-type parent
+    // worker) kept passing.
+    it('delegates successfully when parentWorkerId names an embedded-agent worker on the parent session (Issue #1293, canReceiveSessionMessages accept-side coverage)', async () => {
+      await setupDelegateEnvironment('feat/embedded-parent-worker');
+
+      const parentSession = await sessionManager.createSession(
+        { type: 'quick', locationPath: TEST_REPO_PATH },
+        { createdBy: 'parent-user-embedded-parent-worker' },
+      );
+      const embeddedParentWorker = await sessionManager.createWorker(parentSession.id, {
+        type: 'embedded-agent',
+        embeddedAgentId: TEST_EMBEDDED_AGENT_DEF.id,
+      });
+      expect(embeddedParentWorker).not.toBeNull();
+      expect(embeddedParentWorker!.type).toBe('embedded-agent');
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test embedded-agent parent worker delegation',
+        branch: 'feat/embedded-parent-worker',
+        parentSessionId: parentSession.id,
+        parentWorkerId: embeddedParentWorker!.id,
+      }, nextId++);
+
+      expect(response.result?.isError).toBeUndefined();
+      const data = parseToolResult(response) as { sessionId: string };
+      expect(data.sessionId).toBeDefined();
+    });
+
     // -------------------------------------------------------------------------
     // Issue #844: OS username plumbing through delegate_to_worktree
     // -------------------------------------------------------------------------

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -646,12 +646,16 @@ describe('MCP Server Tools', () => {
 
   /**
    * Create a real, owned parent session and return the ids `delegate_to_worktree`
-   * now requires (Issue #1293 S1/S3). `createdBy` only needs to be a
+   * now requires (Issue #1293 S1/S3/S3b). `createdBy` only needs to be a
    * non-empty string -- it does not need to resolve in `userRepository` --
    * since S3(b) only rejects an UNSET `createdBy`, not an orphan UUID.
-   * Tests that specifically exercise parent-resolution edge cases (missing
-   * session, no createdBy, orphan UUID) create their own parent session
-   * inline instead of using this helper.
+   * `parentWorkerId` must be the REAL id of an agent worker on the created
+   * session (S3b resolves it against `parentSession.workers` and requires
+   * `canReceiveSessionMessages`) -- a fabricated placeholder string is no
+   * longer accepted. Tests that specifically exercise parent-resolution
+   * edge cases (missing session, no createdBy, orphan UUID, missing/wrong
+   * worker) create their own parent session inline instead of using this
+   * helper.
    */
   async function createValidDelegateParent(
     createdBy = 'delegate-test-parent-user',
@@ -660,7 +664,25 @@ describe('MCP Server Tools', () => {
       { type: 'quick', locationPath: TEST_REPO_PATH },
       { createdBy },
     );
-    return { parentSessionId: parent.id, parentWorkerId: 'parent-worker-id' };
+    const agentWorker = parent.workers.find((w) => w.type === 'agent' || w.type === 'embedded-agent');
+    if (!agentWorker) {
+      throw new Error('createValidDelegateParent: created session has no agent worker');
+    }
+    return { parentSessionId: parent.id, parentWorkerId: agentWorker.id };
+  }
+
+  /**
+   * Find a real message-capable worker id on an already-created session
+   * (Issue #1293 S3b), for tests that construct their own parent session
+   * inline (e.g. to control `createdBy`) rather than using
+   * `createValidDelegateParent`.
+   */
+  function firstAgentWorkerId(session: Awaited<ReturnType<typeof sessionManager.createSession>>): string {
+    const worker = session.workers.find((w) => w.type === 'agent' || w.type === 'embedded-agent');
+    if (!worker) {
+      throw new Error('firstAgentWorkerId: session has no agent worker');
+    }
+    return worker.id;
   }
 
   afterEach(async () => {
@@ -2640,7 +2662,7 @@ describe('MCP Server Tools', () => {
         branch: 'feat/embedded-by-id',
         agentId: TEST_EMBEDDED_AGENT_DEF.id,
         parentSessionId: parentSession.id,
-        parentWorkerId: 'parent-worker-id',
+        parentWorkerId: firstAgentWorkerId(parentSession),
         skipMessageCallbackPrompt: true,
       }, nextId++);
 
@@ -2674,7 +2696,7 @@ describe('MCP Server Tools', () => {
         branch: 'feat/embedded-by-name',
         agentName: TEST_EMBEDDED_AGENT_DEF.name,
         parentSessionId: parentSession.id,
-        parentWorkerId: 'parent-worker-id',
+        parentWorkerId: firstAgentWorkerId(parentSession),
         skipMessageCallbackPrompt: true,
       }, nextId++);
 
@@ -2777,7 +2799,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Implement callback feature',
         branch: 'feat/callback-test',
         parentSessionId: parent.parentSessionId,
-        parentWorkerId: 'caller-worker-456',
+        parentWorkerId: parent.parentWorkerId,
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2788,7 +2810,7 @@ describe('MCP Server Tools', () => {
       // Should contain both the original prompt and callback instructions
       expect(agentPrompt).toContain('Implement callback feature');
       expect(agentPrompt).toContain(`toSessionId: "${parent.parentSessionId}"`);
-      expect(agentPrompt).toContain('toWorkerId: "caller-worker-456"');
+      expect(agentPrompt).toContain(`toWorkerId: "${parent.parentWorkerId}"`);
       expect(agentPrompt).toContain('[Message Callback Instructions]');
 
       // Verify structure includes separator and all required fields
@@ -2834,7 +2856,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Implement feature without callback',
         branch: 'feat/skip-callback',
         parentSessionId: parent.parentSessionId,
-        parentWorkerId: 'caller-worker-456',
+        parentWorkerId: parent.parentWorkerId,
         skipMessageCallbackPrompt: true,
       }, nextId++);
 
@@ -2940,7 +2962,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test createdBy inheritance',
         branch: 'feat/inherit-created-by',
         parentSessionId: parentSession.id,
-        parentWorkerId: 'dummy-worker-id',
+        parentWorkerId: firstAgentWorkerId(parentSession),
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -2975,6 +2997,94 @@ describe('MCP Server Tools', () => {
       expect(data.error).toContain('fabricated-parent-session-id');
       expect(data.error).toContain('Parent session not found');
       expect(createWorktreeSpy).not.toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------------
+    // Issue #1293 S3b (Architect ruling, bundled per CodeRabbit finding on
+    // PR #1302): parentWorkerId must resolve against the PARENT session's
+    // own workers (never a global lookup) and must name a worker capable of
+    // receiving send_session_message. Validation is UNCONDITIONAL --
+    // skipMessageCallbackPrompt does not exempt it, because the id is
+    // stored on the child session and exported as
+    // AGENT_CONSOLE_PARENT_WORKER_ID regardless of the prompt append, and
+    // an unresolvable id is embedded verbatim into the delegated agent's
+    // standing callback instructions (buildMessageCallbackPrompt) when the
+    // prompt IS appended.
+    // -------------------------------------------------------------------------
+    it('errors naming the id when parentWorkerId does not resolve to any worker in the parent session (Issue #1293 T2b)', async () => {
+      await setupDelegateEnvironment('feat/stale-worker');
+
+      const parentSession = await sessionManager.createSession(
+        { type: 'quick', locationPath: TEST_REPO_PATH },
+        { createdBy: 'parent-user-stale-worker' },
+      );
+      const createWorktreeSpy = jest.spyOn(worktreeService, 'createWorktree');
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test stale parentWorkerId',
+        branch: 'feat/stale-worker',
+        parentSessionId: parentSession.id,
+        parentWorkerId: 'fabricated-worker-id-not-in-session',
+      }, nextId++);
+
+      expect(response.result?.isError).toBe(true);
+      const data = parseToolResult(response) as { error: string };
+      expect(data.error).toContain('fabricated-worker-id-not-in-session');
+      expect(data.error).toContain(parentSession.id);
+      expect(data.error).toContain('Parent worker not found');
+      expect(createWorktreeSpy).not.toHaveBeenCalled();
+    });
+
+    it('errors naming the type when parentWorkerId names a worker that cannot receive session messages (Issue #1293 T2b)', async () => {
+      await setupDelegateEnvironment('feat/wrong-worker-type');
+
+      const parentSession = await sessionManager.createSession(
+        { type: 'quick', locationPath: TEST_REPO_PATH },
+        { createdBy: 'parent-user-wrong-worker-type' },
+      );
+      // Every quick session also gets a git-diff worker, which cannot
+      // receive send_session_message (canReceiveSessionMessages is
+      // agent/embedded-agent only).
+      const gitDiffWorker = parentSession.workers.find((w) => w.type === 'git-diff');
+      expect(gitDiffWorker).toBeDefined();
+      const createWorktreeSpy = jest.spyOn(worktreeService, 'createWorktree');
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test wrong-type parentWorkerId',
+        branch: 'feat/wrong-worker-type',
+        parentSessionId: parentSession.id,
+        parentWorkerId: gitDiffWorker!.id,
+      }, nextId++);
+
+      expect(response.result?.isError).toBe(true);
+      const data = parseToolResult(response) as { error: string };
+      expect(data.error).toContain(gitDiffWorker!.id);
+      expect(data.error).toContain('cannot receive session messages');
+      expect(data.error).toContain('git-diff');
+      expect(createWorktreeSpy).not.toHaveBeenCalled();
+    });
+
+    it('delegates successfully when parentWorkerId names a real agent worker on the parent session (Issue #1293 T3 extension)', async () => {
+      await setupDelegateEnvironment('feat/valid-own-worker');
+
+      // The self-referential case every legitimate caller exercises: a
+      // worker passing its OWN session/worker ids (AGENT_CONSOLE_SESSION_ID
+      // / AGENT_CONSOLE_WORKER_ID) as the delegate's parent.
+      const parent = await createValidDelegateParent();
+
+      const response = await callTool(app, mcpSessionId, 'delegate_to_worktree', {
+        repositoryId: 'test-repo',
+        prompt: 'Test valid own-worker delegation',
+        branch: 'feat/valid-own-worker',
+        parentSessionId: parent.parentSessionId,
+        parentWorkerId: parent.parentWorkerId,
+      }, nextId++);
+
+      expect(response.result?.isError).toBeUndefined();
+      const data = parseToolResult(response) as { sessionId: string };
+      expect(data.sessionId).toBeDefined();
     });
 
     // -------------------------------------------------------------------------
@@ -3029,7 +3139,7 @@ describe('MCP Server Tools', () => {
           prompt: 'Test username plumbing',
           branch: 'feat/username-resolved',
           parentSessionId: parentSession.id,
-          parentWorkerId: 'parent-worker-id',
+          parentWorkerId: firstAgentWorkerId(parentSession),
         }, nextId++);
 
         expect(response.result?.isError).toBeUndefined();
@@ -3090,7 +3200,7 @@ describe('MCP Server Tools', () => {
           prompt: 'Delegation from an orphan parent',
           branch: 'feat/orphan-uuid',
           parentSessionId: parentSession.id,
-          parentWorkerId: 'parent-worker-id',
+          parentWorkerId: firstAgentWorkerId(parentSession),
         }, nextId++);
 
         expect(response.result?.isError).toBeUndefined();
@@ -3137,7 +3247,7 @@ describe('MCP Server Tools', () => {
           prompt: 'Test SSH_AUTH_SOCK fallback propagation',
           branch: 'feat/ssh-fallback',
           parentSessionId: parentSession.id,
-          parentWorkerId: 'parent-worker-id',
+          parentWorkerId: firstAgentWorkerId(parentSession),
         }, nextId++);
 
         expect(response.result?.isError).toBeUndefined();
@@ -3189,7 +3299,7 @@ describe('MCP Server Tools', () => {
           prompt: 'Delegation from orphan parent',
           branch: 'feat/ssh-orphan',
           parentSessionId: parentSession.id,
-          parentWorkerId: 'parent-worker-id',
+          parentWorkerId: firstAgentWorkerId(parentSession),
         }, nextId++);
 
         expect(response.result?.isError).toBeUndefined();
@@ -3254,7 +3364,7 @@ describe('MCP Server Tools', () => {
           prompt: 'Fix diff worker elevation',
           // branch intentionally omitted -> exercises the suggestion path
           parentSessionId: parentSession.id,
-          parentWorkerId: 'parent-worker-id',
+          parentWorkerId: firstAgentWorkerId(parentSession),
         }, nextId++);
 
         expect(response.result?.isError).toBeUndefined();
@@ -3293,7 +3403,7 @@ describe('MCP Server Tools', () => {
             prompt: 'Delegation from an orphan parent',
             // branch intentionally omitted -> exercises the suggestion path
             parentSessionId: parentSession.id,
-            parentWorkerId: 'parent-worker-id',
+            parentWorkerId: firstAgentWorkerId(parentSession),
           }, nextId++);
 
           expect(response.result?.isError).toBeUndefined();
@@ -3433,7 +3543,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test parent metadata persistence',
         branch: 'feat/persist-parent',
         parentSessionId: parent.parentSessionId,
-        parentWorkerId: 'parent-wkr-xyz',
+        parentWorkerId: parent.parentWorkerId,
       }, nextId++);
 
       expect(response.result?.isError).toBeUndefined();
@@ -3450,7 +3560,7 @@ describe('MCP Server Tools', () => {
       };
 
       expect(statusData.parentSessionId).toBe(parent.parentSessionId);
-      expect(statusData.parentWorkerId).toBe('parent-wkr-xyz');
+      expect(statusData.parentWorkerId).toBe(parent.parentWorkerId);
     });
 
     it('should return parentSessionId and parentWorkerId in list_sessions response', async () => {
@@ -3463,7 +3573,7 @@ describe('MCP Server Tools', () => {
         prompt: 'Test parent metadata in list_sessions',
         branch: 'feat/list-parent',
         parentSessionId: parent.parentSessionId,
-        parentWorkerId: 'parent-wkr-list',
+        parentWorkerId: parent.parentWorkerId,
       }, nextId++);
 
       expect(delegateResponse.result?.isError).toBeUndefined();
@@ -3483,7 +3593,7 @@ describe('MCP Server Tools', () => {
       const delegatedSession = listData.sessions.find((s) => s.id === delegateData.sessionId);
       expect(delegatedSession).toBeDefined();
       expect(delegatedSession!.parentSessionId).toBe(parent.parentSessionId);
-      expect(delegatedSession!.parentWorkerId).toBe('parent-wkr-list');
+      expect(delegatedSession!.parentWorkerId).toBe(parent.parentWorkerId);
     });
 
     // Issue #1293: a "not provided" variant existed here previously; it is

--- a/packages/server/src/mcp/__tests__/mcp-server.test.ts
+++ b/packages/server/src/mcp/__tests__/mcp-server.test.ts
@@ -2856,10 +2856,20 @@ describe('MCP Server Tools', () => {
     // caught by a handler-level check. These three tests replace the old
     // "returns a custom XOR error" / "silently succeeds without parent IDs"
     // tests, whose premises (reaching the handler with a partial or absent
-    // pair) are no longer reachable. Mirrors the dual-branch assertion the
-    // pre-existing "without repositoryId" schema test above uses, since the
-    // MCP SDK may surface a required-field violation as a JSON-RPC-level
-    // error or as a tool-result isError depending on transport specifics.
+    // pair) are no longer reachable.
+    //
+    // Polarity note: the two "only one id provided" cases below assert on
+    // the SDK's own schema-validation wording ("Invalid arguments for tool
+    // delegate_to_worktree" / naming the specific missing field), NOT just
+    // `isError: true`. A bare `isError: true` check does not discriminate
+    // this fix from the OLD runtime XOR guard, which also produced
+    // `isError: true` (with a different, custom message) for exactly this
+    // "one id present, one missing" shape -- verified empirically by
+    // running these two tests against the pre-fix production code, where
+    // a bare `isError` assertion passed for the wrong reason. Only the
+    // "both omitted" case was reachable-but-successful pre-fix (the XOR
+    // guard is satisfied when both are absent), so it alone needed no
+    // wording assertion to fail pre-fix correctly.
     it('should reject the call when only parentSessionId is provided (parentWorkerId missing) -- schema-required (Issue #1293 T1)', async () => {
       await setupDelegateEnvironment('feat/partial-caller');
 
@@ -2871,11 +2881,13 @@ describe('MCP Server Tools', () => {
         // parentWorkerId is intentionally omitted -- now a schema violation
       }, nextId++);
 
-      if (response.error) {
-        expect(response.error).toBeDefined();
-      } else {
-        expect(response.result?.isError).toBe(true);
-      }
+      // The SDK's schema-rejection text is a plain string, not the tool's
+      // usual `{"error": "..."}` JSON payload -- parseToolResult() would
+      // throw JSON.parse on it, so read the raw content text directly.
+      expect(response.result?.isError).toBe(true);
+      const message = response.result?.content?.[0]?.text ?? '';
+      expect(message).toContain('Invalid arguments for tool delegate_to_worktree');
+      expect(message).toContain('parentWorkerId');
     });
 
     it('should reject the call when only parentWorkerId is provided (parentSessionId missing) -- schema-required (Issue #1293 T1)', async () => {
@@ -2889,11 +2901,10 @@ describe('MCP Server Tools', () => {
         parentWorkerId: 'caller-worker-456',
       }, nextId++);
 
-      if (response.error) {
-        expect(response.error).toBeDefined();
-      } else {
-        expect(response.result?.isError).toBe(true);
-      }
+      expect(response.result?.isError).toBe(true);
+      const message = response.result?.content?.[0]?.text ?? '';
+      expect(message).toContain('Invalid arguments for tool delegate_to_worktree');
+      expect(message).toContain('parentSessionId');
     });
 
     it('should reject the call when both parentSessionId and parentWorkerId are omitted -- schema-required (Issue #1293 T1)', async () => {

--- a/packages/server/src/mcp/mcp-auth.ts
+++ b/packages/server/src/mcp/mcp-auth.ts
@@ -214,9 +214,13 @@ export interface ClaimedSession {
  *
  * The spec sketches the signature as `(caller, claimedSessionId, mode)`; this
  * implementation passes the already-resolved `{ sessionId, createdBy }` (tools
- * resolve the session anyway) plus `null` for tools invoked without a claimed
- * session (e.g. `delegate_to_worktree` without `parentSessionId`), keeping the
- * helper pure and `sessionManager`-free
+ * resolve the session anyway) plus `null` for a tool invoked with no existing
+ * session to claim ownership over, keeping the helper pure and
+ * `sessionManager`-free. Every current call site resolves a real session
+ * first and always passes a non-null `claimed` object, so the `null` branch
+ * has no production call site today -- it remains part of the contract for
+ * a future tool shaped that way, and is exercised directly by unit tests in
+ * `mcp-auth.test.ts`
  * (docs/design/embedded-agent-worker.md § "MCP caller identity").
  *
  * Rules, in order:

--- a/packages/server/src/mcp/mcp-auth.ts
+++ b/packages/server/src/mcp/mcp-auth.ts
@@ -22,6 +22,19 @@ const logger = createLogger('mcp-auth');
 /**
  * Verified identity of an MCP caller. `userId` is a `users.id` UUID,
  * directly comparable to `Session.createdBy`.
+ *
+ * This identity is consumed for AUTHORIZATION only, via
+ * `checkCallerOwnsSession` ("may this caller act on that session?").
+ * Ownership (a delegated session's `createdBy`) deliberately derives from
+ * the parent session instead -- never from this identity -- because a
+ * fallback to the caller's own identity would silently rescue a caller
+ * who omitted `parentSessionId` / `parentWorkerId`, defeating the point
+ * of requiring them. In `enforce` mode,
+ * `checkCallerOwnsSession`'s mismatch check guarantees this identity's
+ * `userId` and the claimed session's `createdBy` already agree whenever
+ * both exist, so there is no second source to arbitrate. No code in this
+ * codebase should consume `McpCallerIdentity.userId` to derive a
+ * session's `createdBy`.
  */
 export interface McpCallerIdentity {
   sessionId: string;

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -737,7 +737,9 @@ export function createMcpApp(deps: McpDependencies): Hono {
         .string()
         .min(1, 'parentWorkerId must be non-empty')
         .describe(
-          "Required. The parent session's worker ID, from your own AGENT_CONSOLE_WORKER_ID environment variable.",
+          "Required. The parent session's worker ID, from your own AGENT_CONSOLE_WORKER_ID environment variable. " +
+            'Must name an existing worker in that session capable of receiving send_session_message ' +
+            '(an agent or embedded-agent worker).',
         ),
       skipMessageCallbackPrompt: z
         .boolean()
@@ -851,6 +853,24 @@ export function createMcpApp(deps: McpDependencies): Hono {
         );
         if (authError) return errorResult(authError.error);
         const parentCreatedBy = parentSession.createdBy;
+
+        // Resolve parentWorkerId against the PARENT session's own workers
+        // (never a global lookup) and require it to name a worker capable
+        // of receiving send_session_message. Unconditional: the id is
+        // stored on the child session and exported as
+        // AGENT_CONSOLE_PARENT_WORKER_ID regardless of
+        // skipMessageCallbackPrompt, and an unresolvable id poisons every
+        // callback the delegated agent will ever attempt (it is embedded
+        // verbatim into the standing prompt instructions below).
+        const parentWorker = parentSession.workers.find((w) => w.id === parentWorkerId);
+        if (!parentWorker) {
+          return errorResult(`Parent worker not found in session ${parentSessionId}: ${parentWorkerId}`);
+        }
+        if (!canReceiveSessionMessages(parentWorker)) {
+          return errorResult(
+            `Parent worker ${parentWorkerId} cannot receive session messages (type: ${parentWorker.type})`,
+          );
+        }
 
         // Resolve parent's createdBy (a users.id UUID) to its OS username
         // so the suggestion call and `git worktree add` both run as the

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -681,7 +681,11 @@ export function createMcpApp(deps: McpDependencies): Hono {
       'Use this to delegate work to a new agent running in an isolated worktree. ' +
       'Note: once started, the worktree and session persist on the server even if the MCP client disconnects. ' +
       'To delegate to a repository other than your own, use list_repositories to discover available repositories. ' +
-      'Optionally pass parentSessionId and parentWorkerId to have the delegated agent report results back via send_session_message.',
+      'Requires parentSessionId and parentWorkerId, from your own AGENT_CONSOLE_SESSION_ID / AGENT_CONSOLE_WORKER_ID ' +
+      'environment variables (every legitimate caller holds both). The parent session determines the delegated ' +
+      "session's ownership (createdBy inheritance) -- this is not a reporting convenience. By default, callback " +
+      'instructions are appended to the prompt so the delegated agent reports results back via send_session_message; ' +
+      'set skipMessageCallbackPrompt to suppress that.',
     {
       repositoryId: z.string().describe(
         'The repository ID. The calling agent can get this from the AGENT_CONSOLE_REPOSITORY_ID environment variable. ' +
@@ -723,19 +727,17 @@ export function createMcpApp(deps: McpDependencies): Hono {
       parentSessionId: z
         .string()
         .min(1, 'parentSessionId must be non-empty')
-        .optional()
         .describe(
-          "The parent session's ID, from the AGENT_CONSOLE_SESSION_ID environment variable. " +
-            'When provided together with parentWorkerId, callback instructions are appended to the prompt ' +
-            'so the delegated agent reports results back via send_session_message.',
+          "Required. The parent session's ID, from your own AGENT_CONSOLE_SESSION_ID environment variable. " +
+            "The parent session determines the delegated session's ownership (createdBy is inherited from it) -- " +
+            'this is not just a reporting convenience. Callback instructions are appended to the prompt (unless ' +
+            'skipMessageCallbackPrompt is set) so the delegated agent reports results back via send_session_message.',
         ),
       parentWorkerId: z
         .string()
         .min(1, 'parentWorkerId must be non-empty')
-        .optional()
         .describe(
-          "The parent session's worker ID, from the AGENT_CONSOLE_WORKER_ID environment variable. " +
-            'Must be provided together with parentSessionId.',
+          "Required. The parent session's worker ID, from your own AGENT_CONSOLE_WORKER_ID environment variable.",
         ),
       skipMessageCallbackPrompt: z
         .boolean()
@@ -778,16 +780,14 @@ export function createMcpApp(deps: McpDependencies): Hono {
       templateVars,
     }) => {
       try {
-        // Validate parent IDs: both must be provided together
-        if (!!parentSessionId !== !!parentWorkerId) {
-          return errorResult('parentSessionId and parentWorkerId must be provided together');
-        }
-
-        // Build effective prompt with optional callback instructions
-        const effectivePrompt =
-          parentSessionId && parentWorkerId && !skipMessageCallbackPrompt
-            ? buildMessageCallbackPrompt(prompt, parentSessionId, parentWorkerId)
-            : prompt;
+        // Build effective prompt with optional callback instructions.
+        // parentSessionId/parentWorkerId are required by the schema, so the
+        // only thing gating the append is skipMessageCallbackPrompt -- the
+        // old truthy check on both ids is now dead code since the schema
+        // makes their absence unrepresentable.
+        const effectivePrompt = skipMessageCallbackPrompt
+          ? prompt
+          : buildMessageCallbackPrompt(prompt, parentSessionId, parentWorkerId);
 
         // Validate repository
         const repo = repositoryManager.getRepository(repositoryId);
@@ -827,25 +827,38 @@ export function createMcpApp(deps: McpDependencies): Hono {
           return errorResult(`Agent not found: ${suggestionAgentId}`);
         }
 
-        // Inherit createdBy from parent session (if delegated)
-        const parentSession = parentSessionId ? sessionManager.getSession(parentSessionId) : undefined;
+        // Resolve the parent session and inherit its createdBy for
+        // ownership. Both checks below are required-but-unresolvable
+        // errors: the schema only guarantees the ids are non-empty
+        // strings, not that they name a real, owned session. A stale
+        // parentSessionId or a legacy parent with no createdBy used to
+        // degrade silently to a null-owned, dead-agent session -- the
+        // incident this Issue closes.
+        const parentSession = sessionManager.getSession(parentSessionId);
+        if (!parentSession) {
+          return errorResult(`Parent session not found: ${parentSessionId}`);
+        }
+        if (!parentSession.createdBy) {
+          return errorResult(
+            `Parent session ${parentSessionId} has no createdBy; delegation from an ownerless (legacy) session is not possible`,
+          );
+        }
         const authError = checkCallerOwnsSession(
           getMcpCallerIdentity(),
-          parentSessionId ? { sessionId: parentSessionId, createdBy: parentSession?.createdBy } : null,
+          { sessionId: parentSessionId, createdBy: parentSession.createdBy },
           mcpAuthMode,
           { toolName: 'delegate_to_worktree' },
         );
         if (authError) return errorResult(authError.error);
-        const parentCreatedBy = parentSession?.createdBy;
+        const parentCreatedBy = parentSession.createdBy;
 
         // Resolve parent's createdBy (a users.id UUID) to its OS username
         // so the suggestion call and `git worktree add` both run as the
-        // requesting user in multi-user mode. When `parentCreatedBy` is
-        // unset, or the UUID does not resolve (legacy / orphan sessions),
-        // `requestUsername` is null and `runAsUser` bypasses elevation —
-        // current behaviour preserved. Resolution shared with `run_process`
-        // / `create_conditional_wakeup` via `resolveRequestUsername` (see
-        // `.claude/rules/elevation-helpers.md`).
+        // requesting user in multi-user mode. When the UUID does not resolve
+        // (orphan sessions), `requestUsername` is null and `runAsUser`
+        // bypasses elevation — current behaviour preserved. Resolution
+        // shared with `run_process` / `create_conditional_wakeup` via
+        // `resolveRequestUsername` (see `.claude/rules/elevation-helpers.md`).
         const requestUsername = await resolveRequestUsername(
           parentCreatedBy,
           userRepository,

--- a/packages/server/src/mcp/mcp-server.ts
+++ b/packages/server/src/mcp/mcp-server.ts
@@ -836,6 +836,13 @@ export function createMcpApp(deps: McpDependencies): Hono {
         // parentSessionId or a legacy parent with no createdBy used to
         // degrade silently to a null-owned, dead-agent session -- the
         // incident this Issue closes.
+        //
+        // Guard order is load-bearing: session-exists -> createdBy-set ->
+        // caller-owns -> worker-resolves. Several tests assert an earlier
+        // guard's error while passing a placeholder parentWorkerId that
+        // would fail the later worker-resolution guard too; hoisting worker
+        // resolution above the createdBy check would flip those tests'
+        // expected error without making the guard itself wrong.
         const parentSession = sessionManager.getSession(parentSessionId);
         if (!parentSession) {
           return errorResult(`Parent session not found: ${parentSessionId}`);


### PR DESCRIPTION
## Summary

`delegate_to_worktree` accepted a call missing `parentSessionId`/`parentWorkerId` and returned success while no agent ever started, leaving a session that could not be removed without `force`. This closes the caller-error route by making the schema strict and the handler explicit, per the Architect's ruling and Acceptance Criteria in the Issue (R1-R3, S1-S4, T1-T4, V) plus an S3b amendment added during review (below).

- **S1** — `parentSessionId` and `parentWorkerId` are now schema-required (`.optional()` removed, `.min(1)` retained). No refinement, no union — the invalid combination is unrepresentable. Descriptions rewritten to state that the parent session determines the delegated session's ownership (`createdBy` inheritance), not just a reporting convenience.
- **S2** — The runtime XOR guard (`!!parentSessionId !== !!parentWorkerId`) is deleted with nothing replacing it.
- **S3** — The handler now explicitly errors when `getSession(parentSessionId)` misses (`Parent session not found: <id>`) or when the parent session has no `createdBy` (ownerless/legacy). The `parentSession?.createdBy` optional chains are gone; the value is non-optional after these checks.
- **S3b (Architect amendment, bundled per a CodeRabbit finding on this PR)** — `parentWorkerId` is now resolved against the PARENT session's own workers (never a global lookup), and the resolved worker must satisfy `canReceiveSessionMessages`. Two distinct errors: `Parent worker not found in session <sessionId>: <workerId>` vs. a message naming the worker's type when it exists but cannot receive session messages. Validation is unconditional — `skipMessageCallbackPrompt` does not exempt it, because the id is stored on the child session and exported as `AGENT_CONSOLE_PARENT_WORKER_ID` regardless of the prompt append, and an unresolvable id is embedded verbatim into the delegated agent's standing callback instructions when the prompt IS appended. See the resolved review thread on this PR for the full ruling and rationale.
- **S4** — `McpCallerIdentity` in `mcp-auth.ts` gains a JSDoc block recording that identity is consumed for authorization only (`checkCallerOwnsSession`), never for `createdBy` derivation, and why. A grep-based containment test (`mcp-auth.test.ts`) guards against a future regression that would assign `createdBy` from a caller identity's `userId`.

## Test plan

Protocol tests via `createMcpApp` + real transport (`packages/server/src/mcp/__tests__/mcp-server.test.ts`, `delegate-embedded-agent-activation.test.ts`, `mcp-auth.test.ts`). Classified per `testing.md`:

- **T1 (new-mechanism contract, fails against unmodified code)** — schema rejects missing `parentSessionId`, missing `parentWorkerId`, and both missing. 3 tests in the `delegate_to_worktree` describe block. Two of the three ("only one id provided") assert on the MCP SDK's own schema-validation wording rather than a bare `isError` check, after polarity verification showed a bare check does not discriminate the new schema-required behavior from the OLD runtime XOR guard, which also produced `isError: true` for that exact shape (see Verification below).
- **T2 (new-mechanism contract, fails against unmodified code)** — two tests: a fabricated `parentSessionId` returns `Parent session not found: <id>` naming the id and never calls `createWorktree`; an ownerless (legacy, no `createdBy`) parent returns an explicit error and never calls `createWorktree`/`createSession`. Against pre-fix code both degrade silently (`requestUsername`/`sshAuthSockFallback` resolve to `null`/`undefined` and the call still succeeds) — this silent degradation is the incident's actual route, so these are the tests that matter most.
- **T2b (new-mechanism contract, fails against unmodified code, S3b)** — two tests: a `parentWorkerId` that names no worker in the parent session returns `Parent worker not found in session <id>: <workerId>`; a `parentWorkerId` naming the parent's `git-diff` worker (exists, but cannot receive session messages) returns an error naming the type. Both verified to fail without the S3b guard block and pass with it.
- **T3 (invariant-preservation, passes both before and after)** — pre-existing tests ("should inherit createdBy from parent session", "plumbs resolved OS username...") continue to pass with a valid parent, proving `createdBy`/`requestUsername` threading is unchanged. Extended with two explicit tests: (a) "delegates successfully when parentWorkerId names a real agent worker on the parent session", the self-referential case every legitimate caller exercises (a worker passing its own `AGENT_CONSOLE_SESSION_ID`/`AGENT_CONSOLE_WORKER_ID`); (b) "...names an embedded-agent worker on the parent session" — the `canReceiveSessionMessages` accept-side case S3b's own tests (T2b) had not covered (T2b's negative case only exercised the reject-side `git-diff`). **This second test does NOT flip against pre-fix code** — pre-fix had no `parentWorkerId` validation at all, so it passed then and passes now; classified invariant-preservation, not new-mechanism, per an explicit owner instruction not to manufacture false polarity for it. Its value is prospective: nothing today can make it fail (`canReceiveSessionMessages` already accepts `embedded-agent` by definition), but it is the test that would fail if that predicate were ever narrowed to agent-only, or if the S3b guard were rewritten to hardcode `type === 'agent'` instead of consuming the shared predicate — a mistake every *other* test in this file (all using an `agent`-type parent worker) would miss silently.
- **T4 (invariant-preservation, passes both before and after)** — "should NOT append callback instructions when skipMessageCallbackPrompt is true" continues to pass with both ids present, proving the callback-instruction gate is still governed solely by `skipMessageCallbackPrompt`.
- **Containment** — a grep-based test in `mcp-auth.test.ts` scans `packages/server/src` for `createdBy: <expr>.userId` / `createdBy = <expr>.userId` shapes and asserts zero matches, backed by S4's JSDoc as the standing design record.

Several existing tests whose entire premise (reaching the handler with `parentSessionId` omitted, or with a fabricated non-existent id or worker id) is no longer reachable were updated or removed, with comments pointing to the tests that now cover the equivalent behavior:
- Tests titled "...when delegate_to_worktree is called without parentSessionId" (Issue #844/#918/#876 blocks) — removed; covered by the new T1 tests.
- "should NOT include callback instructions when parent IDs are not provided" and "should not include parentSessionId/parentWorkerId when not provided" — removed; covered by T1.
- "should return validation error when only parentSessionId/parentWorkerId is provided" — rewritten to assert schema-level rejection instead of the old custom XOR error message.
- "passes null requestUsername when parent session has no createdBy (legacy)" (both the OS-username-plumbing and sshAuthSockFallback variants) — rewritten to assert the new S3(b) error instead of silent `null` resolution.
- `delegate-embedded-agent-activation.test.ts`'s "activation failure (missing session.createdBy...)" test — rewritten; the scenario it exercised (a delegated session created with no `createdBy`) is now unreachable through `delegate_to_worktree` at all, since S3(b) rejects an ownerless parent before any session is created.
- Every call site across `mcp-server.test.ts` and `delegate-embedded-agent-activation.test.ts` that previously passed a fabricated placeholder `parentSessionId` or `parentWorkerId` while asserting success now uses a real session/worker id, since S3(a)/S3(b) now reject a non-existent or wrong-type target. The `createValidDelegateParent()` test helper (formerly `mcp-server.test.ts:647-665`, the specific site CodeRabbit flagged) now returns the real agent worker id from the session it creates instead of a fabricated placeholder string.

`pre-pr-completeness.md` Q10 is **N/A** — no shared wire-crossing type/schema was added or changed; the zod schema modified here is the MCP tool's own input schema in `mcp-server.ts`, not a `packages/shared` valibot schema.

## Verification

- Full suite: `bun run test` — 3823 pass, 1 skip (pre-existing, unrelated, environment-gated), 0 fail. `bun run typecheck` — clean across all packages.
- `node .claude/skills/orchestrator/preflight-check.js` — clean (coverage, rule/skill duplication, language, blame-shift checks all pass).
- CodeRabbit CLI (`coderabbit review --agent --base main`): **authentication failure**, not a rate limit — `automatic_login_failed` / `authentication_failed` in a headless session with no way to complete the interactive browser login. The GitHub-side bot reviewed instead (see below).
- **CodeRabbit GitHub-side review**: posted one Major finding (unvalidated `parentWorkerId`) on the first commit. Taken to the Architect for an AC-scope ruling since it was outside the original S1-S4 text; ruled **bundle** (see S3b above). Implemented, and the review thread is resolved (CodeRabbit auto-detected the fix across commits `3f068f7`..`45ec343` and marked it addressed).
- **Polarity verification** (`workflow.md` "no partial polarity"): all 8 new-mechanism tests (3× T1, 2× T2, 2× T2b, plus the T3 self-referential extension used only as a sanity check) were run against unmodified production code via `git diff` + `git apply -R` restricted to `mcp-server.ts`/`mcp-auth.ts` (tests kept at HEAD; no `git stash` used, since this repo has concurrent delegates sharing the stash ref). Result: 6 of the initial 8 failed pre-fix as expected; 2 of the 3 T1 "only one id provided" cases passed pre-fix for a real reason — the OLD runtime XOR guard also returned `isError: true` for that exact shape, so a bare `isError` check could not discriminate the new schema-required behavior from it. Redesigned those two to assert on the MCP SDK's schema-validation wording instead (verified absent from the old guard's message), re-ran the full pre-fix/post-fix cycle, and confirmed all cases now correctly fail pre-fix and pass post-fix.

### Shipping-path E2E (real dev instance, throwaway `AGENT_CONSOLE_HOME`, real `/mcp` HTTP transport — not a unit test)

Started the server from this branch (`AGENT_CONSOLE_HOME=/tmp/agent-console-1293-verify PORT=13457 bun src/index.ts`), registered a throwaway local git repo, created a real parent session via `POST /api/sessions` (`createdBy` populated by the real auth path), then drove `delegate_to_worktree` over the real JSON-RPC `/mcp` endpoint:

1. **Valid parent ids → session created, worker `pid` non-null.** `delegate_to_worktree` with the real parent session/worker ids returned success. Read from the primary source (the sqlite `workers` table, not the tool's own reply): `SELECT id, session_id, type, pid FROM workers WHERE session_id = '<created-session-id>'` returned `pid: 1502891` for the agent worker (git-diff worker's pid is null by design — no PTY). `ps -p 1502891` confirmed a real, running process with the server as its parent. This is the incident's signature, checked in the positive direction: before this fix, an ownerless delegated session left `pid` NULL with a dead agent; here a properly-owned one has a live process.
2. **Fabricated `parentSessionId` → tool error, zero worktree side effect.** Calling `delegate_to_worktree` with `parentSessionId: "fabricated-nonexistent-session-id"` returned `{"error":"Parent session not found: fabricated-nonexistent-session-id", isError: true}`. Checked from the primary source: `sessions` table count stayed at 2 (parent + the one delegation from step 1), and the worktree directory listing under the repo showed only the single `wt-001-*` worktree created by step 1 — no second worktree was created for the rejected call.

(This E2E predates the S3b amendment; S3b's own contract is covered by the T2b protocol tests above, which exercise the identical real-transport `createMcpApp` handler.)

Cleaned up: killed the throwaway server and its spawned worker process, and removed the throwaway `AGENT_CONSOLE_HOME` and repo directories via a flagless recursive delete helper (verified empty afterward; the sandbox blocks the standard force-recursive removal command even against a self-created temp path).

Closes #1293

