### PR TITLE
chore(preflight): state the escalation obligation on an integration gap

### DIFF
--- a/.claude/skills/orchestrator/__tests__/preflight-check.test.js
+++ b/.claude/skills/orchestrator/__tests__/preflight-check.test.js
@@ -19,7 +19,27 @@ describe('formatCoverageVerdict (Issue #1189)', () => {
       hasIntegrationGap: true,
       hasCommentOnlyExemptions: false,
     });
-    expect(result).toBe('**Integration test gap detected — review recommended.** ⚠');
+    expect(result).toBe(
+      "**Integration test gap detected — raise it with the requester before opening the PR; this is not the implementer's to waive.** ⚠",
+    );
+  });
+
+  // The wording is load-bearing, not cosmetic. A delegate who reads the gap as
+  // "advisory, so I may decide it myself" is applying the script's exit code as
+  // the escalation criterion, which is not the rule's criterion -- see
+  // `.claude/rules/workflow.md`, "A joint decision does not unlock a strong
+  // preflight recommend". Observed once: the integration gap on a cross-package
+  // PR was seen, classified as self-waivable because it left the exit code
+  // clean, and never surfaced.
+  it('names the escalation obligation rather than merely recommending review', () => {
+    const result = formatCoverageVerdict({
+      hasUnitGaps: false,
+      gapsCount: 0,
+      hasIntegrationGap: true,
+      hasCommentOnlyExemptions: false,
+    });
+    expect(result).toContain('raise it with the requester');
+    expect(result).not.toContain('review recommended');
   });
 
   it('does not claim exempted files have corresponding tests — uses exemption-specific wording', () => {

--- a/.claude/skills/orchestrator/preflight-check.js
+++ b/.claude/skills/orchestrator/preflight-check.js
@@ -97,6 +97,16 @@ function printIntegrationTestCoverage(integrationTestNeeds) {
     }
     if (integrationTestNeeds.isCrossPackage) {
       console.log('\n⚠ Cross-package change (client + server) — integration test strongly recommended');
+      console.log(
+        '  This warning is advisory to the SCRIPT (it does not affect the exit code) but not to YOU.',
+      );
+      console.log(
+        '  It is not yours to waive: raise it with whoever assigned the work, and let them decide',
+      );
+      console.log(
+        '  WHICH test to add. See `.claude/rules/workflow.md`, "A joint decision does not unlock a',
+      );
+      console.log('  strong preflight recommend".');
     }
     console.log();
   }
@@ -109,7 +119,7 @@ function printIntegrationTestCoverage(integrationTestNeeds) {
  */
 export function formatCoverageVerdict({ hasUnitGaps, gapsCount, hasIntegrationGap, hasCommentOnlyExemptions }) {
   if (hasUnitGaps) return `**${gapsCount} production file(s) missing test coverage.**`;
-  if (hasIntegrationGap) return '**Integration test gap detected — review recommended.** ⚠';
+  if (hasIntegrationGap) return '**Integration test gap detected — raise it with the requester before opening the PR; this is not the implementer\'s to waive.** ⚠';
   if (hasCommentOnlyExemptions) return '**All test coverage requirements are satisfied (comment-only changes exempted).** ✅';
   return '**All production files have corresponding tests.** ✅';
 }


### PR DESCRIPTION
## What happened

On a cross-package PR (client + server), `preflight-check.js` printed its integration-test warning. The delegate saw it, read the script far enough to confirm that `hasIntegrationGap` does not affect the exit code, and concluded it was theirs to settle in the PR body. It never reached the Orchestrator.

They described the mechanism precisely in their retrospective: they had sorted the two findings by **"does it dirty the exit code"** — the sibling-test gap did, so it was escalated and discussed in detail; the integration gap did not, so it was filed as advisory. They knew the rule in `workflow.md`:

> A joint decision does not unlock a strong preflight recommend. ... the joint decision can move *which* test to add but not **whether** to add one.

Knowing it did not help, because at the moment of triage a different, self-invented criterion was doing the sorting.

## Why this change and not a rule change

The rule already says the right thing. What it does not do is say it *where the judgment happens*. The exit code is right there in the terminal, concrete and unambiguous; the rule is in a file the agent read hours earlier. When those two compete, the concrete one wins.

So the obligation moves into the script's own output — the same screen where the gap is reported:

```
⚠ Cross-package change (client + server) — integration test strongly recommended
  This warning is advisory to the SCRIPT (it does not affect the exit code) but not to YOU.
  It is not yours to waive: raise it with whoever assigned the work, and let them decide
  WHICH test to add. See `.claude/rules/workflow.md`, "A joint decision does not unlock a
  strong preflight recommend".
```

and the verdict line stops saying "review recommended", which reads as an invitation to self-assess:

```
- **Integration test gap detected — raise it with the requester before opening the PR;
   this is not the implementer's to waive.** ⚠
```

The exit code is deliberately unchanged. Making the gap fail the build would reject legitimate PRs — the warning is advisory *by design*, per the same rule. What was missing is that "advisory to the script" was being read as "advisory to me".

## History

This is the second time the same gap has cost something. Sprint 2026-06-30 PR #926 shipped a wire-boundary bug after the agent proposed skipping the integration test and the Orchestrator approved on the same reasoning — the joint-judgment failure that put the rule in `workflow.md`. This occurrence is the single-party version: the same conclusion reached without the second party ever hearing about it.

## Test plan

- `.claude/skills/orchestrator/__tests__/preflight-check.test.js` — the existing verdict assertion is updated, plus a new case asserting the line names the escalation obligation (`toContain('raise it with the requester')`) and no longer reads as an invitation to self-assess (`not.toContain('review recommended')`). That second assertion fails against the previous wording, so it guards the change rather than merely describing it.
- `bun test ./.claude/skills/orchestrator/__tests__/preflight-check.test.js` — 5 pass, 0 fail
- `node .claude/skills/orchestrator/preflight-check.js` — runs clean (exercises the modified module end to end)
- `bun run check:lang` — clean

Full suite not run: the diff is confined to `.claude/skills/`, which `.claude/rules/workflow.md` exempts from the full-suite requirement. The changed module is exercised by the targeted test above and by running the script itself.
