### PR TITLE
docs: name the vacuous-assertion shape, and how to tell whose dev server you are on

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -66,6 +66,18 @@ If yes, it is a real guard and its both-worlds pass is the point. If no — if n
 
 Worked example: PR [#1283](https://github.com/ms2sato/agent-console/pull/1283) added a `{{var:+prefix}}` template form, and two of its nine new tests asserted that reserved names (`{{prompt:+X}}`, `{{cwd:+X}}`) are *not* expanded through it. Those two passed against the unmodified engine — the reserved-name guard already existed one pass down. They are not vacuous: dropping the guard from the new pass makes `{{prompt:+X}}` expand to the empty string and the placeholder silently disappear, which is exactly the mistake an implementer might make. Seven tests flipped, two did not, and all nine were correct.
 
+### When an assertion has more than one way to come true
+
+The question above ("would this fail against a plausible wrong implementation?") is asked about the test as a whole. There is a narrower failure that slips past it: the assertion is *satisfied by a different condition than the one the test claims to exercise*. The test is green, the assertion is genuinely true, and it would stay true no matter how badly the thing under test broke.
+
+The shape is always the same — **the production condition is a conjunction, and the test sets up one conjunct while leaving the others at defaults that already decide the outcome.**
+
+Worked example: a component renders a notice when `engine === 'claude-sdk' && restoredMessageCount > 0`. A test for "while the engine is unresolved, the notice must not render" set the engine unresolved but left `restoredMessageCount` at its default `null`. The notice was suppressed by the null, not by the engine check — so the assertion could not detect a regression in the engine logic it existed to guard.
+
+**The one-line self-check, at writing time:** *if I remove the condition this test is about, does the assertion still come out the same?* If yes, that condition is not being tested. Equivalently: name every input the production expression reads, and confirm the test moves the one under test **off** the value that would satisfy the assertion by itself.
+
+This is not caught by a green suite, by CI, or usually by review — the assertion is true, the test name is accurate, and nothing looks wrong. Three instances landed in one day (Sprint 2026-08-18), in three different PRs by three different delegates, at three different layers: a grep-shaped containment test whose pattern a two-file split would bypass ([#1356](https://github.com/ms2sato/agent-console/pull/1356)); a wire-boundary test whose job fake always returned `[]`, so the one optional field it existed to protect never traversed the parse path ([#1357](https://github.com/ms2sato/agent-console/pull/1357)); and the engine case above ([#1360](https://github.com/ms2sato/agent-console/pull/1360)). Two were found by CodeRabbit, one by reading a screenshot. None by the suite.
+
 **When reporting polarity, state the category per test.** "7 of 9 flipped" invites a partial-polarity finding; "7 bug/contract tests flipped, 2 invariant-preservation tests hold in both worlds and fail against a guard-less implementation" is the same fact, correctly classified.
 
 ### Demonstrating polarity without breaking the build

--- a/.claude/skills/dev-environment-quirks/SKILL.md
+++ b/.claude/skills/dev-environment-quirks/SKILL.md
@@ -96,6 +96,24 @@ git -C <serving-checkout> log -1 --format='%ci %h %s'
 
 If the process start time predates the commit time, the server is running old code — restart (or re-rsync / re-bundle) before drawing any verification conclusion from its behavior. (Lesson: Sprint 2026-08-01 — merged PRs #1237/#1241 were believed E2E-verified on the shared dev server, which was in fact running a binary from before the merges; the gap sat undetected for two days. See `.claude/rules/pre-pr-completeness.md` Q13 "Retroactive application".)
 
+## Whose server is on that port? (parallel sessions collide silently)
+
+A LISTEN on your expected port does not mean **your** process is listening. When several delegates work in parallel, each starting a dev server on the default ports, a start-up failure in yours leaves someone else's server answering — and the browser looks completely normal, because it *is* a working instance, just of different code.
+
+Check provenance at start time, every time, not when something looks wrong:
+
+```bash
+ss -tlnp | grep -E ':3457|:5173'        # get the PID actually holding the port
+readlink -f /proc/<pid>/cwd             # must be YOUR worktree
+ps -o lstart=,args= -p <pid>            # start time matches your launch; argv carries the worktree path
+```
+
+Two things make this failure hard to catch by feel: the symptom is *absence* of your change (which reads as "my change didn't work"), and every functional check you run still passes, because the other instance works fine. Confirming the port's owner is one command; noticing by intuition is luck.
+
+**Prefer isolation over detection.** For QA that matters, start the instance on a dedicated port with its own `AGENT_CONSOLE_HOME` (see the next section) rather than competing for the defaults. Detection tells you afterward; isolation removes the collision.
+
+(Lesson: Sprint 2026-08-18 PR [#1360](https://github.com/ms2sato/agent-console/pull/1360) — a delegate's own dev server failed to start on the second launch, and they QA'd against a *different* delegate's server without noticing. They caught it only because a one-line change they had reviewed minutes earlier was missing from the picker; their own retrospective named the root error precisely: treating "the port is LISTENing" as "my process is LISTENing". The first round's provenance was later established from `ps` argv — which happened to contain the absolute worktree path. That was luck, not procedure.)
+
 ## Driving MCP against a throwaway instance you started yourself
 
 Shipping-path verification often needs a disposable instance (`AGENT_CONSOLE_HOME=/tmp/agent-console-<issue>-verify` on a free port — never under `~/.agent-console*`, which a guard protects from cleanup). **The session's pre-registered MCP clients cannot reach it**: those entries point at the shared instances, and rewriting the global `~/.claude.json` to retarget them would disturb every other session on the machine.


### PR DESCRIPTION
## Summary

Two rule/skill additions from today's delegate retrospectives. **Docs only.**

## 1. `testing.md` — the vacuous-assertion shape

The existing polarity section asks whether a test would fail against a plausible wrong implementation. That is a question about the test as a whole, and it misses a narrower failure: **the assertion is satisfied by a different condition than the one the test claims to exercise.**

The shape is always the same — production checks a conjunction, the test sets up one conjunct and leaves the others at defaults that already decide the outcome. Concretely: a notice renders when `engine === 'claude-sdk' && restoredMessageCount > 0`; a test for "unresolved engine must not render the notice" set the engine unresolved but left `restoredMessageCount` at `null`. The notice was suppressed by the null, so the assertion could not detect a regression in the engine logic it existed to guard.

The self-check is one line, applied at writing time: *if I remove the condition this test is about, does the assertion still come out the same?*

What makes this worth a rule rather than a note: **three instances landed in one day**, in three PRs, by three different delegates, at three different layers — a grep-shaped containment test a two-file split would bypass (#1356); a wire-boundary test whose job fake always returned `[]`, so the one optional field it existed to protect never traversed the parse path (#1357); and the engine case above (#1360). Two were caught by CodeRabbit, one by reading a QA screenshot. **None by the suite** — the assertions are true, the test names are accurate, and nothing looks wrong.

## 2. `dev-environment-quirks` — whose server is on that port?

A hazard that exists only because delegates run in parallel: **a LISTEN on your expected port is not proof that YOUR process is listening.** If your start-up failed, another delegate's server answers, and the browser looks entirely normal — it *is* a working instance, just of different code. The symptom (your change missing) reads as "my change didn't work".

The section gives the three-command provenance check (`ss -tlnp` → `readlink -f /proc/<pid>/cwd` → `ps -o lstart=,args=`) and says to run it at start time rather than when something looks wrong, plus the stronger recommendation: prefer a dedicated port + own `AGENT_CONSOLE_HOME` so the collision cannot happen, since detection only tells you afterward.

The delegate who hit this named the root error precisely — treating "the port is LISTENing" as "my process is LISTENing" — and was candid that their eventual catch was luck (a one-line change they had reviewed minutes earlier was visibly missing).

## Test plan

- [x] `bun run check:lang` clean
- [x] `node .claude/skills/orchestrator/preflight-check.js` clean
- [x] Docs-only change — no tests apply
