### PR TITLE
test: freeze the clock in buildPtyNotificationText's same-output equivalence test

### DIFF
--- a/packages/server/src/lib/__tests__/pty-notification.test.ts
+++ b/packages/server/src/lib/__tests__/pty-notification.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest, mock, spyOn } from 'bun:test';
+import { describe, expect, it, jest, mock, setSystemTime, spyOn } from 'bun:test';
 import { formatFieldValue, writePtyNotification, buildPtyNotificationText } from '../pty-notification.js';
 
 describe('formatFieldValue', () => {
@@ -245,8 +245,24 @@ describe('buildPtyNotificationText', () => {
       intent: 'triage' as const,
     };
 
-    const built = buildPtyNotificationText(params);
-    const returnedFromWrite = writePtyNotification({ ...params, writeInput: (data) => { written.push(data); } });
+    // Both buildPtyNotificationText and writePtyNotification independently
+    // call `new Date().toISOString()` for the timestamp field. Without a
+    // frozen clock, the two calls below can straddle a millisecond boundary
+    // on a loaded CI runner, producing two different timestamp strings and
+    // failing the exact-equality assertion for a reason that has nothing to
+    // do with whether the two functions actually agree (Issue #1321).
+    // Freezing time makes this a genuine full-string equality check again:
+    // the only variable removed is the wall clock, so any other divergence
+    // between the two call paths still fails the assertion below.
+    setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    let built: string;
+    let returnedFromWrite: string;
+    try {
+      built = buildPtyNotificationText(params);
+      returnedFromWrite = writePtyNotification({ ...params, writeInput: (data) => { written.push(data); } });
+    } finally {
+      setSystemTime();
+    }
 
     expect(written[0]).toBe(built);
     expect(returnedFromWrite).toBe(built);


### PR DESCRIPTION
## Summary

`packages/server/src/lib/__tests__/pty-notification.test.ts`'s `buildPtyNotificationText > produces the exact same string writePtyNotification writes to the PTY (same-output equivalence)` test independently calls `buildPtyNotificationText` and `writePtyNotification`, each of which internally calls `new Date().toISOString()` for the timestamp field, then asserts the two resulting strings are byte-identical. On a loaded CI runner the two calls can straddle a millisecond boundary, producing two different timestamp strings and failing the assertion for a reason unrelated to whether the two functions actually agree. Root-caused while investigating PR #1318's CI, observed twice today (once via a diagnostic probe PR, once on #1318 itself after an unrelated push).

## Fix

Test-only change. Freezes the clock via `bun:test`'s native `setSystemTime()` around both calls (reset in a `finally` block), so both calls see the same "now". This keeps the assertion a genuine full-string equality check — the only variable removed is the wall clock, so any other divergence between the two call paths still fails the assertion.

**Polarity demonstrated, not just asserted**: temporarily made the two call paths diverge (the `writePtyNotification` call passed different field values than `buildPtyNotificationText`), confirmed the test fails deterministically with a clear diff, then restored the intended fix and confirmed `git diff` matched exactly. Also ran the specific test 30 times in a row post-fix — 30/30 pass, no flakiness reintroduced.

No production code touched.

## Test plan

- [x] Isolated test file: 30 pass, 0 fail
- [x] Polarity: artificially diverged the two call paths → test fails with a clear diff; restored → test passes; `git diff` confirmed clean restoration
- [x] Repeated the specific test 30x in a row → deterministic, 0 flakes
- [x] `bun run typecheck` — exit 0, all packages
- [x] `bun run test` (full suite) — exit 0: server 3881 pass/1 skip, client 2146, shared 606, integration 75, embedded-agent 295, scripts 528 — 0 fail anywhere
- [x] `node .claude/skills/orchestrator/preflight-check.js` — exit 0

Closes #1321

## Merge disposition note (2026-08-16)

**CodeRabbit state**: commit status `state=success` / `description="Review rate limited"` at head `b9ecd4a0` — read from the commit-status API, not the rollup, whose `state` reads `success` either way. `reviewDecision` empty, 0 inline comments, no formal review submitted. **This PR was never reviewed by the bot.** The local CLI is unavailable in delegated worktree sessions (the headless browser-auth failure, hit repeatedly today — note it exits `0` while reporting `authentication_failed`, so an exit-code check would falsely read as clean).

**Disposition**: merging under [PR Merge Authority](https://github.com/ms2sato/agent-console/blob/main/.claude/skills/orchestrator/SKILL.md#pr-merge-authority) — the diff is **test-only**, a single file (`packages/server/src/lib/__tests__/pty-notification.test.ts`), with no production change. Per the `coderabbit-ops` rate-limit disposition, an unavailable CodeRabbit verdict removes the safety net but does not change who may merge.

**Why this was not deferred to the next review window**: the flake it fixes lives on `main` and fired twice today, and the window it would consume is needed for #1318, whose surface is orders of magnitude larger and genuinely benefits from review. Spending a scarce repository-wide review slot on a one-file test change, while a large security-sensitive PR waits an extra hour, is the wrong allocation.

**What substitutes for the review here**: the change was verified beyond the usual bar — polarity demonstrated by deliberately diverging the two call paths and confirming the test fails with a clear diff, then restoring and confirming `git diff` matched exactly; the specific test run 30 consecutive times post-fix with zero flakes; full suite, typecheck and preflight green. Critically, the fix **freezes the clock rather than weakening the assertion**, so the full-string equality check this test exists to enforce is preserved — a fix that made it pass by relaxing the comparison would have been worse than the flake.
