### PR TITLE
fix(server): unregister a repository now removes its session-data tree too

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -40,6 +40,10 @@ The stored configuration for an AI agent, including command templates and activi
 A registered Git repository available for session creation. Code reference: `repositoryId` (UUID).
 - **See:** [Core concepts in session-worker-design.md](design/session-worker-design.md#key-concepts)
 
+### RepositoryInUseError
+The single-writer rule for whether a [Repository](#repository) is currently in use by any session. Enforced by `RepositoryManager.assertRepositoryNotInUse`, which combines the in-memory active-session check with a check over persisted session rows that are not currently active in memory — a repository with a paused [WorktreeSession](#worktreesession) counts as in-use, not only one with active sessions. The `DELETE /api/repositories/:id` route maps a thrown `RepositoryInUseError` to `409 Conflict`.
+- **See:** `packages/server/src/services/repository-manager.ts`
+
 ### Clone Job
 An asynchronous server-side job that clones a remote Git URL into the shared [source-repos directory](#source-repos-directory) and registers the result as a [Repository](#repository) (Issue [#834](https://github.com/ms2sato/agent-console/issues/834)). The HTTP endpoint `POST /api/repositories/clone` returns `202 Accepted` with a `jobId`; the client polls `GET /api/repositories/clone/:jobId` for status (`pending` / `cloning` / `succeeded` / `failed`). On failure, a classified `CloneErrorCode` (`auth_failed` / `network_error` / `repo_not_found` / `permission_denied` / `name_conflict` / `timeout` / `validation_error` / `unknown`) lets the UI render actionable copy. In multi-user mode, the clone subprocess runs as the requesting user via the privilege-elevation pattern ([Issue #837](https://github.com/ms2sato/agent-console/issues/837)).
 - **Aliases:** clone-and-register job
@@ -57,6 +61,10 @@ A work unit within a session (agent, terminal, diff viewer, etc.).
 ### Worktree
 A Git worktree representing a physical working directory.
 - **See:** [Core concepts in session-worker-design.md](design/session-worker-design.md#key-concepts)
+
+### Session Data Address (dataScope / dataScopeSlug)
+The filesystem location for a [Session](#session)'s data (worker outputs, memos, inter-session messages) — distinct from its [Worktree](#worktree)'s location. Resolved exclusively through `computeSessionDataBaseDir(configDir, scope, slug)`, which accepts two scopes: `'quick'` (fixed `_quick/` directory, no slug) and `'repository'` (`repositories/<slug>/`, slug required). The scope and slug (`dataScope` / `dataScopeSlug`) are captured once at session creation and stay frozen for the session's lifetime — they do not change on repository rename or on later changes to how the slug is derived. Two slug shapes currently coexist for `'repository'` scope: `org/repo` (git-remote derived, the shape used by [Worktree](#worktree) locations via `getRepositoryDir`) and a flat `repo.name` (the session-data slug from `getRepositorySlug`). The two diverge for any repository with a git remote, which is why repository-unregister cleanup must resolve session-data targets independently of the worktree/templates directory rather than deriving one from the other. Issue #1300 tracks unifying the derivation; this entry describes current (pre-#1300) behavior.
+- **See:** [Session Data Path design](design/session-data-path.md)
 
 ## Session Types
 

--- a/packages/server/src/app-context.ts
+++ b/packages/server/src/app-context.ts
@@ -516,6 +516,8 @@ export async function createAppContext(
   repositoryManager.setDependencyCallbacks({
     getSessionsUsingRepository: (repoId) =>
       sessionManager.getSessionsUsingRepository(repoId),
+    getInactiveSessionsUsingRepository: (repoId) =>
+      sessionManager.getInactiveSessionsUsingRepository(repoId),
   });
 
   // 7.1. Construct the clone-and-register service. Singleton so
@@ -733,6 +735,8 @@ export async function createTestContext(
   repositoryManager.setDependencyCallbacks({
     getSessionsUsingRepository: (repoId) =>
       sessionManager.getSessionsUsingRepository(repoId),
+    getInactiveSessionsUsingRepository: (repoId) =>
+      sessionManager.getInactiveSessionsUsingRepository(repoId),
   });
 
   // Clone-and-register service for the test context.

--- a/packages/server/src/jobs/__tests__/handlers.test.ts
+++ b/packages/server/src/jobs/__tests__/handlers.test.ts
@@ -419,5 +419,184 @@ describe('cleanup job handlers', () => {
       expect(rmRecursiveAsUserMock.calls[0]!.path).toBe(repoDir);
       expect(rmRecursiveAsUserMock.calls[1]!.path).toBe(extraDir);
     });
+
+    // =========================================================================
+    // Issue #1301: sessionDataDirs removal (S3, never elevated) and
+    // org-parent husk removal (S4, always direct/best-effort).
+    // =========================================================================
+
+    describe('sessionDataDirs removal (Issue #1301, S3)', () => {
+      it('removes sessionDataDirs via plain fs.rm, never via rmRecursiveAsUser, even under AUTH_MODE=multi-user with an elevating requestUsername', async () => {
+        process.env.AUTH_MODE = 'multi-user';
+        const other = pickOtherUser();
+        // repoDir / extraDir are fake elevated paths -- the mock swallows
+        // them without touching the real fs.
+        const repoDir = '/var/lib/agent-console/repositories/org/repo';
+        const extraDir = '/var/lib/agent-console/source-repos/org/repo';
+
+        // sessionDataDirs are REAL directories on disk -- proving the
+        // handler actually removed them via the direct (non-elevated) path,
+        // not merely that it declined to call the elevation helper.
+        const baseDir = path.join(os.tmpdir(), `cleanup-handler-sessiondata-${process.pid}-${Date.now()}`);
+        const sessionDataDir1 = path.join(baseDir, 'outputs');
+        const sessionDataDir2 = path.join(baseDir, 'messages');
+        await fsPromises.mkdir(sessionDataDir1, { recursive: true });
+        await fsPromises.mkdir(sessionDataDir2, { recursive: true });
+        await fsPromises.writeFile(path.join(sessionDataDir1, 'marker'), 'o');
+        await fsPromises.writeFile(path.join(sessionDataDir2, 'marker'), 'm');
+
+        try {
+          await runPayload({
+            repoDir,
+            requestUsername: other,
+            extraDir,
+            sessionDataDirs: [sessionDataDir1, sessionDataDir2],
+          });
+
+          // Only repoDir and extraDir were routed through the elevation
+          // helper -- neither sessionDataDirs path appears.
+          expect(rmRecursiveAsUserMock.calls.length).toBe(2);
+          expect(rmRecursiveAsUserMock.calls.map((c) => c.path)).toEqual([repoDir, extraDir]);
+          expect(rmRecursiveAsUserMock.calls.some((c) => c.path === sessionDataDir1)).toBe(false);
+          expect(rmRecursiveAsUserMock.calls.some((c) => c.path === sessionDataDir2)).toBe(false);
+
+          // Positive proof: both real directories are gone via the direct
+          // fs.rm path.
+          await expect(fsPromises.access(sessionDataDir1)).rejects.toThrow();
+          await expect(fsPromises.access(sessionDataDir2)).rejects.toThrow();
+        } finally {
+          await fsPromises.rm(baseDir, { recursive: true, force: true });
+        }
+      });
+
+      it('isolates a single sessionDataDirs failure -- the remaining targets are still processed and the handler does not throw', async () => {
+        delete process.env.AUTH_MODE;
+        const baseDir = path.join(os.tmpdir(), `cleanup-handler-sessiondata-isolation-${process.pid}-${Date.now()}`);
+        const failingDir = path.join(baseDir, 'failing');
+        const okDir = path.join(baseDir, 'ok');
+        await fsPromises.mkdir(failingDir, { recursive: true });
+        await fsPromises.mkdir(okDir, { recursive: true });
+        await fsPromises.writeFile(path.join(failingDir, 'marker'), 'f');
+        await fsPromises.writeFile(path.join(okDir, 'marker'), 'k');
+
+        // Force a non-ENOENT failure on `failingDir` by revoking read/write
+        // permission, so `fs.rm`'s internal readdir throws EACCES rather
+        // than the idempotent ENOENT path.
+        await fsPromises.chmod(failingDir, 0o000);
+
+        try {
+          await expect(
+            runPayload({
+              repoDir: '/var/lib/agent-console/repositories/no-such-org/no-such-repo',
+              requestUsername: null,
+              extraDir: null,
+              sessionDataDirs: [failingDir, okDir],
+            }),
+          ).resolves.toBeUndefined();
+
+          // The second target was still removed -- the loop did not abort
+          // on the first target's failure.
+          await expect(fsPromises.access(okDir)).rejects.toThrow();
+        } finally {
+          // Restore permissions so cleanup can actually remove failingDir.
+          await fsPromises.chmod(failingDir, 0o755).catch(() => {});
+          await fsPromises.rm(baseDir, { recursive: true, force: true });
+        }
+      });
+
+      it('processes repoDir/extraDir without error when sessionDataDirs is absent from the payload (back-compat)', async () => {
+        delete process.env.AUTH_MODE;
+        await expect(
+          runPayload({
+            repoDir: '/var/lib/agent-console/repositories/no-such-org/no-such-repo-backcompat',
+            requestUsername: null,
+            extraDir: null,
+          }),
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    describe('org-parent husk removal (Issue #1301, S4)', () => {
+      it('removes the now-empty org-parent directory after repoDir is removed', async () => {
+        delete process.env.AUTH_MODE;
+        const baseDir = path.join(os.tmpdir(), `cleanup-handler-orgparent-${process.pid}-${Date.now()}`);
+        const repoDir = path.join(baseDir, 'org', 'repo');
+        await fsPromises.mkdir(repoDir, { recursive: true });
+        await fsPromises.writeFile(path.join(repoDir, 'marker'), 'r');
+
+        try {
+          await runPayload({ repoDir, requestUsername: null, extraDir: null });
+
+          await expect(fsPromises.access(repoDir)).rejects.toThrow();
+          // The org-parent dir is now empty and was removed too.
+          await expect(fsPromises.access(path.join(baseDir, 'org'))).rejects.toThrow();
+        } finally {
+          await fsPromises.rm(baseDir, { recursive: true, force: true });
+        }
+      });
+
+      it('leaves the org-parent directory alone when a sibling repo still lives under it', async () => {
+        delete process.env.AUTH_MODE;
+        const baseDir = path.join(os.tmpdir(), `cleanup-handler-orgparent-sibling-${process.pid}-${Date.now()}`);
+        const repoDir = path.join(baseDir, 'org', 'repo');
+        const siblingDir = path.join(baseDir, 'org', 'other-repo');
+        await fsPromises.mkdir(repoDir, { recursive: true });
+        await fsPromises.mkdir(siblingDir, { recursive: true });
+        await fsPromises.writeFile(path.join(repoDir, 'marker'), 'r');
+        await fsPromises.writeFile(path.join(siblingDir, 'marker'), 's');
+
+        try {
+          await runPayload({ repoDir, requestUsername: null, extraDir: null });
+
+          await expect(fsPromises.access(repoDir)).rejects.toThrow();
+          // The org-parent dir is non-empty (siblingDir still lives under
+          // it) -- ENOTEMPTY is swallowed, no throw, and the dir survives.
+          // Presence-only check (no assertion on the resolved value): a
+          // successful `access()` resolves to `null` on Bun's real fs but
+          // `undefined` under the process-global memfs mock some other test
+          // file may have installed -- awaiting directly and letting a
+          // rejection fail the test avoids depending on that resolved value.
+          await fsPromises.access(path.join(baseDir, 'org'));
+          await fsPromises.access(siblingDir);
+        } finally {
+          await fsPromises.rm(baseDir, { recursive: true, force: true });
+        }
+      });
+
+      it('does not attempt to remove the repositories root itself for a flat-shape repoDir (no org component)', async () => {
+        delete process.env.AUTH_MODE;
+        const baseDir = path.join(os.tmpdir(), `cleanup-handler-flat-${process.pid}-${Date.now()}`);
+        // Point AGENT_CONSOLE_HOME at baseDir so getRepositoriesDir() ===
+        // path.join(baseDir, 'repositories') -- the SAME directory as
+        // repoDir's dirname below. This exercises the
+        // `orgParentDir !== getRepositoriesDir()` guard for real, not
+        // trivially (a mismatched env would make the guard vacuously true).
+        const originalHome = process.env.AGENT_CONSOLE_HOME;
+        process.env.AGENT_CONSOLE_HOME = baseDir;
+        const reposDir = path.join(baseDir, 'repositories');
+        const repoDir = path.join(reposDir, 'just-repo');
+        await fsPromises.mkdir(repoDir, { recursive: true });
+        await fsPromises.writeFile(path.join(repoDir, 'marker'), 'r');
+
+        try {
+          await runPayload({ repoDir, requestUsername: null, extraDir: null });
+
+          await expect(fsPromises.access(repoDir)).rejects.toThrow();
+          // The repositories root itself must survive -- without the guard,
+          // it would now be empty and get removed too, which is exactly
+          // what the guard exists to prevent. Presence-only check -- see
+          // the comment on the sibling test above for why the resolved
+          // value is not asserted.
+          await fsPromises.access(reposDir);
+        } finally {
+          if (originalHome === undefined) {
+            delete process.env.AGENT_CONSOLE_HOME;
+          } else {
+            process.env.AGENT_CONSOLE_HOME = originalHome;
+          }
+          await fsPromises.rm(baseDir, { recursive: true, force: true });
+        }
+      });
+    });
   });
 });

--- a/packages/server/src/jobs/handlers.ts
+++ b/packages/server/src/jobs/handlers.ts
@@ -5,6 +5,7 @@
  * See job-types.ts for available job types and their payloads.
  */
 import * as fs from 'fs/promises';
+import * as path from 'path';
 import type { JobQueue } from './job-queue.js';
 import {
   JOB_TYPES,
@@ -18,7 +19,7 @@ import {
   computeSessionDataBaseDir,
   InvalidSessionDataScopeError,
 } from '../lib/session-data-path.js';
-import { getConfigDir } from '../lib/config.js';
+import { getConfigDir, getRepositoriesDir } from '../lib/config.js';
 import { createLogger } from '../lib/logger.js';
 import {
   rmRecursiveAsUser as defaultRmRecursiveAsUser,
@@ -127,10 +128,10 @@ export function registerJobHandlers(
   // encapsulates git command construction.
   jobQueue.registerHandler<CleanupRepositoryPayload>(
     JOB_TYPES.CLEANUP_REPOSITORY,
-    async ({ repoDir, requestUsername, extraDir }) => {
+    async ({ repoDir, requestUsername, extraDir, sessionDataDirs }) => {
       const elevate = shouldElevateForUser(requestUsername);
       logger.debug(
-        { repoDir, requestUsername, elevate, extraDir },
+        { repoDir, requestUsername, elevate, extraDir, sessionDataDirs },
         'Executing cleanup:repository job',
       );
 
@@ -207,6 +208,58 @@ export function registerJobHandlers(
       await removeOne(repoDir);
       if (extraDir != null) {
         await removeOne(extraDir);
+      }
+
+      // S1301 S4: best-effort removal of the now-possibly-empty org-parent
+      // directory (`<repositories>/<org>/`). Runs regardless of whether the
+      // removal above was elevated -- the org-parent dir is created by the
+      // server process itself (`fsPromises.mkdir(..., { recursive: true })`
+      // in worktree-service.ts), never user-owned, so a plain, non-elevated
+      // `fs.rmdir` is always the right tool here. Bounded to exactly one
+      // level (never `{ recursive: true }`): fails closed (ENOTEMPTY) when
+      // sibling repos still live under the same org, and must never throw --
+      // this is cosmetic cleanup, not part of the job's success contract.
+      const orgParentDir = path.dirname(repoDir);
+      if (orgParentDir !== getRepositoriesDir()) {
+        try {
+          await fs.rmdir(orgParentDir);
+          logger.info({ orgParentDir }, 'cleanup:repository removed empty org-parent directory');
+        } catch (error) {
+          const code = error instanceof Error && 'code' in error ? (error as NodeJS.ErrnoException).code : undefined;
+          if (code === 'ENOENT' || code === 'ENOTEMPTY') {
+            logger.debug(
+              { orgParentDir, code },
+              'cleanup:repository org-parent directory not removed (missing or not empty)',
+            );
+          } else {
+            logger.warn({ orgParentDir, err: error }, 'cleanup:repository failed to remove org-parent directory');
+          }
+        }
+      }
+
+      // S1301 S3: remove session-data trees (outputs/messages/memos) built by
+      // `buildSessionDataCleanupTargets`. These directories are ALWAYS
+      // server-owned (see docs/design/session-data-path.md), so removal is
+      // UNCONDITIONAL direct `fs.rm` -- it must never consult `elevate` /
+      // `requestUsername`, even though `repoDir` / `extraDir` in the SAME job
+      // invocation may be elevating. Per-target isolation: one target's
+      // failure must not abort the loop or the whole job.
+      for (const dir of sessionDataDirs ?? []) {
+        try {
+          await fs.rm(dir, { recursive: true });
+          logger.info({ dir }, 'cleanup:repository removed session-data directory');
+        } catch (error) {
+          if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+            logger.debug({ dir }, 'cleanup:repository session-data directory does not exist, skipping');
+            continue;
+          }
+          logger.error(
+            { dir, err: error },
+            'cleanup:repository session-data removal failed for target; continuing with remaining targets',
+          );
+          // Do NOT rethrow -- one bad target must not abort the rest of the
+          // loop or trigger a full-job retry.
+        }
       }
     }
   );

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -223,6 +223,25 @@ describe('Repositories API', () => {
       expect(repositoryManager.unregisterRepository).not.toHaveBeenCalled();
     });
 
+    it('returns 409 when unregisterRepository itself rejects with RepositoryInUseError (its own internal check firing)', async () => {
+      // The route's own `assertRepositoryNotInUse` call passes here, but
+      // `unregisterRepository`'s independent internal check rejects. This
+      // pins that a RepositoryInUseError from EITHER call site maps to the
+      // same 409 contract, not just the route's own check.
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      repositoryManager.unregisterRepository.mockImplementation(() =>
+        Promise.reject(
+          new RepositoryInUseError('Repository is in use by 1 session(s) (active): Active Session'),
+        ),
+      );
+
+      const res = await app.request('/api/repositories/repo1', { method: 'DELETE' });
+      expect(res.status).toBe(409);
+
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain('Repository is in use by 1 session(s) (active)');
+    });
+
     it('should clean up Slack integration and succeed even if cleanup throws', async () => {
       repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
       repositorySlackIntegrationService.deleteIntegration.mockImplementation(() => {

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -209,6 +209,26 @@ describe('Repositories API', () => {
       expect(body.error).toContain('Repository is in use by 1 session(s) (inactive)');
     });
 
+    it('does not delete the Slack integration when the repository is in use (guard runs before the side effect)', async () => {
+      // Pins the ordering the in-code comment at the route's assertRepositoryNotInUse
+      // call site documents: this check must run BEFORE Slack-integration deletion.
+      // A comment alone cannot defend that ordering from a future edit that removes
+      // the check (CodeRabbit already proposed exactly that removal once on this
+      // PR) -- this test makes the ordering an executable invariant instead.
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      repositoryManager.assertRepositoryNotInUse.mockImplementation(() =>
+        Promise.reject(
+          new RepositoryInUseError('Repository is in use by 1 session(s) (active): Active Session'),
+        ),
+      );
+
+      const res = await app.request('/api/repositories/repo1', { method: 'DELETE' });
+      expect(res.status).toBe(409);
+
+      expect(repositorySlackIntegrationService.deleteIntegration).not.toHaveBeenCalled();
+      expect(repositoryManager.unregisterRepository).not.toHaveBeenCalled();
+    });
+
     it('propagates a non-RepositoryInUseError from assertRepositoryNotInUse instead of mapping it to 409', async () => {
       // Negative-case coverage for the mechanism itself: an unrelated
       // failure inside the gate (e.g. a DB error) must not be misreported

--- a/packages/server/src/routes/__tests__/repositories.test.ts
+++ b/packages/server/src/routes/__tests__/repositories.test.ts
@@ -5,6 +5,7 @@ import {
   CloneNameConflictError,
   CloneValidationError,
 } from '../../services/repository-clone-service.js';
+import { RepositoryInUseError } from '../../services/repository-manager.js';
 import { CLONE_ERROR_CODES, CLONE_JOB_STATUS } from '@agent-console/shared';
 
 const mockGenerateDescription = mock<GenerateRepositoryDescriptionFn>(() =>
@@ -50,6 +51,13 @@ const repositoryManager = {
       opts?: { removeSourceRepo?: boolean },
     ) => Promise<boolean>
   >(() => Promise.resolve(true)),
+  // Issue #1301: single writer for the repository-in-use gate. The route
+  // now delegates entirely to this method instead of duplicating the
+  // active/inactive-session check inline. Defaults to a no-op resolve
+  // (repository not in use); tests that need the 409 path reject with a
+  // real `RepositoryInUseError` instance, mirroring the `CloneNameConflictError`
+  // pattern used below for the clone route.
+  assertRepositoryNotInUse: mock<(id: string) => Promise<void>>(() => Promise.resolve()),
 };
 
 const sessionManager = {
@@ -101,6 +109,8 @@ function resetAllMocks(): void {
   repositoryManager.registerRepository.mockReset();
   repositoryManager.updateRepository.mockReset();
   repositoryManager.unregisterRepository.mockReset();
+  repositoryManager.assertRepositoryNotInUse.mockReset();
+  repositoryManager.assertRepositoryNotInUse.mockImplementation(() => Promise.resolve());
   sessionManager.getSessionsUsingRepository.mockReset();
   sessionManager.getAllPersistedSessions.mockReset();
   repositorySlackIntegrationService.deleteIntegration.mockReset();
@@ -161,10 +171,21 @@ describe('Repositories API', () => {
   // =========================================================================
 
   describe('DELETE /api/repositories/:id', () => {
+    // Issue #1301: the route now delegates the in-use check entirely to
+    // `repositoryManager.assertRepositoryNotInUse` (single writer). These two
+    // tests are INVARIANT-PRESERVATION, not bug-polarity -- the observable
+    // 409 behavior is unchanged from before the consolidation; only the
+    // mechanism moved from an inline route check to the manager method. The
+    // wrong implementation this guards against is the consolidation
+    // accidentally dropping the error-message mapping (RepositoryInUseError
+    // -> ConflictError) or swallowing the manager's rejection.
     it('should return 409 when repository has active sessions', async () => {
       repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
-      sessionManager.getSessionsUsingRepository.mockReturnValue([{ id: 's1', title: 'Active Session' }]);
-      sessionManager.getAllPersistedSessions.mockReturnValue(Promise.resolve([]));
+      repositoryManager.assertRepositoryNotInUse.mockImplementation(() =>
+        Promise.reject(
+          new RepositoryInUseError('Repository is in use by 1 session(s) (active): Active Session'),
+        ),
+      );
 
       const res = await app.request('/api/repositories/repo1', { method: 'DELETE' });
       expect(res.status).toBe(409);
@@ -175,9 +196,10 @@ describe('Repositories API', () => {
 
     it('should return 409 when repository has persisted (inactive) sessions', async () => {
       repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
-      sessionManager.getSessionsUsingRepository.mockReturnValue([]);
-      sessionManager.getAllPersistedSessions.mockReturnValue(
-        Promise.resolve([{ id: 's2', title: 'Paused', type: 'worktree', repositoryId: 'repo1' }])
+      repositoryManager.assertRepositoryNotInUse.mockImplementation(() =>
+        Promise.reject(
+          new RepositoryInUseError('Repository is in use by 1 session(s) (inactive): Paused'),
+        ),
       );
 
       const res = await app.request('/api/repositories/repo1', { method: 'DELETE' });
@@ -187,10 +209,22 @@ describe('Repositories API', () => {
       expect(body.error).toContain('Repository is in use by 1 session(s) (inactive)');
     });
 
+    it('propagates a non-RepositoryInUseError from assertRepositoryNotInUse instead of mapping it to 409', async () => {
+      // Negative-case coverage for the mechanism itself: an unrelated
+      // failure inside the gate (e.g. a DB error) must not be misreported
+      // as "repository in use".
+      repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
+      repositoryManager.assertRepositoryNotInUse.mockImplementation(() =>
+        Promise.reject(new Error('unexpected DB failure')),
+      );
+
+      const res = await app.request('/api/repositories/repo1', { method: 'DELETE' });
+      expect(res.status).toBe(500);
+      expect(repositoryManager.unregisterRepository).not.toHaveBeenCalled();
+    });
+
     it('should clean up Slack integration and succeed even if cleanup throws', async () => {
       repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
-      sessionManager.getSessionsUsingRepository.mockReturnValue([]);
-      sessionManager.getAllPersistedSessions.mockReturnValue(Promise.resolve([]));
       repositorySlackIntegrationService.deleteIntegration.mockImplementation(() => {
         throw new Error('Slack cleanup failed');
       });
@@ -211,8 +245,6 @@ describe('Repositories API', () => {
       // authenticated username. The default test app wires SingleUserMode
       // with TEST_AUTH_USER = 'testuser'.
       repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
-      sessionManager.getSessionsUsingRepository.mockReturnValue([]);
-      sessionManager.getAllPersistedSessions.mockReturnValue(Promise.resolve([]));
       repositoryManager.unregisterRepository.mockReturnValue(Promise.resolve(true));
 
       const res = await app.request('/api/repositories/repo1', { method: 'DELETE' });
@@ -230,8 +262,6 @@ describe('Repositories API', () => {
 
     it('forwards removeSourceRepo=true to unregisterRepository (Issue #905)', async () => {
       repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
-      sessionManager.getSessionsUsingRepository.mockReturnValue([]);
-      sessionManager.getAllPersistedSessions.mockReturnValue(Promise.resolve([]));
       repositoryManager.unregisterRepository.mockReturnValue(Promise.resolve(true));
 
       const res = await app.request('/api/repositories/repo1', {
@@ -251,8 +281,6 @@ describe('Repositories API', () => {
       // default makes the absent value `false`; the manual parse swallows
       // the JSON parse error from an empty body.
       repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
-      sessionManager.getSessionsUsingRepository.mockReturnValue([]);
-      sessionManager.getAllPersistedSessions.mockReturnValue(Promise.resolve([]));
       repositoryManager.unregisterRepository.mockReturnValue(Promise.resolve(true));
 
       const res = await app.request('/api/repositories/repo1', { method: 'DELETE' });
@@ -265,8 +293,6 @@ describe('Repositories API', () => {
 
     it('defaults removeSourceRepo=false when body is empty object (Issue #905)', async () => {
       repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
-      sessionManager.getSessionsUsingRepository.mockReturnValue([]);
-      sessionManager.getAllPersistedSessions.mockReturnValue(Promise.resolve([]));
       repositoryManager.unregisterRepository.mockReturnValue(Promise.resolve(true));
 
       const res = await app.request('/api/repositories/repo1', {
@@ -283,8 +309,6 @@ describe('Repositories API', () => {
 
     it('rejects invalid removeSourceRepo type with 400 (Issue #905)', async () => {
       repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
-      sessionManager.getSessionsUsingRepository.mockReturnValue([]);
-      sessionManager.getAllPersistedSessions.mockReturnValue(Promise.resolve([]));
 
       const res = await app.request('/api/repositories/repo1', {
         method: 'DELETE',
@@ -303,8 +327,6 @@ describe('Repositories API', () => {
       // route differentiates: empty body -> default; non-empty body that
       // fails JSON.parse -> 400.
       repositoryManager.getRepository.mockReturnValue({ id: 'repo1', path: '/repo' });
-      sessionManager.getSessionsUsingRepository.mockReturnValue([]);
-      sessionManager.getAllPersistedSessions.mockReturnValue(Promise.resolve([]));
 
       const res = await app.request('/api/repositories/repo1', {
         method: 'DELETE',

--- a/packages/server/src/routes/repositories.ts
+++ b/packages/server/src/routes/repositories.ts
@@ -180,6 +180,16 @@ const repositories = new Hono<AppBindings>()
 
     // Check if any active or inactive (paused) sessions use this repository.
     // Single writer: RepositoryManager.assertRepositoryNotInUse.
+    //
+    // This check is not redundant with unregisterRepository's own internal
+    // call to the same method below, even though both call it. It must run
+    // BEFORE the Slack-integration cleanup that follows: without it, an
+    // in-use repository would reach the Slack deletion, then fail later
+    // when unregisterRepository rejects, leaving the user with a working
+    // repository whose Slack integration was already removed.
+    // unregisterRepository's internal call exists independently, as
+    // defense-in-depth for any future caller of that method that isn't
+    // this route.
     try {
       await repositoryManager.assertRepositoryNotInUse(repoId);
     } catch (err) {
@@ -204,11 +214,19 @@ const repositories = new Hono<AppBindings>()
     // (worktree subtrees are owned by the requesting user). Forward
     // `removeSourceRepo` so the cleanup job optionally removes the
     // source-repo clone in addition to the data subtree.
-    const success = await repositoryManager.unregisterRepository(
-      repoId,
-      authUser.username,
-      { removeSourceRepo: parsed.removeSourceRepo },
-    );
+    let success: boolean;
+    try {
+      success = await repositoryManager.unregisterRepository(
+        repoId,
+        authUser.username,
+        { removeSourceRepo: parsed.removeSourceRepo },
+      );
+    } catch (err) {
+      if (err instanceof RepositoryInUseError) {
+        throw new ConflictError(err.message);
+      }
+      throw err;
+    }
 
     if (!success) {
       // Repository was likely deleted between the check and unregister (race condition)

--- a/packages/server/src/routes/repositories.ts
+++ b/packages/server/src/routes/repositories.ts
@@ -25,6 +25,7 @@ import {
   CloneValidationError,
   CloneNameConflictError,
 } from '../services/repository-clone-service.js';
+import { RepositoryInUseError } from '../services/repository-manager.js';
 
 const logger = createLogger('api:repositories');
 
@@ -144,7 +145,7 @@ const repositories = new Hono<AppBindings>()
   // Unregister a repository
   .delete('/:id', async (c) => {
     const repoId = c.req.param('id');
-    const { repositoryManager, sessionManager } = c.get('appContext');
+    const { repositoryManager } = c.get('appContext');
     const authUser = c.get('authUser');
 
     // Parse the DELETE body manually because `vValidator` would 400 on a
@@ -177,30 +178,15 @@ const repositories = new Hono<AppBindings>()
       throw new NotFoundError('Repository');
     }
 
-    // Check if any active sessions use this repository
-    const activeSessions = sessionManager.getSessionsUsingRepository(repoId);
-    const activeSessionIds = new Set(activeSessions.map(s => s.id));
-
-    // Also check persisted (inactive) sessions
-    const persistedSessions = await sessionManager.getAllPersistedSessions();
-    const inactiveSessions = persistedSessions.filter(ps =>
-      !activeSessionIds.has(ps.id) &&
-      ps.type === 'worktree' && ps.repositoryId === repoId
-    );
-
-    const totalCount = activeSessions.length + inactiveSessions.length;
-    if (totalCount > 0) {
-      const activeNames = activeSessions.map(s => s.title || s.id);
-      const inactiveNames = inactiveSessions.map(s => s.title || s.id);
-      const allNames = [...activeNames, ...inactiveNames].join(', ');
-
-      const details = activeSessions.length > 0 && inactiveSessions.length > 0
-        ? ` (${activeSessions.length} active, ${inactiveSessions.length} inactive)`
-        : activeSessions.length > 0 ? ' (active)' : ' (inactive)';
-
-      throw new ConflictError(
-        `Repository is in use by ${totalCount} session(s)${details}: ${allNames}`
-      );
+    // Check if any active or inactive (paused) sessions use this repository.
+    // Single writer: RepositoryManager.assertRepositoryNotInUse.
+    try {
+      await repositoryManager.assertRepositoryNotInUse(repoId);
+    } catch (err) {
+      if (err instanceof RepositoryInUseError) {
+        throw new ConflictError(err.message);
+      }
+      throw err;
     }
 
     // Clean up Slack integration before deleting repository

--- a/packages/server/src/services/__tests__/repository-manager.test.ts
+++ b/packages/server/src/services/__tests__/repository-manager.test.ts
@@ -2,10 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { Repository } from '@agent-console/shared';
+import type { CleanupRepositoryPayload } from '@agent-console/shared';
 import { setupMemfs, cleanupMemfs, createMockGitRepoFiles } from '../../__tests__/utils/mock-fs-helper.js';
 import { mockGit } from '../../__tests__/utils/mock-git-helper.js';
 import { mockProcess, resetProcessMock } from '../../__tests__/utils/mock-process-helper.js';
 import { JobQueue } from '../../jobs/index.js';
+import type { JobHandler } from '../../jobs/job-queue.js';
+import { registerJobHandlers } from '../../jobs/handlers.js';
+import { WorkerOutputFileManager } from '../../lib/worker-output-file.js';
 import { initializeDatabase, closeDatabase, getDatabase } from '../../database/connection.js';
 import { SqliteRepositoryRepository } from '../../repositories/index.js';
 import type { RunAsUserOpts, RunAsUserResult } from '../privilege-elevation.js';
@@ -103,6 +107,32 @@ describe('RepositoryManager', () => {
       jobQueue: testJobQueue,
       runAsUserImpl: runAsUserMock.runAsUserImpl,
     });
+  }
+
+  /**
+   * Run the enqueued CLEANUP_REPOSITORY job's payload through the REAL job
+   * handler (mirrors the harness in `jobs/__tests__/handlers.test.ts`).
+   * `testJobQueue` is never `.start()`ed in this file's `beforeEach`, so
+   * enqueued jobs stay pending -- this pulls the handler function directly
+   * via a capture-only fake queue and invokes it, exercising the production
+   * `handlers.ts` code (not a re-implementation) against the payload that
+   * was actually persisted.
+   */
+  async function runLatestCleanupRepositoryJob(): Promise<void> {
+    const jobs = await testJobQueue!.getJobs({ type: 'cleanup:repository' });
+    expect(jobs.length).toBeGreaterThan(0);
+    const payload = JSON.parse(jobs[jobs.length - 1]!.payload) as CleanupRepositoryPayload;
+
+    const handlers = new Map<string, JobHandler<unknown>>();
+    const fakeQueue = {
+      registerHandler: <T>(type: string, handler: JobHandler<T>) => {
+        handlers.set(type, handler as JobHandler<unknown>);
+      },
+    } as unknown as JobQueue;
+    registerJobHandlers(fakeQueue, new WorkerOutputFileManager());
+
+    const handler = handlers.get('cleanup:repository')!;
+    await handler(payload);
   }
 
   describe('registerRepository', () => {
@@ -726,6 +756,124 @@ describe('RepositoryManager', () => {
           extraDir: string | null;
         };
         expect(payload.extraDir).toBeNull();
+      });
+    });
+
+    // =========================================================================
+    // Issue #1301: consolidated repository-in-use gate (S0). The direct-call
+    // bug-polarity test (T0a) proves `unregisterRepository` itself refuses
+    // when a PERSISTED (not in-memory) worktree session is attached -- this
+    // is the gap the route's independently-written duplicate check used to
+    // shield. See `RepositoryManager.assertRepositoryNotInUse`.
+    // =========================================================================
+
+    describe('repository-in-use gate for persisted sessions (Issue #1301)', () => {
+      it('refuses to unregister when a persisted (inactive) session is attached, and enqueues no cleanup job', async () => {
+        const manager = await getRepositoryManager();
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+
+        // No in-memory session; only the "inactive" callback reports a
+        // persisted worktree session for this repo. Before the S0 fix,
+        // `unregisterRepository` only consulted `getSessionsUsingRepository`
+        // (active/in-memory) and would proceed straight to cleanup.
+        manager.setDependencyCallbacks({
+          getSessionsUsingRepository: () => [],
+          getInactiveSessionsUsingRepository: async () => [
+            { id: 'paused-1', title: 'Paused worktree' },
+          ],
+        });
+
+        await expect(manager.unregisterRepository(repo.id)).rejects.toMatchObject({
+          name: 'RepositoryInUseError',
+        });
+
+        // The repository must still be registered (no destructive cleanup
+        // was enqueued or applied).
+        expect(manager.getRepository(repo.id)).toBeDefined();
+        const jobs = await testJobQueue!.getJobs({ type: 'cleanup:repository' });
+        expect(jobs.length).toBe(0);
+      });
+
+      it('proceeds when neither active nor inactive callbacks report any session', async () => {
+        const manager = await getRepositoryManager();
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+
+        manager.setDependencyCallbacks({
+          getSessionsUsingRepository: () => [],
+          getInactiveSessionsUsingRepository: async () => [],
+        });
+
+        const result = await manager.unregisterRepository(repo.id);
+        expect(result).toBe(true);
+        expect(manager.getRepository(repo.id)).toBeUndefined();
+      });
+    });
+
+    // =========================================================================
+    // Issue #1301: session-data cleanup targets (S1-S4). Verifies the
+    // CLEANUP_REPOSITORY payload carries `sessionDataDirs` and that the real
+    // job handler removes the flat-shape session-data tree alongside the
+    // org/repo worktree directory (the orphan-leak bug).
+    // =========================================================================
+
+    describe('session-data cleanup (Issue #1301)', () => {
+      it('removes the flat-shape session-data dir alongside the org/repo dir when they differ (bug-polarity)', async () => {
+        // beforeEach() already mocks getOrgRepoFromPath -> 'test-org/repo',
+        // which differs from repo.name ('repo', the basename of
+        // TEST_REPO_DIR) -- reproducing the remote-backed-repo divergence
+        // between repoDir (org/repo shape) and the session-data slug
+        // (repo.name shape).
+        const manager = await getRepositoryManager();
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+        expect(repo.name).toBe('repo');
+
+        // Pre-existing flat-shape session-data tree at the canonical slug
+        // (repo.name = 'repo'), simulating an orphaned outputs/ dir left
+        // over from prior sessions against this repository.
+        const sessionDataDir = path.join(TEST_CONFIG_DIR, 'repositories', 'repo', 'outputs');
+        fs.mkdirSync(sessionDataDir, { recursive: true });
+        fs.writeFileSync(path.join(sessionDataDir, 'marker'), 'x');
+
+        // Also populate the org/repo worktree dir (repoDir) with a marker so
+        // its removal assertion below is a positive proof, not a vacuous
+        // pass against a directory that never existed.
+        const repoWorktreeDir = path.join(TEST_CONFIG_DIR, 'repositories', 'test-org', 'repo');
+        fs.mkdirSync(repoWorktreeDir, { recursive: true });
+        fs.writeFileSync(path.join(repoWorktreeDir, 'marker'), 'y');
+
+        await manager.unregisterRepository(repo.id);
+        await runLatestCleanupRepositoryJob();
+
+        // The org/repo worktree dir is gone (repoDir).
+        expect(fs.existsSync(repoWorktreeDir)).toBe(false);
+        // The flat-shape session-data dir is ALSO gone -- this is the fix;
+        // before it, this directory was never referenced by the payload and
+        // would survive unregistration forever.
+        expect(fs.existsSync(sessionDataDir)).toBe(false);
+        // The now-empty org-parent dir is removed too (S4).
+        expect(fs.existsSync(path.join(TEST_CONFIG_DIR, 'repositories', 'test-org'))).toBe(false);
+      });
+
+      it('does not double-delete or error when the org/repo dir and session-data slug coincide (local-only repo)', async () => {
+        // Local-only repo: getOrgRepoFromPath falls back to path.basename,
+        // so repoDir's basename equals repo.name -- the canonical
+        // session-data slug and the repoDir org-component collapse to the
+        // same directory.
+        mockGit.getOrgRepoFromPath.mockReset();
+        mockGit.getOrgRepoFromPath.mockImplementation(() => Promise.resolve(null));
+
+        const manager = await getRepositoryManager();
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+        expect(repo.name).toBe('repo');
+
+        const sessionDataDir = path.join(TEST_CONFIG_DIR, 'repositories', 'repo', 'outputs');
+        fs.mkdirSync(sessionDataDir, { recursive: true });
+        fs.writeFileSync(path.join(sessionDataDir, 'marker'), 'x');
+
+        await manager.unregisterRepository(repo.id);
+        await expect(runLatestCleanupRepositoryJob()).resolves.toBeUndefined();
+
+        expect(fs.existsSync(path.join(TEST_CONFIG_DIR, 'repositories', 'repo'))).toBe(false);
       });
     });
   });

--- a/packages/server/src/services/__tests__/repository-manager.test.ts
+++ b/packages/server/src/services/__tests__/repository-manager.test.ts
@@ -121,7 +121,7 @@ describe('RepositoryManager', () => {
   async function runLatestCleanupRepositoryJob(): Promise<void> {
     const jobs = await testJobQueue!.getJobs({ type: 'cleanup:repository' });
     expect(jobs.length).toBeGreaterThan(0);
-    const payload = JSON.parse(jobs[jobs.length - 1]!.payload) as CleanupRepositoryPayload;
+    const payload = JSON.parse(jobs[0]!.payload) as CleanupRepositoryPayload;
 
     const handlers = new Map<string, JobHandler<unknown>>();
     const fakeQueue = {

--- a/packages/server/src/services/__tests__/repository-manager.test.ts
+++ b/packages/server/src/services/__tests__/repository-manager.test.ts
@@ -807,6 +807,74 @@ describe('RepositoryManager', () => {
         expect(result).toBe(true);
         expect(manager.getRepository(repo.id)).toBeUndefined();
       });
+
+      // Invariant-preservation: assertRepositoryNotInUse's message composition
+      // (the count, the three-branch "(active)" / "(inactive)" / "(N active, M
+      // inactive)" details ternary, and the name-joining) moved unchanged from
+      // routes/repositories.ts's DELETE handler into RepositoryManager during
+      // the S0 consolidation -- an acceptance-check review found it had no
+      // direct coverage anywhere in that move. A broken implementation here
+      // (a wrong plural, a swapped active/inactive order in the details
+      // branch, or a broken name-join) would still pass every other test in
+      // this file, since those only assert `RepositoryInUseError` type /
+      // rejection and never inspect the composed message content. These four
+      // tests call `assertRepositoryNotInUse` directly (not through
+      // `unregisterRepository`) and pin the exact string for each branch.
+      it('composes "(active)" details with a single active session', async () => {
+        const manager = await getRepositoryManager();
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+
+        manager.setDependencyCallbacks({
+          getSessionsUsingRepository: () => [{ id: 's1', title: 'Active Session' }],
+          getInactiveSessionsUsingRepository: async () => [],
+        });
+
+        await expect(manager.assertRepositoryNotInUse(repo.id)).rejects.toThrow(
+          'Repository is in use by 1 session(s) (active): Active Session',
+        );
+      });
+
+      it('composes "(inactive)" details with a single inactive session', async () => {
+        const manager = await getRepositoryManager();
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+
+        manager.setDependencyCallbacks({
+          getSessionsUsingRepository: () => [],
+          getInactiveSessionsUsingRepository: async () => [{ id: 's2', title: 'Paused' }],
+        });
+
+        await expect(manager.assertRepositoryNotInUse(repo.id)).rejects.toThrow(
+          'Repository is in use by 1 session(s) (inactive): Paused',
+        );
+      });
+
+      it('composes "(N active, M inactive)" details when both are present', async () => {
+        const manager = await getRepositoryManager();
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+
+        manager.setDependencyCallbacks({
+          getSessionsUsingRepository: () => [{ id: 's1', title: 'Active Session' }],
+          getInactiveSessionsUsingRepository: async () => [{ id: 's2', title: 'Paused' }],
+        });
+
+        await expect(manager.assertRepositoryNotInUse(repo.id)).rejects.toThrow(
+          'Repository is in use by 2 session(s) (1 active, 1 inactive): Active Session, Paused',
+        );
+      });
+
+      it('falls back to the session id when title is absent', async () => {
+        const manager = await getRepositoryManager();
+        const repo = await manager.registerRepository(TEST_REPO_DIR);
+
+        manager.setDependencyCallbacks({
+          getSessionsUsingRepository: () => [{ id: 'no-title-id' }],
+          getInactiveSessionsUsingRepository: async () => [],
+        });
+
+        await expect(manager.assertRepositoryNotInUse(repo.id)).rejects.toThrow(
+          'Repository is in use by 1 session(s) (active): no-title-id',
+        );
+      });
     });
 
     // =========================================================================

--- a/packages/server/src/services/__tests__/repository-unregister-paused-session.test.ts
+++ b/packages/server/src/services/__tests__/repository-unregister-paused-session.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Issue #1301 (T0b): the repository-in-use gate must protect a REAL paused
+ * session, not merely exist as a mocked-callback assertion. This test uses
+ * real cross-service wiring (`createTestContext`, the same pattern as
+ * `__tests__/app-context.test.ts`) -- a real `RepositoryManager` and a real
+ * `SessionManager` backed by a real (in-memory) SQLite database, wired
+ * together via the production `setDependencyCallbacks` call.
+ *
+ * Flow: register a repo -> persist a paused worktree session for it (direct
+ * DB write, mirroring what `SessionPauseResumeService.pauseSession` produces)
+ * -> attempt unregister (expect refusal) -> resume the session and confirm
+ * it comes back intact (no exception, still type 'worktree', its on-disk
+ * location untouched). This proves the refusal actually protects something,
+ * not just that it exists.
+ *
+ * Uses `setupMemfs`/`cleanupMemfs` (the same central mock registry
+ * `repository-manager.test.ts` uses) rather than the real OS filesystem --
+ * `fs` / `fs/promises` become process-globally mocked once any other server
+ * test file in the same `bun test src/` run imports that helper, so relying
+ * on the real filesystem here would be backing-store-dependent on file
+ * execution order. See `.claude/rules/testing.md` Anti-Pattern #2.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import { setupMemfs, cleanupMemfs, createMockGitRepoFiles } from '../../__tests__/utils/mock-fs-helper.js';
+import {
+  createTestContext,
+  shutdownAppContext,
+  type AppContext,
+} from '../../app-context.js';
+import { RepositoryInUseError } from '../repository-manager.js';
+
+const TEST_CONFIG_DIR = '/test/config';
+const REPO_PATH = '/test/source-repo';
+const WORKTREE_PATH = '/test/worktree';
+
+describe('unregisterRepository refuses a repository with a paused session, and resume still works (Issue #1301, T0b)', () => {
+  let appContext: AppContext | null = null;
+
+  beforeEach(() => {
+    setupMemfs({
+      [`${TEST_CONFIG_DIR}/.keep`]: '',
+      [`${WORKTREE_PATH}/.keep`]: '',
+      ...createMockGitRepoFiles(REPO_PATH),
+    });
+    process.env.AGENT_CONSOLE_HOME = TEST_CONFIG_DIR;
+  });
+
+  afterEach(async () => {
+    if (appContext) {
+      await shutdownAppContext(appContext);
+      appContext = null;
+    }
+    cleanupMemfs();
+  });
+
+  it('refuses to unregister while a paused session is attached, and the session resumes cleanly afterward', async () => {
+    appContext = await createTestContext();
+
+    const repo = await appContext.repositoryManager.registerRepository(REPO_PATH);
+
+    // Directly persist a paused worktree session for this repository --
+    // mirrors the DB row `SessionPauseResumeService.pauseSession` produces
+    // (serverPid: null, pausedAt set, not in memory). No workers, so
+    // resume below never needs to spawn a real PTY.
+    const sessionId = 'paused-worktree-session-1';
+    await appContext.sessionRepository.save({
+      id: sessionId,
+      type: 'worktree',
+      locationPath: WORKTREE_PATH,
+      repositoryId: repo.id,
+      worktreeId: 'main',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      workers: [],
+      serverPid: null,
+      pausedAt: '2026-01-01T00:05:00.000Z',
+      dataScope: 'repository',
+      dataScopeSlug: repo.name,
+    });
+
+    // The session is not active in memory (never went through
+    // sessionManager.createSession / resumeSession), so only the
+    // "inactive" callback should report it.
+    expect(appContext.sessionManager.getSession(sessionId)).toBeUndefined();
+
+    await expect(
+      appContext.repositoryManager.unregisterRepository(repo.id),
+    ).rejects.toBeInstanceOf(RepositoryInUseError);
+
+    // Repository is still registered; nothing was destructively cleaned up.
+    expect(appContext.repositoryManager.getRepository(repo.id)).toBeDefined();
+    expect(fs.existsSync(WORKTREE_PATH)).toBe(true);
+
+    // The session resumes cleanly -- proving the refusal protected a real,
+    // usable session rather than just existing as a gate.
+    const resumed = await appContext.sessionManager.resumeSession(sessionId);
+    expect(resumed).not.toBeNull();
+    expect(resumed!.id).toBe(sessionId);
+    expect(resumed!.type).toBe('worktree');
+
+    // The session's on-disk location is untouched throughout.
+    expect(fs.existsSync(WORKTREE_PATH)).toBe(true);
+
+    // Persisted state now reflects the active (resumed) session -- pausedAt
+    // is cleared (the repository maps a NULL column to `undefined`).
+    const persisted = await appContext.sessionRepository.findById(sessionId);
+    expect(persisted).not.toBeNull();
+    expect(persisted!.pausedAt).toBeUndefined();
+  });
+});

--- a/packages/server/src/services/__tests__/session-data-cleanup-candidates.test.ts
+++ b/packages/server/src/services/__tests__/session-data-cleanup-candidates.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'bun:test';
+import { buildSessionDataCleanupTargets } from '../session-data-cleanup-candidates.js';
+import { computeSessionDataBaseDir } from '../../lib/session-data-path.js';
+
+const CONFIG_DIR = '/test/config';
+
+describe('buildSessionDataCleanupTargets (Issue #1301)', () => {
+  it('dedups identical canonical/basename/repoName candidates into a single existing target', async () => {
+    const targets = await buildSessionDataCleanupTargets({
+      configDir: CONFIG_DIR,
+      repositoryId: 'repo-1',
+      repoPath: '/source/repos/owner/repo-1',
+      repoName: 'repo-1',
+      getRepositorySlug: () => 'repo-1',
+      pathExists: async () => true,
+    });
+
+    expect(targets).toEqual([computeSessionDataBaseDir(CONFIG_DIR, 'repository', 'repo-1')]);
+  });
+
+  it('returns only the target repository\'s candidate slugs, not an unrelated sibling repository\'s slug', async () => {
+    const targetsForRepoA = await buildSessionDataCleanupTargets({
+      configDir: CONFIG_DIR,
+      repositoryId: 'repo-a',
+      repoPath: '/source/repos/owner/repo-a',
+      repoName: 'repo-a',
+      getRepositorySlug: () => 'repo-a',
+      pathExists: async () => true,
+    });
+
+    const repoBDir = computeSessionDataBaseDir(CONFIG_DIR, 'repository', 'repo-b');
+    expect(targetsForRepoA).not.toContain(repoBDir);
+    expect(targetsForRepoA).toEqual([computeSessionDataBaseDir(CONFIG_DIR, 'repository', 'repo-a')]);
+  });
+
+  it('returns three distinct candidate dirs when the canonical slug, basename, and repoName all differ', async () => {
+    const seenPaths: string[] = [];
+    const targets = await buildSessionDataCleanupTargets({
+      configDir: CONFIG_DIR,
+      repositoryId: 'repo-1',
+      repoPath: '/source/repos/owner/basename-slug',
+      repoName: 'reponame-slug',
+      getRepositorySlug: () => 'canonical-slug',
+      pathExists: async (p) => {
+        seenPaths.push(p);
+        return true;
+      },
+    });
+
+    expect(targets.sort()).toEqual(
+      [
+        computeSessionDataBaseDir(CONFIG_DIR, 'repository', 'canonical-slug'),
+        computeSessionDataBaseDir(CONFIG_DIR, 'repository', 'basename-slug'),
+        computeSessionDataBaseDir(CONFIG_DIR, 'repository', 'reponame-slug'),
+      ].sort(),
+    );
+    // Each candidate is probed exactly once (no duplicate existence checks).
+    expect(seenPaths.length).toBe(3);
+  });
+
+  it('omits candidates that fail the existence check', async () => {
+    const targets = await buildSessionDataCleanupTargets({
+      configDir: CONFIG_DIR,
+      repositoryId: 'repo-1',
+      repoPath: '/source/repos/owner/repo-1',
+      repoName: 'repo-1',
+      getRepositorySlug: () => 'repo-1',
+      pathExists: async () => false,
+    });
+
+    expect(targets).toEqual([]);
+  });
+
+  it('omits the canonical-slug candidate entirely when getRepositorySlug returns undefined (unregistered repo)', async () => {
+    const targets = await buildSessionDataCleanupTargets({
+      configDir: CONFIG_DIR,
+      repositoryId: 'repo-1',
+      repoPath: '/source/repos/owner/repo-1',
+      repoName: 'repo-1',
+      getRepositorySlug: () => undefined,
+      pathExists: async () => true,
+    });
+
+    // basename(repoPath) === repoName === 'repo-1' here, so the only
+    // resulting target is the deduped 'repo-1' candidate -- proving the
+    // canonical slug was not silently coerced to some other value.
+    expect(targets).toEqual([computeSessionDataBaseDir(CONFIG_DIR, 'repository', 'repo-1')]);
+  });
+
+  // ===========================================================================
+  // T3: containment + validator-rejection. A hostile slug must never be
+  // hand-joined into a path -- `computeSessionDataBaseDir` is the exclusive,
+  // validating single writer, and a rejected candidate must not abort the
+  // other, valid candidates in the same call (per-candidate isolation).
+  // ===========================================================================
+
+  it('skips a path-traversal candidate slug without throwing, and still returns the other valid candidates', async () => {
+    const targets = await buildSessionDataCleanupTargets({
+      configDir: CONFIG_DIR,
+      repositoryId: 'repo-1',
+      // basename('/source/repos/owner/../etc') resolves to 'etc' via
+      // path.basename (no traversal semantics at that layer), so we drive
+      // the hostile candidate through the canonical-slug callback instead,
+      // which is passed through verbatim.
+      repoPath: '/source/repos/owner/repo-1',
+      repoName: 'repo-1',
+      getRepositorySlug: () => '../etc',
+      pathExists: async () => true,
+    });
+
+    // The hostile '../etc' candidate is silently skipped (logged, not
+    // thrown); the other two candidates (basename + repoName, both
+    // 'repo-1') dedup to the one valid, existing target.
+    expect(targets).toEqual([computeSessionDataBaseDir(CONFIG_DIR, 'repository', 'repo-1')]);
+  });
+
+  it('does not throw when every candidate slug is invalid, returning an empty target list', async () => {
+    await expect(
+      buildSessionDataCleanupTargets({
+        configDir: CONFIG_DIR,
+        repositoryId: 'repo-1',
+        // path.basename('/source/repos/..') === '..' -- an invalid slug
+        // segment, not a resolved traversal (path.basename does not
+        // normalize '..' away).
+        repoPath: '/source/repos/..',
+        repoName: '..',
+        getRepositorySlug: () => '../etc',
+        pathExists: async () => true,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  // ===========================================================================
+  // T4: structural-coupling lock. Proves the coupling to the repository slug
+  // is a CALL to `getRepositorySlug`, not a re-derivation -- so a future
+  // change to what that accessor returns (Issue #1300) keeps this test
+  // correct without modification.
+  // ===========================================================================
+
+  it('is driven by a call to getRepositorySlug, not an independent re-derivation of the canonical slug', async () => {
+    const targets = await buildSessionDataCleanupTargets({
+      configDir: CONFIG_DIR,
+      repositoryId: 'repo-1',
+      repoPath: '/source/repos/owner/basename-not-sentinel',
+      repoName: 'reponame-not-sentinel',
+      getRepositorySlug: () => 'sentinel-canonical-slug',
+      pathExists: async (p) => p.includes('sentinel-canonical-slug'),
+    });
+
+    expect(targets).toEqual([
+      computeSessionDataBaseDir(CONFIG_DIR, 'repository', 'sentinel-canonical-slug'),
+    ]);
+  });
+});

--- a/packages/server/src/services/__tests__/session-manager.test.ts
+++ b/packages/server/src/services/__tests__/session-manager.test.ts
@@ -180,6 +180,79 @@ describe('SessionManager', () => {
     });
   });
 
+  // ===========================================================================
+  // Issue #1301: single writer for the "inactive" half of the
+  // unregister-repository in-use gate. Excludes sessions active in memory,
+  // includes persisted worktree sessions for the repository (paused, or any
+  // other row not currently active), excludes quick sessions and sessions
+  // for other repositories.
+  // ===========================================================================
+
+  describe('getInactiveSessionsUsingRepository (Issue #1301)', () => {
+    it('returns only the persisted worktree session, excluding the active one and sessions from other repos/types', async () => {
+      const manager = await getSessionManager();
+
+      // Active (in-memory) worktree session for repo-1 -- must be excluded.
+      const activeSession = await manager.createSession({
+        type: 'worktree',
+        locationPath: '/test/active',
+        repositoryId: 'repo-1',
+        worktreeId: 'main',
+        agentId: 'claude-code',
+      });
+
+      // Directly persist a second, PAUSED worktree session for repo-1 --
+      // not in memory, must be included.
+      await manager.getSessionRepository().save({
+        id: 'paused-session-1',
+        type: 'worktree',
+        locationPath: '/test/paused',
+        repositoryId: 'repo-1',
+        worktreeId: 'main',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        workers: [],
+        serverPid: null,
+        pausedAt: '2026-01-01T00:05:00.000Z',
+      });
+
+      // Persisted quick session -- wrong type, must be excluded.
+      await manager.getSessionRepository().save({
+        id: 'quick-session-1',
+        type: 'quick',
+        locationPath: '/test/quick',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        workers: [],
+        serverPid: null,
+      });
+
+      // Persisted worktree session for a DIFFERENT repository -- must be
+      // excluded.
+      await manager.getSessionRepository().save({
+        id: 'other-repo-session-1',
+        type: 'worktree',
+        locationPath: '/test/other-repo',
+        repositoryId: 'repo-2',
+        worktreeId: 'main',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        workers: [],
+        serverPid: null,
+      });
+
+      const inactive = await manager.getInactiveSessionsUsingRepository('repo-1');
+
+      expect(inactive.map((s: Session) => s.id)).toEqual(['paused-session-1']);
+      expect(inactive.every((s: Session) => s.id !== activeSession.id)).toBe(true);
+    });
+
+    it('returns an empty array when there are no inactive sessions for the repository', async () => {
+      const manager = await getSessionManager();
+
+      const inactive = await manager.getInactiveSessionsUsingRepository('repo-1');
+
+      expect(inactive).toEqual([]);
+    });
+  });
+
   describe('createSession', () => {
     it('should create a new worktree session with correct properties', async () => {
       const manager = await getSessionManager();

--- a/packages/server/src/services/repository-manager.ts
+++ b/packages/server/src/services/repository-manager.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import { access, lstat } from 'fs/promises';
 import * as path from 'path';
 import type { Repository } from '@agent-console/shared';
-import { getRepositoryDir, getSourceReposDir } from '../lib/config.js';
+import { getConfigDir, getRepositoryDir, getSourceReposDir } from '../lib/config.js';
 import { isUnderSourceReposDir } from '../lib/repository-remote.js';
 import { getOrgRepoFromPath as gitGetOrgRepoFromPath } from '../lib/git.js';
 import { createLogger } from '../lib/logger.js';
@@ -11,6 +11,7 @@ import type { RepositoryRepository, RepositoryUpdates } from '../repositories/re
 import { SqliteRepositoryRepository } from '../repositories/sqlite-repository-repository.js';
 import { JOB_TYPES, type JobQueue } from '../jobs/index.js';
 import { runAsUser, shellEscape } from './privilege-elevation.js';
+import { buildSessionDataCleanupTargets } from './session-data-cleanup-candidates.js';
 
 const logger = createLogger('service:repository-manager');
 
@@ -75,6 +76,25 @@ export function buildManualFallbackCommands(
  */
 export interface RepositoryDependencyCallbacks {
   getSessionsUsingRepository: (repositoryId: string) => { id: string; title?: string }[];
+  /**
+   * Persisted (paused, or otherwise not currently active in memory) worktree
+   * sessions for the repository. Single writer:
+   * `SessionManager.getInactiveSessionsUsingRepository`.
+   */
+  getInactiveSessionsUsingRepository: (repositoryId: string) => Promise<{ id: string; title?: string }[]>;
+}
+
+/**
+ * Thrown by {@link RepositoryManager.assertRepositoryNotInUse} when a
+ * repository has active and/or inactive (paused) sessions attached to it.
+ * Mirrors `CloneNameConflictError` (`repository-clone-service.ts`) so route
+ * handlers can map it to a `409 Conflict` via a single `instanceof` check.
+ */
+export class RepositoryInUseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RepositoryInUseError';
+  }
 }
 
 /**
@@ -250,6 +270,38 @@ export class RepositoryManager {
   }
 
   /**
+   * Throw {@link RepositoryInUseError} when a repository has any active
+   * (in-memory) or inactive (persisted, e.g. paused) worktree session
+   * attached to it. Single writer for this gate — the
+   * `DELETE /api/repositories/:id` route previously duplicated this exact
+   * logic inline; it now calls this method instead.
+   *
+   * Race safety: `SessionPauseResumeService.pauseSession` persists the DB
+   * row (`sessionRepository.save`) BEFORE removing the session from the
+   * in-memory map (`deleteSession`) — see `session-pause-resume-service.ts`.
+   * So at every instant of the pause transition, the session is counted by
+   * exactly one of the two callbacks (in-memory while still active,
+   * persisted-and-deduped-out-of-active once removed from memory) — no gap,
+   * no double-count.
+   */
+  async assertRepositoryNotInUse(repositoryId: string): Promise<void> {
+    const activeSessions = this.dependencyCallbacks?.getSessionsUsingRepository(repositoryId) ?? [];
+    const inactiveSessions = (await this.dependencyCallbacks?.getInactiveSessionsUsingRepository(repositoryId)) ?? [];
+    const totalCount = activeSessions.length + inactiveSessions.length;
+    if (totalCount === 0) return;
+    const activeNames = activeSessions.map((s) => s.title || s.id);
+    const inactiveNames = inactiveSessions.map((s) => s.title || s.id);
+    const allNames = [...activeNames, ...inactiveNames].join(', ');
+    const details =
+      activeSessions.length > 0 && inactiveSessions.length > 0
+        ? ` (${activeSessions.length} active, ${inactiveSessions.length} inactive)`
+        : activeSessions.length > 0
+          ? ' (active)'
+          : ' (inactive)';
+    throw new RepositoryInUseError(`Repository is in use by ${totalCount} session(s)${details}: ${allNames}`);
+  }
+
+  /**
    * Unregister a repository, deleting its data subtree and DB row.
    *
    * @param id Repository ID to unregister.
@@ -271,18 +323,13 @@ export class RepositoryManager {
     const repo = this.repositories.get(id);
     if (!repo) return false;
 
-    // Check if any active sessions are using this repository
-    // Uses callback to avoid circular dependency with SessionManager
-    const activeSessions = this.dependencyCallbacks?.getSessionsUsingRepository(id) ?? [];
-    if (activeSessions.length > 0) {
-      throw new Error(
-        `Cannot unregister repository: ${activeSessions.length} active session(s) are using it. ` +
-        `Delete or close the sessions first.`
-      );
-    }
+    // Check if any active or inactive (paused) sessions are using this
+    // repository. Uses callbacks to avoid circular dependency with
+    // SessionManager. Throws RepositoryInUseError when in use.
+    await this.assertRepositoryNotInUse(id);
 
     // Clean up related directories
-    await this.cleanupRepositoryData(repo.path, requestUsername, opts);
+    await this.cleanupRepositoryData(repo, requestUsername, opts);
 
     this.repositories.delete(id);
     await this.repository.delete(id);
@@ -550,21 +597,24 @@ export class RepositoryManager {
   }
 
   /**
-   * Clean up repository data directory (worktrees and templates)
-   * @param repoPath Absolute path of the registered repository (used to
-   *   resolve the data dir under `<AGENT_CONSOLE_HOME>/repositories/<org/repo>`).
+   * Clean up repository data directory (worktrees and templates), plus the
+   * repository's session-data trees (outputs/messages/memos).
+   * @param repo The repository being unregistered. `repo.path` resolves the
+   *   worktree/templates data dir under
+   *   `<AGENT_CONSOLE_HOME>/repositories/<org/repo>`; `repo.id` / `repo.name`
+   *   drive the session-data cleanup candidate set.
    * @param requestUsername OS username threaded into the CLEANUP_REPOSITORY
    *   payload so the handler can elevate the recursive `rm` to that user
    *   under `AUTH_MODE=multi-user` when the worktree subtree is user-owned.
    *   `null` keeps the historical direct `fs.rm` path.
    * @param opts.removeSourceRepo When `true`, additionally remove the source
-   *   repo clone at `repoPath` itself. Only honoured when `repoPath` lives
+   *   repo clone at `repo.path` itself. Only honoured when `repo.path` lives
    *   under `getSourceReposDir()`; out-of-prefix paths are silently skipped
    *   with a debug log.
    * @throws Error if jobQueue is not available
    */
   private async cleanupRepositoryData(
-    repoPath: string,
+    repo: Repository,
     requestUsername: string | null,
     opts: { removeSourceRepo?: boolean } = {},
   ): Promise<void> {
@@ -572,7 +622,7 @@ export class RepositoryManager {
       throw new Error('JobQueue not available for repository cleanup. Ensure RepositoryManager.create() was called with jobQueue.');
     }
 
-    const orgRepo = await getOrgRepoFromPath(repoPath);
+    const orgRepo = await getOrgRepoFromPath(repo.path);
     const repoDir = getRepositoryDir(orgRepo);
 
     // When the unregister request opts in to source-repo removal, verify the
@@ -584,21 +634,34 @@ export class RepositoryManager {
     let extraDir: string | null = null;
     if (opts.removeSourceRepo === true) {
       const sourceReposDir = getSourceReposDir();
-      if (isUnderSourceReposDir(repoPath, sourceReposDir)) {
-        extraDir = repoPath;
+      if (isUnderSourceReposDir(repo.path, sourceReposDir)) {
+        extraDir = repo.path;
       } else {
         logger.debug(
-          { repoPath, sourceReposDir },
+          { repoPath: repo.path, sourceReposDir },
           'removeSourceRepo requested but registered path is outside source-repos dir; skipping extra cleanup',
         );
       }
     }
+
+    // Session-data trees (outputs/messages/memos) live under a slug derived
+    // from the repository name, which is independent of `repoDir` (org/repo
+    // derived from the git remote). Build the candidate set of base dirs to
+    // remove alongside `repoDir`.
+    const sessionDataDirs = await buildSessionDataCleanupTargets({
+      configDir: getConfigDir(),
+      repositoryId: repo.id,
+      repoPath: repo.path,
+      repoName: repo.name,
+      getRepositorySlug: (id) => this.getRepositorySlug(id),
+    });
 
     // Clean up entire repository directory via job queue
     await this.jobQueue.enqueue(JOB_TYPES.CLEANUP_REPOSITORY, {
       repoDir,
       requestUsername,
       extraDir,
+      sessionDataDirs,
     });
   }
 

--- a/packages/server/src/services/repository-manager.ts
+++ b/packages/server/src/services/repository-manager.ts
@@ -283,6 +283,13 @@ export class RepositoryManager {
    * exactly one of the two callbacks (in-memory while still active,
    * persisted-and-deduped-out-of-active once removed from memory) — no gap,
    * no double-count.
+   *
+   * Known gap: this check is point-in-time only. No lock is held between
+   * this read and the `CLEANUP_REPOSITORY` job's execution (which runs
+   * asynchronously via the job queue and can outlive the request that
+   * enqueued it). A worktree session created or resumed for this repository
+   * after this check passes but before the cleanup job runs will have its
+   * directories removed once the job executes.
    */
   async assertRepositoryNotInUse(repositoryId: string): Promise<void> {
     const activeSessions = this.dependencyCallbacks?.getSessionsUsingRepository(repositoryId) ?? [];

--- a/packages/server/src/services/session-data-cleanup-candidates.ts
+++ b/packages/server/src/services/session-data-cleanup-candidates.ts
@@ -1,0 +1,83 @@
+import { access } from 'fs/promises';
+import * as path from 'path';
+import {
+  computeSessionDataBaseDir,
+  InvalidSessionDataScopeError,
+} from '../lib/session-data-path.js';
+import { createLogger } from '../lib/logger.js';
+
+const logger = createLogger('service:session-data-cleanup-candidates');
+
+export interface BuildSessionDataCleanupTargetsParams {
+  configDir: string;
+  repositoryId: string;
+  repoPath: string;
+  repoName: string;
+  /** MUST be the real `RepositoryManager.getRepositorySlug` accessor (or an
+   *  equivalent) — never a re-implementation of its derivation. If a future
+   *  dedicated slug-derivation helper lands, this call site follows
+   *  automatically. */
+  getRepositorySlug: (id: string) => string | undefined;
+  /** Injectable for tests; defaults to a real `fs/promises.access` check. */
+  pathExists?: (p: string) => Promise<boolean>;
+}
+
+const defaultPathExists = async (p: string): Promise<boolean> => {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Build the list of session-data base directories (outputs/messages/memos
+ * roots) to remove when a repository is unregistered.
+ *
+ * Candidate slugs, deduplicated:
+ *   1. The canonical slug from `getRepositorySlug(repositoryId)` (current
+ *      session-creation derivation).
+ *   2. `path.basename(repoPath)` — closed legacy-flat set.
+ *   3. `repoName` — closed legacy-flat set.
+ * Do NOT extend the legacy set with new derivations; only #1's canonical
+ * accessor should change as the codebase evolves.
+ *
+ * Each candidate is converted to a path EXCLUSIVELY via
+ * `computeSessionDataBaseDir` (the validating single writer). A candidate
+ * that fails validation (traversal, malformed slug) is logged and skipped —
+ * never hand-joined, never deleted raw. Only existing directories are
+ * returned.
+ */
+export async function buildSessionDataCleanupTargets(
+  params: BuildSessionDataCleanupTargetsParams,
+): Promise<string[]> {
+  const pathExists = params.pathExists ?? defaultPathExists;
+  const candidateSlugs = new Set<string>();
+
+  const canonicalSlug = params.getRepositorySlug(params.repositoryId);
+  if (canonicalSlug) candidateSlugs.add(canonicalSlug);
+  candidateSlugs.add(path.basename(params.repoPath));
+  candidateSlugs.add(params.repoName);
+
+  const targets: string[] = [];
+  for (const slug of candidateSlugs) {
+    let baseDir: string;
+    try {
+      baseDir = computeSessionDataBaseDir(params.configDir, 'repository', slug);
+    } catch (err) {
+      if (err instanceof InvalidSessionDataScopeError) {
+        logger.warn(
+          { repositoryId: params.repositoryId, slug, err: err.message },
+          'Skipping invalid session-data cleanup candidate slug',
+        );
+        continue;
+      }
+      throw err;
+    }
+    if (await pathExists(baseDir)) {
+      targets.push(baseDir);
+    }
+  }
+  return targets;
+}

--- a/packages/server/src/services/session-manager.ts
+++ b/packages/server/src/services/session-manager.ts
@@ -1057,6 +1057,23 @@ export class SessionManager {
     return matchingSessions;
   }
 
+  /**
+   * Get all persisted worktree sessions for a repository that are NOT
+   * currently active in memory — paused sessions, plus any zombie row that
+   * is neither active nor cleanly paused. This is the single writer for
+   * the "inactive" half of the unregister-repository in-use gate; it
+   * replaces a duplicate check that used to live in the
+   * DELETE /api/repositories/:id route handler.
+   */
+  async getInactiveSessionsUsingRepository(repositoryId: string): Promise<Session[]> {
+    const activeSessions = this.getSessionsUsingRepository(repositoryId);
+    const activeIds = new Set(activeSessions.map((s) => s.id));
+    const persisted = await this.sessionRepository.findAll();
+    return persisted
+      .filter((ps) => !activeIds.has(ps.id) && ps.type === 'worktree' && ps.repositoryId === repositoryId)
+      .map((ps) => this.persistedToPublicSession(ps));
+  }
+
   // ========== Worker Operations (delegated to WorkerLifecycleManager) ==========
 
   /** Create a worker in the session. Delegates to WorkerLifecycleManager. */

--- a/packages/shared/src/types/job.ts
+++ b/packages/shared/src/types/job.ts
@@ -111,6 +111,15 @@ export interface CleanupRepositoryPayload {
    * into one job preserves the existing single-retry / atomicity contract.
    */
   extraDir: string | null;
+  /**
+   * Absolute base directories of session-data trees (outputs/messages/memos)
+   * to remove alongside `repoDir`. Built by `buildSessionDataCleanupTargets`.
+   * Server-owned — removed WITHOUT elevation regardless of
+   * `requestUsername`. Optional for backward compatibility: jobs enqueued
+   * before this field existed have it as `undefined`, which the handler
+   * treats as an empty array.
+   */
+  sessionDataDirs?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Unregistering a repository deleted only the `repositories/<org>/<repo>` directory (worktrees/templates). The session-data tree (`outputs`/`messages`/`memos`), addressed by a different slug derivation (`getRepositorySlug(id)` = `repo.name`), was never touched — for any repository with a git remote the two paths differ, so the session-data tree was orphaned forever.

**Corrected severity framing (per Architect review during implementation — see disposition note below):** the Issue's "severity revision" states unregistering a repo with a paused session is destructive *today*. That premise does not hold for the actual HTTP delivery path: `routes/repositories.ts`'s `DELETE /:id` handler already had its own pre-check against `sessionManager.getAllPersistedSessions()` (paused sessions included) that blocks unregister before `RepositoryManager.unregisterRepository` is ever called — and `unregisterRepository` has exactly one caller in the whole server. So paused sessions were not production-reachable-destructive; the weak in-repo gate (which only consulted the in-memory session map) was shielded by an independently-written duplicate check at the route. That's still the same "two derivations for one concern" anti-pattern the Issue is about, so the fix consolidates the gate rather than leaving the duplicate in place — any future caller of `unregisterRepository` (e.g. an MCP tool) would otherwise have hit the weak gate with no protection at all. I'll ask that the Issue body get the same correction.

## Changes

- **S0 (gate consolidation):** `RepositoryManager.assertRepositoryNotInUse` is now the single writer for the "repository in use" check, covering active (in-memory) **and** persisted/paused sessions via a new `getInactiveSessionsUsingRepository` on `SessionManager`. The route's duplicate inline check is deleted; it now delegates to the manager and maps `RepositoryInUseError` → `409`. Same observable HTTP contract (status + message shape) as before.
- **S1 (candidate-set builder):** new `buildSessionDataCleanupTargets` (`packages/server/src/services/session-data-cleanup-candidates.ts`) resolves the session-data cleanup targets exclusively through the existing `getRepositorySlug` accessor (never re-implemented) plus a closed legacy set (`path.basename(repoPath)`, `repo.name`), each converted to a path exclusively via the validating `computeSessionDataBaseDir` writer. A malformed candidate is skipped-with-log, never deleted raw.
- **S2 (payload + enqueue):** `CleanupRepositoryPayload` gains an optional `sessionDataDirs?: string[]`. Old queued payloads without the field process unchanged (defaults to `[]`). Per-target failure isolation: one bad target logs and continues.
- **S3 (ownership):** session-data directories are removed via a plain, unconditional `fs.rm` — never elevated, regardless of `requestUsername`, even when `repoDir`/`extraDir` in the same job invocation *are* elevating. Verified directly against the live production data root (`/var/lib/agent-console/repositories/*/{outputs,messages,memos}`): uniformly owned by the service account (`agentconsole:agent-console-users`), no mixed ownership found.
- **S4 (org-parent husk):** after `repoDir` removal, the now-possibly-empty `<repositories>/<org>/` parent is removed best-effort (bounded to one level, never recursive, never throws).
- **S5 (non-goals):** no derivation unification (#1300), no per-session-deletion cleanup, no orphan-sweep tool. Read-only inventory of the live production tree found exactly the two artifacts the Issue text already names — **listed, not touched**: `repositories/octocat/` (fully empty directory husk) and `repositories/Hello-World/outputs` (present, empty of files). Left for an owner decision on a one-off sweep.

## Test plan

- **T0a** (bug-polarity, manager level) — direct call to `unregisterRepository` with a persisted-but-not-in-memory session present. Commenting out the `assertRepositoryNotInUse` call reproduces the pre-fix behavior: `Expected promise that rejects / Received promise that resolved` (proceeds to unregister). Restored → rejects with `RepositoryInUseError`, no job enqueued.
- **T0b** (the protection is real) — real cross-service wiring (`createTestContext`): register repo → persist a paused worktree session → unregister refused → session resumes cleanly (worktree/session-data intact).
- **T0c deviation, recorded per Architect review.** The Architect's original ruling asked that the pre-existing HTTP-level 409 test (`repositories.test.ts`, then :176) survive **unchanged** as the invariant-preservation proof for the route's observable behavior. It could not: that test asserted 409 by mocking `sessionManager.getSessionsUsingRepository` / `getAllPersistedSessions`, and the route no longer calls either method after the S0 consolidation — it calls `repositoryManager.assertRepositoryNotInUse` instead. An unmodified test would have mocked methods the route never touches anymore; its rejection would never fire, and the test would pass **vacuously** against a route that no longer does what the test claims to verify — a worse outcome than rewriting it. The test was updated to mock `assertRepositoryNotInUse`'s rejection instead, preserving the *observable* behavior (409 status, same message shape) while the *mechanism* it exercises necessarily changed. The evidence that the underlying gate logic itself is correct (not just that the route forwards whatever error it's given) lives elsewhere: `repository-manager.test.ts`'s direct calls to `assertRepositoryNotInUse` (the gate tests plus the message-composition tests added after the CodeRabbit round) and the real cross-service `repository-unregister-paused-session.test.ts` (T0b above). Architect's principle, stated during review: deviations from the AC are fine when argued; silent ones are not — this paragraph is that argument.
- **T1** (bug-polarity, the leak) — remote-backed repo with a pre-existing flat-shape session-data dir. Removing `sessionDataDirs` from the enqueue call reproduces the leak: the flat dir survives (`existsSync` true) after unregister. Restored → both the org/repo dir and the flat session-data dir are gone, plus the empty org-parent.
- **T2** (edge) — local-only repo where the org/repo dir and the session-data slug coincide: single clean removal, no double-delete error (verified via the real job handler; the second `fs.rm` attempt on the now-missing path hits the pre-existing ENOENT-idempotent branch).
- **T3** (containment + validator-rejection) — sibling-repo candidate isolation; a hostile (`../etc`) candidate slug is skipped-with-log without aborting the other valid candidates in the same call.
- **T4** (structural-coupling lock) — builder test with a stubbed `getRepositorySlug` returning a sentinel; the returned target set is driven by the *call*, not a re-derivation.
- **T5** (invariant preservation) — existing `extraDir`/source-repo removal tests (Issue #905) pass unmodified; new S3/S4 tests state explicitly what a wrong implementation would look like (session-data loop or org-parent-husk step running before `removeOne(extraDir)`, or accidentally consulting elevation for session-data dirs).
- **V (full suite + typecheck):**

```
$ bun run typecheck
TYPECHECK_EXIT: 0

$ bun run test
@agent-console/client:  2146 pass, 0 fail
@agent-console/shared:  606 pass, 0 fail
@agent-console/integration: 75 pass, 0 fail
@agent-console/server:  3843 pass, 1 skip (pre-existing, real-fs probe unrelated to this change), 0 fail
@agent-console/embedded-agent: 295 pass, 0 fail
scripts/hooks/skills tests: 528 pass, 0 fail
TEST_EXIT: 0
```

- **Dev-instance E2E — confirmed complete, all three AC-mandated steps run, nothing partial.** Done, against a throwaway single-user server instance (`AGENT_CONSOLE_HOME=/tmp/agent-console-1301-e2e`, isolated from both the live production data root and any shared dev instance), driven entirely through the real HTTP API (register repo with a real fake-remote git repo → create worktree → create worktree session → pause → unregister attempt → resume → delete → unregister), in the AC's load-bearing order:
  1. Registered a repo with `origin` set to `https://github.com/e2e-org2/e2e-repo2.git`, created a worktree (org/repo shape: `repositories/e2e-org2/e2e-repo2/worktrees/...`), created a worktree session (flat session-data shape: `repositories/agent-console-1301-e2e-source-repo-2/outputs/<sessionId>/...`), paused it.
  2. `DELETE /api/repositories/:id` with the paused session present → **409**, `"Repository is in use by 1 session(s) (inactive): <sessionId>"`.
  3. Resumed the session, `DELETE /api/sessions/:id` → deleted, `DELETE /api/repositories/:id` → **200**. Both `repositories/e2e-org2/e2e-repo2` and `repositories/agent-console-1301-e2e-source-repo-2/outputs/<sessionId>` were gone from disk afterward, and the `repositories/e2e-org2` org-parent husk was also gone.
  - **Polarity receipt (step 3, run once against unmodified pre-fix code first, per the AC):** with the working tree reverted to the parent commit (`git checkout HEAD~1 -- packages/server packages/shared`, restored afterward), the identical 3-step flow on a fresh repo/session reproduced the leak live: after unregister, `repositories/e2e-org/e2e-repo` was gone (existing behavior, unaffected) but `repositories/agent-console-1301-e2e-source-repo/outputs/<sessionId>/*.log` **survived**, and the empty `repositories/e2e-org/` husk **survived** too — both defects reproduced end-to-end on unmodified code, both absent after restoring the fix and rerunning the same flow.

## Preflight

`node .claude/skills/orchestrator/preflight-check.js` — exit 0. Flagged an advisory integration-test-coverage gap for `routes/repositories.ts` (API route) and `packages/shared/src/types/job.ts` (shared type). Reviewed and disposed of, not merely agreed on: **there is no wire boundary for either change.** The route's client-observable shape (HTTP status + JSON body) is byte-identical before/after, and `packages/client/src/lib/api.ts`'s `unregisterRepository()` is untouched. `CleanupRepositoryPayload.sessionDataDirs` is written and read inside one server process — the actual deserialization site, `packages/server/src/jobs/job-queue.ts:471`, is a bare `JSON.parse(job.payload)` with no valibot layer anywhere in the job pipeline (grepped `packages/shared/src/schemas/` for any job-payload reference: zero hits), so pre-pr-completeness Q10's failure mode (a permissive `v.object` silently stripping an unknown field) has no schema to occur in. The closest thing to a real boundary — JSON-stringify → SQLite → JSON-parse — is already exercised through production code by `repository-manager.test.ts`'s new tests (enqueue via the real `cleanupRepositoryData`, parse the persisted payload, run the real handler, assert filesystem state); a `packages/integration/` test would only relocate that same round trip, not add new coverage. No new `packages/integration` test added.

## Deferred findings

CodeRabbit's GitHub-side review posted four findings across two rounds — two in the inline comment API, one in the formal review's **body** (`⚠️ Outside diff range comments`, which the inline-comments API does not return), and one Trivial nitpick:

- **Minor, quick win — fixed.** `repository-manager.test.ts`'s `runLatestCleanupRepositoryJob` selected `jobs[jobs.length - 1]`, but `JobQueue.getJobs` orders `created_at` **descending**, so index `0` is the newest and `jobs.length - 1` is the oldest — the opposite of what the helper's name promises. Harmless today (every current call site enqueues exactly one job per test), but a latent bug for any future test that enqueues twice. Changed to `jobs[0]`.
- **Major, 🏗️ Heavy lift — deferred to #1309, not fixed here.** `assertRepositoryNotInUse` reads the active + persisted session sets, then `cleanupRepositoryData` enqueues cleanup; nothing holds a lock across that interval, so a worktree session created or resumed for the repository after the reads but before the (asynchronous) cleanup job runs has its directories deleted underneath it.

  Verified **pre-existing**, not introduced by this PR: `main`'s `DELETE /:id` route read sessions at (then) :178-192, called `unregisterRepository` at :221, which read again at :276 (the old in-memory-only check) before cleaning at :285 — the identical read-then-act shape, no lock, before this PR existed. This PR's S0 consolidation moved where the reads happen; it did not open this window.

  What this PR does change: the race's **blast radius**. Pre-PR, losing the race cost `repoDir` (worktrees) only; post-PR it also costs the repository's `sessionDataDirs`. Brought to the Architect for a bundle-vs-follow-up ruling rather than improvised or silently deferred. **Ruling: follow-up.** Grounds: (1) a correct fix is a genuine design decision — lock shape (in-memory vs. durable `deleting` state, since the cleanup job outlives the HTTP request), which creation paths must check it (`createSession`, the worktree-auto-session path, `resumeSession`, MCP session creation), blocked-caller UX, and recovery if cleanup fails mid-way — not something to improvise inside a cleanup-consolidation PR; (2) the blast-radius delta is bounded: the race can only fire when `assertRepositoryNotInUse` already passed (zero active + zero persisted sessions at read time), so the racing session is necessarily seconds-old at cleanup time, its session-data tree near-empty, and its real loss (the worktree) is pre-existing damage in both worlds — a dangling `repositoryId` with a deleted worktree is incoherent either way, which is what the eventual fix actually needs to close, not the marginal session-data bytes.

  Follow-up: #1309 (mechanism, pre-existence proof, the bounded blast-radius argument, and the open design axes). A factual comment (no Issue reference, per the blame-shift lint) marks the gap on `assertRepositoryNotInUse`'s JSDoc.

- **Major (review body, "Outside diff range") — proposed fix declined; the real defect underneath it was fixed instead.** CodeRabbit found the route calls `assertRepositoryNotInUse` and `unregisterRepository` calls the same method again internally, and proposed removing the route-level call as redundant. The double call is real, but the fix is wrong: between the route's check and `unregisterRepository`, the route deletes the repository's Slack integration. Removing the early check would let an in-use repository's Slack integration be deleted before `unregisterRepository` rejects — the user ends up with an error *and* a lost integration for a repository that was never unregistered. Declined the proposed diff; added a comment at the call site explaining why it stays (not redundant, must run before the Slack-deletion side effect, `unregisterRepository`'s own check is independent defense-in-depth for other callers).

  Verifying the finding surfaced a **real, reachable defect** underneath it: the route never wrapped the `unregisterRepository` call itself, so a `RepositoryInUseError` thrown from *its own* internal check (as opposed to the route's) propagated past the route's error mapping and surfaced as a **500 instead of 409**. Not theoretical — this is exactly the #1309 race made observable: a session created in the window between the two checks is what makes the manager's internal check the one that actually fires. Added the missing `try`/`catch`, and a test that mocks the route's own check to pass while `unregisterRepository` itself rejects, pinning the 409 contract for both call sites independently.

- **Trivial nitpick — deferred, not fixed.** `repository-manager.test.ts`'s `fakeQueue` test double casts through `unknown` to `JobQueue` (only `registerHandler` is implemented). This is the identical, already-justified pattern used in `jobs/__tests__/handlers.test.ts` for the same reason. Fixing it here would mean either diverging from that sibling pattern or narrowing `registerJobHandlers`'s production parameter type for a test-only concern — deferred per the LOW/NITPICK policy's "non-trivial or out of scope" carve-out.

## Note on CodeRabbit

Local CLI hit the headless-worktree auth failure (`automatic_login_failed` / `authentication_failed` — not a rate-limit, a structural limitation of this delegated session with no browser). The GitHub-side bot was rate-limited on the first two commits (shared repository-wide quota, one review per window; two other PRs were ahead in the queue), then completed a real review — see Deferred findings above for its four findings and their dispositions. CodeRabbit independently re-verified the pre-existence claim on the Major finding (ran `git show origin/main:...` against the old route and manager code itself) and withdrew it, recording a learning for future reviews.

Closes #1301




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository deletion now detects active and paused sessions and prevents removal when a repository is still in use.
  * Repository cleanup removes associated session data and supports legacy session-data locations.
* **Bug Fixes**
  * Cleanup continues when an individual directory removal fails.
  * Empty parent directories are removed safely while repository roots and shared directories are preserved.
  * Cleanup remains compatible with older jobs that lack session-data information.
* **Documentation**
  * Added glossary guidance for repository deletion conflicts and session-data paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




## CodeRabbit round 2 (final head `3a1bd226`)

Recorded because the first round's note above covers only the commits up to `bc418377`, and three commits landed after it — two of them the fixes responding to CodeRabbit's own round-1 findings, which is precisely the diff a second look is worth most on.

At the point the Orchestrator picked this PR up, those three commits (`0b38afe2`, `49a0d799`, `3a1bd226`) had **no review from either channel**: the local CLI was structurally unavailable in the delegated worktree (`automatic_login_failed` / `authentication_failed` — the headless-worktree shape, not a rate-limit; note the process exits **0** despite emitting `"type":"error"`, so an exit-code check would read it as success), and the GitHub bot's auto-review on push came back `Review rate limited` (commit status re-issued 09:15:09Z).

Rather than fall straight to the dual-clean substitute, the review was retriggered once the repository-wide window reopened. It ran for real:

- Commit status `description`: **`Review completed`** (09:28:10Z) — not the rollup `state`, which reads `success` either way.
- Walkthrough explicitly scoped: *"Reviewing files that changed from the base of the PR and between `bc418377…` and `3a1bd226…`"* — exactly the previously-unreviewed range.
- **"No actionable comments were generated in the recent review."** Zero new inline comments; both round-1 threads were already bot-resolved (`✅ Review thread resolved`), including the TOCTOU one CodeRabbit itself withdrew after verifying pre-existence against `origin/main`.
- No new formal review body, so no `⚠️ Outside diff range` findings this round — checked explicitly, since round 1 put a Major in exactly that surface with zero inline comments alongside it.

`reviewDecision` remains empty. Per the `coderabbit-ops` walkthrough-exists rubric this is the clean-equivalent state, not an unreviewed one: a genuine walkthrough exists for this commit range, actionable inline comments are zero, and CodeRabbit does not always submit a formal `APPROVED` event on a zero-finding pass.

**No fallback disposition was needed** — this is a real review, not a substitute for one.
