### PR TITLE
fix: surface exit-127 (agent binary not found) as a worker output message

### DIFF
--- a/packages/server/src/__tests__/utils/mock-pty.ts
+++ b/packages/server/src/__tests__/utils/mock-pty.ts
@@ -18,7 +18,7 @@ export class MockPty {
   // Note: Single callback that gets replaced, matching PtyInstance interface contract
   // which specifies "Only one callback is supported. Subsequent calls will replace the previous callback."
   private dataCallback: ((data: string) => void) | null = null;
-  private exitCallback: ((event: { exitCode: number; signal?: number }) => void) | null = null;
+  private exitCallback: ((event: { exitCode: number; signal?: number }) => void | Promise<void>) | null = null;
   killed = false;
   /** Set true when dispose() is called. Mirrors PtyInstance's optional dispose(). */
   disposed = false;
@@ -136,10 +136,8 @@ export class MockPty {
     }
   }
 
-  simulateExit(exitCode: number, signal?: number) {
-    if (this.exitCallback) {
-      this.exitCallback({ exitCode, signal });
-    }
+  async simulateExit(exitCode: number, signal?: number): Promise<void> {
+    await this.exitCallback?.({ exitCode, signal });
   }
 }
 

--- a/packages/server/src/__tests__/utils/mock-pty.ts
+++ b/packages/server/src/__tests__/utils/mock-pty.ts
@@ -56,7 +56,7 @@ export class MockPty {
     };
   }
 
-  onExit(callback: (event: { exitCode: number; signal?: number }) => void): MockDisposable {
+  onExit(callback: (event: { exitCode: number; signal?: number }) => void | Promise<void>): MockDisposable {
     this.exitCallback = callback;
     return {
       dispose: () => {

--- a/packages/server/src/lib/__tests__/command-token.test.ts
+++ b/packages/server/src/lib/__tests__/command-token.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'bun:test';
+import { extractCommandToken } from '../command-token.js';
+
+describe('extractCommandToken', () => {
+  it('extracts the program name from a plain template', () => {
+    expect(extractCommandToken('claude --dangerously-skip-permissions')).toBe('claude');
+  });
+
+  it('skips a single VAR=value assignment prefix', () => {
+    expect(extractCommandToken('FOO=bar claude --flag')).toBe('claude');
+  });
+
+  it('skips multiple assignment prefixes', () => {
+    expect(extractCommandToken('A=1 B=2 mycmd --x')).toBe('mycmd');
+  });
+
+  it('falls back to the full string when every token is an assignment', () => {
+    expect(extractCommandToken('FOO=bar BAZ=qux')).toBe('FOO=bar BAZ=qux');
+  });
+
+  it('falls back to the full string when the candidate still has an unexpanded placeholder', () => {
+    expect(extractCommandToken('{{cmd}} --flag')).toBe('{{cmd}} --flag');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(extractCommandToken('')).toBe('');
+  });
+
+  it('falls back to the original (unmodified) input for whitespace-only input', () => {
+    expect(extractCommandToken('   ')).toBe('   ');
+  });
+});

--- a/packages/server/src/lib/__tests__/pty-notification.test.ts
+++ b/packages/server/src/lib/__tests__/pty-notification.test.ts
@@ -279,4 +279,25 @@ describe('buildPtyNotificationText', () => {
     expect(result).toContain('type=ci:failed');
     expect(result).toContain('intent=triage');
   });
+
+  it('builds an internal-agent-spawn-failed notification with command, username, and exitCode (Issue #1294)', () => {
+    const result = buildPtyNotificationText({
+      kind: 'internal-agent-spawn-failed',
+      tag: 'internal:agent-spawn-failed',
+      fields: {
+        command: 'claude',
+        username: 'testuser',
+        exitCode: '127',
+        diagnosis: "usually means 'claude' is not installed or not on PATH for user 'testuser'",
+        remedy: "install and authenticate the agent CLI for user 'testuser'",
+      },
+      intent: 'triage',
+    });
+
+    expect(result).toContain('[internal:agent-spawn-failed]');
+    expect(result).toContain('command=claude');
+    expect(result).toContain('username=testuser');
+    expect(result).toContain('exitCode=127');
+    expect(result).toContain('intent=triage');
+  });
 });

--- a/packages/server/src/lib/__tests__/pty-notification.test.ts
+++ b/packages/server/src/lib/__tests__/pty-notification.test.ts
@@ -288,8 +288,8 @@ describe('buildPtyNotificationText', () => {
         command: 'claude',
         username: 'testuser',
         exitCode: '127',
-        diagnosis: "usually means 'claude' is not installed or not on PATH for user 'testuser'",
-        remedy: "install and authenticate the agent CLI for user 'testuser'",
+        diagnosis: "usually means a required program is missing for user 'testuser': the spawn shell itself, or the agent command 'claude', is not installed or not on PATH",
+        remedy: "install and authenticate the agent CLI for user 'testuser', or adjust this agent's command template -- check the server log's wrapperCommand field for this event to see which one was actually attempted",
       },
       intent: 'triage',
     });

--- a/packages/server/src/lib/__tests__/worker-output-file.test.ts
+++ b/packages/server/src/lib/__tests__/worker-output-file.test.ts
@@ -138,6 +138,28 @@ describe('WorkerOutputFileManager', () => {
     });
   });
 
+  describe('forceFlush (Issue #1294)', () => {
+    it('flushes buffered data below the threshold to the live file immediately', async () => {
+      manager.bufferOutput('session-force-flush', 'worker-force-flush', 'below threshold', quickResolver);
+
+      const filePath = manager.getOutputFilePath('session-force-flush', 'worker-force-flush', quickResolver);
+      // Below the 256-byte threshold and before the interval fires: not yet on disk.
+      expect(vol.existsSync(filePath)).toBe(false);
+
+      await manager.forceFlush('session-force-flush', 'worker-force-flush');
+
+      expect(vol.existsSync(filePath)).toBe(true);
+      expect(vol.readFileSync(filePath, 'utf-8')).toBe('below threshold');
+    });
+
+    it('is a no-op when nothing is pending', async () => {
+      await expect(manager.forceFlush('session-force-flush-noop', 'worker-force-flush-noop')).resolves.toBeUndefined();
+
+      const filePath = manager.getOutputFilePath('session-force-flush-noop', 'worker-force-flush-noop', quickResolver);
+      expect(vol.existsSync(filePath)).toBe(false);
+    });
+  });
+
   describe('readHistoryWithOffset', () => {
     it('should read full history when no offset specified', async () => {
       // Create file with content

--- a/packages/server/src/lib/command-token.ts
+++ b/packages/server/src/lib/command-token.ts
@@ -1,0 +1,26 @@
+/**
+ * Extract the display token (the program name) from an EXPANDED agent
+ * commandTemplate -- the string `expandTemplate` returns, before any of
+ * this server's own env/sentinel wrapping (see `UserMode.spawnPty` /
+ * `sentinel-spawn-command.ts`). Using the wrapped shell string instead
+ * would name our own plumbing ("env" / "sh") rather than the agent's
+ * command.
+ *
+ * Skips leading `VAR=value` shell-assignment-style tokens (a template idiom
+ * some custom agents use, e.g. `FOO=bar mycommand args`) so the returned
+ * token names the actual program. Falls back to the full command string
+ * when extraction is ambiguous -- no non-assignment token found, or the
+ * candidate still contains a literal `{{` (an unexpanded placeholder) --
+ * so callers always have something reasonable to display rather than a
+ * misleading truncation.
+ */
+export function extractCommandToken(expandedCommand: string): string {
+  const tokens = expandedCommand.trim().split(/\s+/).filter(Boolean);
+  const isAssignment = (token: string): boolean => /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+  const candidate = tokens.find((token) => !isAssignment(token));
+
+  if (candidate === undefined || candidate.includes('{{')) {
+    return expandedCommand;
+  }
+  return candidate;
+}

--- a/packages/server/src/lib/pty-notification.ts
+++ b/packages/server/src/lib/pty-notification.ts
@@ -120,6 +120,19 @@ export interface InternalConditionalWakeupPtyNotification extends BasePtyNotific
   intent: PtyNotificationIntent;
 }
 
+export interface InternalAgentSpawnFailedPtyNotification extends BasePtyNotificationParams {
+  kind: 'internal-agent-spawn-failed';
+  tag: 'internal:agent-spawn-failed';
+  fields: {
+    command: string;
+    username: string;
+    exitCode: string;
+    diagnosis: string;
+    remedy: string;
+  };
+  intent: PtyNotificationIntent;
+}
+
 export type WritePtyNotificationParams =
   | InboundEventPtyNotification
   | InternalMessagePtyNotification
@@ -127,7 +140,8 @@ export type WritePtyNotificationParams =
   | InternalReviewCommentPtyNotification
   | InternalReviewedPtyNotification
   | InternalProcessPtyNotification
-  | InternalConditionalWakeupPtyNotification;
+  | InternalConditionalWakeupPtyNotification
+  | InternalAgentSpawnFailedPtyNotification;
 
 /**
  * Build the structured notification text (`\n[tag] key1=val1 key2=val2

--- a/packages/server/src/lib/worker-output-file.ts
+++ b/packages/server/src/lib/worker-output-file.ts
@@ -504,6 +504,19 @@ export class WorkerOutputFileManager {
   }
 
   /**
+   * Force an immediate flush of a worker's buffered output to disk,
+   * bypassing the size/interval-triggered scheduling. Callers that must
+   * guarantee synthesized bytes are durable before proceeding (e.g. the
+   * exit-127 diagnostic append in worker-manager.ts) use this
+   * instead of relying on `bufferOutput`'s deferred flush -- a worker that
+   * already has zero attached WebSocket connections has no other trigger
+   * that would ever flush the pending buffer.
+   */
+  async forceFlush(sessionId: string, workerId: string): Promise<void> {
+    await this.flushBuffer(sessionId, workerId);
+  }
+
+  /**
    * Flush the pending buffer. MUST be called inside the serialization domain.
    * Legacy `.log.gz` files are migrated to `.log` on first write.
    */

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -688,6 +688,9 @@ describe('WorkerManager', () => {
   });
 
   describe('exit-127 diagnostic message (Issue #1294)', () => {
+    // T4 (S3 command-token unit coverage) lives in
+    // packages/server/src/lib/__tests__/command-token.test.ts -- not here,
+    // since it's pure-function coverage with no WorkerManager dependency.
     it('T1: appends a message with the command token, username, and exit code to the worker output stream', async () => {
       const worker = createTestAgentWorker();
       await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
@@ -749,6 +752,37 @@ describe('WorkerManager', () => {
 
       expect(worker.outputBuffer).toBe(before);
       expect(worker.outputBuffer).not.toContain('internal:agent-spawn-failed');
+    });
+
+    // T6 -- CodeRabbit MAJOR regression guard (PR #1315). This is also a
+    // Q14-shaped case (pre-pr-completeness.md): a new resource-acquisition
+    // step (the diagnostic append+flush) was added inside a function whose
+    // existing failure path (the rest of onExit's teardown) predates it, and
+    // the new step must not block that existing rollback.
+    it('T6: teardown still completes (detachPty runs, exit callbacks fire) when a connected client\'s onData throws during the exit-127 fan-out', async () => {
+      const worker = createTestAgentWorker();
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+      let onExitFired = false;
+      workerManager.attachCallbacks(worker, {
+        // The concrete reachable trigger CodeRabbit named: a connection's
+        // synchronous onData callback throwing during
+        // appendSyntheticOutput's fan-out loop.
+        onData: () => {
+          throw new Error('boom: synchronous onData throws');
+        },
+        onExit: () => {
+          onExitFired = true;
+        },
+      });
+
+      const mockPty = ptyFactory.instances[ptyFactory.instances.length - 1];
+      // Must not throw/reject: the fix wraps the synthesis call in try/catch
+      // so a throwing onData cannot abort the rest of onExit's teardown.
+      await mockPty.simulateExit(127);
+
+      expect(worker.pty).toBeNull();
+      expect(onExitFired).toBe(true);
     });
   });
 

--- a/packages/server/src/services/__tests__/worker-manager.test.ts
+++ b/packages/server/src/services/__tests__/worker-manager.test.ts
@@ -36,6 +36,7 @@ import type { LookupOsUserFn } from '../os-user-lookup.js';
 import type { runAsUser, RunAsUserOpts } from '../privilege-elevation.js';
 import type { listDescendantPids, signalPids } from '../../lib/process-tree.js';
 import * as os from 'node:os';
+import * as fs from 'fs/promises';
 
 const TEST_CONFIG_DIR = '/test/config';
 
@@ -683,6 +684,71 @@ describe('WorkerManager', () => {
         errorSpy.mockRestore();
         jest.useRealTimers();
       }
+    });
+  });
+
+  describe('exit-127 diagnostic message (Issue #1294)', () => {
+    it('T1: appends a message with the command token, username, and exit code to the worker output stream', async () => {
+      const worker = createTestAgentWorker();
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+      const mockPty = ptyFactory.instances[ptyFactory.instances.length - 1];
+      await mockPty.simulateExit(127);
+
+      expect(worker.outputBuffer).toContain('[internal:agent-spawn-failed]');
+      expect(worker.outputBuffer).toContain('command=claude');
+      expect(worker.outputBuffer).toContain('username=testuser');
+      expect(worker.outputBuffer).toContain('exitCode=127');
+    });
+
+    it('T2: flushes the message to the output file on disk even with zero clients ever attached (delegate-path shape)', async () => {
+      const outputFileManager = new WorkerOutputFileManager();
+      const userMode = new SingleUserMode(ptyFactory.provider, { id: 'test-user-id', username: 'testuser', homeDir: '/home/testuser' });
+      const wm = new WorkerManager(userMode, agentManager, outputFileManager);
+
+      const worker = wm.initializeAgentWorker({
+        id: 'agent-127-t2',
+        name: 'Test Agent',
+        createdAt: new Date().toISOString(),
+        agentId: CLAUDE_CODE_AGENT_ID,
+      });
+      // NOTE: never call attachCallbacks on this worker anywhere in this test --
+      // that's the point (zero clients ever attached).
+      await wm.activateAgentWorkerPty(worker, { ...defaultAgentActivationParams, sessionId: 'session-t2' });
+
+      const mockPty = ptyFactory.instances[ptyFactory.instances.length - 1];
+      await mockPty.simulateExit(127);
+
+      const filePath = defaultResolver.getOutputFilePath('session-t2', worker.id);
+      const onDisk = await fs.readFile(filePath, 'utf-8');
+      expect(onDisk).toContain('[internal:agent-spawn-failed]');
+      expect(onDisk).toContain('command=claude');
+      expect(onDisk).toContain('username=testuser');
+
+      const history = await outputFileManager.readHistoryWithOffset('session-t2', worker.id, defaultResolver);
+      expect(history.data).toContain('[internal:agent-spawn-failed]');
+    });
+
+    it('T3: does not append a synthetic message on a non-127 exit', async () => {
+      const worker = createTestAgentWorker();
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+      const mockPty = ptyFactory.instances[ptyFactory.instances.length - 1];
+      await mockPty.simulateExit(1);
+
+      expect(worker.outputBuffer).not.toContain('internal:agent-spawn-failed');
+    });
+
+    it('T5: healthy exit (0) leaves the output stream byte-identical -- guards against firing on every exit', async () => {
+      const worker = createTestAgentWorker();
+      await workerManager.activateAgentWorkerPty(worker, defaultAgentActivationParams);
+
+      const before = worker.outputBuffer;
+      const mockPty = ptyFactory.instances[ptyFactory.instances.length - 1];
+      await mockPty.simulateExit(0);
+
+      expect(worker.outputBuffer).toBe(before);
+      expect(worker.outputBuffer).not.toContain('internal:agent-spawn-failed');
     });
   });
 

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -49,6 +49,8 @@ import { expandTemplate } from '../lib/template.js';
 import { computeDefaultBaseSpec } from './git-diff-service.js';
 import { serverConfig } from '../lib/server-config.js';
 import type { WorkerOutputFileManager } from '../lib/worker-output-file.js';
+import { buildPtyNotificationText } from '../lib/pty-notification.js';
+import { extractCommandToken } from '../lib/command-token.js';
 import type { McpTokenRegistry } from '../mcp/mcp-auth.js';
 import { writeUserOwnedSecretFile, rmRecursiveAsUser, shouldElevateForUser, type runAsUser } from './privilege-elevation.js';
 import { lookupOsUser, type LookupOsUserFn } from './os-user-lookup.js';
@@ -597,8 +599,8 @@ export class WorkerManager {
           // only an operator-opted-in `enforce` would reject them
           // (fail-closed). The worker itself still starts either way.
           logger.warn(
-            { workerId: worker.id, sessionId },
-            'Agent worker activated without session.createdBy; skipping MCP token mint (MCP calls from this worker will be rejected if AGENT_CONSOLE_MCP_AUTH=enforce is set; see Issue #1107)',
+            { workerId: worker.id, sessionId, username: params.username },
+            `Agent worker activated without session.createdBy; worker will spawn as server-process user '${params.username}' -- command resolution and file access use that identity, so per-user CLI installs will not resolve (skipping MCP token mint; MCP calls from this worker will be rejected if AGENT_CONSOLE_MCP_AUTH=enforce is set; see Issue #1107)`,
           );
         } else if (this.mcpTokenRegistry) {
           // lookupOsUserFn is an injectable seam (LookupOsUserFn); the built-in
@@ -720,7 +722,7 @@ export class WorkerManager {
       worker.activityState = 'idle';
       this.globalActivityCallback?.(sessionId, worker.id, 'idle');
 
-      this.setupWorkerEventHandlers(worker, sessionId, params.resolver);
+      this.setupWorkerEventHandlers(worker, sessionId, params.resolver, { command, username: params.username });
     } catch (err) {
       // Both cleanup calls are null-safe (no-op when nothing was ever set)
       // and never throw (internal failures are logged as warnings) -- see
@@ -789,7 +791,12 @@ export class WorkerManager {
    * Setup event handlers for a PTY worker.
    * Stores disposables on the worker for cleanup when worker is killed.
    */
-  private setupWorkerEventHandlers(worker: InternalPtyWorker, sessionId: string, resolver: SessionDataPathResolver): void {
+  private setupWorkerEventHandlers(
+    worker: InternalPtyWorker,
+    sessionId: string,
+    resolver: SessionDataPathResolver,
+    agentSpawnInfo?: { command: string; username: string },
+  ): void {
     if (!sessionId || sessionId.trim() === '') {
       throw new Error(
         `Cannot setup event handlers: sessionId is required (got: ${sessionId === '' ? 'empty string' : String(sessionId)})`
@@ -908,7 +915,7 @@ export class WorkerManager {
     }
 
     const pty = worker.pty;
-    const onExitDisposable = pty.onExit(({ exitCode, signal }) => {
+    const onExitDisposable = pty.onExit(async ({ exitCode, signal }) => {
       const signalStr = signal !== undefined ? String(signal) : null;
       logger.info({ workerId: worker.id, pid: pty.pid, exitCode, signal: signalStr }, 'Worker exited');
 
@@ -918,6 +925,17 @@ export class WorkerManager {
       // that is already gone. No-op if the watchdog was never armed or
       // already cleared.
       clearSentinelWatchdog();
+
+      // Exit 127 ("command not found") on an agent worker means the shell
+      // could not resolve the agent binary for the spawn user -- surface
+      // this as a synthesized diagnostic message on the worker's own output
+      // stream. Must be awaited BEFORE the rest of teardown:
+      // the delegate path never has a WebSocket client attached to trigger
+      // a flush, so the bytes must be forced to disk here or they are lost
+      // with the pending buffer.
+      if (worker.type === 'agent' && exitCode === 127 && agentSpawnInfo) {
+        await this.appendSpawnFailureNotification(worker, sessionId, resolver, agentSpawnInfo, exitCode);
+      }
 
       // Mark worker as deactivated (PTY no longer running)
       this.detachPty(worker);
@@ -952,6 +970,71 @@ export class WorkerManager {
 
     // Store disposables on worker for cleanup
     worker.disposables = disposables;
+  }
+
+  /**
+   * Append server-authored text directly to a PTY worker's output stream --
+   * advances outputOffset, buffers it for file persistence, and fans out to
+   * currently-attached connections. Mirrors the post-sentinel-gate tail of
+   * the onData handler above, minus the sentinel-detection and
+   * activity-detector steps (irrelevant for synthesized text). Does NOT
+   * write into the PTY itself -- there is no live PTY left once a worker
+   * has exited.
+   */
+  private appendSyntheticOutput(worker: InternalPtyWorker, sessionId: string, resolver: SessionDataPathResolver, text: string): void {
+    worker.outputBuffer += text;
+    const maxBufferSize = serverConfig.WORKER_OUTPUT_BUFFER_SIZE;
+    if (worker.outputBuffer.length > maxBufferSize) {
+      worker.outputBuffer = worker.outputBuffer.slice(-maxBufferSize);
+    }
+    worker.outputOffset += Buffer.byteLength(text, 'utf-8');
+    this.workerOutputFileManager.bufferOutput(sessionId, worker.id, text, resolver, worker.epoch);
+    const callbacksSnapshot = Array.from(worker.connectionCallbacks.values());
+    for (const callbacks of callbacksSnapshot) {
+      callbacks.onData(text, worker.outputOffset, worker.epoch);
+    }
+  }
+
+  /**
+   * Synthesize and deliver the exit-127 diagnostic message for an agent
+   * worker. The command token comes from the EXPANDED
+   * commandTemplate captured at activation time (`agentSpawnInfo.command`),
+   * never from the final sentinel/env-wrapped shell string -- see
+   * `extractCommandToken`'s doc for why. Forces the buffered bytes to disk
+   * before returning: the delegate path (zero attached clients) has no
+   * other trigger that would flush them, and the caller's teardown must not
+   * proceed until this is durable (R-c / S2).
+   */
+  private async appendSpawnFailureNotification(
+    worker: InternalAgentWorker,
+    sessionId: string,
+    resolver: SessionDataPathResolver,
+    agentSpawnInfo: { command: string; username: string },
+    exitCode: number,
+  ): Promise<void> {
+    const commandToken = extractCommandToken(agentSpawnInfo.command);
+    const { username } = agentSpawnInfo;
+
+    logger.warn(
+      { workerId: worker.id, sessionId, command: commandToken, username, exitCode },
+      'Agent worker exited 127 (command not found); synthesizing diagnostic message on worker output stream',
+    );
+
+    const text = buildPtyNotificationText({
+      kind: 'internal-agent-spawn-failed',
+      tag: 'internal:agent-spawn-failed',
+      fields: {
+        command: commandToken,
+        username,
+        exitCode: String(exitCode),
+        diagnosis: `usually means '${commandToken}' is not installed or not on PATH for user '${username}'`,
+        remedy: `install and authenticate the agent CLI for user '${username}', or adjust this agent's command template`,
+      },
+      intent: 'triage',
+    });
+
+    this.appendSyntheticOutput(worker, sessionId, resolver, text);
+    await this.workerOutputFileManager.forceFlush(sessionId, worker.id);
   }
 
   // ========== Worker I/O ==========

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -928,13 +928,17 @@ export class WorkerManager {
       // already cleared.
       clearSentinelWatchdog();
 
-      // Exit 127 ("command not found") on an agent worker means the shell
-      // could not resolve the agent binary for the spawn user -- surface
-      // this as a synthesized diagnostic message on the worker's own output
-      // stream. Must be awaited BEFORE the rest of teardown:
-      // the delegate path never has a WebSocket client attached to trigger
-      // a flush, so the bytes must be forced to disk here or they are lost
-      // with the pending buffer.
+      // Exit 127 ("command not found") on an agent worker is usually the
+      // spawn-shell chain itself failing to start, not the agent's own
+      // command -- the agent command is TYPED into an already-alive
+      // interactive shell (see sentinel-spawn-command.ts), and an
+      // interactive shell survives its own "command not found" rather
+      // than exiting. Surface this as a synthesized diagnostic message
+      // naming both suspects, hedged (see appendSpawnFailureNotification).
+      // Must be awaited BEFORE the rest of teardown: the delegate path
+      // never has a WebSocket client attached to trigger a flush, so the
+      // bytes must be forced to disk here or they are lost with the
+      // pending buffer.
       if (worker.type === 'agent' && exitCode === 127 && agentSpawnInfo) {
         await this.appendSpawnFailureNotification(worker, sessionId, resolver, agentSpawnInfo, exitCode);
       }
@@ -1039,8 +1043,8 @@ export class WorkerManager {
         command: commandToken,
         username,
         exitCode: String(exitCode),
-        diagnosis: `usually means '${commandToken}' is not installed or not on PATH for user '${username}'`,
-        remedy: `install and authenticate the agent CLI for user '${username}', or adjust this agent's command template`,
+        diagnosis: `usually means a required program is missing for user '${username}': the spawn shell itself, or the agent command '${commandToken}', is not installed or not on PATH`,
+        remedy: `install and authenticate the agent CLI for user '${username}', or adjust this agent's command template -- check the server log's wrapperCommand field for this event to see which one was actually attempted`,
       },
       intent: 'triage',
     });

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -940,7 +940,22 @@ export class WorkerManager {
       // bytes must be forced to disk here or they are lost with the
       // pending buffer.
       if (worker.type === 'agent' && exitCode === 127 && agentSpawnInfo) {
-        await this.appendSpawnFailureNotification(worker, sessionId, resolver, agentSpawnInfo, exitCode);
+        // This listener is a synchronous PTY event callback that nothing
+        // awaits (same constraint documented on the revokeAndDeleteMcpToken
+        // fire-and-forget call below) -- an unhandled rejection here would
+        // propagate out of the async listener and skip every teardown step
+        // after this block (detachPty, MCP token revoke, prompt file
+        // delete, per-connection and global exit callbacks). Catch and log
+        // instead of letting a failure (e.g. a connected client's onData
+        // throwing during appendSyntheticOutput's fan-out) abort teardown.
+        try {
+          await this.appendSpawnFailureNotification(worker, sessionId, resolver, agentSpawnInfo, exitCode);
+        } catch (err) {
+          logger.error(
+            { workerId: worker.id, sessionId, err },
+            'Failed to synthesize exit-127 diagnostic message; continuing teardown',
+          );
+        }
       }
 
       // Mark worker as deactivated (PTY no longer running)

--- a/packages/server/src/services/worker-manager.ts
+++ b/packages/server/src/services/worker-manager.ts
@@ -51,6 +51,8 @@ import { serverConfig } from '../lib/server-config.js';
 import type { WorkerOutputFileManager } from '../lib/worker-output-file.js';
 import { buildPtyNotificationText } from '../lib/pty-notification.js';
 import { extractCommandToken } from '../lib/command-token.js';
+import { buildDirectSentinelShellCommand, buildElevatedSentinelCommand } from './sentinel-spawn-command.js';
+import { getUnsetEnvPrefix } from './env-filter.js';
 import type { McpTokenRegistry } from '../mcp/mcp-auth.js';
 import { writeUserOwnedSecretFile, rmRecursiveAsUser, shouldElevateForUser, type runAsUser } from './privilege-elevation.js';
 import { lookupOsUser, type LookupOsUserFn } from './os-user-lookup.js';
@@ -722,7 +724,7 @@ export class WorkerManager {
       worker.activityState = 'idle';
       this.globalActivityCallback?.(sessionId, worker.id, 'idle');
 
-      this.setupWorkerEventHandlers(worker, sessionId, params.resolver, { command, username: params.username });
+      this.setupWorkerEventHandlers(worker, sessionId, params.resolver, { command, username: params.username, sentinel });
     } catch (err) {
       // Both cleanup calls are null-safe (no-op when nothing was ever set)
       // and never throw (internal failures are logged as warnings) -- see
@@ -795,7 +797,7 @@ export class WorkerManager {
     worker: InternalPtyWorker,
     sessionId: string,
     resolver: SessionDataPathResolver,
-    agentSpawnInfo?: { command: string; username: string },
+    agentSpawnInfo?: { command: string; username: string; sentinel: string },
   ): void {
     if (!sessionId || sessionId.trim() === '') {
       throw new Error(
@@ -1009,14 +1011,24 @@ export class WorkerManager {
     worker: InternalAgentWorker,
     sessionId: string,
     resolver: SessionDataPathResolver,
-    agentSpawnInfo: { command: string; username: string },
+    agentSpawnInfo: { command: string; username: string; sentinel: string },
     exitCode: number,
   ): Promise<void> {
     const commandToken = extractCommandToken(agentSpawnInfo.command);
     const { username } = agentSpawnInfo;
 
+    // Display-only reuse of the SAME builders production spawns with
+    // (sentinel-spawn-command.ts is the single source of truth both sides
+    // import) -- lets a future investigator immediately tell "wrapper failed
+    // pre-sentinel" from "something else failed post-sentinel" without
+    // reproducing the investigation. This is a structured-log-only field;
+    // the user-facing message built below is unaffected.
+    const wrapperCommand = shouldElevateForUser(username)
+      ? buildElevatedSentinelCommand(agentSpawnInfo.sentinel)
+      : buildDirectSentinelShellCommand(agentSpawnInfo.sentinel, getUnsetEnvPrefix());
+
     logger.warn(
-      { workerId: worker.id, sessionId, command: commandToken, username, exitCode },
+      { workerId: worker.id, sessionId, command: commandToken, username, exitCode, wrapperCommand },
       'Agent worker exited 127 (command not found); synthesizing diagnostic message on worker output stream',
     );
 

--- a/scripts/smoke/check-exit-127-diagnostic.ts
+++ b/scripts/smoke/check-exit-127-diagnostic.ts
@@ -258,13 +258,16 @@ try {
     console.log(`PASSED: ${passes} assertion(s) passed`);
     exitCode = 0;
   }
-
-  await closeDatabase();
 } catch (err) {
   console.error('Unexpected exception while running the exit-127 diagnostic smoke.');
   console.error(err);
   exitCode = 2;
 } finally {
+  try {
+    await closeDatabase();
+  } catch {
+    // best-effort; do not let a close failure mask the original outcome
+  }
   if (smokeDir) {
     try {
       await rm(smokeDir, { recursive: true, force: true });

--- a/scripts/smoke/check-exit-127-diagnostic.ts
+++ b/scripts/smoke/check-exit-127-diagnostic.ts
@@ -1,0 +1,277 @@
+#!/usr/bin/env bun
+/**
+ * Post-deploy smoke test for the exit-127 diagnostic message (Issue #1294).
+ *
+ * ## Why this smoke exists instead of a UI-reachable repro
+ *
+ * Issue #1294's acceptance criteria originally called for reproducing the
+ * bug via the UI: pick an agent whose `commandTemplate` names a missing
+ * binary, create a worker, watch it fail. That recipe turned out to be
+ * IMPOSSIBLE against the production spawn path. Both
+ * `buildDirectSentinelShellCommand` and `buildElevatedSentinelCommand`
+ * (`../../packages/server/src/services/sentinel-spawn-command.js`) end in a
+ * bare `exec $SHELL` -- the agent's own command is not typed until AFTER
+ * that interactive login shell is already alive and has echoed the
+ * sentinel. A bad `commandTemplate` therefore produces a normal
+ * "command not found" line printed BY the interactive shell (which does
+ * not die from it) followed by that shell sitting there ready for more
+ * input -- never an exit 127 on the PTY's child process itself. There is no
+ * UI-reachable way to make the wrapper's OWN `exec $SHELL` fail.
+ *
+ * The architect-confirmed, production-representative trigger is instead:
+ * point the SPAWNED PROCESS's `$SHELL` at a nonexistent binary. That makes
+ * the wrapper's outer `exec $SHELL -l -c '...'` itself fail to exec, before
+ * the sentinel is ever echoed -- reproducing the exact signature this Issue
+ * was diagnosed from: exit 127, milliseconds after spawn, zero PTY bytes,
+ * pre-sentinel. This is exactly the shape a misconfigured multi-user login
+ * shell (the real-world trigger) produces, just forced deterministically.
+ *
+ * ## What this smoke exercises
+ *
+ *   - The REAL production chain end-to-end: `bunPtyProvider` (real PTY) ->
+ *     `SingleUserMode.spawnPty` (real spawn-command construction) ->
+ *     `WorkerManager.activateAgentWorkerPty` / `setupWorkerEventHandlers`'s
+ *     `onExit` handler -> `appendSpawnFailureNotification` ->
+ *     `WorkerOutputFileManager` (real fs, no memfs -- this runs as a
+ *     standalone `bun` script, not under `bun:test`, so there is no memfs
+ *     mock active).
+ *   - The T2 property from `worker-manager.test.ts` (Issue #1294) against a
+ *     REAL process instead of MockPty: zero WebSocket clients ever
+ *     attached, the diagnostic message still reaches disk because the
+ *     `onExit` handler force-flushes before returning.
+ *   - `worker.pty` transitioning to `null` (proof `detachPty` ran) only
+ *     AFTER the diagnostic append+flush completed, since the awaited
+ *     `appendSpawnFailureNotification` call runs strictly before
+ *     `detachPty` in the `onExit` handler.
+ *
+ * ## What this smoke does NOT exercise
+ *
+ *   - The elevated/multi-user spawn path specifically. The wrapper shape is
+ *     identical between direct and elevated per `sentinel-spawn-command.ts`
+ *     (both end in `exec $SHELL`), and the unit tests plus
+ *     `check-login-shell-sentinel.ts --elevated` already cover elevation
+ *     itself. This smoke isolates the WorkerManager exit-observer +
+ *     output-capture chain, not privilege elevation.
+ *   - The agent-console HTTP/WebSocket server. No server process runs here;
+ *     `WorkerManager` is exercised directly, same as `worker-manager.test.ts`.
+ *
+ * Usage:
+ *   bun scripts/smoke/check-exit-127-diagnostic.ts
+ *
+ * Exit codes:
+ *   0  all assertions passed
+ *   1  the scenario ran but an assertion failed (the system is wrong)
+ *   2  bad usage / cannot run at all (self-check failure, or an unexpected
+ *      exception during setup). Distinct from 1 so operators can tell apart
+ *      "the smoke ran and found a real problem" vs "the smoke could not run".
+ *
+ * Sync contract: NONE -- `bunPtyProvider`, `SingleUserMode`, `WorkerManager`,
+ * and `WorkerOutputFileManager` are imported directly from production
+ * source. A regression in the exit-127 diagnostic path changes this smoke's
+ * outcome automatically.
+ */
+
+import * as crypto from 'crypto';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { rm, mkdtemp } from 'fs/promises';
+import { tmpdir } from 'os';
+
+import { bunPtyProvider } from '../../packages/server/src/lib/pty-provider.js';
+import { SingleUserMode } from '../../packages/server/src/services/user-mode.js';
+import { WorkerManager, type GlobalWorkerExitCallback } from '../../packages/server/src/services/worker-manager.js';
+import { WorkerOutputFileManager } from '../../packages/server/src/lib/worker-output-file.js';
+import { SessionDataPathResolver } from '../../packages/server/src/lib/session-data-path-resolver.js';
+import { AgentManager, CLAUDE_CODE_AGENT_ID } from '../../packages/server/src/services/agent-manager.js';
+import { SqliteAgentRepository } from '../../packages/server/src/repositories/sqlite-agent-repository.js';
+import { initializeDatabase, closeDatabase, getDatabase } from '../../packages/server/src/database/connection.js';
+
+process.chdir('/');
+
+const EXIT_WAIT_TIMEOUT_MS = 5000;
+const POLL_MS = 50;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(pred: () => boolean, timeoutMs: number): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (pred()) return true;
+    await sleep(POLL_MS);
+  }
+  return pred();
+}
+
+/**
+ * Prove this environment can spawn and observe the exit of a basic PTY via
+ * `bunPtyProvider` before trusting the real scenario below. If spawning
+ * itself is broken, the scenario would fail for an unrelated reason and
+ * misreport a real regression.
+ */
+async function selfCheck(): Promise<void> {
+  try {
+    const pty = bunPtyProvider.spawn('sh', ['-c', 'echo ok'], {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+    });
+    const exited = new Promise<void>((resolve) => {
+      pty.onExit(() => resolve());
+    });
+    pty.onData(() => {});
+    const ok = await Promise.race([exited.then(() => true), sleep(EXIT_WAIT_TIMEOUT_MS).then(() => false)]);
+    if (!ok) {
+      throw new Error('basic PTY did not exit within timeout');
+    }
+  } catch (err) {
+    console.error('Self-check failed: could not spawn/observe a basic PTY via bunPtyProvider -- cannot run this smoke.');
+    console.error(err);
+    process.exit(2);
+  }
+}
+
+await selfCheck();
+
+const smokeUsername = os.userInfo().username;
+const smokeHomeDir = os.homedir();
+
+let smokeDir: string | undefined;
+let exitCode = 0;
+
+try {
+  smokeDir = await mkdtemp(path.join(tmpdir(), 'agent-console-smoke-1294-'));
+  const resolver = new SessionDataPathResolver(smokeDir);
+
+  // Real SQLite, in-memory -- mirrors worker-manager.test.ts's AgentManager
+  // construction exactly, minus the memfs test-file wrapper.
+  await initializeDatabase(':memory:');
+  const db = getDatabase();
+  const agentManager = await AgentManager.create(new SqliteAgentRepository(db));
+
+  const userMode = new SingleUserMode(bunPtyProvider, {
+    id: 'smoke-user-id',
+    username: smokeUsername,
+    homeDir: smokeHomeDir,
+  });
+  const outputFileManager = new WorkerOutputFileManager();
+  const workerManager = new WorkerManager(userMode, agentManager, outputFileManager);
+
+  const sessionId = `smoke-session-${crypto.randomUUID()}`;
+
+  let observedExitCode: number | undefined;
+  let observedExitSessionId: string | undefined;
+  let observedExitWorkerId: string | undefined;
+  const onExit: GlobalWorkerExitCallback = (sid, wid, code) => {
+    observedExitSessionId = sid;
+    observedExitWorkerId = wid;
+    observedExitCode = code;
+  };
+  workerManager.setGlobalWorkerExitCallback(onExit);
+
+  const worker = workerManager.initializeAgentWorker({
+    id: `smoke-worker-${crypto.randomUUID()}`,
+    name: 'Smoke Agent',
+    createdAt: new Date().toISOString(),
+    agentId: CLAUDE_CODE_AGENT_ID,
+  });
+
+  console.log('==> activating agent worker PTY with SHELL pointed at a nonexistent binary');
+  // Deliberately: no attachCallbacks() call anywhere in this scenario --
+  // zero WebSocket clients ever attached, mirroring T2's delegate-path
+  // shape but against a real process.
+  await workerManager.activateAgentWorkerPty(worker, {
+    sessionId,
+    locationPath: '/',
+    // SHELL flows through additionalEnvVars in spawnDirectPty, spread AFTER
+    // baseEnv and BEFORE the AGENT_CONSOLE_* security-pinned vars, so it
+    // overrides the inherited $SHELL cleanly. Verified against
+    // env-filter.ts: filterRepositoryEnvVars (which strips SHELL as a
+    // PROTECTED_ENV_VAR) is only invoked by session-manager.ts when parsing
+    // repository config -- WorkerManager.activateAgentWorkerPty takes
+    // repositoryEnvVars -> additionalEnvVars UNFILTERED, so calling it
+    // directly (as this smoke does) is not subject to that filter.
+    repositoryEnvVars: { SHELL: '/nonexistent-xyz-127-smoke' },
+    username: smokeUsername,
+    resolver,
+    agentId: CLAUDE_CODE_AGENT_ID,
+    startupIntent: 'fresh',
+    revived: false,
+  });
+
+  console.log('==> waiting for the real process to exit 127');
+  const ptyDetached = await waitFor(() => worker.pty === null, EXIT_WAIT_TIMEOUT_MS);
+
+  // ---------- assertions ----------
+  const failures: string[] = [];
+  let passes = 0;
+  const expect = (cond: boolean, label: string, detail?: string) => {
+    if (cond) {
+      console.log(`  OK    ${label}`);
+      passes++;
+    } else {
+      console.error(`  FAIL  ${label}${detail ? ` -- ${detail}` : ''}`);
+      failures.push(label);
+    }
+  };
+
+  console.log('==> exit-observer chain');
+  expect(
+    ptyDetached,
+    'worker.pty became null within timeout (detachPty ran; onExit fired and completed)',
+    `worker.pty=${JSON.stringify(worker.pty)}`,
+  );
+  expect(
+    observedExitCode === 127,
+    'the real spawned process exited with code 127',
+    `observed exitCode=${String(observedExitCode)}`,
+  );
+  expect(observedExitSessionId === sessionId, 'exit callback reported the expected sessionId');
+  expect(observedExitWorkerId === worker.id, 'exit callback reported the expected workerId');
+
+  console.log('==> output file on disk (real fs, zero clients ever attached)');
+  const outputFilePath = resolver.getOutputFilePath(sessionId, worker.id);
+  let onDisk = '';
+  try {
+    onDisk = await fs.readFile(outputFilePath, 'utf-8');
+  } catch (err) {
+    console.error(`  could not read output file at ${outputFilePath}: ${String(err)}`);
+  }
+  expect(onDisk.includes('[internal:agent-spawn-failed]'), 'output file contains the diagnostic tag');
+  expect(onDisk.includes('exitCode=127'), 'output file contains exitCode=127');
+  expect(onDisk.includes(`username=${smokeUsername}`), `output file contains username=${smokeUsername}`);
+
+  console.log('==> readHistoryWithOffset (manager read API)');
+  const history = await outputFileManager.readHistoryWithOffset(sessionId, worker.id, resolver);
+  expect(
+    history.data.includes('[internal:agent-spawn-failed]'),
+    'readHistoryWithOffset also returns the diagnostic message',
+  );
+
+  console.log();
+  if (failures.length > 0) {
+    console.error(`FAILED: ${failures.length} assertion(s) failed`);
+    exitCode = 1;
+  } else {
+    console.log(`PASSED: ${passes} assertion(s) passed`);
+    exitCode = 0;
+  }
+
+  await closeDatabase();
+} catch (err) {
+  console.error('Unexpected exception while running the exit-127 diagnostic smoke.');
+  console.error(err);
+  exitCode = 2;
+} finally {
+  if (smokeDir) {
+    try {
+      await rm(smokeDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup; do not let it change the exit code
+    }
+  }
+}
+
+process.exit(exitCode);


### PR DESCRIPTION
## Summary

Terminal-agent workers whose agent binary is missing for the spawn user die ~12ms after spawn with `exitCode: 127`. The user sees nothing: 0-byte output log, session looks idle, the only record is `exitCode: 127` in the server journal (requires `adm` group membership to read).

This PR synthesizes a diagnostic message — command token, spawn username, exit code, hedged diagnosis, remedy — directly into the worker's own output stream on exit 127, and rewords the ownerless-session WARN log so the spawn-user consequence is the headline instead of the MCP-token detail.

Closes #1294

## What changed (S1-S5)

- **S1/S2**: new `WorkerManager.appendSpawnFailureNotification` / `appendSyntheticOutput` — on `worker.type === 'agent' && exitCode === 127`, builds the message via `buildPtyNotificationText` (text-formatter reuse only, per the Architect's R-c correction — `writePtyNotification`/`writeInput` is not usable, there's no live PTY 12ms after exit), joins the output pipeline strictly after the sentinel gate, then **awaits** a new `WorkerOutputFileManager.forceFlush(sessionId, workerId)` before the rest of `onExit`'s teardown proceeds — the delegate path (MCP-created session, no browser ever attaches) has no other trigger that would ever flush the pending buffer.
- **S3**: new `extractCommandToken` (`packages/server/src/lib/command-token.ts`) — first non-`VAR=value` token of the **expanded** `commandTemplate` (captured via a closure param on `setupWorkerEventHandlers`, since `worker.pendingCommand` is already cleared by the time `onExit` fires), never the final env/sentinel-wrapped shell string. Falls back to the full string on ambiguity (all-assignment / unexpanded placeholder / empty).
- **S4**: reworded the ownerless-session WARN (`Agent worker activated without session.createdBy...`) so `worker will spawn as server-process user '<x>'; command resolution and file access use that identity` is the headline and the MCP-token-mint skip is the trailing clause.
- **S5 non-goals**: tool-result surfacing (the 127 exit races the already-returned response), embedded agents (#1291 track), non-127 exit codes — none of these are touched. The output-capture repair (why the shell's own `sh: 1: <cmd>: not found` never reaches disk) is filed separately as **#1310** and out of scope here — this PR's synthesis does not depend on it (it bypasses the PTY data path entirely).

**Additional, from an Architect consult during E2E verification (see "E2E note" below)**: the exit-127 structured log line now also carries `wrapperCommand` — the actual spawned wrapper command string, reconstructed via the same `buildDirectSentinelShellCommand`/`buildElevatedSentinelCommand` builders production spawns with — so a future investigator can tell a pre-sentinel wrapper failure from a post-sentinel one without re-running an investigation. This is a structured-log-only addition; the user-facing message (S1) is unchanged.

## E2E note: the AC's original recipe was impossible (my finding, the Architect's premise)

The AC's V section specified: register an agent whose `commandTemplate` names a nonexistent binary, create a session, let it exit, confirm the message is visible in the worker view. I ran exactly this on a throwaway single-user dev instance running this branch's code — the worker's PTY never exited.

Root cause: `buildDirectSentinelShellCommand`/`buildElevatedSentinelCommand` (`sentinel-spawn-command.ts`) both end in a bare `exec $SHELL`. The sentinel-injected agent command is delivered via `pty.write(command + '\r')` — **typed as input into an already-alive interactive login shell**, not exec'd as the spawned process's own argv. Interactive shells do not exit on command-not-found. Verified directly: typing a plain bogus command prints `command not found` and returns to the prompt; typing `exec <missing-binary>` explicitly prints `bash: exec: ...: not found` and **still** returns to the prompt (matches documented bash behavior — interactive `exec` failure doesn't exit the shell unless `execfail`/non-interactive). Same wrapper shape on both direct and elevated spawn paths.

So a bad `commandTemplate` cannot produce a real PTY exit 127 via the documented UI flow — the premise behind the AC's V-section recipe (mine, per the Architect's own framing when they confirmed this at source) doesn't hold. The Architect ruled the fix's logic (S1-S5, T1-T5) is unaffected — it triggers on `exitCode === 127` regardless of cause — but prescribed replacing the recipe with a smoke test driving the **real** production chain, since a real trigger does exist: pointing the spawn env's `$SHELL` at a nonexistent binary makes the wrapper's own `exec $SHELL` fail before the sentinel is ever echoed — a real, millisecond-fast, pre-sentinel 127, reproducing the exact signature this Issue was diagnosed from.

See `scripts/smoke/check-exit-127-diagnostic.ts`'s header comment for the full writeup, and #1294's issue body (appended "Mechanism refinement" section) for the correction-trail record, including an unverified hypothesis about the original production 127s' actual cause.

**Scope of what the smoke proves, precisely.** The smoke forces a **wrapper** failure by pointing the spawn env's `SHELL` at a nonexistent binary (`/nonexistent-xyz-127-smoke`) — this is a deliberately-injected, synthetic trigger for verification purposes. It proves the capture path (exit observer → `appendSyntheticOutput` → `forceFlush` → on-disk bytes, zero clients attached) works correctly against a **real spawned process** exiting with a **real 127**. It does **not** prove that a broken `$SHELL` is how the original production 127s this Issue was diagnosed from actually happened — that remains a plausible, unverified hypothesis (see #1294's issue body). The fix itself doesn't care why `exitCode === 127`; the smoke's job is only to prove the capture chain, not to re-diagnose production.

## Tests (per `testing.md` classification)

- **T1** (new-mechanism contract, must fail pre-fix) — `worker-manager.test.ts`: exit 127 → message with command token/username/exitCode appended to `worker.outputBuffer`.
- **T2** (new-mechanism contract, must fail pre-fix) — zero clients ever attached (delegate-path shape) → message present **in the output file on disk** (`fs.readFile`, not any in-memory buffer) and via `readHistoryWithOffset`.
- **T3** (invariant preservation) — non-127 exit → no synthetic message. Verified it fails against a wrong implementation (guard removed, fires on every exit).
- **T4** (new-mechanism contract) — `command-token.test.ts`: plain template / `VAR=x` prefix / multi-prefix / all-assignment fallback / placeholder fallback / empty / whitespace-only.
- **T5** (invariant preservation) — healthy exit (0) leaves `worker.outputBuffer` byte-identical. Guards against "synthetic append fires on every exit" — verified it fails against that wrong implementation.
- **New**: `scripts/smoke/check-exit-127-diagnostic.ts` — real-process E2E replacement for the AC's UI recipe (see above). Not part of `bun run test` / CI, run manually per its header (matches the convention of its siblings `check-pty-early-output.ts` / `check-login-shell-sentinel.ts`).
- Sibling coverage also added/updated: `pty-notification.test.ts` (new `internal-agent-spawn-failed` variant), `worker-output-file.test.ts` (new `forceFlush` method).

T1/T2/T4 confirmed to fail pre-fix (stubbed/commented the new logic, restored after, verified with `git diff --stat`/`git status` clean). T3/T5 confirmed to fail against a plausible wrong implementation (guard removed).

## Duplication check (workflow.md step 6)

`appendSyntheticOutput`'s body is a near-duplicate of the `onData` handler's post-sentinel-gate tail (outputOffset advance / `bufferOutput` / connection fan-out), minus the sentinel-detection and activity-detector steps (documented in its own JSDoc). Reviewed and deliberately left as separate, documented code rather than refactored into one shared call site: the `onData` handler is sentinel-watchdog-critical and heavily commented/tested, and consolidating would add diff surface to that path for a 6-line stylistic gain. Flagging per the duplication-check step rather than silently leaving it.

## Verification

`bun run typecheck` — 0 errors, all 6 packages.

`bun run test` (full suite):
```
server:          3852 pass, 1 skip, 0 fail  (10599 expect() calls)
client:          2146 pass, 0 fail
shared:          606 pass, 0 fail
integration:     75 pass, 0 fail
embedded-agent:  295 pass, 0 fail
scripts/hooks/skills: 528 pass, 0 fail
TEST_EXIT: 0
```

`node .claude/skills/orchestrator/preflight-check.js` — coverage / duplication / language / blame-shift checks all clean.

`bun scripts/smoke/check-exit-127-diagnostic.ts`:
```
==> exit-observer chain
  OK    worker.pty became null within timeout (detachPty ran; onExit fired and completed)
  OK    the real spawned process exited with code 127
  OK    exit callback reported the expected sessionId
  OK    exit callback reported the expected workerId
==> output file on disk (real fs, zero clients ever attached)
  OK    output file contains the diagnostic tag
  OK    output file contains exitCode=127
  OK    output file contains username=ms2sato
==> readHistoryWithOffset (manager read API)
  OK    readHistoryWithOffset also returns the diagnostic message

PASSED: 8 assertion(s) passed
```

CodeRabbit CLI review: ran `coderabbit review --agent --base main`. It emitted `{"type":"status","phase":"auth","status":"starting_login"}` then `{"type":"status","phase":"auth","status":"awaiting_browser_auth","authUrl":"..."}` and then hung — no rate-limit countdown, no further output — until a 280s external `timeout` killed it (exit code **124**, from the `timeout` wrapper; the CLI process itself never exited on its own). Per this repo's `coderabbit-ops` troubleshooting doc, this is the **headless-worktree auth failure** shape: `--agent` needs an interactive browser login to complete `awaiting_browser_auth`, which a delegated worktree session has no way to do. It is a structural limitation of the session, not a quota condition, and will not resolve by waiting or retrying. This is explicitly **not** a rate-limit — no rate-limit message was ever shown. **Caution for anyone automating this check**: a naive read of "exit code" alone is misleading here — the auth-hang case does not self-report failure via a distinct non-zero code the way an explicit `authentication_failed` reply would; it simply never returns without an external timeout. Read the JSON status stream (`awaiting_browser_auth` with no follow-up), not just the exit code.

Relying on the GitHub-side bot review for this PR, scheduled by the Orchestrator against the shared repository-wide review window. **At PR-open time the commit status is expected to read `Review rate limited`** — the window was last consumed by PR #1304's review (completed 09:28:10Z, PR #1304 merged 09:30Z at `82c31a85`) and has not yet reopened. The Orchestrator will retrigger with an `@coderabbitai review` comment once the window reopens (~an hour after 09:28Z). This is a known, expected, tracked state — not an unnoticed gap.

## Definition of Done extras

- Filed #1310 ("Terminal-agent exit-127 output capture: identify why the shell's 'not found' stderr never reaches the output file (I-9 instance)") for the still-open output-capture gap, per S5.
- Appended a "Mechanism refinement" section to #1294's issue body (correction-trail convention: append, don't rewrite) documenting the E2E finding above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostics when an agent fails to start with exit code 127.
  - Failure details now include the command, account, exit code, diagnosis, and recommended action.
  - Diagnostics are saved to worker output and delivered even when no clients are connected.
  - Buffered worker output is flushed immediately when needed, preventing delayed or missing messages.

- **Tests**
  - Added coverage for command parsing, failure notifications, output flushing, and exit-code handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->