### PR TITLE
docs: record three CodeRabbit and polarity lessons from PR #1304

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -76,6 +76,20 @@ Do not use `git stash --patch` to separate an added block from the exports it ne
 
 After restoring, confirm the round trip left nothing behind — `git diff --stat` should match what it was before, and `git status` should be clean of stray edits.
 
+**When the polarity subject is a running process rather than an in-process test, revert whole directories instead.** Commenting out a block works when the thing under test is loaded by the test runner in the same process. It does not scale to a dev-instance E2E, where the fix spans several files, the code is already loaded into a live server, and what must be shown is that the *original symptom reproduces* against unmodified code. There, check out the parent commit for the affected trees, run the real end-to-end flow against a throwaway instance, then restore:
+
+```bash
+git checkout HEAD~1 -- packages/server packages/shared   # revert the fix, keep everything else
+# start a throwaway instance, run the full E2E, observe the symptom reproduce
+git checkout HEAD -- packages/server packages/shared     # restore
+```
+
+**The gotcha: `git checkout <ref> -- <dir>` does not delete files that do not exist in `<ref>`.** Files added by the fix are silently left in place. That is usually harmless — nothing imports them once the wiring files are reverted — but it means the reverted tree is "pre-fix plus some orphans", not a clean parent checkout. Know that going in rather than discovering it when an unexpected module loads. If a leftover file *would* change behavior, delete it explicitly for the duration of the run.
+
+Prefer this over `git stash` for anything touching a worktree: **`refs/stash` is shared across all worktrees of the same repository**, so a concurrent agent can pop your stash or you can pop theirs.
+
+(Lesson: Sprint 2026-08-16 PR [#1304](https://github.com/ms2sato/agent-console/pull/1304) — the AC required demonstrating that a repository-unregister leak reproduced end-to-end on unmodified code. Neither documented option fit: the fix spanned two packages and the subject was a live HTTP server, not a test module. The directory-revert round trip reproduced both defects live, then showed both absent after restoring.)
+
 ## Evaluation Criteria
 
 ### Test Validity

--- a/.claude/skills/coderabbit-ops/SKILL.md
+++ b/.claude/skills/coderabbit-ops/SKILL.md
@@ -78,6 +78,15 @@ Three descriptions observed, all with `state=success`:
 
 Note the `updated_at` too: the status is re-issued per head SHA, so **updating a PR branch resets it**. A `Review completed` from before a rebase says nothing about the current head.
 
+**This is `workflow.md` Sub-pattern 7 (stale state carried across idle) wearing a CodeRabbit costume, and it is easiest to miss on the *last* push.** Once a genuine review has landed mid-PR, "CodeRabbit is handled for this PR" quietly becomes a background fact, and the next push is evaluated on CI alone. The re-read discipline is not "check the description once per PR" but **"check it for the head you are about to merge"** — including a head whose only change is a test, and including a head you pushed yourself thirty seconds ago.
+
+Two shapes to watch for, both observed on the same PR:
+
+- **The review you remember was of an earlier commit.** Read the walkthrough's own scope line — it states the range explicitly (`Reviewing files that changed from the base of the PR and between <sha> and <sha>`). If that range ends before your current head, the commits in between are unreviewed no matter how thorough the review you are remembering was.
+- **The commits most likely to go unreviewed are the fix commits responding to the review itself** — which is exactly the diff a second pass is worth most on, since it was written under the pressure of a finding.
+
+(Lesson: Sprint 2026-08-16 PR [#1304](https://github.com/ms2sato/agent-console/pull/1304) — a real review landed at `bc418377`; three commits followed, two of them the fixes for that review's own findings. The rollup read `CodeRabbit=SUCCESS` throughout while the description read `Review rate limited`. The delegate had correctly re-read the description after each of the first two pushes and reported honestly, then skipped it on the third after mentally filing CodeRabbit as resolved. Retriggering once the repository-wide window reopened produced a genuine review of exactly that range with no actionable comments — so the gap cost one wait, not a fallback disposition.)
+
 (Sprint 2026-07-18b — three PRs (#1227, #1231, #1229) carried `CodeRabbit=SUCCESS` in the rollup while the description read `Review rate limited`. Reading only the rollup state would have merged all three as "CodeRabbit clean" with no review. #1227 in particular later produced a Major finding that a standards document would otherwise have shipped with.)
 
 ### The review-body surface: findings that live in no inline comment

--- a/.claude/skills/coderabbit-ops/troubleshooting.md
+++ b/.claude/skills/coderabbit-ops/troubleshooting.md
@@ -22,18 +22,26 @@ Before merge, confirm the GitHub bot review is APPROVED. If `CHANGES_REQUESTED`,
 | Times out with no result, or replies `authentication_failed` / `automatic_login_failed` | **Headless-worktree auth failure.** `coderabbit review --agent` needs an interactive browser-based login; a delegated worktree session has no browser to complete it. This is a structural limitation of the session, not a quota condition, and will not resolve by waiting or retrying. | Skip the local CLI for this session. Rely on the GitHub-side bot review (per the rate-limit fallback note above), and record the auth-failure reason (not "rate-limited") in the PR body so the distinction is visible later. |
 | Replies with an explicit rate-limit message naming a countdown (e.g. "next review available in: N minutes") | **True rate-limit.** The account's request quota is exhausted; the countdown is the real recovery time. | Follow the existing rate-limit fallback disposition (wait it out, or fall back to the GitHub bot per the sections above). |
 
-**Do not read the exit code — it lies.** The CLI exits **0** on the auth failure while emitting the failure only inside its JSON stream:
+**The auth failure has two different observable shapes, and no exit code identifies either one.** Both were seen on the same day, in different delegated sessions:
 
 ```
+# Shape A — self-reports, then exits 0
 {"type":"status","phase":"auth","status":"automatic_login_failed","message":"Automatic login timed out. ..."}
 {"type":"action_required","phase":"auth","action":"run_interactive_login","command":"coderabbit auth login"}
 {"type":"error","phase":"auth","status":"authentication_failed","message":"Automatic login timed out. ..."}
 [exited with code 0]
+
+# Shape B — never self-reports; hangs on the browser-auth poll until something external kills it
+{"type":"status","phase":"auth","status":"starting_login"}
+{"type":"status","phase":"auth","status":"awaiting_browser_auth","authUrl":"https://..."}
+(no further output; killed by `timeout` at 280s, exit 124)
 ```
 
-Anything that scripts this check must grep the stream for `"status":"authentication_failed"` (or a countdown string for the rate-limit case) and must never branch on `$?` — a wrapper that trusts the exit code reports "CodeRabbit CLI clean" for a run that never authenticated, which is the worst possible failure shape here: a fabricated clean verdict.
+Shape A exits **0** while reporting failure; shape B never reports failure at all and exits with whatever killed it. So the exit code is worse than uninformative — under shape A it actively says "success". Anything scripting this check must read the **status stream** (`"status":"authentication_failed"`, or a countdown string for the rate-limit case) and must never branch on `$?`. A wrapper that trusts the exit code reports "CodeRabbit CLI clean" for a run that never authenticated: a fabricated clean verdict, the worst outcome available here.
 
-**In a delegated worktree session, expect this every time.** The failure is structural — `--agent` needs an interactive browser login the session cannot complete — so it does not vary run to run and retrying only burns minutes. Attempt it once, record the structural reason, and move to the GitHub-side bot. Note also that the timing is not a reliable tell: the same failure has arrived near-instantly and after ~3 minutes of browser-auth polling in the same session on the same PR. **Classify on the status codes, never on how long it took.**
+**Do not pipe the CLI through `head` / `tail` while diagnosing it.** Shape B was first reported as "timed out with *zero output*" — an artifact of the pipe swallowing the stream, not the CLI's actual behavior. The `awaiting_browser_auth` line, which is what identifies the shape, was there all along. Capture the full stream, then read it. (Same trap as `cmd | tail; echo $?` in `workflow.md`'s Verification Checklist: the pipe changes what you are measuring.)
+
+**In a delegated worktree session, expect one of these two shapes every time.** The failure is structural — `--agent` needs an interactive browser login the session cannot complete — so it will not vary with retries or resolve with waiting. Attempt once, record the structural reason, and move to the GitHub-side bot. **Timing is not a tell either**: shape A has arrived near-instantly and after ~3 minutes of polling in the same session on the same PR. Classify on the stream contents alone.
 
 Conflating the two in a PR body misleads whoever reads it later: an auth failure never self-resolves within the session (it needs a different environment, not more time), while a rate-limit does resolve after its countdown. State which one actually happened. (Sprint 2026-07-18b — PRs [#1204](https://github.com/ms2sato/agent-console/pull/1204), [#1207](https://github.com/ms2sato/agent-console/pull/1207), [#1208](https://github.com/ms2sato/agent-console/pull/1208), [#1209](https://github.com/ms2sato/agent-console/pull/1209), and [#1212](https://github.com/ms2sato/agent-console/pull/1212) all hit the headless-auth-failure shape rather than a true rate-limit; each PR body named the auth failure explicitly instead of defaulting to "rate-limited.")
 

--- a/.claude/skills/coderabbit-ops/troubleshooting.md
+++ b/.claude/skills/coderabbit-ops/troubleshooting.md
@@ -22,6 +22,19 @@ Before merge, confirm the GitHub bot review is APPROVED. If `CHANGES_REQUESTED`,
 | Times out with no result, or replies `authentication_failed` / `automatic_login_failed` | **Headless-worktree auth failure.** `coderabbit review --agent` needs an interactive browser-based login; a delegated worktree session has no browser to complete it. This is a structural limitation of the session, not a quota condition, and will not resolve by waiting or retrying. | Skip the local CLI for this session. Rely on the GitHub-side bot review (per the rate-limit fallback note above), and record the auth-failure reason (not "rate-limited") in the PR body so the distinction is visible later. |
 | Replies with an explicit rate-limit message naming a countdown (e.g. "next review available in: N minutes") | **True rate-limit.** The account's request quota is exhausted; the countdown is the real recovery time. | Follow the existing rate-limit fallback disposition (wait it out, or fall back to the GitHub bot per the sections above). |
 
+**Do not read the exit code — it lies.** The CLI exits **0** on the auth failure while emitting the failure only inside its JSON stream:
+
+```
+{"type":"status","phase":"auth","status":"automatic_login_failed","message":"Automatic login timed out. ..."}
+{"type":"action_required","phase":"auth","action":"run_interactive_login","command":"coderabbit auth login"}
+{"type":"error","phase":"auth","status":"authentication_failed","message":"Automatic login timed out. ..."}
+[exited with code 0]
+```
+
+Anything that scripts this check must grep the stream for `"status":"authentication_failed"` (or a countdown string for the rate-limit case) and must never branch on `$?` — a wrapper that trusts the exit code reports "CodeRabbit CLI clean" for a run that never authenticated, which is the worst possible failure shape here: a fabricated clean verdict.
+
+**In a delegated worktree session, expect this every time.** The failure is structural — `--agent` needs an interactive browser login the session cannot complete — so it does not vary run to run and retrying only burns minutes. Attempt it once, record the structural reason, and move to the GitHub-side bot. Note also that the timing is not a reliable tell: the same failure has arrived near-instantly and after ~3 minutes of browser-auth polling in the same session on the same PR. **Classify on the status codes, never on how long it took.**
+
 Conflating the two in a PR body misleads whoever reads it later: an auth failure never self-resolves within the session (it needs a different environment, not more time), while a rate-limit does resolve after its countdown. State which one actually happened. (Sprint 2026-07-18b — PRs [#1204](https://github.com/ms2sato/agent-console/pull/1204), [#1207](https://github.com/ms2sato/agent-console/pull/1207), [#1208](https://github.com/ms2sato/agent-console/pull/1208), [#1209](https://github.com/ms2sato/agent-console/pull/1209), and [#1212](https://github.com/ms2sato/agent-console/pull/1212) all hit the headless-auth-failure shape rather than a true rate-limit; each PR body named the auth failure explicitly instead of defaulting to "rate-limited.")
 
 ## Q: The local CLI was clean. Can I trust the GitHub bot will be too?


### PR DESCRIPTION
## Why

Three lessons from PR #1304's retrospective. Each was hit in practice by an agent, not reasoned about in the abstract, and in all three cases the existing documentation was *almost* right — which is why nobody noticed the gap until it cost something.

## 1. The CodeRabbit CLI auth failure has two shapes, and no exit code identifies either

`troubleshooting.md` already told readers which message distinguishes a headless auth failure from a rate limit. It did not say that **the exit code is useless**, or that the failure presents in more than one way.

- **Shape A** — emits `automatic_login_failed` → `authentication_failed`, then **exits 0**. It reports failure while the exit code says success.
- **Shape B** — emits `starting_login` → `awaiting_browser_auth`, then hangs on the browser-auth poll and **never self-reports at all**. It ends only when something external kills it (exit 124 under `timeout`).

Both were hit the same day in different delegated sessions — same structural cause, nothing in common between the exit codes. Anything scripting this check must read the **status stream** and never branch on `$?`. A wrapper that trusts the exit code reports "CodeRabbit CLI clean" for a run that never authenticated: a fabricated clean verdict, the worst outcome available here.

**Correction, recorded rather than quietly fixed.** The first version of this PR described only shape A and claimed both delegates had hit it. That was wrong. Shape B was initially reported as "timed out with *zero output*" — an artifact of piping the CLI through `tail`, which swallowed the stream; the `awaiting_browser_auth` line that identifies the shape had been there all along. The delegate re-ran it unpiped and corrected themselves. The section now also warns against piping the CLI while diagnosing it — the same trap as `cmd | tail; echo $?` in `workflow.md`'s Verification Checklist, where the pipe changes what you are measuring.

Without that correction the rule would have documented one shape and left anyone hitting the other with no matching entry.

Also recorded: in a delegated worktree the failure is structural and invariant — attempt once, record the reason, move on — and **timing is not a tell**. Shape A arrived near-instantly and after ~3 minutes of polling in the same session on the same PR. Classify on the stream contents alone.

## 2. Where the per-head-SHA status reset actually bites

`SKILL.md` already stated that the commit status is re-issued per head SHA. What it did not say is *when* that matters: once a genuine review lands mid-PR, "CodeRabbit is handled for this PR" becomes a background fact, and the next push is evaluated on CI alone.

On #1304 three commits went unreviewed that way — **two of them the fixes responding to that review's own findings**, which is the diff a second pass is worth most on, since it was written under the pressure of a finding. The rollup read `CodeRabbit=SUCCESS` the whole time; only the `description` said `Review rate limited`.

Framed as an instance of `workflow.md` Sub-pattern 7 (stale state carried across idle) rather than a new finding — the delegate identified that cross-reference themselves. Adds the practical tell: the walkthrough states its own scope (`Reviewing files that changed ... between <sha> and <sha>`), so you can check what was actually covered instead of trusting a remembered review.

The gap cost one wait, not a fallback disposition: retriggering after the repository-wide window reopened produced a genuine review of exactly that range with no actionable comments.

## 3. A third way to demonstrate polarity

`testing.md` documented two techniques, both assuming the subject is a module loaded in the test runner's process. Neither fits a dev-instance E2E where the fix spans packages and the subject is a **live server** — and where what must be shown is that the original symptom reproduces.

Adds the directory-revert round trip (`git checkout HEAD~1 -- <dirs>` → run the real E2E → `git checkout HEAD -- <dirs>`), plus:

- **The non-obvious gotcha**: `git checkout <ref> -- <dir>` does not delete files absent from `<ref>`, so the reverted tree is "pre-fix plus orphans", not a clean parent checkout. Harmless on #1304, but worth knowing before rather than discovering mid-run.
- **Why not `git stash`**: `refs/stash` is shared across all worktrees of the same repository, so concurrent agents can pop each other's.

## Test plan

Documentation only — no production code, no tests to add.

- `bun run check:lang` — clean, 118 files scanned (re-run after the correction commit).
- `node .claude/skills/orchestrator/preflight-check.js` — all four checks pass, including the rule/skill duplication invariant, which is relevant here since this touches both a rule and a skill.

## Note on CodeRabbit

Titled `docs:`, so `.coderabbit.yaml`'s `ignore_title_keywords` skips auto-review by design — the quota is one review per window repository-wide, and #1315 is contending for it. An empty `reviewDecision` is the expected state for this PR, not a wait condition.
