### PR TITLE
fix(server): promote inter-session message write log to info level

### DIFF
--- a/packages/server/src/services/__tests__/inter-session-message-service.test.ts
+++ b/packages/server/src/services/__tests__/inter-session-message-service.test.ts
@@ -118,13 +118,9 @@ describe('InterSessionMessageService', () => {
       const sourcePath = join(import.meta.dir, '..', 'inter-session-message-service.ts');
       const source = await Bun.file(sourcePath).text();
 
-      const infoCallPattern =
-        /logger\.info\(\s*\{\s*toSessionId,\s*toWorkerId,\s*fromSessionId,\s*messageId\s*\},\s*'Message file written',\s*\);/;
-      const debugCallPattern =
-        /logger\.debug\(\s*\{\s*toSessionId,\s*toWorkerId,\s*fromSessionId,\s*messageId\s*\},\s*'Message file written',\s*\);/;
+      const call = source.match(/logger\.(info|debug)\([^)]*?'Message file written'/s);
 
-      expect(infoCallPattern.test(source)).toBe(true);
-      expect(debugCallPattern.test(source)).toBe(false);
+      expect(call?.[1]).toBe('info');
     });
 
     it('should reject message content exceeding 64 KB', async () => {

--- a/packages/server/src/services/__tests__/inter-session-message-service.test.ts
+++ b/packages/server/src/services/__tests__/inter-session-message-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { join } from 'path';
 import { vol } from 'memfs';
 import { setupMemfs, cleanupMemfs } from '../../__tests__/utils/mock-fs-helper.js';
 import {
@@ -95,6 +96,35 @@ describe('InterSessionMessageService', () => {
       const files = vol.readdirSync(dirPath) as string[];
       const tmpFiles = files.filter((f) => f.startsWith('.tmp-'));
       expect(tmpFiles).toHaveLength(0);
+    });
+
+    // NOTE: `lib/logger.js`'s pino instance is disabled (level: 'silent') for
+    // NODE_ENV==='test' (see `logger.test.ts`), so `logger.debug(...)` and
+    // `logger.info(...)` are both no-ops at test runtime and cannot be told
+    // apart by spying on the real logger. Mocking `lib/logger.js` itself is
+    // also not viable: it is imported by many other production files, and
+    // `mock.module()` is process-global in bun:test (see `testing.md`
+    // Anti-Pattern #2). Instead, this test reads the production source
+    // directly (same technique as `build-output.test.ts`) and asserts on
+    // the literal log-call shape for the 'Message file written' event,
+    // guarding the Issue #1330 diagnosability hardening (debug -> info) by
+    // regression-testing the log level rather than the (unobservable in
+    // tests) logger behavior. `Bun.file()` is used instead of `node:fs`
+    // because this suite's `setupMemfs()` mocks the `fs`/`fs/promises`
+    // module specifiers process-wide (see `mock-fs-helper.ts`); `Bun.file()`
+    // is a Bun-native API that does not go through those specifiers, so it
+    // reads the real file from disk rather than the in-memory test volume.
+    it("logs the message-file-written event at 'info' level, not 'debug'", async () => {
+      const sourcePath = join(import.meta.dir, '..', 'inter-session-message-service.ts');
+      const source = await Bun.file(sourcePath).text();
+
+      const infoCallPattern =
+        /logger\.info\(\s*\{\s*toSessionId,\s*toWorkerId,\s*fromSessionId,\s*messageId\s*\},\s*'Message file written',\s*\);/;
+      const debugCallPattern =
+        /logger\.debug\(\s*\{\s*toSessionId,\s*toWorkerId,\s*fromSessionId,\s*messageId\s*\},\s*'Message file written',\s*\);/;
+
+      expect(infoCallPattern.test(source)).toBe(true);
+      expect(debugCallPattern.test(source)).toBe(false);
     });
 
     it('should reject message content exceeding 64 KB', async () => {

--- a/packages/server/src/services/inter-session-message-service.ts
+++ b/packages/server/src/services/inter-session-message-service.ts
@@ -100,7 +100,7 @@ export class InterSessionMessageService {
       throw err;
     }
 
-    logger.debug(
+    logger.info(
       { toSessionId, toWorkerId, fromSessionId, messageId },
       'Message file written',
     );


### PR DESCRIPTION
## Summary

- Investigating #1330 (a phantom `[internal:message]` PTY notification announcing a message file that never existed) required hours of raw PTY-output-log forensics because the successful message-write event was only logged at `debug` level, so the production server logs held no direct trace of what actually happened.
- Promotes the "Message file written" log in `InterSessionMessageService.sendMessage()` from `debug` to `info`. Inter-session messages are human-scale frequency, so the log-volume cost is negligible.
- This is a diagnosability hardening only — the root cause of #1330 was not conclusively established (see the Issue for the full investigation writeup, including a hypothesis about `fromSessionId` impersonation among same-`createdBy` sibling sessions that `checkCallerOwnsSession` does not guard against). Does not close #1330.

## Test plan

- [x] Added a sibling test in `inter-session-message-service.test.ts` asserting the log call is emitted at `info` (not `debug`) level. Note: this repo's logger is silenced under `NODE_ENV=test` and `mock.module()` is process-global, so the test reads the production source directly (same technique as `build-output.test.ts`) rather than spying on the logger — documented inline in the test.
  - This test locks the log call's **text**, not its behavior. A regression that wraps the logger in something filtering `info` would pass this test. Accepted residual for a log-level guard.
- [x] `bun run typecheck` — exit 0
- [x] `bun run test` (full suite) — exit 0, all packages green (client 2146, shared 614, integration 73+3, server 3985/1 pre-existing unrelated skip, embedded-agent 295, scripts/hooks/skills 538)
- [x] `node .claude/skills/orchestrator/preflight-check.js` — coverage / language / blame-shift all clean
- [x] Local `coderabbit review --agent --base main` hit the known **headless-worktree auth failure** (not a rate-limit — `{"type":"error","phase":"auth","status":"authentication_failed", ...}`), a structural limitation of this delegated session per the `coderabbit-ops` skill's troubleshooting guide. Skipping the local CLI for this PR and relying on the GitHub-side bot review.
- [x] GitHub-side CodeRabbit bot also came back `Review rate limited` for this commit (checked via commit-status `description`, not just the rollup's `state`). Both CodeRabbit channels unavailable for this PR → dual-clean disposition applied per `coderabbit-ops` skill: Architect independent audit (full diff read + confirmed CI `test` completion) + Orchestrator acceptance. Verdict: CLEAN.

Closes: (none — references #1330, does not close it)