### PR TITLE
fix: guard secure-context-only browser APIs against plain-HTTP LAN access

### DIFF
--- a/packages/client/src/components/sessions/DeleteWorktreeDialog.tsx
+++ b/packages/client/src/components/sessions/DeleteWorktreeDialog.tsx
@@ -9,7 +9,7 @@ import {
   AlertDialogCancel,
 } from '../ui/alert-dialog';
 import { deleteWorktreeAsync } from '../../lib/api';
-import { generateTaskId } from '../../lib/id';
+import { generateClientId } from '../../lib/id';
 import { useWorktreeDeletionTasksContext } from '../../routes/__root';
 
 export interface DeleteWorktreeDialogProps {
@@ -34,7 +34,7 @@ export function DeleteWorktreeDialog({
 
   const handleDeleteWorktree = async (force: boolean = false) => {
     // Generate task ID
-    const taskId = generateTaskId();
+    const taskId = generateClientId();
 
     // Add task to sidebar with retry info
     addTask({

--- a/packages/client/src/components/sessions/SessionSettingsMenu.tsx
+++ b/packages/client/src/components/sessions/SessionSettingsMenu.tsx
@@ -17,6 +17,7 @@ import { openPath, openInVSCode, fetchSessionPrLink } from '../../lib/api';
 import { sessionKeys } from '../../lib/query-keys';
 import { hasVSCode } from '../../lib/capabilities';
 import { logger } from '../../lib/logger';
+import { copyToClipboard } from '../../lib/clipboard';
 
 export type MenuAction = 'edit' | 'restart' | 'delete-worktree' | 'pause' | 'view-initial-prompt';
 
@@ -98,7 +99,7 @@ export function SessionSettingsMenu({
 
   const handleCopyPath = async () => {
     try {
-      await navigator.clipboard.writeText(worktreePath);
+      await copyToClipboard(worktreePath);
       setCopySuccess(true);
       setTimeout(() => setCopySuccess(false), 2000);
     } catch (err) {

--- a/packages/client/src/components/sessions/__tests__/DeleteWorktreeDialog.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/DeleteWorktreeDialog.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, mock, afterEach, afterAll } from 'bun:test';
+import { screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { DeleteWorktreeDialog, type DeleteWorktreeDialogProps } from '../DeleteWorktreeDialog';
+import { WorktreeDeletionTasksContext } from '../../../contexts/root-contexts';
+import type { UseWorktreeDeletionTasksReturn } from '../../../hooks/useWorktreeDeletionTasks';
+import { renderWithRouter } from '../../../test/renderWithRouter';
+
+// DeleteWorktreeDialog resolves addTask/markAsFailed from
+// WorktreeDeletionTasksContext (re-exported by routes/__root) and navigate
+// from @tanstack/react-router. Mirrors PauseSessionDialog.test.tsx's pattern
+// (a real router via renderWithRouter + a real Context.Provider fed a mock
+// return value) instead of `mock.module`-ing routes/__root or the router
+// package -- mock.module is process-global in bun:test and would poison
+// every other test file that real-imports those modules in the same process
+// (testing.md Anti-Pattern #2).
+const originalFetch = globalThis.fetch;
+let resolveDeleteWorktree: (() => void) | null = null;
+let rejectDeleteWorktree: ((err: Error) => void) | null = null;
+const mockFetch = mock(
+  (_input: RequestInfo | URL, _init?: RequestInit) =>
+    new Promise<Response>((resolve, reject) => {
+      resolveDeleteWorktree = () => resolve(new Response(JSON.stringify({ accepted: true }), { status: 200 }));
+      rejectDeleteWorktree = (err) => reject(err);
+    })
+);
+globalThis.fetch = Object.assign(mockFetch, { preconnect: () => {} }) as typeof fetch;
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  cleanup();
+  mockFetch.mockClear();
+  resolveDeleteWorktree = null;
+  rejectDeleteWorktree = null;
+});
+
+function createMockDeletionTasks(overrides: Partial<UseWorktreeDeletionTasksReturn> = {}): UseWorktreeDeletionTasksReturn {
+  return {
+    tasks: [],
+    addTask: mock(() => {}),
+    removeTask: mock(() => {}),
+    getTask: mock(() => undefined),
+    markAsFailed: mock(() => {}),
+    handleWorktreeDeletionCompleted: mock(() => {}),
+    handleWorktreeDeletionFailed: mock(() => {}),
+    ...overrides,
+  };
+}
+
+async function renderDialog(
+  props: Partial<DeleteWorktreeDialogProps> = {},
+  deletionTasks: UseWorktreeDeletionTasksReturn = createMockDeletionTasks(),
+  initialPath = '/some-session-page'
+) {
+  const defaultProps: DeleteWorktreeDialogProps = {
+    open: true,
+    onOpenChange: mock(() => {}),
+    repositoryId: 'repo-1',
+    worktreePath: '/tmp/worktrees/repo-1/feature-branch',
+    sessionId: 'session-1',
+  };
+
+  return renderWithRouter(
+    <WorktreeDeletionTasksContext.Provider value={deletionTasks}>
+      <DeleteWorktreeDialog {...defaultProps} {...props} />
+    </WorktreeDeletionTasksContext.Provider>,
+    initialPath
+  );
+}
+
+describe('DeleteWorktreeDialog', () => {
+  it('adds a deletion task, closes the dialog, navigates home, and calls the delete API on confirm', async () => {
+    const onOpenChange = mock(() => {});
+    const deletionTasks = createMockDeletionTasks();
+    const { router } = await renderDialog({ onOpenChange }, deletionTasks);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Worktree' }));
+
+    // Assert synchronously (before resolving the mocked fetch promise) --
+    // addTask/onOpenChange/navigate all happen before the API call is
+    // awaited, matching PauseSessionDialog's Issue #1247 pattern.
+    expect(deletionTasks.addTask).toHaveBeenCalledTimes(1);
+    const addTaskArg = (deletionTasks.addTask as ReturnType<typeof mock>).mock.calls[0]?.[0] as {
+      id: string;
+      sessionId: string;
+      sessionTitle: string;
+      repositoryId: string;
+      worktreePath: string;
+    };
+    expect(typeof addTaskArg.id).toBe('string');
+    expect(addTaskArg.id.length).toBeGreaterThan(0);
+    expect(addTaskArg.sessionId).toBe('session-1');
+    expect(addTaskArg.repositoryId).toBe('repo-1');
+    expect(addTaskArg.worktreePath).toBe('/tmp/worktrees/repo-1/feature-branch');
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(router.state.location.pathname).toBe('/');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const requestedUrl = (mockFetch.mock.calls[0]?.[0] as string | URL).toString();
+    expect(requestedUrl).toContain(`taskId=${addTaskArg.id}`);
+
+    resolveDeleteWorktree?.();
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    expect(deletionTasks.markAsFailed).not.toHaveBeenCalled();
+  });
+
+  it('marks the task as failed with the error message when the delete API call rejects', async () => {
+    const deletionTasks = createMockDeletionTasks();
+    await renderDialog({}, deletionTasks);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Worktree' }));
+
+    const addTaskArg = (deletionTasks.addTask as ReturnType<typeof mock>).mock.calls[0]?.[0] as { id: string };
+
+    rejectDeleteWorktree?.(new Error('Network error'));
+
+    await waitFor(() => {
+      expect(deletionTasks.markAsFailed).toHaveBeenCalledWith(addTaskArg.id, 'Network error');
+    });
+  });
+
+  it('still produces a valid taskId and calls addTask/deleteWorktreeAsync when crypto.randomUUID is unavailable (non-secure context, #1345)', async () => {
+    // Simulate non-secure context: crypto exists but without randomUUID
+    // (same technique as lib/__tests__/id.test.ts's "non-secure context
+    // fallback" block). This proves the renamed generateClientId import at
+    // this call site actually routes through the guarded fallback, not
+    // just that the helper itself works in isolation.
+    const originalCrypto = globalThis.crypto;
+    Object.defineProperty(globalThis, 'crypto', {
+      value: { getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto) },
+      writable: true,
+      configurable: true,
+    });
+
+    try {
+      const deletionTasks = createMockDeletionTasks();
+
+      await renderDialog({}, deletionTasks);
+      // No try/catch here: if handleDeleteWorktree threw synchronously (the
+      // pre-fix crypto.randomUUID() call would throw when crypto lacks
+      // randomUUID), fireEvent.click would surface it and fail the test.
+      fireEvent.click(screen.getByRole('button', { name: 'Delete Worktree' }));
+
+      expect(deletionTasks.addTask).toHaveBeenCalled();
+      const addTaskArg = (deletionTasks.addTask as ReturnType<typeof mock>).mock.calls[0]?.[0] as { id: string };
+      expect(typeof addTaskArg.id).toBe('string');
+      expect(addTaskArg.id.length).toBeGreaterThan(0);
+      expect(mockFetch).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+});

--- a/packages/client/src/components/sessions/__tests__/SessionSettingsMenu.test.tsx
+++ b/packages/client/src/components/sessions/__tests__/SessionSettingsMenu.test.tsx
@@ -27,6 +27,51 @@ afterEach(() => {
   mockFetch.mockClear();
 });
 
+// Preserve the original clipboard descriptor so we can restore it per-test.
+// happy-dom provides a real clipboard implementation; we swap it out for a
+// jest-mock so we can assert on `writeText` calls without touching the OS
+// (mirrors the McpInstallSection / EmbeddedAgentWorkerView copy-button
+// mock patterns, #1345).
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+  Object.getPrototypeOf(navigator),
+  'clipboard',
+);
+
+let writeTextMock: ReturnType<typeof mock>;
+
+function installClipboardMock() {
+  writeTextMock = mock(() => Promise.resolve());
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: writeTextMock },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function restoreClipboard() {
+  Reflect.deleteProperty(navigator, 'clipboard');
+  if (originalClipboardDescriptor && !('clipboard' in navigator)) {
+    Object.defineProperty(Object.getPrototypeOf(navigator), 'clipboard', originalClipboardDescriptor);
+  }
+}
+
+// happy-dom does not implement `window.isSecureContext` (it is
+// `undefined`, i.e. falsy). Real browsers treat `http://localhost` as a
+// secure context, so we stub `true` here for the happy-path test below.
+const originalIsSecureContextDescriptor = Object.getOwnPropertyDescriptor(window, 'isSecureContext');
+
+function installSecureContext() {
+  Object.defineProperty(window, 'isSecureContext', { value: true, writable: true, configurable: true });
+}
+
+function restoreSecureContext() {
+  if (originalIsSecureContextDescriptor) {
+    Object.defineProperty(window, 'isSecureContext', originalIsSecureContextDescriptor);
+  } else {
+    Reflect.deleteProperty(window, 'isSecureContext');
+  }
+}
+
 function renderMenu(props: Partial<React.ComponentProps<typeof SessionSettingsMenu>> = {}) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -84,6 +129,79 @@ describe('SessionSettingsMenu', () => {
 
       fireEvent.click(pauseButton);
       expect(onMenuAction).toHaveBeenCalledWith('pause');
+    });
+  });
+
+  describe('Copy Path (#1345)', () => {
+    afterEach(() => {
+      restoreClipboard();
+      restoreSecureContext();
+    });
+
+    it('copies the worktree path to the clipboard (secure context)', async () => {
+      installClipboardMock();
+      installSecureContext();
+
+      renderMenu({ worktreePath: '/path/to/worktree' });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Session settings' }));
+      });
+
+      const copyPathButton = screen.getByRole('button', { name: 'Copy Path' });
+      await act(async () => {
+        fireEvent.click(copyPathButton);
+        await Promise.resolve();
+      });
+
+      expect(writeTextMock).toHaveBeenCalledTimes(1);
+      expect(writeTextMock.mock.calls[0]?.[0]).toBe('/path/to/worktree');
+      // NOTE: handleCopyPath unconditionally closes the menu
+      // (setIsMenuOpen(false)) in the same synchronous batch as
+      // setCopySuccess(true), so the "Copied!" label is never actually
+      // rendered to the user -- this is pre-existing behavior, unrelated to
+      // the clipboard-guard change (#1345), not asserted here.
+      expect(screen.queryByRole('button', { name: 'Session settings' })).toBeTruthy();
+    });
+
+    it('falls back to document.execCommand("copy") when navigator.clipboard is unavailable (non-secure context)', async () => {
+      // navigator.clipboard is only defined in a secure context (HTTPS or
+      // localhost/127.0.0.1). Dev-server access over plain-HTTP LAN
+      // (e.g. http://192.168.1.12:5173/) leaves it undefined, so the
+      // primary path must fall back to the legacy execCommand('copy')
+      // technique instead of silently failing (#1345).
+      Object.defineProperty(navigator, 'clipboard', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(window, 'isSecureContext', { value: false, writable: true, configurable: true });
+
+      const execCommandMock = mock(() => true);
+      // happy-dom does not implement execCommand, so assign it directly
+      // rather than spyOn-wrapping a nonexistent method.
+      Object.defineProperty(document, 'execCommand', {
+        value: execCommandMock,
+        configurable: true,
+      });
+
+      try {
+        renderMenu({ worktreePath: '/path/to/worktree' });
+
+        await act(async () => {
+          fireEvent.click(screen.getByRole('button', { name: 'Session settings' }));
+        });
+
+        const copyPathButton = screen.getByRole('button', { name: 'Copy Path' });
+        await act(async () => {
+          fireEvent.click(copyPathButton);
+          await Promise.resolve();
+        });
+
+        expect(execCommandMock).toHaveBeenCalledWith('copy');
+      } finally {
+        Reflect.deleteProperty(document, 'execCommand');
+      }
     });
   });
 });

--- a/packages/client/src/components/settings/McpInstallSection.tsx
+++ b/packages/client/src/components/settings/McpInstallSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { getServerPort } from '../../lib/server-info';
 import { buildMcpInstallCommand } from '../../lib/mcp-install-url';
 import { logger } from '../../lib/logger';
+import { copyToClipboard } from '../../lib/clipboard';
 
 /**
  * Settings-page section that shows the exact `claude mcp add ...` command
@@ -33,7 +34,7 @@ export function McpInstallSection() {
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(command);
+      await copyToClipboard(command);
       setCopied(true);
       if (timeoutRef.current !== null) {
         clearTimeout(timeoutRef.current);

--- a/packages/client/src/components/settings/__tests__/McpInstallSection.test.tsx
+++ b/packages/client/src/components/settings/__tests__/McpInstallSection.test.tsx
@@ -37,14 +37,35 @@ function restoreClipboard() {
   }
 }
 
+// happy-dom does not implement `window.isSecureContext` (it is
+// `undefined`, i.e. falsy) regardless of the test host. Real browsers treat
+// `http://localhost` as a secure context, so we stub `true` here to match
+// real-browser behavior for the happy-path tests below, mirroring the
+// EmbeddedAgentWorkerView copy-markdown test pattern (#1159).
+const originalIsSecureContextDescriptor = Object.getOwnPropertyDescriptor(window, 'isSecureContext');
+
+function installSecureContext() {
+  Object.defineProperty(window, 'isSecureContext', { value: true, writable: true, configurable: true });
+}
+
+function restoreSecureContext() {
+  if (originalIsSecureContextDescriptor) {
+    Object.defineProperty(window, 'isSecureContext', originalIsSecureContextDescriptor);
+  } else {
+    Reflect.deleteProperty(window, 'isSecureContext');
+  }
+}
+
 beforeEach(() => {
   resetServerInfo();
   installClipboardMock();
+  installSecureContext();
 });
 
 afterEach(() => {
   cleanup();
   restoreClipboard();
+  restoreSecureContext();
 });
 
 describe('McpInstallSection', () => {
@@ -103,5 +124,45 @@ describe('McpInstallSection', () => {
 
     // After the click resolves, the button label should reflect the "copied" state.
     expect(screen.getByRole('button', { name: 'Copy install command' }).textContent).toBe('Copied!');
+  });
+
+  it('falls back to document.execCommand("copy") and shows "Copied!" when navigator.clipboard is unavailable (non-secure context, #1345)', async () => {
+    setServerPort(3457);
+
+    // navigator.clipboard is only defined in a secure context (HTTPS or
+    // localhost/127.0.0.1). Dev-server access over plain-HTTP LAN
+    // (e.g. http://192.168.1.12:5173/) leaves it undefined, so the primary
+    // path must fall back to the legacy execCommand('copy') technique
+    // instead of silently failing (#1345).
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, 'isSecureContext', { value: false, writable: true, configurable: true });
+
+    const execCommandMock = mock(() => true);
+    // happy-dom does not implement execCommand, so assign it directly
+    // rather than spyOn-wrapping a nonexistent method.
+    Object.defineProperty(document, 'execCommand', {
+      value: execCommandMock,
+      configurable: true,
+    });
+
+    try {
+      render(<McpInstallSection />);
+      const copyButton = screen.getByRole('button', { name: 'Copy install command' });
+
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+
+      expect(execCommandMock).toHaveBeenCalledWith('copy');
+      expect(writeTextMock).not.toHaveBeenCalled();
+      expect(screen.getByRole('button', { name: 'Copy install command' }).textContent).toBe('Copied!');
+    } finally {
+      Reflect.deleteProperty(document, 'execCommand');
+    }
   });
 });

--- a/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
+++ b/packages/client/src/components/workers/EmbeddedAgentWorkerView.tsx
@@ -15,6 +15,7 @@ import { ContextUsageBar } from './ContextUsageBar';
 import { crossedThreshold } from './context-usage-threshold';
 import { useEmbeddedAgents } from '../../hooks/useEmbeddedAgents';
 import { logger } from '../../lib/logger';
+import { copyToClipboard } from '../../lib/clipboard';
 
 /** Defaults when `EmbeddedAgentDefinition.handoff.softRatio`/`hardRatio` are unset -- see docs/design/embedded-agent-worker.md "Context Handoff (Phase A)" § UI. */
 const DEFAULT_SOFT_RATIO = 0.75;
@@ -420,30 +421,6 @@ function PreviewablePre(props: JSX.IntrinsicElements['pre'] & ExtraProps) {
 const COPY_MARKDOWN_FEEDBACK_MS = 1500;
 
 /**
- * Legacy clipboard-copy technique via a temporary hidden textarea + the
- * deprecated `document.execCommand('copy')` API. Used as a fallback when
- * `navigator.clipboard` is unavailable, which happens whenever the page is
- * served from a non-secure context (plain HTTP, e.g. LAN dev-server access
- * at http://192.168.x.x:5173/) -- `navigator.clipboard` is undefined outside
- * HTTPS/localhost, so the modern API silently cannot be used there (#1159).
- */
-function copyViaExecCommand(text: string): boolean {
-  const textarea = document.createElement('textarea');
-  textarea.value = text;
-  // Keep off-screen so it never affects layout or scroll position.
-  textarea.style.position = 'fixed';
-  textarea.style.left = '-9999px';
-  document.body.appendChild(textarea);
-  try {
-    textarea.focus();
-    textarea.select();
-    return document.execCommand('copy');
-  } finally {
-    document.body.removeChild(textarea);
-  }
-}
-
-/**
  * Icon-only button pinned to the bottom-right of an assistant message
  * bubble. Copies the message's raw markdown SOURCE (the `text` prop, as
  * received from the agent) to the clipboard -- never the rendered HTML the
@@ -461,32 +438,10 @@ function CopyMarkdownButton({ text }: { text: string }) {
   }, []);
 
   const handleCopy = async () => {
-    let ok = false;
-    let lastError: unknown;
-
-    if (navigator.clipboard && window.isSecureContext) {
-      try {
-        await navigator.clipboard.writeText(text);
-        ok = true;
-      } catch (err) {
-        lastError = err;
-      }
-    }
-
-    // Fall back to the legacy execCommand('copy') technique when the
-    // Clipboard API is unavailable (non-secure context, e.g. LAN access
-    // over plain HTTP) or when it threw above.
-    if (!ok) {
-      try {
-        ok = copyViaExecCommand(text);
-        if (!ok) lastError = new Error('execCommand("copy") returned false');
-      } catch (err) {
-        lastError = err;
-      }
-    }
-
-    if (!ok) {
-      logger.error('Failed to copy markdown:', lastError);
+    try {
+      await copyToClipboard(text);
+    } catch (err) {
+      logger.error('Failed to copy markdown:', err);
       return;
     }
 

--- a/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
+++ b/packages/client/src/components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx
@@ -1568,6 +1568,22 @@ describe('EmbeddedAgentWorkerView', () => {
 
         expect(execCommandMock).toHaveBeenCalledWith('copy');
         expect(consoleErrorSpy).toHaveBeenCalled();
+        // Pin the exact error shape thrown by the shared copyToClipboard
+        // helper (lib/clipboard.ts) now that the extraction moved this
+        // construction out of this component -- guards against the
+        // extraction silently changing what handleCopy logs (#1345).
+        // logger.error('Failed to copy markdown:', err) forwards args
+        // straight through to console.error, so the error is the second
+        // positional arg. Locate the call by its message rather than
+        // assuming index 0 -- React/testing-library may emit unrelated
+        // console.error calls (e.g. dev warnings) earlier in the spy.
+        const copyErrorCall = (consoleErrorSpy.mock.calls as unknown[][]).find(
+          (call) => call[0] === 'Failed to copy markdown:'
+        );
+        expect(copyErrorCall).toBeDefined();
+        const loggedError = copyErrorCall?.[1];
+        expect(loggedError).toBeInstanceOf(Error);
+        expect((loggedError as Error).message).toBe('execCommand("copy") returned false');
         expect(screen.getByRole('button', { name: 'Copy as markdown' })).toBeTruthy();
         expect(screen.queryByRole('button', { name: 'Copied!' })).toBeNull();
       } finally {

--- a/packages/client/src/components/workers/__tests__/embedded-agent-store.test.ts
+++ b/packages/client/src/components/workers/__tests__/embedded-agent-store.test.ts
@@ -515,6 +515,42 @@ describe('embedded-agent-store', () => {
     expect(sent.clientMessageId?.length).toBeGreaterThan(0);
   });
 
+  it('sendUserMessage still produces a valid clientMessageId when crypto.randomUUID is unavailable (non-secure context, #1345)', () => {
+    // Simulate non-secure context: crypto exists but without randomUUID
+    // (same technique as lib/__tests__/id.test.ts's "non-secure context
+    // fallback" block). This proves the call site routes through
+    // generateClientId()'s guarded fallback rather than calling
+    // crypto.randomUUID() directly.
+    const originalCrypto = globalThis.crypto;
+    Object.defineProperty(globalThis, 'crypto', {
+      value: { getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto) },
+      writable: true,
+      configurable: true,
+    });
+
+    try {
+      const instance = getOrCreateEmbeddedAgentWorker('s14b', 'w14b');
+      const ws = MockWebSocket.getLastInstance();
+      ws!.simulateOpen();
+
+      expect(() => {
+        instance.sendUserMessage('hello agent').catch(() => {});
+      }).not.toThrow();
+
+      const sent = (
+        lastSentMessages(ws!) as { type: string; text?: string; clientMessageId?: string }[]
+      ).find((m) => m.type === 'embedded-user-message')!;
+      expect(typeof sent.clientMessageId).toBe('string');
+      expect(sent.clientMessageId?.length).toBeGreaterThan(0);
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
   describe('sendUserMessage confirmation (#1024: preserve draft on reject)', () => {
     it('resolves once the server echoes the message back as a user-message event carrying the SAME clientMessageId (correlated, not "any echo")', async () => {
       const instance = getOrCreateEmbeddedAgentWorker('s30', 'w30');

--- a/packages/client/src/components/workers/embedded-agent-store.ts
+++ b/packages/client/src/components/workers/embedded-agent-store.ts
@@ -15,6 +15,7 @@ import { getWorkerWsUrl } from '../../lib/websocket-url.js';
 import { getReconnectDelay, shouldReconnect } from '../../lib/websocket-reconnect.js';
 import { subscribe as subscribeApp } from '../../lib/app-websocket.js';
 import { logger } from '../../lib/logger.js';
+import { generateClientId } from '../../lib/id.js';
 
 /**
  * Module-level store for embedded-agent workers, mirroring
@@ -266,7 +267,7 @@ class EmbeddedAgentController implements EmbeddedAgentInstance {
     // practice (MessagePanel disables Send while a prior send is pending)
     // but avoids leaking an unsettled promise if it ever does.
     this.rejectPendingSend('Superseded by a newer send');
-    const clientMessageId = crypto.randomUUID();
+    const clientMessageId = generateClientId();
     return new Promise((resolve, reject) => {
       const sent = this.send({ type: 'embedded-user-message', text, clientMessageId });
       if (!sent) {

--- a/packages/client/src/hooks/__tests__/useCreateWorktree.test.ts
+++ b/packages/client/src/hooks/__tests__/useCreateWorktree.test.ts
@@ -11,8 +11,8 @@ import type { CreateWorktreeFormRequest } from '../../components/worktrees/Creat
 // WorktreeCreationTasksContext.Provider instead of `mock.module`-ing routes/__root --
 // mock.module is process-global in bun:test and would poison every other test file
 // that real-imports routes/__root in the same process (testing.md Anti-Pattern #2).
-const mockAddTask = mock(() => {});
-const mockRemoveTask = mock(() => {});
+const mockAddTask = mock<UseWorktreeCreationTasksReturn['addTask']>(() => {});
+const mockRemoveTask = mock<UseWorktreeCreationTasksReturn['removeTask']>(() => {});
 
 function createWrapper(): ({ children }: { children: ReactNode }) => ReactNode {
   const contextValue: UseWorktreeCreationTasksReturn = {
@@ -73,12 +73,7 @@ describe('useCreateWorktree', () => {
 
     // addTask should be called once with repository info and a generated taskId
     expect(mockAddTask).toHaveBeenCalledTimes(1);
-    const addTaskArg = (mockAddTask.mock.calls as unknown as Array<[{
-      id: string;
-      repositoryId: string;
-      repositoryName: string;
-      request: Record<string, unknown>;
-    }]>)[0][0];
+    const addTaskArg = mockAddTask.mock.calls[0][0];
     expect(addTaskArg.repositoryId).toBe('repo-1');
     expect(addTaskArg.repositoryName).toBe('Test Repository');
     expect(typeof addTaskArg.id).toBe('string');
@@ -121,8 +116,8 @@ describe('useCreateWorktree', () => {
 
     // removeTask should be called with the same taskId that was passed to addTask
     expect(mockRemoveTask).toHaveBeenCalledTimes(1);
-    const addTaskId = ((mockAddTask.mock.calls as unknown as Array<[{ id: string }]>)[0][0]).id;
-    expect((mockRemoveTask.mock.calls as unknown as Array<[string]>)[0][0]).toBe(addTaskId);
+    const addTaskId = mockAddTask.mock.calls[0][0].id;
+    expect(mockRemoveTask.mock.calls[0][0]).toBe(addTaskId);
 
     // Error should be set
     expect(result.current.error).toBeTruthy();
@@ -168,7 +163,7 @@ describe('useCreateWorktree', () => {
       });
 
       expect(mockAddTask).toHaveBeenCalledTimes(1);
-      const addTaskArg = (mockAddTask.mock.calls as unknown as Array<[{ id: string }]>)[0][0];
+      const addTaskArg = mockAddTask.mock.calls[0][0];
       expect(typeof addTaskArg.id).toBe('string');
       expect(addTaskArg.id.length).toBeGreaterThan(0);
     } finally {

--- a/packages/client/src/hooks/__tests__/useCreateWorktree.test.ts
+++ b/packages/client/src/hooks/__tests__/useCreateWorktree.test.ts
@@ -147,6 +147,39 @@ describe('useCreateWorktree', () => {
     expect(result.current.error).toBe('Unknown error');
   });
 
+  it('should still call addTask with a valid taskId when crypto.randomUUID is unavailable (non-secure context, #1345)', async () => {
+    // Simulate non-secure context: crypto exists but without randomUUID
+    // (same technique as lib/__tests__/id.test.ts's "non-secure context
+    // fallback" block). This proves the renamed generateClientId import at
+    // this call site actually routes through the guarded fallback, not
+    // just that the helper itself works in isolation.
+    const originalCrypto = globalThis.crypto;
+    Object.defineProperty(globalThis, 'crypto', {
+      value: { getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto) },
+      writable: true,
+      configurable: true,
+    });
+
+    try {
+      const { result } = renderHook(() => useCreateWorktree(defaultParams), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.handleCreateWorktree(mockFormRequest);
+      });
+
+      expect(mockAddTask).toHaveBeenCalledTimes(1);
+      const addTaskArg = (mockAddTask.mock.calls as unknown as Array<[{ id: string }]>)[0][0];
+      expect(typeof addTaskArg.id).toBe('string');
+      expect(addTaskArg.id.length).toBeGreaterThan(0);
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
   it('clearError should reset error to null', async () => {
     // Mock fetch to fail
     mockFetch.mockRejectedValue(new Error('Some error'));

--- a/packages/client/src/hooks/useCreateWorktree.ts
+++ b/packages/client/src/hooks/useCreateWorktree.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { createWorktreeAsync } from '../lib/api';
-import { generateTaskId } from '../lib/id';
+import { generateClientId } from '../lib/id';
 import { useWorktreeCreationTasksContext } from '../routes/__root';
 import type { CreateWorktreeFormRequest } from '../components/worktrees/CreateWorktreeForm';
 
@@ -22,7 +22,7 @@ export function useCreateWorktree({ repositoryId, repositoryName }: UseCreateWor
   const clearError = useCallback(() => setError(null), []);
 
   const handleCreateWorktree = useCallback(async (formRequest: CreateWorktreeFormRequest) => {
-    const taskId = generateTaskId();
+    const taskId = generateClientId();
     const request = { ...formRequest, taskId };
 
     try {

--- a/packages/client/src/lib/__tests__/clipboard.test.ts
+++ b/packages/client/src/lib/__tests__/clipboard.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { copyToClipboard } from '../clipboard';
+
+// Preserve the original clipboard/isSecureContext descriptors so we can
+// restore them per-test. happy-dom provides a real clipboard implementation
+// and no `window.isSecureContext`; both are stubbed to exercise the
+// secure-context and non-secure-context branches deterministically (#1345).
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+  Object.getPrototypeOf(navigator),
+  'clipboard',
+);
+const originalIsSecureContextDescriptor = Object.getOwnPropertyDescriptor(window, 'isSecureContext');
+
+function installClipboard(writeText: (text: string) => Promise<void>) {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: mock(writeText) },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function installUndefinedClipboard() {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function restoreClipboard() {
+  Reflect.deleteProperty(navigator, 'clipboard');
+  if (originalClipboardDescriptor && !('clipboard' in navigator)) {
+    Object.defineProperty(Object.getPrototypeOf(navigator), 'clipboard', originalClipboardDescriptor);
+  }
+}
+
+function installSecureContext(value: boolean) {
+  Object.defineProperty(window, 'isSecureContext', { value, writable: true, configurable: true });
+}
+
+function restoreSecureContext() {
+  if (originalIsSecureContextDescriptor) {
+    Object.defineProperty(window, 'isSecureContext', originalIsSecureContextDescriptor);
+  } else {
+    Reflect.deleteProperty(window, 'isSecureContext');
+  }
+}
+
+function installExecCommand(result: boolean) {
+  const execCommandMock = mock(() => result);
+  Object.defineProperty(document, 'execCommand', {
+    value: execCommandMock,
+    configurable: true,
+  });
+  return execCommandMock;
+}
+
+function restoreExecCommand() {
+  Reflect.deleteProperty(document, 'execCommand');
+}
+
+describe('copyToClipboard', () => {
+  it('uses navigator.clipboard.writeText when available in a secure context', async () => {
+    const writeTextMock = mock(() => Promise.resolve());
+    installClipboard(writeTextMock);
+    installSecureContext(true);
+    const execCommandMock = installExecCommand(true);
+
+    try {
+      await copyToClipboard('hello world');
+
+      expect(writeTextMock).toHaveBeenCalledWith('hello world');
+      expect(execCommandMock).not.toHaveBeenCalled();
+    } finally {
+      restoreClipboard();
+      restoreSecureContext();
+      restoreExecCommand();
+    }
+  });
+
+  it('falls back to document.execCommand("copy") when navigator.clipboard is unavailable (non-secure context)', async () => {
+    installUndefinedClipboard();
+    installSecureContext(false);
+    const execCommandMock = installExecCommand(true);
+
+    try {
+      await expect(copyToClipboard('fallback text')).resolves.toBeUndefined();
+      expect(execCommandMock).toHaveBeenCalledWith('copy');
+    } finally {
+      restoreClipboard();
+      restoreSecureContext();
+      restoreExecCommand();
+    }
+  });
+
+  it('throws when both navigator.clipboard is unavailable and the execCommand fallback fails', async () => {
+    installUndefinedClipboard();
+    installSecureContext(false);
+    const execCommandMock = installExecCommand(false);
+
+    try {
+      await expect(copyToClipboard('doomed text')).rejects.toThrow('execCommand("copy") returned false');
+      expect(execCommandMock).toHaveBeenCalledWith('copy');
+    } finally {
+      restoreClipboard();
+      restoreSecureContext();
+      restoreExecCommand();
+    }
+  });
+});

--- a/packages/client/src/lib/__tests__/clipboard.test.ts
+++ b/packages/client/src/lib/__tests__/clipboard.test.ts
@@ -78,6 +78,22 @@ describe('copyToClipboard', () => {
     }
   });
 
+  it('falls back to document.execCommand("copy") when writeText rejects', async () => {
+    const writeTextMock = mock(() => Promise.reject(new Error('Clipboard denied')));
+    installClipboard(writeTextMock);
+    installSecureContext(true);
+    const execCommandMock = installExecCommand(true);
+    try {
+      await expect(copyToClipboard('fallback text')).resolves.toBeUndefined();
+      expect(writeTextMock).toHaveBeenCalledWith('fallback text');
+      expect(execCommandMock).toHaveBeenCalledWith('copy');
+    } finally {
+      restoreClipboard();
+      restoreSecureContext();
+      restoreExecCommand();
+    }
+  });
+
   it('falls back to document.execCommand("copy") when navigator.clipboard is unavailable (non-secure context)', async () => {
     installUndefinedClipboard();
     installSecureContext(false);

--- a/packages/client/src/lib/__tests__/id.test.ts
+++ b/packages/client/src/lib/__tests__/id.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { generateTaskId } from '../id';
+import { generateClientId } from '../id';
 
-describe('generateTaskId', () => {
+describe('generateClientId', () => {
   it('should return a string', () => {
-    const id = generateTaskId();
+    const id = generateClientId();
     expect(typeof id).toBe('string');
     expect(id.length).toBeGreaterThan(0);
   });
 
   it('should return a UUID when crypto.randomUUID is available', () => {
-    const id = generateTaskId();
+    const id = generateClientId();
     // UUID v4 format: xxxxxxxx-xxxx-4xxx-[89ab]xxx-xxxxxxxxxxxx
     const uuidPattern =
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -38,21 +38,21 @@ describe('generateTaskId', () => {
     });
 
     it('should return a fallback ID when crypto.randomUUID is not available', () => {
-      const id = generateTaskId();
+      const id = generateClientId();
       expect(typeof id).toBe('string');
       expect(id.length).toBeGreaterThan(0);
     });
 
     it('should return a fallback ID matching timestamp-hex format', () => {
-      const id = generateTaskId();
+      const id = generateClientId();
       // Format: {timestamp}-{hex}
       const fallbackPattern = /^\d+-[0-9a-f]+$/;
       expect(id).toMatch(fallbackPattern);
     });
 
     it('should generate unique fallback IDs', () => {
-      const id1 = generateTaskId();
-      const id2 = generateTaskId();
+      const id1 = generateClientId();
+      const id2 = generateClientId();
       expect(id1).not.toBe(id2);
     });
   });

--- a/packages/client/src/lib/clipboard.ts
+++ b/packages/client/src/lib/clipboard.ts
@@ -1,0 +1,45 @@
+/**
+ * Legacy clipboard-copy technique via a temporary hidden textarea + the
+ * deprecated `document.execCommand('copy')` API. Used as a fallback when
+ * `navigator.clipboard` is unavailable, which happens whenever the page is
+ * served from a non-secure context (plain HTTP, e.g. LAN dev-server access
+ * at http://192.168.x.x:5173/) -- `navigator.clipboard` is undefined outside
+ * HTTPS/localhost, so the modern API silently cannot be used there (#1159).
+ */
+function copyViaExecCommand(text: string): boolean {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  // Keep off-screen so it never affects layout or scroll position.
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  try {
+    textarea.focus();
+    textarea.select();
+    return document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+/**
+ * Copy `text` to the clipboard, using the modern `navigator.clipboard` API
+ * when available and falling back to the legacy `execCommand('copy')`
+ * technique otherwise (non-secure context, e.g. LAN access over plain HTTP,
+ * or a `navigator.clipboard.writeText` failure). Throws if both the modern
+ * API and the fallback fail.
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Fall through to the legacy execCommand('copy') technique below.
+    }
+  }
+
+  if (!copyViaExecCommand(text)) {
+    throw new Error('execCommand("copy") returned false');
+  }
+}

--- a/packages/client/src/lib/id.ts
+++ b/packages/client/src/lib/id.ts
@@ -1,11 +1,11 @@
 /**
- * Generate a unique task ID with fallback for non-secure contexts.
+ * Generate a unique client-side ID with fallback for non-secure contexts.
  *
  * crypto.randomUUID() requires a secure context (HTTPS or localhost).
  * When the app is accessed via IP address over HTTP, we fall back to
  * a timestamp + random hex string.
  */
-export function generateTaskId(): string {
+export function generateClientId(): string {
   return typeof crypto !== 'undefined' && 'randomUUID' in crypto
     ? crypto.randomUUID()
     : `${Date.now()}-${Math.random().toString(16).slice(2)}`;

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -20,7 +20,7 @@ import {
 import { useAppWsEvent } from '../hooks/useAppWs';
 import { useCreateWorktree } from '../hooks/useCreateWorktree';
 import { emitSessionDeleted } from '../lib/app-websocket';
-import { generateTaskId } from '../lib/id';
+import { generateClientId } from '../lib/id';
 import { formatPath } from '../lib/path';
 import { ConfirmDialog } from '../components/ui/confirm-dialog';
 import { ErrorDialog, useErrorDialog } from '../components/ui/error-dialog';
@@ -312,7 +312,7 @@ export function DashboardPage() {
 
   // Handle pull worktree request from WorktreeRow
   const handlePullWorktree = useCallback(async (repositoryId: string, worktreePath: string) => {
-    const taskId = generateTaskId();
+    const taskId = generateClientId();
     // Set a timeout to auto-remove the entry if WebSocket never responds
     const timeoutId = setTimeout(() => {
       logger.warn(`[Pull] Timeout: ${worktreePath} (${PULL_TIMEOUT_MS}ms elapsed)`);
@@ -879,7 +879,7 @@ export function WorktreeRow({ worktree, session, pausedSession, repositoryId, is
 
   const executeDelete = async (force: boolean) => {
     // Generate task ID
-    const taskId = generateTaskId();
+    const taskId = generateClientId();
 
     // Use session ID if available, otherwise generate a synthetic one for the task
     const effectiveSessionId = session?.id ?? `no-session-${taskId}`;

--- a/packages/client/src/routes/worktree-creation-tasks/$taskId.tsx
+++ b/packages/client/src/routes/worktree-creation-tasks/$taskId.tsx
@@ -4,7 +4,7 @@ import { AlertCircleIcon } from '../../components/Icons';
 import { Spinner } from '../../components/ui/Spinner';
 import { useWorktreeCreationTasksContext } from '../__root';
 import { createWorktreeAsync } from '../../lib/api';
-import { generateTaskId } from '../../lib/id';
+import { generateClientId } from '../../lib/id';
 import { logger } from '../../lib/logger';
 
 export const Route = createFileRoute('/worktree-creation-tasks/$taskId')({
@@ -38,7 +38,7 @@ function useWorktreeCreationTask(taskId: string): {
     if (!task) return;
 
     // Generate a new task ID for the retry
-    const newTaskId = generateTaskId();
+    const newTaskId = generateClientId();
 
     // Build new request with new taskId
     const newRequest = { ...task.request, taskId: newTaskId };

--- a/packages/client/src/routes/worktree-deletion-tasks/$taskId.tsx
+++ b/packages/client/src/routes/worktree-deletion-tasks/$taskId.tsx
@@ -4,7 +4,7 @@ import { AlertCircleIcon, CheckIcon } from '../../components/Icons';
 import { Spinner } from '../../components/ui/Spinner';
 import { useWorktreeDeletionTasksContext } from '../__root';
 import { deleteWorktreeAsync } from '../../lib/api';
-import { generateTaskId } from '../../lib/id';
+import { generateClientId } from '../../lib/id';
 import { logger } from '../../lib/logger';
 
 export const Route = createFileRoute('/worktree-deletion-tasks/$taskId')({
@@ -38,7 +38,7 @@ function useWorktreeDeletionTask(taskId: string): {
     if (!task) return;
 
     // Generate a new task ID for the retry
-    const newTaskId = generateTaskId();
+    const newTaskId = generateClientId();
 
     // Remove the failed task
     removeTaskFromContext(taskId);


### PR DESCRIPTION
## Summary

Fixes three call sites that used secure-context-only browser APIs (`crypto.randomUUID()`, `navigator.clipboard.writeText`) without guarding for non-secure contexts. In a non-secure context (plain HTTP to a LAN address, e.g. `http://192.168.1.12:5173`) both APIs are `undefined`, so calls throw or fail silently.

The codebase had already solved this exact problem twice — `lib/id.ts`'s `generateTaskId()` and `EmbeddedAgentWorkerView.tsx`'s inline clipboard guard — but neither remedy had propagated to these three sites. This PR consolidates both patterns into one reusable place per API instead of adding a third copy.

### Id generation (`crypto.randomUUID`)

- Renamed `generateTaskId()` → `generateClientId()` in `lib/id.ts` (same secure-context fallback logic, generalized JSDoc). Chose a rename over a sibling function because the old name was purely accidental — the underlying logic was never task-specific, and a sibling would have duplicated the exact same fallback body for no benefit.
- Updated all 5 existing call sites' imports/calls to the new name.
- `embedded-agent-store.ts`'s `sendUserMessage` (the reported crash site, line ~269) now builds `clientMessageId` via `generateClientId()` instead of a raw `crypto.randomUUID()` call.

### Clipboard (`navigator.clipboard.writeText`)

- Extracted the existing guarded copy logic (secure-context check + `document.execCommand('copy')` fallback) out of `EmbeddedAgentWorkerView.tsx` into a new `lib/clipboard.ts` exporting `copyToClipboard(text): Promise<void>`. `EmbeddedAgentWorkerView.tsx` now imports it instead of keeping a local copy.
- Migrated `McpInstallSection.tsx` and `SessionSettingsMenu.tsx` (both unguarded) to use `copyToClipboard`.

### Out-of-scope finding (not fixed here)

While adding test coverage for `SessionSettingsMenu`'s "Copy Path" action (which had zero prior test coverage), found that `handleCopyPath` unconditionally closes the dropdown menu (`setIsMenuOpen(false)`) in the same synchronous batch as `setCopySuccess(true)`, so the "Copied!" label is never actually visible to the user. Confirmed via `git log -p` this is pre-existing behavior, unrelated to this fix. Flagging for a possible separate follow-up; not addressed here to keep this PR's review surface scoped to the secure-context guard.

## Test plan

Sibling tests added/updated for every touched production file (`test-trigger.md`). For every non-secure-context branch, polarity was verified by reverting only the guarded production line, confirming the specific new test fails, then restoring:

- `lib/__tests__/clipboard.test.ts` (new) — happy path (secure context), non-secure-context `execCommand` fallback, both-fail throw. Reverting `copyToClipboard` to a guard-less call flips 2 of 3 new tests to fail.
- `lib/__tests__/id.test.ts` — renamed for `generateClientId`; existing non-secure-context fallback coverage preserved.
- `components/workers/__tests__/embedded-agent-store.test.ts` — new test stubs `crypto` without `randomUUID`, asserts `sendUserMessage` still produces a valid `clientMessageId` and doesn't throw. Reverting the call site to raw `crypto.randomUUID()` reproduces the original crash (`crypto.randomUUID is not a function`).
- `components/settings/__tests__/McpInstallSection.test.tsx` — added `isSecureContext` stub to existing happy-path tests (needed once the guard was added) + new non-secure-context fallback test.
- `components/sessions/__tests__/SessionSettingsMenu.test.tsx` — added secure-context happy-path + non-secure-context fallback tests for "Copy Path" (previously zero coverage for this action).
- `components/sessions/__tests__/DeleteWorktreeDialog.test.tsx` (new — no sibling test existed before this PR) — happy path, API-failure path, and non-secure-context fallback.
- `hooks/__tests__/useCreateWorktree.test.ts` — added non-secure-context fallback regression test.
- `components/workers/__tests__/EmbeddedAgentWorkerView.test.tsx` — existing copy-markdown tests (happy/fallback/both-fail) continue to pass unchanged after the extraction; added an assertion pinning the exact error shape now thrown by the shared helper.

`happy-dom` does not implement `window.isSecureContext` (undefined/falsy) and does implement a working `crypto.randomUUID`/`navigator.clipboard` by default, so every non-secure-context test explicitly constructs the absent-API condition via `Object.defineProperty` rather than relying on the test environment.

**Integration test coverage**: `preflight-check.js` flagged an integration-test-gap warning for the 4 touched UI components. Not applicable here — this fix is pure client-local browser-API-availability branching with no server/wire-boundary contract change, which is what `packages/integration` boundary tests exist for.

### Verification

```
bun run typecheck  # 0 errors, all 6 workspace packages
bun run test       # TEST_EXIT: 0 — shared 619, integration 75+3, server 3992 (+1 pre-existing unrelated skip), embedded-agent 295, client 2182, root scripts/hooks/skills 538 — all pass, 0 fail
```

### Note on CodeRabbit

Local `coderabbit review --agent --base main` hit the headless-worktree auth failure (`authentication_failed` / `automatic_login_failed`, exit 0) — a structural limitation of this delegated worktree session (no browser for the interactive login), not a rate-limit. Skipped per `coderabbit-ops/troubleshooting.md`; relying on the GitHub-side bot review post-PR-open.

Closes #1345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable copy-to-clipboard support, including fallback behavior when modern clipboard access is unavailable.
  - Copy actions across settings, sessions, and worker views now work in more browser environments.

- **Bug Fixes**
  - Improved task and message ID generation when secure random UUID support is unavailable.
  - Retry and creation flows now continue functioning with fallback-generated IDs.

- **Tests**
  - Added comprehensive coverage for clipboard fallbacks, ID generation, worktree deletion, and related failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->